### PR TITLE
Crash / Attachment viewer: Cannot draw a recycled Bitmap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Bugfix 🐛:
  - Change user or room avatar: when selecting Gallery, I'm not proposed to crop the selected image (#1590)
  - Fix uploads still don't work with room v6 (#1879)
  - Can't handle ongoing call events in background (#1992)
+ - Crash / Attachment viewer: Cannot draw a recycled Bitmap #2034
 
 Translations 🗣:
  -

--- a/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/AnimatedImageViewHolder.kt
+++ b/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/AnimatedImageViewHolder.kt
@@ -27,4 +27,9 @@ class AnimatedImageViewHolder constructor(itemView: View) :
     val imageLoaderProgress: ProgressBar = itemView.findViewById(R.id.imageLoaderProgress)
 
     internal val target = DefaultImageLoaderTarget(this, this.touchImageView)
+
+    override fun onRecycled() {
+        super.onRecycled()
+        touchImageView.setImageDrawable(null)
+    }
 }

--- a/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/ImageLoaderTarget.kt
+++ b/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/ImageLoaderTarget.kt
@@ -50,6 +50,7 @@ internal class DefaultImageLoaderTarget(val holder: AnimatedImageViewHolder, pri
     override fun onLoadFailed(uid: String, errorDrawable: Drawable?) {
         if (holder.boundResourceUid != uid) return
         holder.imageLoaderProgress.isVisible = false
+        holder.touchImageView.setImageDrawable(errorDrawable)
     }
 
     override fun onResourceCleared(uid: String, placeholder: Drawable?) {
@@ -77,11 +78,13 @@ internal class DefaultImageLoaderTarget(val holder: AnimatedImageViewHolder, pri
         override fun onResourceLoading(uid: String, placeholder: Drawable?) {
             if (holder.boundResourceUid != uid) return
             holder.imageLoaderProgress.isVisible = true
+            holder.touchImageView.setImageDrawable(placeholder)
         }
 
         override fun onLoadFailed(uid: String, errorDrawable: Drawable?) {
             if (holder.boundResourceUid != uid) return
             holder.imageLoaderProgress.isVisible = false
+            holder.touchImageView.setImageDrawable(errorDrawable)
         }
 
         override fun onResourceCleared(uid: String, placeholder: Drawable?) {

--- a/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/VideoLoaderTarget.kt
+++ b/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/VideoLoaderTarget.kt
@@ -47,6 +47,8 @@ internal class DefaultVideoLoaderTarget(val holder: VideoViewHolder, private val
     }
 
     override fun onThumbnailResourceCleared(uid: String, placeholder: Drawable?) {
+        if (holder.boundResourceUid != uid) return
+        holder.thumbnailImage.setImageDrawable(placeholder)
     }
 
     override fun onThumbnailResourceReady(uid: String, resource: Drawable) {

--- a/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/VideoViewHolder.kt
+++ b/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/VideoViewHolder.kt
@@ -123,7 +123,7 @@ class VideoViewHolder constructor(itemView: View) :
             videoView.setVideoPath(mVideoPath)
         } catch (failure: Throwable) {
             // Couldn't open
-            Log.v(VideoViewHolder::class.java.name, "Failed to start video ${failure.message}")
+            Log.v(VideoViewHolder::class.java.name, "Failed to start video")
         }
 
         if (!wasPaused) {

--- a/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/VideoViewHolder.kt
+++ b/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/VideoViewHolder.kt
@@ -16,6 +16,7 @@
 
 package im.vector.lib.attachmentviewer
 
+import android.util.Log
 import android.view.View
 import android.widget.ImageView
 import android.widget.ProgressBar
@@ -118,8 +119,13 @@ class VideoViewHolder constructor(itemView: View) :
                         eventListener?.get()?.onEvent(AttachmentEvents.VideoEvent(isPlaying, progress, duration))
                     }
         }
+        try {
+            videoView.setVideoPath(mVideoPath)
+        } catch (failure: Throwable) {
+            // Couldn't open
+            Log.v(VideoViewHolder::class.java.name, "Failed to start video ${failure.message}")
+        }
 
-        videoView.setVideoPath(mVideoPath)
         if (!wasPaused) {
             videoView.start()
             if (progress > 0) {

--- a/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/ZoomableImageViewHolder.kt
+++ b/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/ZoomableImageViewHolder.kt
@@ -39,4 +39,9 @@ class ZoomableImageViewHolder constructor(itemView: View) :
     }
 
     internal val target = DefaultImageLoaderTarget.ZoomableImageTarget(this, touchImageView)
+
+    override fun onRecycled() {
+        super.onRecycled()
+        touchImageView.setImageDrawable(null)
+    }
 }


### PR DESCRIPTION
Fixes  #2034

Some cleaning. Can't reproduce crash after those changes
