### PR TITLE
Ensure users do not accidentally ignore other users (#1890)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Features ✨:
 
 Improvements 🙌:
  - Give user the possibility to prevent accidental call (#1869)
+ - Ensure users do not accidentally ignore other users (#1890)
 
 Bugfix 🐛:
  - Fix invisible toolbar (Status.im theme) (#1746)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/accountdata/UpdateIgnoredUserIdsTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/accountdata/UpdateIgnoredUserIdsTask.kt
@@ -18,14 +18,14 @@
 package org.matrix.android.sdk.internal.session.user.accountdata
 
 import com.zhuinden.monarchy.Monarchy
+import org.greenrobot.eventbus.EventBus
+import org.matrix.android.sdk.api.session.accountdata.UserAccountDataTypes
 import org.matrix.android.sdk.internal.database.model.IgnoredUserEntity
 import org.matrix.android.sdk.internal.di.SessionDatabase
 import org.matrix.android.sdk.internal.di.UserId
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.session.sync.model.accountdata.IgnoredUsersContent
-import org.matrix.android.sdk.api.session.accountdata.UserAccountDataTypes
 import org.matrix.android.sdk.internal.task.Task
-import org.greenrobot.eventbus.EventBus
 import javax.inject.Inject
 
 internal interface UpdateIgnoredUserIdsTask : Task<UpdateIgnoredUserIdsTask.Params, Unit> {
@@ -51,7 +51,7 @@ internal class DefaultUpdateIgnoredUserIdsTask @Inject constructor(
                 { it.userId }
         ).toMutableSet()
 
-        val original = ignoredUserIds.toList()
+        val original = ignoredUserIds.toSet()
 
         ignoredUserIds.removeAll { it in params.userIdsToUnIgnore }
         ignoredUserIds.addAll(params.userIdsToIgnore)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -1491,7 +1491,7 @@ class RoomDetailFragment @Inject constructor(
                 promptReasonToReportContent(action)
             }
             is EventSharedAction.IgnoreUser                 -> {
-                roomDetailViewModel.handle(RoomDetailAction.IgnoreUser(action.senderId))
+                action.senderId?.let { askConfirmationToIgnoreUser(it) }
             }
             is EventSharedAction.OnUrlClicked               -> {
                 onUrlClicked(action.url, action.title)
@@ -1507,10 +1507,19 @@ class RoomDetailFragment @Inject constructor(
                     startActivity(KeysBackupRestoreActivity.intent(it))
                 }
             }
-            else                                            -> {
-                Toast.makeText(context, "Action $action is not implemented yet", Toast.LENGTH_LONG).show()
-            }
         }
+    }
+
+    private fun askConfirmationToIgnoreUser(senderId: String) {
+        AlertDialog.Builder(requireContext())
+                .setTitle(R.string.room_participants_action_ignore_title)
+                .setMessage(R.string.room_participants_action_ignore_prompt_msg)
+                .setNegativeButton(R.string.cancel, null)
+                .setPositiveButton(R.string.room_participants_action_ignore) { _, _ ->
+                    roomDetailViewModel.handle(RoomDetailAction.IgnoreUser(senderId))
+                }
+                .show()
+                .withColoredButton(DialogInterface.BUTTON_POSITIVE)
     }
 
     /**

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1801,7 +1801,7 @@
     <string name="report_content_custom_title">"Report this content"</string>
     <string name="report_content_custom_hint">"Reason for reporting this content"</string>
     <string name="report_content_custom_submit">"REPORT"</string>
-    <string name="block_user">"BLOCK USER"</string>
+    <string name="block_user">"IGNORE USER"</string>
 
     <string name="content_reported_title">"Content reported"</string>
     <string name="content_reported_content">"This content was reported.\n\nIf you don't want to see any more content from this user, you can block him to hide his messages"</string>
@@ -1814,7 +1814,7 @@
 
     <string name="no_network_indicator">There is no network connection right now</string>
 
-    <string name="message_ignore_user">Block user</string>
+    <string name="message_ignore_user">Ignore user</string>
 
     <string name="room_list_quick_actions_notifications_all_noisy">"All messages (noisy)"</string>
     <string name="room_list_quick_actions_notifications_all">"All messages"</string>


### PR DESCRIPTION
Fixes #1890 

The confirmation dialog already exist when ignoring user from the room member detail.

I just add the confirmation dialog when ignoring from the message bottom sheet.