### PR TITLE
Translations: Fix zh-rCN string's typo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Bugfix 🐛:
  -
 
 Translations 🗣:
- -
+ - Fix zh-rCN string's typo
 
 SDK API changes ⚠️:
  - 

--- a/vector/src/main/res/values-zh-rCN/strings.xml
+++ b/vector/src/main/res/values-zh-rCN/strings.xml
@@ -1877,7 +1877,7 @@ Element 在后台时的工作将被显著的限制，这可能会影响消息通
 \n
 \n您想要通过网页客户端登录吗？</string>
     <string name="login_registration_disabled">抱歉，此服务器不接受新账户。</string>
-    <string name="login_registration_not_supported">应用无法再次服务器上创建账户。
+    <string name="login_registration_not_supported">应用无法在此服务器上创建账户。
 \n
 \n您想要通过网页客户端注册吗？</string>
 


### PR DESCRIPTION
Hi there, I found a typo of the zh-rCN string when using element.

By default(EN), the string value is:
```xml
<string name="login_registration_not_supported">The application is not able to create an account on this homeserver.\n\nDo you want to signup using a web client?</string>
```

The origin value in zh-rCN is:
```xml
    <string name="login_registration_not_supported">应用无法再次服务器上创建账户。
\n
\n您想要通过网页客户端注册吗？</string>
```

Which means 
> The application is not able to create an account (~~on this~~) homeserver <strong>again</strong>...

It doesn't make sense in Chinese.
The right word should be <strong>在此</strong> which means <strong>on this</strong> (homeserver), instand of <strong>再次</strong>

This is an input error due to the similar pronunciation of two words.