### PR TITLE
Fix date format for some Asian languages (#1928)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Improvements 🙌:
  - Ensure users do not accidentally ignore other users (#1890)
 
 Bugfix 🐛:
+ - Fix incorrect date format for some Asian languages (#1928)
  - Fix invisible toolbar (Status.im theme) (#1746)
  - Fix relative date time formatting (#822)
  - Fix crash reported by RageShake

--- a/vector/src/main/java/im/vector/app/core/date/VectorDateFormatter.kt
+++ b/vector/src/main/java/im/vector/app/core/date/VectorDateFormatter.kt
@@ -17,6 +17,7 @@
 package im.vector.app.core.date
 
 import android.content.Context
+import android.text.format.DateFormat
 import android.text.format.DateUtils
 import im.vector.app.core.resources.LocaleProvider
 import org.threeten.bp.LocalDateTime
@@ -45,8 +46,9 @@ class VectorDateFormatter @Inject constructor(private val context: Context,
     private val messageHourFormatter by lazy {
         DateTimeFormatter.ofPattern("H:mm", localeProvider.current())
     }
+
     private val messageDayFormatter by lazy {
-        DateTimeFormatter.ofPattern("EEE d MMM", localeProvider.current())
+        DateTimeFormatter.ofPattern(DateFormat.getBestDateTimePattern(localeProvider.current(), "EEE d MMM"))
     }
 
     fun formatMessageHour(localDateTime: LocalDateTime): String {


### PR DESCRIPTION
With DateFormat.getBestDateTimePattern to generate best localized pattern.

Signed-off-by: Yihong Gao <yihong.ui@gmail.com>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [X] UI change has been tested on both light and dark themes
- [X] Pull request is based on the develop branch
- [X] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [X] Pull request includes screenshots or videos if containing UI changes

Locale | EN | JP | zh_CN 
--- | --- | --- | ---
Screen Shot With Fix | ![en_US](https://user-images.githubusercontent.com/7749575/90324463-0d1c5a00-df24-11ea-89ca-645706df7774.png) | ![JP](https://user-images.githubusercontent.com/7749575/90324464-0db4f080-df24-11ea-9797-0535f18b71ec.png) | ![zh_CN](https://user-images.githubusercontent.com/7749575/90324465-0e4d8700-df24-11ea-86ad-aac9050fb830.png)

- [X] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
