### PR TITLE
Cleanup temporary code added during developpement

### DIFF
--- a/vector/src/main/java/im/vector/app/features/command/Command.kt
+++ b/vector/src/main/java/im/vector/app/features/command/Command.kt
@@ -44,9 +44,7 @@ enum class Command(val command: String, val parameters: String, @StringRes val d
     POLL("/poll", "Question | Option 1 | Option 2 ...", R.string.command_description_poll),
     SHRUG("/shrug", "<message>", R.string.command_description_shrug),
     PLAIN("/plain", "<message>", R.string.command_description_plain),
-    DISCARD_SESSION("/discardsession", "", R.string.command_description_discard_session),
-    // TODO temporary command
-    VERIFY_USER("/verify", "<user-id>", R.string.command_description_verify);
+    DISCARD_SESSION("/discardsession", "", R.string.command_description_discard_session);
 
     val length
         get() = command.length + 1

--- a/vector/src/main/java/im/vector/app/features/command/CommandParser.kt
+++ b/vector/src/main/java/im/vector/app/features/command/CommandParser.kt
@@ -279,11 +279,6 @@ object CommandParser {
 
                     ParsedCommand.SendShrug(message)
                 }
-                Command.VERIFY_USER.command            -> {
-                    val message = textMessage.substring(Command.VERIFY_USER.command.length).trim()
-
-                    ParsedCommand.VerifyUser(message)
-                }
                 Command.POLL.command                   -> {
                     val rawCommand = textMessage.substring(Command.POLL.command.length).trim()
                     val split = rawCommand.split("|").map { it.trim() }

--- a/vector/src/main/java/im/vector/app/features/command/ParsedCommand.kt
+++ b/vector/src/main/java/im/vector/app/features/command/ParsedCommand.kt
@@ -53,7 +53,6 @@ sealed class ParsedCommand {
     object ClearScalarToken : ParsedCommand()
     class SendSpoiler(val message: String) : ParsedCommand()
     class SendShrug(val message: CharSequence) : ParsedCommand()
-    class VerifyUser(val userId: String) : ParsedCommand()
     class SendPoll(val question: String, val options: List<String>) : ParsedCommand()
     object DiscardSession: ParsedCommand()
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
@@ -419,7 +419,7 @@ class RoomDetailViewModel @AssistedInject constructor(
             R.id.clear_all           -> state.asyncRoomSummary()?.hasFailedSending == true
             R.id.open_matrix_apps    -> true
             R.id.voice_call,
-            R.id.video_call          -> state.asyncRoomSummary()?.canStartCall == true  && webRtcPeerConnectionManager.currentCall == null
+            R.id.video_call          -> state.asyncRoomSummary()?.canStartCall == true && webRtcPeerConnectionManager.currentCall == null
             R.id.hangup_call         -> webRtcPeerConnectionManager.currentCall != null
             else                     -> false
         }
@@ -531,14 +531,6 @@ class RoomDetailViewModel @AssistedInject constructor(
                                 }
                             }
                             room.sendTextMessage(sequence)
-                            _viewEvents.post(RoomDetailViewEvents.SlashCommandHandled())
-                            popDraft()
-                        }
-                        is ParsedCommand.VerifyUser               -> {
-                            session
-                                    .cryptoService()
-                                    .verificationService()
-                                    .requestKeyVerificationInDMs(supportedVerificationMethodsProvider.provide(), slashCommandResult.userId, room.roomId)
                             _viewEvents.post(RoomDetailViewEvents.SlashCommandHandled())
                             popDraft()
                         }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
@@ -34,13 +34,6 @@ import androidx.preference.PreferenceCategory
 import androidx.preference.SwitchPreference
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.textfield.TextInputEditText
-import im.vector.matrix.android.api.MatrixCallback
-import im.vector.matrix.android.internal.crypto.crosssigning.isVerified
-import im.vector.matrix.android.internal.crypto.model.ImportRoomKeysResult
-import im.vector.matrix.android.internal.crypto.model.rest.DeviceInfo
-import im.vector.matrix.android.internal.crypto.model.rest.DevicesListResponse
-import im.vector.matrix.rx.SecretsSynchronisationInfo
-import im.vector.matrix.rx.rx
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.dialogs.ExportKeysDialog
@@ -63,6 +56,13 @@ import im.vector.app.features.pin.PinCodeStore
 import im.vector.app.features.pin.PinLocker
 import im.vector.app.features.pin.PinMode
 import im.vector.app.features.themes.ThemeUtils
+import im.vector.matrix.android.api.MatrixCallback
+import im.vector.matrix.android.internal.crypto.crosssigning.isVerified
+import im.vector.matrix.android.internal.crypto.model.ImportRoomKeysResult
+import im.vector.matrix.android.internal.crypto.model.rest.DeviceInfo
+import im.vector.matrix.android.internal.crypto.model.rest.DevicesListResponse
+import im.vector.matrix.rx.SecretsSynchronisationInfo
+import im.vector.matrix.rx.rx
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import me.gujun.android.span.span
@@ -294,6 +294,10 @@ class VectorSettingsSecurityPrivacyFragment @Inject constructor(
         }
 
         mCrossSigningStatePreference.isVisible = true
+        if (!vectorPreferences.developerMode()) {
+            // When not in developer mode, intercept click on this preference
+            mCrossSigningStatePreference.onPreferenceClickListener = Preference.OnPreferenceClickListener { true }
+        }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsAction.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsAction.kt
@@ -18,8 +18,4 @@ package im.vector.app.features.settings.crosssigning
 
 import im.vector.app.core.platform.VectorViewModelAction
 
-sealed class CrossSigningSettingsAction : VectorViewModelAction {
-    object SetUpRecovery : CrossSigningSettingsAction()
-    object VerifySession : CrossSigningSettingsAction()
-    object SetupCrossSigning : CrossSigningSettingsAction()
-}
+sealed class CrossSigningSettingsAction : VectorViewModelAction

--- a/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsController.kt
@@ -22,7 +22,6 @@ import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.ui.list.genericItem
 import im.vector.app.core.ui.list.genericItemWithValue
 import im.vector.app.core.utils.DimensionConverter
-import im.vector.app.features.crypto.verification.epoxy.bottomSheetVerificationActionItem
 import me.gujun.android.span.span
 import javax.inject.Inject
 
@@ -32,11 +31,7 @@ class CrossSigningSettingsController @Inject constructor(
         private val dimensionConverter: DimensionConverter
 ) : TypedEpoxyController<CrossSigningSettingsViewState>() {
 
-    interface InteractionListener {
-        fun setupRecovery()
-        fun verifySession()
-        fun initCrossSigning()
-    }
+    interface InteractionListener
 
     var interactionListener: InteractionListener? = null
 
@@ -72,44 +67,6 @@ class CrossSigningSettingsController @Inject constructor(
             }
         }
 
-        if (data.recoveryHasToBeSetUp) {
-            if (data.xSigningIsEnableInAccount) {
-                bottomSheetVerificationActionItem {
-                    id("setup_recovery")
-                    title(stringProvider.getString(R.string.settings_setup_secure_backup))
-                    titleColor(colorProvider.getColorFromAttribute(R.attr.riotx_text_primary))
-                    iconRes(R.drawable.ic_arrow_right)
-                    listener {
-                        interactionListener?.setupRecovery()
-                    }
-                }
-            } else {
-                // Propose to setup cross signing
-                bottomSheetVerificationActionItem {
-                    id("setup_xSgning")
-                    title(stringProvider.getString(R.string.setup_cross_signing))
-                    titleColor(colorProvider.getColorFromAttribute(R.attr.riotx_text_primary))
-                    subTitle(stringProvider.getString(R.string.security_prompt_text))
-                    iconRes(R.drawable.ic_arrow_right)
-                    listener {
-                        interactionListener?.initCrossSigning()
-                    }
-                }
-            }
-        }
-
-        if (data.deviceHasToBeVerified) {
-            bottomSheetVerificationActionItem {
-                id("verify")
-                title(stringProvider.getString(R.string.crosssigning_verify_this_session))
-                titleColor(colorProvider.getColor(R.color.riotx_positive_accent))
-                iconRes(R.drawable.ic_arrow_right)
-                iconColor(colorProvider.getColor(R.color.riotx_positive_accent))
-                listener {
-                    interactionListener?.verifySession()
-                }
-            }
-        }
 
         val crossSigningKeys = data.crossSigningInfo
 

--- a/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsFragment.kt
@@ -45,22 +45,13 @@ class CrossSigningSettingsFragment @Inject constructor(
         super.onActivityCreated(savedInstanceState)
         viewModel.observeViewEvents {
             when (it) {
-                is CrossSigningSettingsViewEvents.Failure    -> {
+                is CrossSigningSettingsViewEvents.Failure -> {
                     AlertDialog.Builder(requireContext())
                             .setTitle(R.string.dialog_title_error)
                             .setMessage(errorFormatter.toHumanReadable(it.throwable))
                             .setPositiveButton(R.string.ok, null)
                             .show()
                     Unit
-                }
-                CrossSigningSettingsViewEvents.VerifySession -> {
-                    navigator.requestSelfSessionVerification(requireActivity())
-                }
-                CrossSigningSettingsViewEvents.SetUpRecovery -> {
-                    navigator.upgradeSessionSecurity(requireActivity(), false)
-                }
-                CrossSigningSettingsViewEvents.SetupCrossSigning -> {
-                    navigator.upgradeSessionSecurity(requireActivity(), true)
                 }
             }.exhaustive
         }
@@ -89,17 +80,5 @@ class CrossSigningSettingsFragment @Inject constructor(
         recyclerView.cleanup()
         controller.interactionListener = null
         super.onDestroyView()
-    }
-
-    override fun setupRecovery() {
-        viewModel.handle(CrossSigningSettingsAction.SetUpRecovery)
-    }
-
-    override fun verifySession() {
-        viewModel.handle(CrossSigningSettingsAction.VerifySession)
-    }
-
-    override fun initCrossSigning() {
-        viewModel.handle(CrossSigningSettingsAction.SetupCrossSigning)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsFragment.kt
@@ -29,6 +29,9 @@ import im.vector.app.core.platform.VectorBaseFragment
 import kotlinx.android.synthetic.main.fragment_generic_recycler.*
 import javax.inject.Inject
 
+/**
+ * This Fragment is only used when user activates developer mode from the settings
+ */
 class CrossSigningSettingsFragment @Inject constructor(
         private val controller: CrossSigningSettingsController,
         val viewModelFactory: CrossSigningSettingsViewModel.Factory

--- a/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsViewEvents.kt
@@ -23,8 +23,4 @@ import im.vector.app.core.platform.VectorViewEvents
  */
 sealed class CrossSigningSettingsViewEvents : VectorViewEvents {
     data class Failure(val throwable: Throwable) : CrossSigningSettingsViewEvents()
-
-    object SetUpRecovery : CrossSigningSettingsViewEvents()
-    object VerifySession : CrossSigningSettingsViewEvents()
-    object SetupCrossSigning : CrossSigningSettingsViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsViewModel.kt
@@ -20,14 +20,13 @@ import com.airbnb.mvrx.MvRxViewModelFactory
 import com.airbnb.mvrx.ViewModelContext
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import im.vector.app.core.platform.VectorViewModel
 import im.vector.matrix.android.api.session.Session
 import im.vector.matrix.android.api.session.crypto.crosssigning.MXCrossSigningInfo
 import im.vector.matrix.android.api.util.Optional
 import im.vector.matrix.android.internal.crypto.crosssigning.isVerified
 import im.vector.matrix.android.internal.crypto.model.rest.DeviceInfo
 import im.vector.matrix.rx.rx
-import im.vector.app.core.extensions.exhaustive
-import im.vector.app.core.platform.VectorViewModel
 import io.reactivex.Observable
 import io.reactivex.functions.BiFunction
 
@@ -48,15 +47,12 @@ class CrossSigningSettingsViewModel @AssistedInject constructor(@Assisted privat
                     val xSigningIsEnableInAccount = crossSigningKeys != null
                     val xSigningKeysAreTrusted = session.cryptoService().crossSigningService().checkUserTrust(session.myUserId).isVerified()
                     val xSigningKeyCanSign = session.cryptoService().crossSigningService().canCrossSign()
-                    val hasSeveralDevices = data.invoke()?.first?.size ?: 0 > 1
 
                     copy(
                             crossSigningInfo = crossSigningKeys,
                             xSigningIsEnableInAccount = xSigningIsEnableInAccount,
                             xSigningKeysAreTrusted = xSigningKeysAreTrusted,
-                            xSigningKeyCanSign = xSigningKeyCanSign,
-                            deviceHasToBeVerified = hasSeveralDevices && (xSigningIsEnableInAccount && !xSigningKeyCanSign),
-                            recoveryHasToBeSetUp = !session.sharedSecretStorageService.isRecoverySetup()
+                            xSigningKeyCanSign = xSigningKeyCanSign
                     )
                 }
     }
@@ -67,17 +63,9 @@ class CrossSigningSettingsViewModel @AssistedInject constructor(@Assisted privat
     }
 
     override fun handle(action: CrossSigningSettingsAction) {
-        when (action) {
-            CrossSigningSettingsAction.SetUpRecovery -> {
-                _viewEvents.post(CrossSigningSettingsViewEvents.SetUpRecovery)
-            }
-            CrossSigningSettingsAction.VerifySession -> {
-                _viewEvents.post(CrossSigningSettingsViewEvents.VerifySession)
-            }
-            CrossSigningSettingsAction.SetupCrossSigning -> {
-                _viewEvents.post(CrossSigningSettingsViewEvents.SetupCrossSigning)
-            }
-        }.exhaustive
+        // No op for the moment
+        // when (action) {
+        // }.exhaustive
     }
 
     companion object : MvRxViewModelFactory<CrossSigningSettingsViewModel, CrossSigningSettingsViewState> {

--- a/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/crosssigning/CrossSigningSettingsViewState.kt
@@ -23,8 +23,5 @@ data class CrossSigningSettingsViewState(
         val crossSigningInfo: MXCrossSigningInfo? = null,
         val xSigningIsEnableInAccount: Boolean = false,
         val xSigningKeysAreTrusted: Boolean = false,
-        val xSigningKeyCanSign: Boolean = true,
-
-        val deviceHasToBeVerified: Boolean = false,
-        val recoveryHasToBeSetUp: Boolean = false
+        val xSigningKeyCanSign: Boolean = true
 ) : MvRxState

--- a/vector/src/main/res/values-cs/strings.xml
+++ b/vector/src/main/res/values-cs/strings.xml
@@ -1914,7 +1914,6 @@ Vaši e-mailovou adresu můžete přidat k profilu v nastavení.</string>
     <string name="settings_developer_mode_fail_fast_title">Fail-fast</string>
     <string name="settings_developer_mode_fail_fast_summary">Element se může zbořit častěji, když se objeví neočekávané chyby</string>
 
-    <string name="command_description_verify">Požadavek ověření daného uživatelského ID</string>
     <string name="command_description_shrug">Předsune ¯\\_(ツ)_/¯ do textové zprávy</string>
 
     <string name="create_room_encryption_title">Zapnout šifrování</string>

--- a/vector/src/main/res/values-de/strings.xml
+++ b/vector/src/main/res/values-de/strings.xml
@@ -1984,7 +1984,6 @@ Verwahre deinen Wiederherstellungsschlüssel an einem sehr sicheren Ort wie eine
     <string name="settings_developer_mode_fail_fast_title">Ausfallsicher</string>
     <string name="settings_developer_mode_fail_fast_summary">Element kann häufiger abstürzen, wenn ein unerwarteter Fehler auftritt</string>
 
-    <string name="command_description_verify">Überprüfe die angegebenen Benutzer-ID</string>
     <string name="command_description_shrug">Stellt einer Klartextnachricht ¯\\_(ツ)_/¯ voran</string>
 
     <string name="create_room_encryption_title">Aktiviere Verschlüsselung</string>

--- a/vector/src/main/res/values-eu/strings.xml
+++ b/vector/src/main/res/values-eu/strings.xml
@@ -1929,7 +1929,6 @@ Abisua: Fitxategi hau ezabatu daiteke aplikazioa desinstalatzen bada.</string>
 
     <string name="settings_developer_mode_fail_fast_title">Hutsegin-azkar</string>
     <string name="settings_developer_mode_fail_fast_summary">Element aplikazioa ustekabeko erroreen aurrean maizago kraskatu daiteke</string>
-    <string name="command_description_verify">Eskatu emandako erabiltzaile IDa egiaztatzea</string>
     <string name="command_description_shrug">"Jarri ¯\\_(ツ)_/¯  testu-soileko mezuaren aurretik"</string>
 
     <string name="create_room_encryption_title">Gaitu zifratzea</string>

--- a/vector/src/main/res/values-fi/strings.xml
+++ b/vector/src/main/res/values-fi/strings.xml
@@ -2016,7 +2016,6 @@ Haluatko lisätä paketteja?</string>
     <string name="verification_conclusion_not_secure">Ei turvallinen</string>
     <string name="sent_a_video">Video.</string>
     <string name="sent_an_image">Kuva.</string>
-    <string name="command_description_verify">Pyyntö annetun käyttäjä-ID:n vahvistamiseksi</string>
     <string name="verification_conclusion_compromised">Johonkin näistä on mahdollisesti murtauduttu:
 \n
 \n - Kotipalvelimesi

--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -1933,7 +1933,6 @@ Si vous n’avez pas configuré de nouvelle méthode de récupération, un attaq
 
     <string name="settings_developer_mode_fail_fast_title">Défaillance rapide</string>
     <string name="settings_developer_mode_fail_fast_summary">Element peut planter plus souvent quand une erreur inattendue survient</string>
-    <string name="command_description_verify">Demande de vérification de l’identifiant utilisateur fourni</string>
     <string name="command_description_shrug">Préfixe ¯\\_(ツ)_/¯ à un message en texte brut</string>
 
     <string name="create_room_encryption_title">Activer le chiffrement</string>

--- a/vector/src/main/res/values-hu/strings.xml
+++ b/vector/src/main/res/values-hu/strings.xml
@@ -1930,7 +1930,6 @@ Ha nem te állítottad be a visszaállítási metódust, akkor egy támadó pró
 
     <string name="settings_developer_mode_fail_fast_title">Összeomlás-hamar</string>
     <string name="settings_developer_mode_fail_fast_summary">Element a nem várt hibák esetén többször fog összeomlani</string>
-    <string name="command_description_verify">Az adott felhasználói azonosító ellenőrzésének kérése</string>
     <string name="command_description_shrug">Hozzáteszi a sima szöveges üzenethez ezt: ¯\\_(ツ)_/¯</string>
 
     <string name="create_room_encryption_title">Titkosítás engedélyezése</string>

--- a/vector/src/main/res/values-it/strings.xml
+++ b/vector/src/main/res/values-it/strings.xml
@@ -1981,7 +1981,6 @@
 
     <string name="settings_developer_mode_fail_fast_title">Crash facile</string>
     <string name="settings_developer_mode_fail_fast_summary">Element potrebbe crashare più spesso quando si verifica un errore imprevisto</string>
-    <string name="command_description_verify">Richiedi di verificare l\'ID utente in questione</string>
     <string name="command_description_shrug">Antepone ¯\\_(ツ)_/¯ ad un messaggio testuale</string>
 
     <string name="create_room_encryption_title">Attiva la cifratura</string>

--- a/vector/src/main/res/values-pl/strings.xml
+++ b/vector/src/main/res/values-pl/strings.xml
@@ -1915,7 +1915,6 @@ Spróbuj uruchomić ponownie aplikację.</string>
     <string name="settings_developer_mode_fail_fast_title">Bezproblemowy</string>
     <string name="settings_developer_mode_fail_fast_summary">Element może zawieszać się częściej gdy napotka na niespodziewany błąd</string>
 
-    <string name="command_description_verify">Żądanie weryfikujące podany userID</string>
     <string name="command_description_shrug">Preparuje ¯\\_(ツ)_/¯ dla zwykłej wiadomości tekstowej</string>
 
     <string name="create_room_encryption_title">Aktywuj szyfrowanie</string>

--- a/vector/src/main/res/values-sq/strings.xml
+++ b/vector/src/main/res/values-sq/strings.xml
@@ -1890,7 +1890,6 @@
 
     <string name="settings_developer_mode_fail_fast_summary">Element mund të vithiset më shpesh, kur ndodh një gabim i papritur</string>
     <string name="settings_call_ringtone_use_default_stun">Lejoni shërbyes rrugëzgjidhje asistimi thirrjesh</string>
-    <string name="command_description_verify">Kërko të verifikohet userID-ja i dhënë</string>
     <string name="command_description_shrug">Parashtoji ¯\\_(ツ)_/¯ një mesazhi tekst të thjeshtë</string>
 
     <string name="create_room_encryption_title">Aktivizoni fshehtëzim</string>

--- a/vector/src/main/res/values-zh-rTW/strings.xml
+++ b/vector/src/main/res/values-zh-rTW/strings.xml
@@ -1884,7 +1884,6 @@ Matrix 中的消息可見度類似于電子郵件。我們忘記您的郵件意�
 
     <string name="settings_developer_mode_fail_fast_title">快速失敗</string>
     <string name="settings_developer_mode_fail_fast_summary">在發生非預期的錯誤時，Element 可能更常當機</string>
-    <string name="command_description_verify">請求驗證給定的 userID</string>
     <string name="command_description_shrug">"將  ¯\\_(ツ)_/¯ 附加到純文字訊息中"</string>
 
     <string name="create_room_encryption_title">啟用加密</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2011,7 +2011,6 @@
     <string name="settings_developer_mode_fail_fast_title">Fail-fast</string>
     <string name="settings_developer_mode_fail_fast_summary">Element may crash more often when an unexpected error occurs</string>
 
-    <string name="command_description_verify">Request to verify the given userID</string>
     <string name="command_description_shrug">Prepends ¯\\_(ツ)_/¯ to a plain-text message</string>
 
     <string name="create_room_encryption_title">"Enable encryption"</string>

--- a/vector/src/main/res/xml/vector_settings_security_privacy.xml
+++ b/vector/src/main/res/xml/vector_settings_security_privacy.xml
@@ -7,9 +7,9 @@
         android:icon="@drawable/ic_notification_privacy_warning"
         android:key="SETTINGS_CRYPTOGRAPHY_HS_ADMIN_DISABLED_E2E_DEFAULT"
         android:persistent="false"
-        tools:summary="@string/settings_hs_admin_e2e_disabled"
         app:isPreferenceVisible="false"
-        tools:isPreferenceVisible="true">
+        tools:isPreferenceVisible="true"
+        tools:summary="@string/settings_hs_admin_e2e_disabled">
 
     </im.vector.app.core.preference.VectorPreference>
 
@@ -17,6 +17,7 @@
     <im.vector.app.core.preference.VectorPreferenceCategory
         android:key="SETTINGS_CRYPTOGRAPHY_PREFERENCE_KEY"
         android:title="@string/settings_cryptography">
+
         <im.vector.app.core.preference.VectorPreference
             android:key="SETTINGS_ENCRYPTION_CROSS_SIGNING_PREFERENCE_KEY"
             android:persistent="false"


### PR DESCRIPTION
- Remove access to CrossSigning fragment when not in developer mode, and remove all the actions supported by this Fragment.

- Remove the `/verify` command. It's not the same the EW, it was just a temporary shortcut.