### PR TITLE
More clean up and small optimisation

### DIFF
--- a/matrix-sdk-android/src/debug/java/im/vector/matrix/android/internal/network/interceptors/FormattedJsonHttpLogger.kt
+++ b/matrix-sdk-android/src/debug/java/im/vector/matrix/android/internal/network/interceptors/FormattedJsonHttpLogger.kt
@@ -66,7 +66,7 @@ class FormattedJsonHttpLogger : HttpLoggingInterceptor.Logger {
     }
 
     private fun logJson(formattedJson: String) {
-        val arr = formattedJson.split("\n".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        val arr = formattedJson.lines().dropLastWhile { it.isEmpty() }
         for (s in arr) {
             Timber.v(s)
         }

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/Matrix.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/Matrix.kt
@@ -80,10 +80,12 @@ class Matrix private constructor(context: Context, matrixConfiguration: MatrixCo
                     val matrixConfiguration = (appContext as MatrixConfiguration.Provider).providesMatrixConfiguration()
                     instance = Matrix(appContext, matrixConfiguration)
                 } else {
+                    // TODO: Should set isInit back to false ?
                     throw IllegalStateException("Matrix is not initialized properly." +
                             " You should call Matrix.initialize or let your application implements MatrixConfiguration.Provider.")
                 }
             }
+            // FIXME Race condition. This will throw null pointer if two threads call this method at the same time.
             return instance
         }
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/permalinks/PermalinkParser.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/api/permalinks/PermalinkParser.kt
@@ -45,12 +45,11 @@ object PermalinkParser {
             return PermalinkData.FallbackLink(uri)
         }
 
-        val indexOfQuery = fragment.indexOf("?")
-        val safeFragment = if (indexOfQuery != -1) fragment.substring(0, indexOfQuery) else fragment
+        val safeFragment = fragment.substringBefore('?')
 
         // we are limiting to 2 params
         val params = safeFragment
-                .split(MatrixPatterns.SEP_REGEX.toRegex())
+                .split(MatrixPatterns.SEP_REGEX)
                 .filter { it.isNotEmpty() }
                 .take(2)
 

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/crosssigning/DefaultCrossSigningService.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/crosssigning/DefaultCrossSigningService.kt
@@ -35,7 +35,6 @@ import im.vector.matrix.android.internal.task.TaskThread
 import im.vector.matrix.android.internal.task.configureWith
 import im.vector.matrix.android.internal.util.JsonCanonicalizer
 import im.vector.matrix.android.internal.util.MatrixCoroutineDispatchers
-import im.vector.matrix.android.internal.util.withoutPrefix
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
@@ -393,7 +392,7 @@ internal class DefaultCrossSigningService @Inject constructor(
         } else {
             // Maybe it's signed by a locally trusted device?
             myMasterKey.signatures?.get(userId)?.forEach { (key, value) ->
-                val potentialDeviceId = key.withoutPrefix("ed25519:")
+                val potentialDeviceId = key.removePrefix("ed25519:")
                 val potentialDevice = cryptoStore.getUserDevice(userId, potentialDeviceId)
                 if (potentialDevice != null && potentialDevice.isVerified) {
                     // Check signature validity?

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/verification/SASDefaultVerificationTransaction.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/crypto/verification/SASDefaultVerificationTransaction.kt
@@ -28,7 +28,6 @@ import im.vector.matrix.android.internal.crypto.OutgoingGossipingRequestManager
 import im.vector.matrix.android.internal.crypto.actions.SetDeviceVerificationAction
 import im.vector.matrix.android.internal.crypto.store.IMXCryptoStore
 import im.vector.matrix.android.internal.extensions.toUnsignedInt
-import im.vector.matrix.android.internal.util.withoutPrefix
 import org.matrix.olm.OlmSAS
 import org.matrix.olm.OlmUtility
 import timber.log.Timber
@@ -246,7 +245,7 @@ internal abstract class SASDefaultVerificationTransaction(
 
         // cannot be empty because it has been validated
         theirMacSafe.mac.keys.forEach {
-            val keyIDNoPrefix = it.withoutPrefix("ed25519:")
+            val keyIDNoPrefix = it.removePrefix("ed25519:")
             val otherDeviceKey = otherUserKnownDevices?.get(keyIDNoPrefix)?.fingerprint()
             if (otherDeviceKey == null) {
                 Timber.w("## SAS Verification: Could not find device $keyIDNoPrefix to verify")
@@ -269,7 +268,7 @@ internal abstract class SASDefaultVerificationTransaction(
         if (otherCrossSigningMasterKeyPublic != null) {
             // Did the user signed his master key
             theirMacSafe.mac.keys.forEach {
-                val keyIDNoPrefix = it.withoutPrefix("ed25519:")
+                val keyIDNoPrefix = it.removePrefix("ed25519:")
                 if (keyIDNoPrefix == otherCrossSigningMasterKeyPublic) {
                     // Check the signature
                     val mac = macUsingAgreedMethod(otherCrossSigningMasterKeyPublic, baseInfo + it)

--- a/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/util/StringUtils.kt
+++ b/matrix-sdk-android/src/main/java/im/vector/matrix/android/internal/util/StringUtils.kt
@@ -49,5 +49,3 @@ fun convertFromUTF8(s: String): String {
         s
     }
 }
-
-fun String.withoutPrefix(prefix: String) = if (startsWith(prefix)) substringAfter(prefix) else this


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 16
- [x] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

The usual Kotlin clean up.
I also left some comments pointing out race conditions.

About the 3rd commit, I saw this commit https://github.com/vector-im/riotX-android/commit/bcb811a7e83a56806a26e379f05bd8a5131085ff and thought to point out that a `Semaphore` can be used to limit the number of threads used for a transactions and will also reduce the number of `Dispatchers.Default` threads blocked for IO. Feel free to nuke the commit if it's not deemed useful.