### PR TITLE
Relative date time formatter #822

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Improvements 🙌:
 
 Bugfix 🐛:
  - Fix invisible toolbar (Status.im theme) (#1746)
+ - Fix relative date time formatting (#822)
 
 Translations 🗣:
  - Add PlayStore description resources in the Triple-T format, to let Weblate handle them

--- a/vector/src/main/java/im/vector/app/core/date/VectorDateFormatter.kt
+++ b/vector/src/main/java/im/vector/app/core/date/VectorDateFormatter.kt
@@ -21,7 +21,23 @@ import android.text.format.DateUtils
 import im.vector.app.core.resources.LocaleProvider
 import org.threeten.bp.LocalDateTime
 import org.threeten.bp.format.DateTimeFormatter
+import java.util.Calendar
+import java.util.Date
 import javax.inject.Inject
+
+/**
+ * Returns the timestamp for the start of the day of the provided time.
+ * For example, for the time "Jul 21, 11:11" the start of the day: "Jul 21, 00:00" is returned.
+ */
+fun startOfDay(time: Long): Long {
+    val calendar = Calendar.getInstance()
+    calendar.time = Date(time)
+    calendar.set(Calendar.HOUR_OF_DAY, 0)
+    calendar.set(Calendar.MINUTE, 0)
+    calendar.set(Calendar.SECOND, 0)
+    calendar.set(Calendar.MILLISECOND, 0)
+    return calendar.time.time
+}
 
 class VectorDateFormatter @Inject constructor(private val context: Context,
                                               private val localeProvider: LocaleProvider) {
@@ -41,15 +57,23 @@ class VectorDateFormatter @Inject constructor(private val context: Context,
         return messageDayFormatter.format(localDateTime)
     }
 
+    /**
+     * Formats a localized relative date time for the last 2 days, e.g, "Today, HH:MM", "Yesterday, HH:MM" or
+     * "2 days ago, HH:MM".
+     * For earlier timestamps the absolute date time is returned, e.g. "Month Day, HH:MM".
+     *
+     * @param time the absolute timestamp [ms] that should be formatted relative to now
+     */
     fun formatRelativeDateTime(time: Long?): String {
         if (time == null) {
             return ""
         }
+        val now = System.currentTimeMillis()
         return DateUtils.getRelativeDateTimeString(
                 context,
                 time,
                 DateUtils.DAY_IN_MILLIS,
-                2 * DateUtils.DAY_IN_MILLIS,
+                now - startOfDay(now - 2 * DateUtils.DAY_IN_MILLIS),
                 DateUtils.FORMAT_SHOW_WEEKDAY or DateUtils.FORMAT_SHOW_TIME
         ).toString()
     }


### PR DESCRIPTION
This fixes #822. 

The problem was that the transitionResolution parameter has to go back to the beginning of the day. In general, going back 24h is not enough.

I tried to write some tests but had difficulty to set localization, timezones and time for the test to make the tests deterministic. Anybody experience with doing that?

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 16
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/riotX-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
