### PR TITLE
DM creation: handled denied federation error

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -4,7 +4,16 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
         </value>
       </option>
       <option name="ALIGN_IN_COLUMNS_CASE_BRANCH" value="true" />

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Improvements 🙌:
  - Give user the possibility to prevent accidental call (#1869)
  - Display device information (name, id and key) in Cryptography setting screen (#1784)
  - Ensure users do not accidentally ignore other users (#1890)
+ - Better handling DM creation when invitees cannot be inviting due to denied federation
  - Support new config.json format and config.domain.json files (#1682)
  - Increase Font size on Calling screen (#1643)
  - Make the user's Avatar live in the general settings

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/failure/CreateRoomFailure.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/failure/CreateRoomFailure.kt
@@ -18,8 +18,9 @@
 package org.matrix.android.sdk.api.session.room.failure
 
 import org.matrix.android.sdk.api.failure.Failure
+import org.matrix.android.sdk.api.failure.MatrixError
 
 sealed class CreateRoomFailure : Failure.FeatureFailure() {
-
-    object CreatedWithTimeout: CreateRoomFailure()
+    object CreatedWithTimeout : CreateRoomFailure()
+    data class CreatedWithFederationFailure(val matrixError: MatrixError) : CreateRoomFailure()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomTask.kt
@@ -18,6 +18,9 @@
 package org.matrix.android.sdk.internal.session.room.create
 
 import com.zhuinden.monarchy.Monarchy
+import io.realm.RealmConfiguration
+import kotlinx.coroutines.TimeoutCancellationException
+import org.greenrobot.eventbus.EventBus
 import org.matrix.android.sdk.api.session.room.failure.CreateRoomFailure
 import org.matrix.android.sdk.api.session.room.model.create.CreateRoomParams
 import org.matrix.android.sdk.api.session.room.model.create.CreateRoomPreset
@@ -34,9 +37,6 @@ import org.matrix.android.sdk.internal.session.user.accountdata.DirectChatsHelpe
 import org.matrix.android.sdk.internal.session.user.accountdata.UpdateUserAccountDataTask
 import org.matrix.android.sdk.internal.task.Task
 import org.matrix.android.sdk.internal.util.awaitTransaction
-import io.realm.RealmConfiguration
-import kotlinx.coroutines.TimeoutCancellationException
-import org.greenrobot.eventbus.EventBus
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -55,6 +55,11 @@ internal class DefaultCreateRoomTask @Inject constructor(
 ) : CreateRoomTask {
 
     override suspend fun execute(params: CreateRoomParams): String {
+        val otherUserId = if (params.isDirect()) {
+            params.getFirstInvitedUserId()
+                    ?: throw IllegalStateException("You can't create a direct room without an invitedUser")
+        } else null
+
         val createRoomBody = createRoomBodyBuilder.build(params)
 
         val createRoomResponse = executeRequest<CreateRoomResponse>(eventBus) {
@@ -70,17 +75,14 @@ internal class DefaultCreateRoomTask @Inject constructor(
         } catch (exception: TimeoutCancellationException) {
             throw CreateRoomFailure.CreatedWithTimeout
         }
-        if (params.isDirect()) {
-            handleDirectChatCreation(params, roomId)
+        if (otherUserId != null) {
+            handleDirectChatCreation(roomId, otherUserId)
         }
         setReadMarkers(roomId)
         return roomId
     }
 
-    private suspend fun handleDirectChatCreation(params: CreateRoomParams, roomId: String) {
-        val otherUserId = params.getFirstInvitedUserId()
-                ?: throw IllegalStateException("You can't create a direct room without an invitedUser")
-
+    private suspend fun handleDirectChatCreation(roomId: String, otherUserId: String) {
         monarchy.awaitTransaction { realm ->
             RoomSummaryEntity.where(realm, roomId).findFirst()?.apply {
                 this.directUserId = otherUserId

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1640,6 +1640,7 @@
     <string name="create_room_public_description">"Anyone will be able to join this room"</string>
     <string name="create_room_directory_title">"Room Directory"</string>
     <string name="create_room_directory_description">"Publish this room in the room directory"</string>
+    <string name="create_room_federation_error">"The room has been created, but some invitations have not been sent for the following reason:\n\n%s"</string>
 
     <string name="keys_backup_unable_to_get_trust_info">"An error occurred getting trust info"</string>
     <string name="keys_backup_unable_to_get_keys_backup_data">"An error occurred getting keys backup data"</string>


### PR DESCRIPTION
When creating a DM and inviting a user whose account is on a HomeServer which is not federated, we get an error, but the room is actually created.

This PR inform the user about that and avoid the user to click again on "Create", which will create many rooms.

Here is the displayed dialog:

<img width="336" alt="image" src="https://user-images.githubusercontent.com/3940906/90778068-79b89f80-e2fc-11ea-8b38-028c262f8404.png">

Clicking on OK close the room creation screen.

Note: As we do not know the created roomId, we cannot add it to the DM list. 