### PR TITLE
Feature/verify one session

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Features ✨:
 Improvements 🙌:
  - You can now join room through permalink and within room directory search
  - Add long click gesture to copy userId, user display name, room name, room topic and room alias (#1774)
+ - Do not propose to verify session if there is only one session (#1901)
 
 Bugfix 🐛:
  - Display name not shown under Settings/General (#1926)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Features ✨:
 Improvements 🙌:
  - You can now join room through permalink and within room directory search
  - Add long click gesture to copy userId, user display name, room name, room topic and room alias (#1774)
- - Do not propose to verify session if there is only one session (#1901)
+ - Do not propose to verify session if there is only one session and 4S is not configured (#1901)
 
 Bugfix 🐛:
  - Display name not shown under Settings/General (#1926)

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheet.kt
@@ -39,7 +39,7 @@ data class DeviceVerificationInfoArgs(
         val deviceId: String
 ) : Parcelable
 
-class DeviceVerificationInfoBottomSheet : VectorBaseBottomSheetDialogFragment(), DeviceVerificationInfoEpoxyController.Callback {
+class DeviceVerificationInfoBottomSheet : VectorBaseBottomSheetDialogFragment(), DeviceVerificationInfoBottomSheetController.Callback {
 
     private val viewModel: DeviceVerificationInfoBottomSheetViewModel by fragmentViewModel(DeviceVerificationInfoBottomSheetViewModel::class)
 
@@ -54,17 +54,17 @@ class DeviceVerificationInfoBottomSheet : VectorBaseBottomSheetDialogFragment(),
         injector.inject(this)
     }
 
-    @Inject lateinit var epoxyController: DeviceVerificationInfoEpoxyController
+    @Inject lateinit var controller: DeviceVerificationInfoBottomSheetController
 
     override fun getLayoutResId() = R.layout.bottom_sheet_generic_list_with_title
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         recyclerView.configureWith(
-                epoxyController,
+                controller,
                 showDivider = false,
                 hasFixedSize = false)
-        epoxyController.callback = this
+        controller.callback = this
         bottomSheetTitle.isVisible = false
     }
 
@@ -74,7 +74,7 @@ class DeviceVerificationInfoBottomSheet : VectorBaseBottomSheetDialogFragment(),
     }
 
     override fun invalidate() = withState(viewModel) {
-        epoxyController.setData(it)
+        controller.setData(it)
         super.invalidate()
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
@@ -31,9 +31,9 @@ import im.vector.app.features.crypto.verification.epoxy.bottomSheetVerificationA
 import timber.log.Timber
 import javax.inject.Inject
 
-class DeviceVerificationInfoEpoxyController @Inject constructor(private val stringProvider: StringProvider,
-                                                                private val colorProvider: ColorProvider,
-                                                                private val session: Session)
+class DeviceVerificationInfoBottomSheetController @Inject constructor(private val stringProvider: StringProvider,
+                                                                      private val colorProvider: ColorProvider,
+                                                                      private val session: Session)
     : TypedEpoxyController<DeviceVerificationInfoBottomSheetViewState>() {
 
     var callback: Callback? = null

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
@@ -89,14 +89,18 @@ class DeviceVerificationInfoBottomSheetController @Inject constructor(
                     title(stringProvider.getString(R.string.encryption_information_verified))
                     description(stringProvider.getString(R.string.settings_active_sessions_verified_device_desc))
                 }
-            } else if (data.hasOtherSessions) {
-                // You need to complete security, only if there are other session(s) available
+            } else if (data.canVerifySession) {
+                // You need to complete security, only if there are other session(s) available, or if 4S contains secrets
                 genericItem {
                     id("trust${cryptoDeviceInfo.deviceId}")
                     style(GenericItem.STYLE.BIG_TEXT)
                     titleIconResourceId(shield)
                     title(stringProvider.getString(R.string.crosssigning_verify_this_session))
-                    description(stringProvider.getString(R.string.confirm_your_identity))
+                    if (data.hasOtherSessions) {
+                        description(stringProvider.getString(R.string.confirm_your_identity))
+                    } else {
+                        description(stringProvider.getString(R.string.confirm_your_identity_quad_s))
+                    }
                 }
             }
         } else {
@@ -133,7 +137,7 @@ class DeviceVerificationInfoBottomSheetController @Inject constructor(
             description("(${cryptoDeviceInfo.deviceId})")
         }
 
-        if (isMine && !currentSessionIsTrusted && data.hasOtherSessions) {
+        if (isMine && !currentSessionIsTrusted && data.canVerifySession) {
             // Add complete security
             dividerItem {
                 id("completeSecurityDiv")

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
@@ -16,9 +16,6 @@
 package im.vector.app.features.settings.devices
 
 import com.airbnb.epoxy.TypedEpoxyController
-import org.matrix.android.sdk.api.extensions.orFalse
-import org.matrix.android.sdk.api.session.Session
-import org.matrix.android.sdk.internal.crypto.model.CryptoDeviceInfo
 import im.vector.app.R
 import im.vector.app.core.epoxy.dividerItem
 import im.vector.app.core.epoxy.loadingItem
@@ -28,12 +25,14 @@ import im.vector.app.core.ui.list.GenericItem
 import im.vector.app.core.ui.list.genericFooterItem
 import im.vector.app.core.ui.list.genericItem
 import im.vector.app.features.crypto.verification.epoxy.bottomSheetVerificationActionItem
+import org.matrix.android.sdk.api.extensions.orFalse
+import org.matrix.android.sdk.internal.crypto.model.CryptoDeviceInfo
 import timber.log.Timber
 import javax.inject.Inject
 
-class DeviceVerificationInfoBottomSheetController @Inject constructor(private val stringProvider: StringProvider,
-                                                                      private val colorProvider: ColorProvider,
-                                                                      private val session: Session)
+class DeviceVerificationInfoBottomSheetController @Inject constructor(
+        private val stringProvider: StringProvider,
+        private val colorProvider: ColorProvider)
     : TypedEpoxyController<DeviceVerificationInfoBottomSheetViewState>() {
 
     var callback: Callback? = null

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewModel.kt
@@ -43,7 +43,8 @@ class DeviceVerificationInfoBottomSheetViewModel @AssistedInject constructor(@As
         setState {
             copy(
                     hasAccountCrossSigning = session.cryptoService().crossSigningService().isCrossSigningInitialized(),
-                    accountCrossSigningIsTrusted = session.cryptoService().crossSigningService().isCrossSigningVerified()
+                    accountCrossSigningIsTrusted = session.cryptoService().crossSigningService().isCrossSigningVerified(),
+                    isRecoverySetup = session.sharedSecretStorageService.isRecoverySetup()
             )
         }
         session.rx().liveCrossSigningInfo(session.myUserId)

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewModel.kt
@@ -65,6 +65,14 @@ class DeviceVerificationInfoBottomSheetViewModel @AssistedInject constructor(@As
                     )
                 }
 
+        session.rx().liveUserCryptoDevices(session.myUserId)
+                .map { it.size }
+                .execute {
+                    copy(
+                            hasOtherSessions = it.invoke() ?: 0 > 1
+                    )
+                }
+
         setState {
             copy(deviceInfo = Loading())
         }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewModel.kt
@@ -15,30 +15,18 @@
  */
 package im.vector.app.features.settings.devices
 
-import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.FragmentViewModelContext
 import com.airbnb.mvrx.Loading
-import com.airbnb.mvrx.MvRxState
 import com.airbnb.mvrx.MvRxViewModelFactory
-import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
-import org.matrix.android.sdk.api.session.Session
-import org.matrix.android.sdk.internal.crypto.model.CryptoDeviceInfo
-import org.matrix.android.sdk.internal.crypto.model.rest.DeviceInfo
 import im.vector.app.core.platform.EmptyAction
 import im.vector.app.core.platform.EmptyViewEvents
 import im.vector.app.core.platform.VectorViewModel
+import org.matrix.android.sdk.api.session.Session
+import org.matrix.android.sdk.internal.crypto.model.rest.DeviceInfo
 import org.matrix.android.sdk.rx.rx
-
-data class DeviceVerificationInfoBottomSheetViewState(
-        val cryptoDeviceInfo: Async<CryptoDeviceInfo?> = Uninitialized,
-        val deviceInfo: Async<DeviceInfo> = Uninitialized,
-        val hasAccountCrossSigning: Boolean = false,
-        val accountCrossSigningIsTrusted: Boolean = false,
-        val isMine: Boolean = false
-) : MvRxState
 
 class DeviceVerificationInfoBottomSheetViewModel @AssistedInject constructor(@Assisted initialState: DeviceVerificationInfoBottomSheetViewState,
                                                                              @Assisted val deviceId: String,

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewState.kt
@@ -27,5 +27,6 @@ data class DeviceVerificationInfoBottomSheetViewState(
         val deviceInfo: Async<DeviceInfo> = Uninitialized,
         val hasAccountCrossSigning: Boolean = false,
         val accountCrossSigningIsTrusted: Boolean = false,
-        val isMine: Boolean = false
+        val isMine: Boolean = false,
+        val hasOtherSessions: Boolean = false
 ) : MvRxState

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewState.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices
+
+import com.airbnb.mvrx.Async
+import com.airbnb.mvrx.MvRxState
+import com.airbnb.mvrx.Uninitialized
+import im.vector.matrix.android.internal.crypto.model.CryptoDeviceInfo
+import im.vector.matrix.android.internal.crypto.model.rest.DeviceInfo
+
+data class DeviceVerificationInfoBottomSheetViewState(
+        val cryptoDeviceInfo: Async<CryptoDeviceInfo?> = Uninitialized,
+        val deviceInfo: Async<DeviceInfo> = Uninitialized,
+        val hasAccountCrossSigning: Boolean = false,
+        val accountCrossSigningIsTrusted: Boolean = false,
+        val isMine: Boolean = false
+) : MvRxState

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewState.kt
@@ -28,5 +28,10 @@ data class DeviceVerificationInfoBottomSheetViewState(
         val hasAccountCrossSigning: Boolean = false,
         val accountCrossSigningIsTrusted: Boolean = false,
         val isMine: Boolean = false,
-        val hasOtherSessions: Boolean = false
-) : MvRxState
+        val hasOtherSessions: Boolean = false,
+        val isRecoverySetup: Boolean = false
+) : MvRxState {
+
+    val canVerifySession: Boolean
+        get() = hasOtherSessions || isRecoverySetup
+}

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetViewState.kt
@@ -19,8 +19,8 @@ package im.vector.app.features.settings.devices
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.MvRxState
 import com.airbnb.mvrx.Uninitialized
-import im.vector.matrix.android.internal.crypto.model.CryptoDeviceInfo
-import im.vector.matrix.android.internal.crypto.model.rest.DeviceInfo
+import org.matrix.android.sdk.internal.crypto.model.CryptoDeviceInfo
+import org.matrix.android.sdk.internal.crypto.model.rest.DeviceInfo
 
 data class DeviceVerificationInfoBottomSheetViewState(
         val cryptoDeviceInfo: Async<CryptoDeviceInfo?> = Uninitialized,

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2413,6 +2413,7 @@
     <string name="crosssigning_verify_session">Verify login</string>
     <string name="cross_signing_verify_by_emoji">Interactively Verify by Emoji</string>
     <string name="confirm_your_identity">Confirm your identity by verifying this login from one of your other sessions, granting it access to encrypted messages.</string>
+    <string name="confirm_your_identity_quad_s">Confirm your identity by verifying this login, granting it access to encrypted messages.</string>
     <string name="mark_as_verified">Mark as Trusted</string>
 
     <string name="error_empty_field_choose_user_name">Please choose a username.</string>


### PR DESCRIPTION
First commits are some cleanup.

Last commit fixes #1901: If there is no other session available, we do not propose to verify it:

## When other sessions are available (so no change by this PR)

<img width="344" alt="image" src="https://user-images.githubusercontent.com/3940906/90007621-5d34bb80-dc9b-11ea-860c-13c0525165c8.png">

## When no other sessions are available

<img width="350" alt="image" src="https://user-images.githubusercontent.com/3940906/90007706-85241f00-dc9b-11ea-99e2-a4c14212d75f.png">
