### PR TITLE
Relax IS dicovery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Bugfix 🐛:
  - Change user or room avatar: when selecting Gallery, I'm not proposed to crop the selected image (#1590)
  - Fix uploads still don't work with room v6 (#1879)
  - Can't handle ongoing call events in background (#1992)
+ - Login with Matrix-Id | Autodiscovery fails if identity server is invalid and Homeserver ok (#2027)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/wellknown/WellknownResult.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/wellknown/WellknownResult.kt
@@ -45,7 +45,7 @@ sealed class WellknownResult {
     /**
      * Inform the user that auto-discovery failed due to invalid/empty data and PROMPT for the parameter.
      */
-    object FailPrompt : WellknownResult()
+    data class FailPrompt(val homeServerUrl: String?, val wellKnown: WellKnown?) : WellknownResult()
 
     /**
      * Inform the user that auto-discovery did not return any usable URLs. Do not continue further with the current login process.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/wellknown/GetWellknownTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/wellknown/GetWellknownTask.kt
@@ -97,7 +97,7 @@ internal class DefaultGetWellknownTask @Inject constructor(
             // Success
             val homeServerBaseUrl = wellKnown.homeServer?.baseURL
             if (homeServerBaseUrl.isNullOrBlank()) {
-                WellknownResult.FailPrompt
+                WellknownResult.FailPrompt(null, null)
             } else {
                 if (homeServerBaseUrl.isValidUrl()) {
                     // Check that HS is a real one
@@ -120,11 +120,11 @@ internal class DefaultGetWellknownTask @Inject constructor(
                 is Failure.OtherServerError                -> {
                     when (throwable.httpCode) {
                         HttpsURLConnection.HTTP_NOT_FOUND -> WellknownResult.Ignore
-                        else                              -> WellknownResult.FailPrompt
+                        else                              -> WellknownResult.FailPrompt(null, null)
                     }
                 }
                 is MalformedJsonException, is EOFException -> {
-                    WellknownResult.FailPrompt
+                    WellknownResult.FailPrompt(null, null)
                 }
                 else                                       -> {
                     throw throwable
@@ -162,7 +162,7 @@ internal class DefaultGetWellknownTask @Inject constructor(
                         // All is ok
                         WellknownResult.Prompt(homeServerBaseUrl, identityServerBaseUrl, wellKnown)
                     } else {
-                        WellknownResult.FailError
+                        WellknownResult.FailPrompt(homeServerBaseUrl, wellKnown)
                     }
                 } else {
                     WellknownResult.FailError


### PR DESCRIPTION
Fixes #2027

Align with web and relax IS discovery for login with matrix id.
See https://github.com/vector-im/element-web/issues/11102

I hesitated to create a FailPromptInvalidateIS data class (would be cleaner), but maybe it's better to stick with types defined in spec?