### PR TITLE
Don't pause the sync thread if there is an active or pending call.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Bugfix 🐛:
  - Fix bad color for settings icon on Android < 24 (#1786)
  - Change user or room avatar: when selecting Gallery, I'm not proposed to crop the selected image (#1590)
  - Fix uploads still don't work with room v6 (#1879)
+ - Can't handle ongoing call events in background (#1992)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/call/CallSignalingService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/call/CallSignalingService.kt
@@ -34,4 +34,6 @@ interface CallSignalingService {
     fun removeCallListener(listener: CallsListener)
 
     fun getCallWithId(callId: String) : MxCall?
+
+    fun isThereAnyActiveCall(): Boolean
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/call/ActiveCallHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/call/ActiveCallHandler.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.call
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import org.matrix.android.sdk.api.session.call.MxCall
+import org.matrix.android.sdk.internal.session.SessionScope
+import javax.inject.Inject
+
+@SessionScope
+internal class ActiveCallHandler @Inject constructor() {
+
+    private val activeCallListLiveData: MutableLiveData<MutableList<MxCall>> by lazy {
+        MutableLiveData<MutableList<MxCall>>(mutableListOf())
+    }
+
+    fun addCall(call: MxCall) {
+        activeCallListLiveData.postValue(activeCallListLiveData.value?.apply { add(call) })
+    }
+
+    fun removeCall(callId: String) {
+        activeCallListLiveData.postValue(activeCallListLiveData.value?.apply { removeAll { it.callId == callId } })
+    }
+
+    fun getCallWithId(callId: String): MxCall? {
+        return activeCallListLiveData.value?.find { it.callId == callId }
+    }
+
+    fun getActiveCallsLiveData(): LiveData<MutableList<MxCall>> = activeCallListLiveData
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/call/DefaultCallSignalingService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/call/DefaultCallSignalingService.kt
@@ -49,6 +49,7 @@ import javax.inject.Inject
 internal class DefaultCallSignalingService @Inject constructor(
         @UserId
         private val userId: String,
+        private val activeCallHandler: ActiveCallHandler,
         private val localEchoEventFactory: LocalEchoEventFactory,
         private val roomEventSender: RoomEventSender,
         private val taskExecutor: TaskExecutor,
@@ -56,8 +57,6 @@ internal class DefaultCallSignalingService @Inject constructor(
 ) : CallSignalingService {
 
     private val callListeners = mutableSetOf<CallsListener>()
-
-    private val activeCalls = mutableListOf<MxCall>()
 
     private val cachedTurnServerResponse = object {
         // Keep one minute safe to avoid considering the data is valid and then actually it is not when effectively using it.
@@ -97,7 +96,7 @@ internal class DefaultCallSignalingService @Inject constructor(
     }
 
     override fun createOutgoingCall(roomId: String, otherUserId: String, isVideoCall: Boolean): MxCall {
-        return MxCallImpl(
+        val call = MxCallImpl(
                 callId = UUID.randomUUID().toString(),
                 isOutgoing = true,
                 roomId = roomId,
@@ -106,8 +105,9 @@ internal class DefaultCallSignalingService @Inject constructor(
                 isVideoCall = isVideoCall,
                 localEchoEventFactory = localEchoEventFactory,
                 roomEventSender = roomEventSender
-        ).also {
-            activeCalls.add(it)
+        )
+        activeCallHandler.addCall(call).also {
+            return call
         }
     }
 
@@ -120,8 +120,12 @@ internal class DefaultCallSignalingService @Inject constructor(
     }
 
     override fun getCallWithId(callId: String): MxCall? {
-        Timber.v("## VOIP getCallWithId $callId all calls ${activeCalls.map { it.callId }}")
-        return activeCalls.find { it.callId == callId }
+        Timber.v("## VOIP getCallWithId $callId all calls ${activeCallHandler.getActiveCallsLiveData().value?.map { it.callId }}")
+        return activeCallHandler.getCallWithId(callId)
+    }
+
+    override fun isThereAnyActiveCall(): Boolean {
+        return activeCallHandler.getActiveCallsLiveData().value?.isNotEmpty() == true
     }
 
     internal fun onCallEvent(event: Event) {
@@ -152,6 +156,7 @@ internal class DefaultCallSignalingService @Inject constructor(
                     // Always ignore local echos of invite
                     return
                 }
+
                 event.getClearContent().toModel<CallInviteContent>()?.let { content ->
                     val incomingCall = MxCallImpl(
                             callId = content.callId ?: return@let,
@@ -163,7 +168,7 @@ internal class DefaultCallSignalingService @Inject constructor(
                             localEchoEventFactory = localEchoEventFactory,
                             roomEventSender = roomEventSender
                     )
-                    activeCalls.add(incomingCall)
+                    activeCallHandler.addCall(incomingCall)
                     onCallInvite(incomingCall, content)
                 }
             }
@@ -185,8 +190,8 @@ internal class DefaultCallSignalingService @Inject constructor(
                         return
                     }
 
+                    activeCallHandler.removeCall(content.callId)
                     onCallHangup(content)
-                    activeCalls.removeAll { it.callId == content.callId }
                 }
             }
             EventType.CALL_CANDIDATES -> {
@@ -195,7 +200,7 @@ internal class DefaultCallSignalingService @Inject constructor(
                     return
                 }
                 event.getClearContent().toModel<CallCandidatesContent>()?.let { content ->
-                    activeCalls.firstOrNull { it.callId == content.callId }?.let {
+                    activeCallHandler.getCallWithId(content.callId)?.let {
                         onCallIceCandidate(it, content)
                     }
                 }


### PR DESCRIPTION
Since the app is not getting any push notification for `m.call.answer` and `m.call.hangup` events we can't handle these events when the app is in the background.