### PR TITLE
Improve PIN code feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ allprojects {
                 // PhotoView
                 includeGroupByRegex 'com\\.github\\.chrisbanes'
                 // PFLockScreen-Android
-                includeGroupByRegex 'com\\.github\\.ganfra'
+                includeGroupByRegex 'com\\.github\\.vector-im'
             }
         }
         maven {

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -346,7 +346,7 @@ dependencies {
     implementation 'me.saket:better-link-movement-method:2.2.0'
     implementation 'com.google.android:flexbox:1.1.1'
     implementation "androidx.autofill:autofill:$autofill_version"
-    implementation 'com.github.ganfra:PFLockScreen-Android:1.0.0-beta8'
+    implementation 'com.github.vector-im:PFLockScreen-Android:1.0.0-beta9'
 
     // Custom Tab
     implementation 'androidx.browser:browser:1.2.0'

--- a/vector/src/main/assets/open_source_licenses.html
+++ b/vector/src/main/assets/open_source_licenses.html
@@ -396,6 +396,11 @@ SOFTWARE.
         <br/>
         Copyright @ 2017-2018 Atlassian Pty Ltd
     </li>
+    <li>
+        <b>PFLockScreen-Android</b>
+        <br/>
+        Copyright 2018, Aleksandr Nikiforov
+    </li>
 </ul>
 <pre>
 Apache License

--- a/vector/src/main/java/im/vector/app/features/pin/PinFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/PinFragment.kt
@@ -61,7 +61,7 @@ class PinFragment @Inject constructor(
         val encodedPin = pinCodeStore.getEncodedPin() ?: return
         val authFragment = PFLockScreenFragment()
         val builder = PFFLockScreenConfiguration.Builder(requireContext())
-                .setUseFingerprint(true)
+                .setUseBiometric(true)
                 .setTitle(getString(R.string.auth_pin_confirm_to_disable_title))
                 .setClearCodeOnError(true)
                 .setMode(PFFLockScreenConfiguration.MODE_AUTH)
@@ -71,7 +71,7 @@ class PinFragment @Inject constructor(
             override fun onPinLoginFailed() {
             }
 
-            override fun onFingerprintSuccessful() {
+            override fun onBiometricAuthSuccessful() {
                 lifecycleScope.launch {
                     pinCodeStore.deleteEncodedPin()
                     vectorBaseActivity.setResult(Activity.RESULT_OK)
@@ -79,7 +79,7 @@ class PinFragment @Inject constructor(
                 }
             }
 
-            override fun onFingerprintLoginFailed() {
+            override fun onBiometricAuthLoginFailed() {
             }
 
             override fun onCodeInputSuccessful() {
@@ -122,7 +122,7 @@ class PinFragment @Inject constructor(
         val encodedPin = pinCodeStore.getEncodedPin() ?: return
         val authFragment = PFLockScreenFragment()
         val builder = PFFLockScreenConfiguration.Builder(requireContext())
-                .setUseFingerprint(true)
+                .setUseBiometric(true)
                 .setTitle(getString(R.string.auth_pin_title))
                 .setLeftButton(getString(R.string.auth_pin_forgot))
                 .setClearCodeOnError(true)
@@ -136,12 +136,12 @@ class PinFragment @Inject constructor(
             override fun onPinLoginFailed() {
             }
 
-            override fun onFingerprintSuccessful() {
+            override fun onBiometricAuthSuccessful() {
                 vectorBaseActivity.setResult(Activity.RESULT_OK)
                 vectorBaseActivity.finish()
             }
 
-            override fun onFingerprintLoginFailed() {
+            override fun onBiometricAuthLoginFailed() {
             }
 
             override fun onCodeInputSuccessful() {

--- a/vector/src/main/java/im/vector/app/features/pin/PinFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/PinFragment.kt
@@ -29,6 +29,7 @@ import com.beautycoder.pflockscreen.fragments.PFLockScreenFragment
 import im.vector.app.R
 import im.vector.app.core.extensions.replaceFragment
 import im.vector.app.core.platform.VectorBaseFragment
+import im.vector.app.core.utils.toast
 import im.vector.app.features.MainActivity
 import im.vector.app.features.MainActivityArgs
 import kotlinx.android.parcel.Parcelize
@@ -61,7 +62,7 @@ class PinFragment @Inject constructor(
         val encodedPin = pinCodeStore.getEncodedPin() ?: return
         val authFragment = PFLockScreenFragment()
         val builder = PFFLockScreenConfiguration.Builder(requireContext())
-                .setUseBiometric(true)
+                .setUseBiometric(pinCodeStore.getRemainingBiometricsAttemptsNumber() > 0)
                 .setTitle(getString(R.string.auth_pin_confirm_to_disable_title))
                 .setClearCodeOnError(true)
                 .setMode(PFFLockScreenConfiguration.MODE_AUTH)
@@ -69,6 +70,7 @@ class PinFragment @Inject constructor(
         authFragment.setEncodedPinCode(encodedPin)
         authFragment.setLoginListener(object : PFLockScreenFragment.OnPFLockScreenLoginListener {
             override fun onPinLoginFailed() {
+                onWrongPin()
             }
 
             override fun onBiometricAuthSuccessful() {
@@ -80,6 +82,12 @@ class PinFragment @Inject constructor(
             }
 
             override fun onBiometricAuthLoginFailed() {
+                val remainingAttempts = pinCodeStore.onWrongBiometrics()
+                if (remainingAttempts <= 0) {
+                    // Disable Biometrics
+                    builder.setUseBiometric(false)
+                    authFragment.setConfiguration(builder.build())
+                }
             }
 
             override fun onCodeInputSuccessful() {
@@ -121,8 +129,12 @@ class PinFragment @Inject constructor(
     private fun showAuthFragment() {
         val encodedPin = pinCodeStore.getEncodedPin() ?: return
         val authFragment = PFLockScreenFragment()
+        val canUseBiometrics = pinCodeStore.getRemainingBiometricsAttemptsNumber() > 0
         val builder = PFFLockScreenConfiguration.Builder(requireContext())
                 .setUseBiometric(true)
+                .setAutoShowBiometric(true)
+                .setUseBiometric(canUseBiometrics)
+                .setAutoShowBiometric(canUseBiometrics)
                 .setTitle(getString(R.string.auth_pin_title))
                 .setLeftButton(getString(R.string.auth_pin_forgot))
                 .setClearCodeOnError(true)
@@ -134,22 +146,46 @@ class PinFragment @Inject constructor(
         }
         authFragment.setLoginListener(object : PFLockScreenFragment.OnPFLockScreenLoginListener {
             override fun onPinLoginFailed() {
+                onWrongPin()
             }
 
             override fun onBiometricAuthSuccessful() {
+                pinCodeStore.resetCounters()
                 vectorBaseActivity.setResult(Activity.RESULT_OK)
                 vectorBaseActivity.finish()
             }
 
             override fun onBiometricAuthLoginFailed() {
+                val remainingAttempts = pinCodeStore.onWrongBiometrics()
+                if (remainingAttempts <= 0) {
+                    // Disable Biometrics
+                    builder.setUseBiometric(false)
+                    authFragment.setConfiguration(builder.build())
+                }
             }
 
             override fun onCodeInputSuccessful() {
+                pinCodeStore.resetCounters()
                 vectorBaseActivity.setResult(Activity.RESULT_OK)
                 vectorBaseActivity.finish()
             }
         })
         replaceFragment(R.id.pinFragmentContainer, authFragment)
+    }
+
+    private fun onWrongPin() {
+        val remainingAttempts = pinCodeStore.onWrongPin()
+        when {
+            remainingAttempts > 1  ->
+                requireActivity().toast(resources.getQuantityString(R.plurals.wrong_pin_message_remaining_attempts, remainingAttempts, remainingAttempts))
+            remainingAttempts == 1 ->
+                requireActivity().toast(R.string.wrong_pin_message_last_remaining_attempt)
+            else                   -> {
+                requireActivity().toast(R.string.too_many_pin_failures)
+                // Logout
+                MainActivity.restartApp(requireActivity(), MainActivityArgs(clearCredentials = true))
+            }
+        }
     }
 
     private fun displayForgotPinWarningDialog() {

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2516,6 +2516,12 @@
 
     <string name="alert_push_are_disabled_title">Push notifications are disabled</string>
     <string name="alert_push_are_disabled_description">Review your settings to enable push notifications</string>
+    <plurals name="wrong_pin_message_remaining_attempts">
+        <item quantity="one">Wrong code, %d remaining attempt</item>
+        <item quantity="other">Wrong code, %d remaining attempts</item>
+    </plurals>
+    <string name="wrong_pin_message_last_remaining_attempt">Warning! Last remaining attempt before logout!</string>
+    <string name="too_many_pin_failures">Too many errors, you\'ve been logged out</string>
     <string name="create_pin_title">Choose a PIN for security</string>
     <string name="create_pin_confirm_title">Confirm PIN</string>
     <string name="create_pin_confirm_failure">Failed to validate pin, please tap a new one.</string>


### PR DESCRIPTION
This PR add supports for biometrics to unlock the app.
It also limit the number of wrong PIN code to 3 before automatically log the user out.