### PR TITLE
Support data-mx-[bg-]color attribute on <font> tags in formatted messages.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,7 +41,7 @@ Build 🧱:
 Other changes:
  - Use File extension functions to make code more concise (#1996)
  - Create a script to import SAS strings (#1909)
- - Support `data-mx-bg-color` attribute on `<font>` tags.
+ - Support `data-mx-[bg-]color` attributes on `<font>` tags.
 
 Changes in Element 1.0.5 (2020-08-21)
 ===================================================

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@ Build 🧱:
 Other changes:
  - Use File extension functions to make code more concise (#1996)
  - Create a script to import SAS strings (#1909)
+ - Support `data-mx-bg-color` attribute on `<font>` tags.
 
 Changes in Element 1.0.5 (2020-08-21)
 ===================================================

--- a/vector/src/main/java/im/vector/app/features/html/FontTagHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/html/FontTagHandler.kt
@@ -17,6 +17,7 @@ package im.vector.app.features.html
 
 import android.graphics.Color
 import android.text.style.ForegroundColorSpan
+import android.text.style.BackgroundColorSpan
 import io.noties.markwon.MarkwonConfiguration
 import io.noties.markwon.RenderProps
 import io.noties.markwon.html.HtmlTag
@@ -31,7 +32,13 @@ class FontTagHandler : SimpleTagHandler() {
 
     override fun getSpans(configuration: MarkwonConfiguration, renderProps: RenderProps, tag: HtmlTag): Any? {
         val colorString = tag.attributes()["color"]?.let { parseColor(it) } ?: Color.BLACK
-        return ForegroundColorSpan(colorString)
+        val bgColor = tag.attributes()["data-mx-bg-color"]
+        if(bgColor == null) {
+            return ForegroundColorSpan(colorString)
+        }
+        else {
+            return arrayOf(ForegroundColorSpan(colorString), BackgroundColorSpan(bgColor.let { parseColor(it) }))
+        }
     }
 
     private fun parseColor(colorName: String): Int {

--- a/vector/src/main/java/im/vector/app/features/html/FontTagHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/html/FontTagHandler.kt
@@ -31,17 +31,21 @@ class FontTagHandler : SimpleTagHandler() {
     override fun supportedTags() = listOf("font")
 
     override fun getSpans(configuration: MarkwonConfiguration, renderProps: RenderProps, tag: HtmlTag): Any? {
-        val colorString = tag.attributes()["color"]?.let { parseColor(it) } ?: Color.BLACK
-        val bgColor = tag.attributes()["data-mx-bg-color"]
-        if(bgColor == null) {
-            return ForegroundColorSpan(colorString)
-        }
-        else {
-            return arrayOf(ForegroundColorSpan(colorString), BackgroundColorSpan(bgColor.let { parseColor(it) }))
+        val mxColorString = tag.attributes()["data-mx-color"]
+        val colorString = tag.attributes()["color"]
+        val mxBgColorString = tag.attributes()["data-mx-bg-color"]
+
+        val foregroundColor = mxColorString?.let { parseColor(it, Color.BLACK) } ?: colorString?.let { parseColor(it, Color.BLACK) } ?: Color.BLACK
+
+        if (mxBgColorString != null) {
+            val backgroundColor = parseColor(mxBgColorString, Color.TRANSPARENT)
+            return arrayOf(ForegroundColorSpan(foregroundColor), BackgroundColorSpan(backgroundColor))
+        } else {
+            return ForegroundColorSpan(foregroundColor)
         }
     }
 
-    private fun parseColor(colorName: String): Int {
+    private fun parseColor(colorName: String, failResult: Int): Int {
         try {
             return Color.parseColor(colorName)
         } catch (e: Exception) {
@@ -63,7 +67,7 @@ class FontTagHandler : SimpleTagHandler() {
                 "blue"    -> Color.BLUE
                 "orange"  -> Color.parseColor("#FFA500")
                 "navy"    -> Color.parseColor("#000080")
-                else      -> Color.BLACK
+                else      -> failResult
             }
         }
     }


### PR DESCRIPTION
### Summary

Pretty much what it says on the can :-) As outlined [in the spec](https://matrix.org/docs/spec/client_server/r0.6.1#m-room-message-msgtypes), `<font>` tags can have the `data-mx-bg-color` attribute attached to indicate that text should have a different background colour. While this is somewhat counter to things like good readability in many instances with e.g. dark or light themes, only supporting the foreground colour also renders some text unreadable for some messages that change both.

First time writing Kotlin, so I'm sure the styling could be improved :-)

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [X] UI change has been tested on both light and dark themes
- [X] Pull request is based on the develop branch
- [X] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [X] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
