### PR TITLE
matrix-sdk-android: update okhttp 4.2.2 -> 4.8.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Bugfix 🐛:
  - Fix relative date time formatting (#822)
  - Fix crash reported by RageShake
  - Fix refreshing of sessions list when another session is logged out
+ - Fix http stack corruption after network change (e.g. Wifi -> LTE) (#1934)
 
 Translations 🗣:
  - Add PlayStore description resources in the Triple-T format, to let Weblate handle them

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -132,8 +132,10 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofit_version"
-    implementation 'com.squareup.okhttp3:okhttp:4.2.2'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.2.2'
+
+    implementation platform("com.squareup.okhttp3:okhttp-bom:4.8.1")
+    implementation "com.squareup.okhttp3:okhttp"
+    implementation "com.squareup.okhttp3:logging-interceptor"
     implementation "com.squareup.moshi:moshi-adapters:$moshi_version"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
 


### PR DESCRIPTION
I have been experiencing the following issue with Riot.im, RiotX and now Element on an ungoogled phone with Android 9 (Lineage OS, Android 9):

When I change a network (from Wifi to LTE/4G or vice versa), the loading animation `SyncStateView` spins forever:
![image](https://user-images.githubusercontent.com/668926/90253584-aa529200-de41-11ea-866b-80126cfcdab7.png)

I can write messages to rooms but don't receive updates from the room nor the messages itself are marked as sent.
That means I have to force-stop the app in Android to reset the state after each network change. Changing back to the original network does not help.
This lead to a lot of frustration because when I forgot this, messages only reached me after several hours.

I dug into the code and debugged what is happening in the `SyncThread`. The `syncTask`/`Request` in `doSync`
throws **SocketTimeoutException** after the network change occurred without ever recovering.
The issue is described also over at okhttp:
https://github.com/square/okhttp/issues/4981

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/riotX-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
