### PR TITLE
Use File extension functions to make code more concise.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ Build 🧱:
  - Some dependencies have been upgraded (coroutine, recyclerView, appCompat, core-ktx, firebase-messaging)
 
 Other changes:
- -
+ - Use File extension functions to make code more concise (#1996)
 
 Changes in Element 1.0.5 (2020-08-21)
 ===================================================

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/AttachmentEncryptionTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/AttachmentEncryptionTest.kt
@@ -29,7 +29,6 @@ import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.MethodSorters
-import java.io.ByteArrayInputStream
 import java.io.InputStream
 
 /**
@@ -46,7 +45,7 @@ class AttachmentEncryptionTest {
         val inputStream: InputStream
 
         inputStream = if (`in`.isEmpty()) {
-            ByteArrayInputStream(`in`)
+            `in`.inputStream()
         } else {
             val memoryFile = MemoryFile("file" + System.currentTimeMillis(), `in`.size)
             memoryFile.outputStream.write(`in`)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/attachments/MXEncryptedAttachments.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/attachments/MXEncryptedAttachments.kt
@@ -21,7 +21,6 @@ import android.util.Base64
 import org.matrix.android.sdk.internal.crypto.model.rest.EncryptedFileInfo
 import org.matrix.android.sdk.internal.crypto.model.rest.EncryptedFileKey
 import timber.log.Timber
-import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.security.MessageDigest
@@ -179,7 +178,7 @@ internal object MXEncryptedAttachments {
                     return null
                 }
 
-                return ByteArrayInputStream(outputStream.toByteArray())
+                return outputStream.toByteArray().inputStream()
                         .also { Timber.v("Decrypt in ${System.currentTimeMillis() - t0}ms") }
             } catch (oom: OutOfMemoryError) {
                 Timber.e(oom, "## decryptAttachment() failed: OOM")

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/Helper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/Helper.kt
@@ -21,7 +21,6 @@ import android.util.Base64
 import io.realm.Realm
 import io.realm.RealmConfiguration
 import io.realm.RealmObject
-import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.ObjectOutputStream
 import java.util.zip.GZIPInputStream
@@ -96,7 +95,7 @@ fun <T> deserializeFromRealm(string: String?): T? {
     }
     val decodedB64 = Base64.decode(string.toByteArray(), Base64.DEFAULT)
 
-    val bais = ByteArrayInputStream(decodedB64)
+    val bais = decodedB64.inputStream()
     val gzis = GZIPInputStream(bais)
     val ois = SafeObjectInputStream(gzis)
     return ois.use {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/UploadContentWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/UploadContentWorker.kt
@@ -42,10 +42,7 @@ import org.matrix.android.sdk.internal.worker.SessionWorkerParams
 import org.matrix.android.sdk.internal.worker.WorkerParamsFactory
 import org.matrix.android.sdk.internal.worker.getSessionComponent
 import timber.log.Timber
-import java.io.ByteArrayInputStream
 import java.io.File
-import java.io.FileInputStream
-import java.io.FileOutputStream
 import java.util.UUID
 import javax.inject.Inject
 
@@ -130,7 +127,7 @@ internal class UploadContentWorker(val context: Context, params: WorkerParameter
                         val contentUploadResponse = if (params.isEncrypted) {
                             Timber.v("Encrypt thumbnail")
                             notifyTracker(params) { contentUploadStateTracker.setEncryptingThumbnail(it) }
-                            val encryptionResult = MXEncryptedAttachments.encryptAttachment(ByteArrayInputStream(thumbnailData.bytes), thumbnailData.mimeType)
+                            val encryptionResult = MXEncryptedAttachments.encryptAttachment(thumbnailData.bytes.inputStream(), thumbnailData.mimeType)
                             uploadedThumbnailEncryptedFileInfo = encryptionResult.encryptedFileInfo
                             fileUploader.uploadByteArray(encryptionResult.encryptedByteArray,
                                     "thumb_${attachment.name}",
@@ -176,7 +173,7 @@ internal class UploadContentWorker(val context: Context, params: WorkerParameter
                     cacheFile.createNewFile()
                     cacheFile.deleteOnExit()
 
-                    val outputStream = FileOutputStream(cacheFile)
+                    val outputStream = cacheFile.outputStream()
                     outputStream.use {
                         inputStream.copyTo(outputStream)
                     }
@@ -203,7 +200,7 @@ internal class UploadContentWorker(val context: Context, params: WorkerParameter
                         Timber.v("Encrypt file")
                         notifyTracker(params) { contentUploadStateTracker.setEncrypting(it) }
 
-                        val encryptionResult = MXEncryptedAttachments.encryptAttachment(FileInputStream(cacheFile), attachment.getSafeMimeType())
+                        val encryptionResult = MXEncryptedAttachments.encryptAttachment(cacheFile.inputStream(), attachment.getSafeMimeType())
                         uploadedFileEncryptedFileInfo = encryptionResult.encryptedFileInfo
 
                         fileUploader

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/securestorage/SecretStoringUtils.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/securestorage/SecretStoringUtils.kt
@@ -219,7 +219,7 @@ internal class SecretStoringUtils @Inject constructor(private val context: Conte
 
     @RequiresApi(Build.VERSION_CODES.M)
     private fun decryptStringM(encryptedChunk: ByteArray, keyAlias: String): String {
-        val (iv, encryptedText) = formatMExtract(ByteArrayInputStream(encryptedChunk))
+        val (iv, encryptedText) = formatMExtract(encryptedChunk.inputStream())
 
         val secretKey = getOrGenerateSymmetricKeyForAliasM(keyAlias)
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/FileSaver.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/FileSaver.kt
@@ -19,7 +19,6 @@ package org.matrix.android.sdk.internal.util
 
 import androidx.annotation.WorkerThread
 import java.io.File
-import java.io.FileOutputStream
 import java.io.InputStream
 
 /**
@@ -27,7 +26,7 @@ import java.io.InputStream
  */
 @WorkerThread
 fun writeToFile(inputStream: InputStream, outputFile: File) {
-    FileOutputStream(outputFile).use {
+    outputFile.outputStream().use {
         inputStream.copyTo(it)
     }
 }

--- a/vector/src/main/java/im/vector/app/core/glide/VectorGlideModelLoader.kt
+++ b/vector/src/main/java/im/vector/app/core/glide/VectorGlideModelLoader.kt
@@ -31,7 +31,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import timber.log.Timber
 import java.io.File
-import java.io.FileInputStream
 import java.io.IOException
 import java.io.InputStream
 
@@ -97,7 +96,7 @@ class VectorGlideDataFetcher(private val activeSessionHolder: ActiveSessionHolde
         Timber.v("Load data: $data")
         if (data.isLocalFile() && data.url != null) {
             val initialFile = File(data.url)
-            callback.onDataReady(FileInputStream(initialFile))
+            callback.onDataReady(initialFile.inputStream())
             return
         }
         val contentUrlResolver = activeSessionHolder.getActiveSession().contentUrlResolver()

--- a/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
@@ -518,8 +518,8 @@ fun saveFileIntoLegacy(sourceFile: File, dstDirPath: File, outputFilename: Strin
     var outputStream: FileOutputStream? = null
     try {
         dstFile.createNewFile()
-        inputStream = FileInputStream(sourceFile)
-        outputStream = FileOutputStream(dstFile)
+        inputStream = sourceFile.inputStream()
+        outputStream = dstFile.outputStream()
         val buffer = ByteArray(1024 * 10)
         var len: Int
         while (inputStream.read(buffer).also { len = it } != -1) {

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
@@ -32,7 +32,6 @@ import org.matrix.android.sdk.api.session.content.ContentUrlResolver
 import me.gujun.android.span.span
 import timber.log.Timber
 import java.io.File
-import java.io.FileInputStream
 import java.io.FileOutputStream
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -494,7 +493,7 @@ class NotificationDrawerManager @Inject constructor(private val context: Context
         try {
             val file = File(context.applicationContext.cacheDir, ROOMS_NOTIFICATIONS_FILE_NAME)
             if (file.exists()) {
-                FileInputStream(file).use {
+                file.inputStream().use {
                     val events: ArrayList<NotifiableEvent>? = currentSession?.loadSecureSecret(it, KEY_ALIAS_SECRET_STORAGE)
                     if (events != null) {
                         return events.toMutableList()


### PR DESCRIPTION
+ This change replaces a few usages of `ByteArrayInputStream`, `FileInputStream`, `FileOutputStream` with their equivalent Kotlin extension functions.

Signed-off-by: Tobias Preuss tobias.preuss@googlemail.com

---

_Feel free to rebase the branch before merging it to facilitate a linear history. Let me know if I should do this._