### PR TITLE
Kill RiotX (#1727)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,27 +1,16 @@
-Changes in Riot.imX 0.91.6 (2020-XX-XX)
+Changes in RiotX 0.23.0 (2020-08-05)
 ===================================================
 
-Features ✨:
- -
+This is the very last version of RiotX, published on the PlayStore.
 
-Improvements 🙌:
- -
+This branch will never be merged on develop.
+
+Features ✨:
+ - Inform user that the app will not be updated anymore (#1727)
 
 Bugfix 🐛:
  - Video calls are shown as a voice ones in the timeline (#1676)
  - Fix regression: not able to create a room without IS configured (#1679)
-
-Translations 🗣:
- -
-
-SDK API changes ⚠️:
- - 
-
-Build 🧱:
- -
-
-Other changes:
- -
 
 Changes in Riot.imX 0.91.5 (2020-07-11)
 ===================================================

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -16,8 +16,8 @@ androidExtensions {
 
 // Note: 2 digits max for each value
 ext.versionMajor = 0
-ext.versionMinor = 91
-ext.versionPatch = 6
+ext.versionMinor = 23
+ext.versionPatch = 0
 
 static def getGitTimestamp() {
     def cmd = 'git show -s --format=%ct'
@@ -72,7 +72,7 @@ static def getGplayVersionSuffix() {
     if (gitBranchName() == "master") {
         return ""
     } else {
-        return "-dev"
+        return "" // "-dev"
     }
 }
 
@@ -112,7 +112,7 @@ android {
     ndkVersion "21.3.6528147"
 
     defaultConfig {
-        applicationId "im.vector.app"
+        applicationId "im.vector.riotx"
         // Set to API 21: see #405
         minSdkVersion 21
         targetSdkVersion 29
@@ -183,7 +183,7 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix ".debug"
-            resValue "string", "app_name", "Riot.imX dbg"
+            resValue "string", "app_name", "RiotX dbg"
 
             resValue "bool", "debug_mode", "true"
             buildConfigField "boolean", "LOW_PRIVACY_LOG_ENABLE", "false"
@@ -192,7 +192,7 @@ android {
         }
 
         release {
-            resValue "string", "app_name", "Riot.imX"
+            resValue "string", "app_name", "RiotX"
 
             resValue "bool", "debug_mode", "false"
             buildConfigField "boolean", "LOW_PRIVACY_LOG_ENABLE", "false"

--- a/vector/src/gplay/debug/google-services.json
+++ b/vector/src/gplay/debug/google-services.json
@@ -10,7 +10,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:912726360885:android:4ef8f3a0021e774d",
         "android_client_info": {
-          "package_name": "im.vector.app.debug"
+          "package_name": "im.vector.riotx.debug"
         }
       },
       "oauth_client": [

--- a/vector/src/gplay/release/google-services.json
+++ b/vector/src/gplay/release/google-services.json
@@ -10,7 +10,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:912726360885:android:4ef8f3a0021e774d",
         "android_client_info": {
-          "package_name": "im.vector.app"
+          "package_name": "im.vector.riotx"
         }
       },
       "oauth_client": [

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
+    <!-- To be able to delete RiotX -->
+    <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
+
     <!-- Call feature -->
     <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
     <!-- Commented because Google PlayStore does not like we add permission if we are not requiring it. And it was added for future use -->
@@ -140,8 +143,10 @@
             </intent-filter>
         </activity>
 
+        <!-- Disable incoming share -->
         <activity
             android:name=".features.share.IncomingShareActivity"
+            android:enabled="false"
             android:parentActivityName=".features.home.HomeActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/vector/src/main/java/im/vector/riotx/features/disclaimer/DisclaimerDialog.kt
+++ b/vector/src/main/java/im/vector/riotx/features/disclaimer/DisclaimerDialog.kt
@@ -17,47 +17,19 @@
 package im.vector.riotx.features.disclaimer
 
 import android.app.Activity
-import androidx.preference.PreferenceManager
-import android.view.ViewGroup
-import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
-import androidx.core.content.edit
-import im.vector.riotx.BuildConfig
 import im.vector.riotx.R
-import im.vector.riotx.core.extensions.setTextWithColoredPart
 import im.vector.riotx.core.utils.openPlayStore
 
-// Increase this value to show again the disclaimer dialog after an upgrade of the application
-private const val CURRENT_DISCLAIMER_VALUE = 1
-
-private const val SHARED_PREF_KEY = "LAST_DISCLAIMER_VERSION_VALUE"
-
 fun showDisclaimerDialog(activity: Activity) {
-    val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(activity)
+    val dialogLayout = activity.layoutInflater.inflate(R.layout.dialog_disclaimer_content, null)
 
-    if (sharedPrefs.getInt(SHARED_PREF_KEY, 0) < CURRENT_DISCLAIMER_VALUE) {
-        sharedPrefs.edit {
-            putInt(SHARED_PREF_KEY, CURRENT_DISCLAIMER_VALUE)
-        }
-
-        val dialogLayout = activity.layoutInflater.inflate(R.layout.dialog_disclaimer_content, null)
-
-        val textView = (dialogLayout as ViewGroup).findViewById<TextView>(R.id.dialogDisclaimerContentLine2)
-        @Suppress("ConstantConditionIf")
-        if (BuildConfig.FLAVOR == "gplay") {
-            textView.setTextWithColoredPart(R.string.alpha_disclaimer_content_line_2_gplay, R.string.alpha_disclaimer_content_line_2_gplay_colored_part)
-
-            textView.setOnClickListener {
-                openPlayStore(activity)
+    AlertDialog.Builder(activity)
+            .setView(dialogLayout)
+            .setCancelable(false)
+            .setPositiveButton(R.string.the_beta_is_over_get_element) { _, _ ->
+                openPlayStore(activity, "im.vector.app")
             }
-        } else {
-            textView.setText(R.string.alpha_disclaimer_content_line_2_fdroid)
-        }
-
-        AlertDialog.Builder(activity)
-                .setView(dialogLayout)
-                .setCancelable(false)
-                .setPositiveButton(R.string._continue, null)
-                .show()
-    }
+            .setNegativeButton(R.string.later, null)
+            .show()
 }

--- a/vector/src/main/java/im/vector/riotx/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/riotx/features/home/HomeActivity.kt
@@ -69,7 +69,7 @@ class HomeActivity : VectorBaseActivity(), ToolbarConfigurable, UnknownDeviceDet
     @Inject lateinit var viewModelFactory: HomeActivityViewModel.Factory
 
     private val serverBackupStatusViewModel: ServerBackupStatusViewModel by viewModel()
-    @Inject lateinit var  serverBackupviewModelFactory: ServerBackupStatusViewModel.Factory
+    @Inject lateinit var serverBackupviewModelFactory: ServerBackupStatusViewModel.Factory
 
     @Inject lateinit var activeSessionHolder: ActiveSessionHolder
     @Inject lateinit var vectorUncaughtExceptionHandler: VectorUncaughtExceptionHandler
@@ -225,6 +225,8 @@ class HomeActivity : VectorBaseActivity(), ToolbarConfigurable, UnknownDeviceDet
         super.onDestroy()
     }
 
+    private var disclaimerShown = false
+
     override fun onResume() {
         super.onResume()
 
@@ -238,7 +240,10 @@ class HomeActivity : VectorBaseActivity(), ToolbarConfigurable, UnknownDeviceDet
                     .setNegativeButton(R.string.no) { _, _ -> bugReporter.deleteCrashFile(this) }
                     .show()
         } else {
-            showDisclaimerDialog(this)
+            if (!disclaimerShown) {
+                disclaimerShown = true
+                showDisclaimerDialog(this)
+            }
         }
 
         // Force remote backup state update to update the banner if needed

--- a/vector/src/main/java/im/vector/riotx/features/login/LoginSplashFragment.kt
+++ b/vector/src/main/java/im/vector/riotx/features/login/LoginSplashFragment.kt
@@ -16,8 +16,14 @@
 
 package im.vector.riotx.features.login
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import butterknife.OnClick
+import im.vector.riotx.BuildConfig
 import im.vector.riotx.R
+import im.vector.riotx.core.utils.openPlayStore
+import im.vector.riotx.core.utils.toast
 import javax.inject.Inject
 
 /**
@@ -29,7 +35,19 @@ class LoginSplashFragment @Inject constructor() : AbstractLoginFragment() {
 
     @OnClick(R.id.loginSplashSubmit)
     fun getStarted() {
-        loginViewModel.handle(LoginAction.PostViewEvent(LoginViewEvents.OpenServerSelection))
+        openPlayStore(requireActivity(), "im.vector.app")
+    }
+
+    @OnClick(R.id.loginSplashUninstall)
+    fun uninstall() {
+        @Suppress("DEPRECATION")
+        val intent = Intent(Intent.ACTION_UNINSTALL_PACKAGE)
+        intent.data = Uri.parse("package:" + BuildConfig.APPLICATION_ID)
+        try {
+            startActivity(intent)
+        } catch (anfe: ActivityNotFoundException) {
+            requireActivity().toast(R.string.error_no_external_application_found)
+        }
     }
 
     override fun resetViewModel() {

--- a/vector/src/main/res/layout/dialog_disclaimer_content.xml
+++ b/vector/src/main/res/layout/dialog_disclaimer_content.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -26,7 +25,7 @@
             android:layout_marginTop="92dp"
             android:fontFamily="sans-serif"
             android:lineSpacingExtra="8sp"
-            android:text="@string/alpha_disclaimer_title"
+            android:text="@string/the_beta_is_over_title"
             android:textColor="@color/white"
             android:textSize="24sp"
             android:textStyle="normal" />
@@ -39,20 +38,8 @@
         android:layout_marginStart="24dp"
         android:layout_marginTop="21dp"
         android:layout_marginEnd="24dp"
-        android:text="@string/alpha_disclaimer_content_line_1"
+        android:text="@string/the_beta_is_over_content"
         android:textColor="?riotx_text_primary"
         android:textSize="16sp" />
-
-    <TextView
-        android:id="@+id/dialogDisclaimerContentLine2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="24dp"
-        android:layout_marginTop="21dp"
-        android:layout_marginEnd="24dp"
-        android:layout_marginBottom="21dp"
-        android:textColor="?riotx_text_primary"
-        android:textSize="16sp"
-        tools:text="@string/alpha_disclaimer_content_line_2_gplay" />
 
 </LinearLayout>

--- a/vector/src/main/res/layout/fragment_login_splash.xml
+++ b/vector/src/main/res/layout/fragment_login_splash.xml
@@ -35,101 +35,41 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="48dp"
-                android:text="@string/login_splash_title"
+                android:gravity="center_horizontal"
+                android:text="@string/the_beta_is_over_login_screen_content"
                 android:textAppearance="@style/TextAppearance.Vector.Login.Title"
                 android:transitionName="loginTitleTransition"
-                app:layout_constraintBottom_toTopOf="@+id/loginSplashText1"
+                app:layout_constraintBottom_toTopOf="@+id/loginSplashSubmit"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/loginSplashLogo" />
 
-            <!-- TODO check relative dimension -->
-            <ImageView
-                android:id="@+id/loginSplashPicto1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="2dp"
-                android:importantForAccessibility="no"
-                android:src="@drawable/ic_login_splash_message_circle"
-                android:tint="?vctr_notice_secondary"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/loginSplashText1" />
-
-            <TextView
-                android:id="@+id/loginSplashText1"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="36dp"
-                android:layout_marginTop="32dp"
-                android:gravity="start"
-                android:text="@string/login_splash_text1"
-                android:textAppearance="@style/TextAppearance.Vector.Login.Text"
-                app:layout_constraintBottom_toTopOf="@+id/loginSplashText2"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/loginSplashTitle" />
-
-            <ImageView
-                android:id="@+id/loginSplashPicto2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="2dp"
-                android:importantForAccessibility="no"
-                android:src="@drawable/ic_login_splash_lock"
-                android:tint="?vctr_notice_secondary"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/loginSplashText2" />
-
-            <TextView
-                android:id="@+id/loginSplashText2"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="36dp"
-                android:layout_marginTop="16dp"
-                android:gravity="start"
-                android:text="@string/login_splash_text2"
-                android:textAppearance="@style/TextAppearance.Vector.Login.Text"
-                app:layout_constraintBottom_toTopOf="@id/loginSplashText3"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/loginSplashText1" />
-
-            <ImageView
-                android:id="@+id/loginSplashPicto3"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:importantForAccessibility="no"
-                android:src="@drawable/ic_login_splash_sliders"
-                android:tint="?vctr_notice_secondary"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/loginSplashText3" />
-
-            <TextView
-                android:id="@+id/loginSplashText3"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="36dp"
-                android:layout_marginTop="16dp"
-                android:gravity="start"
-                android:text="@string/login_splash_text3"
-                android:textAppearance="@style/TextAppearance.Vector.Login.Text"
-                app:layout_constraintBottom_toTopOf="@+id/loginSplashSubmit"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/loginSplashText2" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/loginSplashSubmit"
                 style="@style/Style.Vector.Login.Button"
-                android:layout_width="0dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="48dp"
-                android:text="@string/login_splash_submit"
+                android:text="@string/the_beta_is_over_get_element"
                 android:transitionName="loginSubmitTransition"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/loginSplashText3" />
+                app:layout_constraintTop_toBottomOf="@+id/loginSplashTitle" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/loginSplashUninstall"
+                style="@style/Style.Vector.Login.Button.Text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/the_beta_is_over_uninstall"
+                android:transitionName="loginSubmitTransition"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/loginSplashSubmit" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2552,4 +2552,11 @@ Not all features in Riot are implemented in RiotX yet. Main missing (and coming 
 
     <string name="three_pid_revoke_invite_dialog_title">Revoke invite</string>
     <string name="three_pid_revoke_invite_dialog_content">Revoke invite to %1$s?</string>
+
+    <string name="the_beta_is_over_title">The beta is over!</string>
+    <string name="the_beta_is_over_content">Thank you for your contribution to test RiotX.\n\nRiotX will not be updated anymore from the PlayStore, you should properly sign out and then uninstall it.\n\nPlease install the new application Element!</string>
+    <string name="the_beta_is_over_get_element">Get Element</string>
+    <string name="the_beta_is_over_uninstall">Uninstall RiotX</string>
+
+    <string name="the_beta_is_over_login_screen_content">RiotX is deprecated\n\nPlease install Element!</string>
 </resources>


### PR DESCRIPTION
Fixes #1727

- Restore RiotX appId and App name
- Prevent share to RiotX
- Show the warning popup each time the app is launch
- Prevent any new login and propose to uninstall the app

Popup:

<img width="372" alt="image" src="https://user-images.githubusercontent.com/3940906/89408163-497bd900-d720-11ea-8769-dee46d075659.png">

With "Later" and "Get Element" option

First screen (when not logged in/after logging out)

<img width="377" alt="image" src="https://user-images.githubusercontent.com/3940906/89408294-70d2a600-d720-11ea-8c54-271a46cc201f.png">

This PR is draft, to not being merged by mistake :)
