### PR TITLE
Fix IllegalArgumentException: Receiver not registered: NetworkInfoReceiver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Bugfix 🐛:
  - Fix relative date time formatting (#822)
  - Fix crash reported by RageShake
  - Fix refreshing of sessions list when another session is logged out
+ - Fix IllegalArgumentException: Receiver not registered: NetworkInfoReceiver (#1960)
 
 Translations 🗣:
  - Add PlayStore description resources in the Triple-T format, to let Weblate handle them

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkCallbackStrategy.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkCallbackStrategy.kt
@@ -47,7 +47,12 @@ internal class FallbackNetworkCallbackStrategy @Inject constructor(private val c
 
     override fun unregister() {
         networkInfoReceiver.isConnectedCallback = null
-        context.unregisterReceiver(networkInfoReceiver)
+        // Crashes if the SyncThread calls this before registration completed
+        try {
+            context.unregisterReceiver(networkInfoReceiver)
+        } catch (t: Throwable) {
+            Timber.e(t, "Unable to unregister network info receiver")
+        }
     }
 }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkCallbackStrategy.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkCallbackStrategy.kt
@@ -47,12 +47,7 @@ internal class FallbackNetworkCallbackStrategy @Inject constructor(private val c
 
     override fun unregister() {
         networkInfoReceiver.isConnectedCallback = null
-        // Crashes if the SyncThread calls this before registration completed
-        try {
-            context.unregisterReceiver(networkInfoReceiver)
-        } catch (t: Throwable) {
-            Timber.e(t, "Unable to unregister network info receiver")
-        }
+        context.unregisterReceiver(networkInfoReceiver)
     }
 }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkConnectivityChecker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkConnectivityChecker.kt
@@ -75,9 +75,7 @@ internal class DefaultNetworkConnectivityChecker @Inject constructor(private val
 
     override fun register(listener: NetworkConnectivityChecker.Listener) {
         if (listeners.isEmpty()) {
-            if (backgroundDetectionObserver.isInBackground) {
-                unbind()
-            } else {
+            if (!backgroundDetectionObserver.isInBackground) {
                 bind()
             }
             backgroundDetectionObserver.register(backgroundDetectionObserverListener)


### PR DESCRIPTION
SyncThread is calling unregister before registration completed.

Fixes #1960.