### PR TITLE
Give user the possibility to prevent accidental call (#1869)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Features ✨:
  - Protect access to the app by a pin code (#1700)
 
 Improvements 🙌:
- -
+ - Give user the possibility to prevent accidental call (#1869)
 
 Bugfix 🐛:
  - Fix invisible toolbar (Status.im theme) (#1746)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -591,6 +591,20 @@ class RoomDetailFragment @Inject constructor(
     }
 
     private fun safeStartCall(isVideoCall: Boolean) {
+        if (vectorPreferences.preventAccidentalCall()) {
+            AlertDialog.Builder(requireActivity())
+                    .setMessage(if (isVideoCall) R.string.start_video_call_prompt_msg else R.string.start_voice_call_prompt_msg)
+                    .setPositiveButton(if (isVideoCall) R.string.start_video_call else R.string.start_voice_call) { _, _ ->
+                        safeStartCall2(isVideoCall)
+                    }
+                    .setNegativeButton(R.string.cancel, null)
+                    .show()
+        } else {
+            safeStartCall2(isVideoCall)
+        }
+    }
+
+    private fun safeStartCall2(isVideoCall: Boolean) {
         val startCallAction = RoomDetailAction.StartCall(isVideoCall)
         roomDetailViewModel.pendingAction = startCallAction
         if (isVideoCall) {

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -24,11 +24,11 @@ import android.provider.MediaStore
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import com.squareup.seismic.ShakeDetector
-import im.vector.matrix.android.api.extensions.tryThis
 import im.vector.app.BuildConfig
 import im.vector.app.R
 import im.vector.app.features.homeserver.ServerUrlsRepository
 import im.vector.app.features.themes.ThemeUtils
+import im.vector.matrix.android.api.extensions.tryThis
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -110,6 +110,7 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         // notifications
         const val SETTINGS_ENABLE_ALL_NOTIF_PREFERENCE_KEY = "SETTINGS_ENABLE_ALL_NOTIF_PREFERENCE_KEY"
         const val SETTINGS_ENABLE_THIS_DEVICE_PREFERENCE_KEY = "SETTINGS_ENABLE_THIS_DEVICE_PREFERENCE_KEY"
+
         //    public static final String SETTINGS_TURN_SCREEN_ON_PREFERENCE_KEY = "SETTINGS_TURN_SCREEN_ON_PREFERENCE_KEY";
         const val SETTINGS_SYSTEM_CALL_NOTIFICATION_PREFERENCE_KEY = "SETTINGS_SYSTEM_CALL_NOTIFICATION_PREFERENCE_KEY"
         const val SETTINGS_SYSTEM_NOISY_NOTIFICATION_PREFERENCE_KEY = "SETTINGS_SYSTEM_NOISY_NOTIFICATION_PREFERENCE_KEY"
@@ -130,6 +131,7 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         const val SETTINGS_SET_SYNC_DELAY_PREFERENCE_KEY = "SETTINGS_SET_SYNC_DELAY_PREFERENCE_KEY"
 
         // Calls
+        const val SETTINGS_CALL_PREVENT_ACCIDENTAL_CALL_KEY = "SETTINGS_CALL_PREVENT_ACCIDENTAL_CALL_KEY"
         const val SETTINGS_CALL_RINGTONE_USE_RIOT_PREFERENCE_KEY = "SETTINGS_CALL_RINGTONE_USE_RIOT_PREFERENCE_KEY"
         const val SETTINGS_CALL_RINGTONE_URI_PREFERENCE_KEY = "SETTINGS_CALL_RINGTONE_URI_PREFERENCE_KEY"
 
@@ -147,6 +149,7 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         private const val SETTINGS_LABS_SHOW_HIDDEN_EVENTS_PREFERENCE_KEY = "SETTINGS_LABS_SHOW_HIDDEN_EVENTS_PREFERENCE_KEY"
         private const val SETTINGS_LABS_ENABLE_SWIPE_TO_REPLY = "SETTINGS_LABS_ENABLE_SWIPE_TO_REPLY"
         private const val SETTINGS_DEVELOPER_MODE_FAIL_FAST_PREFERENCE_KEY = "SETTINGS_DEVELOPER_MODE_FAIL_FAST_PREFERENCE_KEY"
+
         // SETTINGS_LABS_HIDE_TECHNICAL_E2E_ERRORS
         private const val SETTINGS_LABS_MERGE_E2E_ERRORS = "SETTINGS_LABS_MERGE_E2E_ERRORS"
         const val SETTINGS_LABS_UNREAD_NOTIFICATIONS_AS_TAB = "SETTINGS_LABS_UNREAD_NOTIFICATIONS_AS_TAB"
@@ -642,6 +645,13 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         defaultPrefs.edit {
             putBoolean(SETTINGS_ENABLE_MARKDOWN_KEY, isEnabled)
         }
+    }
+
+    /**
+     * Tells if a confirmation dialog should be displayed before staring a call
+     */
+    fun preventAccidentalCall(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_CALL_PREVENT_ACCIDENTAL_CALL_KEY, false)
     }
 
     /**

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -362,6 +362,8 @@
 
     <!-- Call settings screen -->
     <string name="settings_call_category">Calls</string>
+    <string name="settings_call_show_confirmation_dialog_title">Prevent accidental call</string>
+    <string name="settings_call_show_confirmation_dialog_summary">Ask for confirmation before starting a call</string>
     <string name="settings_call_ringtone_use_app_ringtone">Use default Element ringtone for incoming calls</string>
     <string name="settings_call_ringtone_use_default_stun">Allow fallback call assist server</string>
     <string name="settings_call_ringtone_use_default_stun_sum">Will use "%s" as assist when your home server does not offer one (your IP address will be shared during a call)</string>

--- a/vector/src/main/res/xml/vector_settings_root.xml
+++ b/vector/src/main/res/xml/vector_settings_root.xml
@@ -26,8 +26,7 @@
     <im.vector.app.core.preference.VectorPreference
         android:icon="@drawable/ic_settings_root_call"
         android:title="@string/preference_voice_and_video"
-        app:fragment="im.vector.app.features.settings.VectorSettingsVoiceVideoFragment"
-        app:isPreferenceVisible="@bool/false_not_implemented" />
+        app:fragment="im.vector.app.features.settings.VectorSettingsVoiceVideoFragment" />
 
     <im.vector.app.core.preference.VectorPreference
         android:icon="@drawable/ic_settings_root_ignored_users"

--- a/vector/src/main/res/xml/vector_settings_voice_video.xml
+++ b/vector/src/main/res/xml/vector_settings_voice_video.xml
@@ -1,18 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <im.vector.app.core.preference.VectorPreferenceCategory android:title="@string/settings_call_category">
+
+        <im.vector.app.core.preference.VectorSwitchPreference
+            android:defaultValue="false"
+            android:key="SETTINGS_CALL_PREVENT_ACCIDENTAL_CALL_KEY"
+            android:summary="@string/settings_call_show_confirmation_dialog_summary"
+            android:title="@string/settings_call_show_confirmation_dialog_title" />
 
         <im.vector.app.core.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:disableDependentsState="true"
             android:key="SETTINGS_CALL_RINGTONE_USE_RIOT_PREFERENCE_KEY"
-            android:title="@string/settings_call_ringtone_use_app_ringtone" />
+            android:title="@string/settings_call_ringtone_use_app_ringtone"
+            app:isPreferenceVisible="@bool/false_not_implemented" />
 
         <im.vector.app.core.preference.VectorPreference
             android:dependency="SETTINGS_CALL_RINGTONE_USE_RIOT_PREFERENCE_KEY"
             android:key="SETTINGS_CALL_RINGTONE_URI_PREFERENCE_KEY"
-            android:title="@string/settings_call_ringtone_title" />
+            android:title="@string/settings_call_ringtone_title"
+            app:isPreferenceVisible="@bool/false_not_implemented" />
 
     </im.vector.app.core.preference.VectorPreferenceCategory>
 


### PR DESCRIPTION
Fixes #1869 

A new setting (disabled by default) allow to show a confirmation dialog before starting a call