### PR TITLE
Feature/fix poll reply

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@ Bugfix 🐛:
  - Support for image compression on Android 10
  - Verification popup won't show
  - Android 6: App crash when read Contact permission is granted (#2064)
+ - JSON for verification events leaks in to the room list (#1246)
+ - Replies to poll appears in timeline as unsupported events during sending #1004
 
 Translations 🗣:
  - The SDK is now using SAS string translations from [Weblate Matrix-doc project](https://translate.riot.im/projects/matrix-doc/) (#1909)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Features ✨:
 Improvements 🙌:
  - You can now join room through permalink and within room directory search
  - Add long click gesture to copy userId, user display name, room name, room topic and room alias (#1774)
- - Fix several issues when uploading bug files (#1889)
+ - Fix several issues when uploading big files (#1889)
  - Do not propose to verify session if there is only one session and 4S is not configured (#1901)
  - Call screen does not use proximity sensor (#1735)
 
@@ -28,7 +28,7 @@ Bugfix 🐛:
  - Verification popup won't show
  - Android 6: App crash when read Contact permission is granted (#2064)
  - JSON for verification events leaks in to the room list (#1246)
- - Replies to poll appears in timeline as unsupported events during sending #1004
+ - Replies to poll appears in timeline as unsupported events during sending (#1004)
 
 Translations 🗣:
  - The SDK is now using SAS string translations from [Weblate Matrix-doc project](https://translate.riot.im/projects/matrix-doc/) (#1909)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/EventRelationsAggregationProcessor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/EventRelationsAggregationProcessor.kt
@@ -347,7 +347,7 @@ internal class EventRelationsAggregationProcessor @Inject constructor(@UserId pr
                 if (userId == senderId) {
                     sumModel.myVote = optionIndex
                 }
-                Timber.v("## POLL adding vote $optionIndex for user $senderId in poll :$relatedEventId ")
+                Timber.v("## POLL adding vote $optionIndex for user $senderId in poll :$targetEventId ")
             } else {
                 Timber.v("## POLL Ignoring vote (older than known one)  eventId:$eventId ")
             }
@@ -356,7 +356,7 @@ internal class EventRelationsAggregationProcessor @Inject constructor(@UserId pr
             if (userId == senderId) {
                 sumModel.myVote = optionIndex
             }
-            Timber.v("## POLL adding vote $optionIndex for user $senderId in poll :$relatedEventId ")
+            Timber.v("## POLL adding vote $optionIndex for user $senderId in poll :$targetEventId ")
         }
         sumModel.votes = votes
         if (isLocalEcho) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/DefaultTimeline.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/DefaultTimeline.kt
@@ -17,6 +17,16 @@
 
 package org.matrix.android.sdk.internal.session.room.timeline
 
+import io.realm.OrderedCollectionChangeSet
+import io.realm.OrderedRealmCollectionChangeListener
+import io.realm.Realm
+import io.realm.RealmConfiguration
+import io.realm.RealmQuery
+import io.realm.RealmResults
+import io.realm.Sort
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
 import org.matrix.android.sdk.api.MatrixCallback
 import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.events.model.EventType
@@ -44,16 +54,6 @@ import org.matrix.android.sdk.internal.task.configureWith
 import org.matrix.android.sdk.internal.util.Debouncer
 import org.matrix.android.sdk.internal.util.createBackgroundHandler
 import org.matrix.android.sdk.internal.util.createUIHandler
-import io.realm.OrderedCollectionChangeSet
-import io.realm.OrderedRealmCollectionChangeListener
-import io.realm.Realm
-import io.realm.RealmConfiguration
-import io.realm.RealmQuery
-import io.realm.RealmResults
-import io.realm.Sort
-import org.greenrobot.eventbus.EventBus
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
 import timber.log.Timber
 import java.util.Collections
 import java.util.UUID
@@ -322,7 +322,7 @@ internal class DefaultTimeline(
                 listeners.forEach {
                     it.onNewTimelineEvents(listOf(onLocalEchoCreated.timelineEvent.eventId))
                 }
-                Timber.v("On local echo created: $onLocalEchoCreated")
+                Timber.v("On local echo created: ${onLocalEchoCreated.timelineEvent.eventId}")
                 inMemorySendingEvents.add(0, onLocalEchoCreated.timelineEvent)
                 postSnapshot()
             }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
@@ -63,6 +63,7 @@ import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.crypto.MXCryptoError
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.isAttachmentMessage
+import org.matrix.android.sdk.api.session.events.model.LocalEcho
 import org.matrix.android.sdk.api.session.events.model.isTextMessage
 import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.events.model.toModel
@@ -1218,6 +1219,8 @@ class RoomDetailViewModel @AssistedInject constructor(
     }
 
     private fun handleReplyToOptions(action: RoomDetailAction.ReplyToOptions) {
+        // Do not allow to reply to unsent local echo
+        if (LocalEcho.isLocalEchoId(action.eventId)) return
         room.sendOptionsReply(action.eventId, action.optionIndex, action.optionValue)
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessagePollItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessagePollItem.kt
@@ -75,6 +75,8 @@ abstract class MessagePollItem : AbsMessageItem<MessagePollItem.Holder>() {
             optionsContent?.options?.forEachIndexed { index, item ->
                 if (index < buttons.size) {
                     buttons[index].let {
+                        // current limitation, have to wait for event to be sent in order to reply
+                        it.isEnabled = informationData?.sendState?.isSent() ?: false
                         it.text = item.label
                         it.isVisible = true
                     }

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2067,6 +2067,10 @@
     <string name="sent_an_audio_file">Audio</string>
     <string name="sent_a_file">File</string>
     <string name="send_a_sticker">Sticker</string>
+    <string name="sent_a_poll">Poll</string>
+    <string name="sent_a_bot_buttons">Bot Buttons</string>
+    <string name="sent_a_reaction">Reacted with: %s</string>
+    <string name="sent_verification_conclusion">Verification Conclusion</string>
 
     <string name="verification_request_waiting">Waiting…</string>
     <string name="verification_request_other_cancelled">%s cancelled</string>


### PR DESCRIPTION
Fixes #1246
 - JSON for verification events leaks in to the room list ()

Fixes #1004
 - Replies to poll appears in timeline as unsupported events during sending 

Looks like there was a desync between the timeline filter and the sendingEvent/InMemory filter
Also bus event for local echo creation could add local echos that was never removed (no synced event as they were filtered out)

+ Fixed a bug on poll reply not taken into account: Currently aggregation don't support relation put on a sending event (e.g edit a sending event, reply to a sending event); there was no guard against that for poll buttons, added now