### PR TITLE
Feature/event type filtering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Bugfix 🐛:
  - Speakerphone is not used for ringback tone (#1644, #1645)
  - Back camera preview is not mirrored anymore (#1776)
  - Various report of people that cannot play video (#2107)
+ - Rooms incorrectly marked as unread (#588)
+ - Allow users to show/hide room member state events (#1231) 
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/summary/RoomSummaryConstants.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/summary/RoomSummaryConstants.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.api.session.room.summary
+
+import org.matrix.android.sdk.api.session.events.model.EventType
+
+object RoomSummaryConstants {
+
+    val PREVIEWABLE_TYPES = listOf(
+            // TODO filter message type (KEY_VERIFICATION_READY, etc.)
+            EventType.MESSAGE,
+            EventType.CALL_INVITE,
+            EventType.CALL_HANGUP,
+            EventType.CALL_ANSWER,
+            EventType.ENCRYPTED,
+            EventType.STICKER,
+            EventType.REACTION
+    )
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/timeline/TimelineEventFilters.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/timeline/TimelineEventFilters.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.api.session.room.timeline
+
+data class TimelineEventFilters(
+        /**
+         * A flag to filter edit events
+         */
+        val filterEdits: Boolean = false,
+        /**
+         * A flag to filter redacted events
+         */
+        val filterRedacted: Boolean = false,
+        /**
+         * A flag to filter useless events, such as membership events without any change
+         */
+        val filterUseless: Boolean = false,
+        /**
+         * A flag to filter by types. It should be used with [allowedTypes] field
+         */
+        val filterTypes: Boolean = false,
+        /**
+         * If [filterTypes] is true, the list of types allowed by the list.
+         */
+        val allowedTypes: List<String> = emptyList()
+)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/timeline/TimelineSettings.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/timeline/TimelineSettings.kt
@@ -26,25 +26,9 @@ data class TimelineSettings(
          */
         val initialSize: Int,
         /**
-         * A flag to filter edit events
+         * Filters for timeline event
          */
-        val filterEdits: Boolean = false,
-        /**
-         * A flag to filter redacted events
-         */
-        val filterRedacted: Boolean = false,
-        /**
-         * A flag to filter useless events, such as membership events without any change
-         */
-        val filterUseless: Boolean = false,
-        /**
-         * A flag to filter by types. It should be used with [allowedTypes] field
-         */
-        val filterTypes: Boolean = false,
-        /**
-         * If [filterTypes] is true, the list of types allowed by the list.
-         */
-        val allowedTypes: List<String> = emptyList(),
+        val filters: TimelineEventFilters = TimelineEventFilters(),
         /**
          * If true, will build read receipts for each event.
          */

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryEventsHelper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryEventsHelper.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.room.summary
+
+import io.realm.Realm
+import org.matrix.android.sdk.api.session.room.summary.RoomSummaryConstants
+import org.matrix.android.sdk.api.session.room.timeline.TimelineEventFilters
+import org.matrix.android.sdk.internal.database.model.TimelineEventEntity
+import org.matrix.android.sdk.internal.database.query.latestEvent
+
+internal object RoomSummaryEventsHelper {
+
+    private val previewFilters = TimelineEventFilters(
+            filterTypes = true,
+            allowedTypes = RoomSummaryConstants.PREVIEWABLE_TYPES,
+            filterUseless = true,
+            filterRedacted = false,
+            filterEdits = true
+    )
+
+    fun getLatestPreviewableEvent(realm: Realm, roomId: String): TimelineEventEntity? {
+        return TimelineEventEntity.latestEvent(
+                realm = realm,
+                roomId = roomId,
+                includesSending = true,
+                filters = previewFilters
+        )
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineHiddenReadReceipts.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineHiddenReadReceipts.kt
@@ -18,6 +18,10 @@
 package org.matrix.android.sdk.internal.session.room.timeline
 
 import android.util.SparseArray
+import io.realm.OrderedRealmCollectionChangeListener
+import io.realm.Realm
+import io.realm.RealmQuery
+import io.realm.RealmResults
 import org.matrix.android.sdk.api.session.room.model.ReadReceipt
 import org.matrix.android.sdk.api.session.room.timeline.TimelineSettings
 import org.matrix.android.sdk.internal.database.mapper.ReadReceiptsSummaryMapper
@@ -27,10 +31,6 @@ import org.matrix.android.sdk.internal.database.model.TimelineEventEntity
 import org.matrix.android.sdk.internal.database.model.TimelineEventEntityFields
 import org.matrix.android.sdk.internal.database.query.TimelineEventFilter
 import org.matrix.android.sdk.internal.database.query.whereInRoom
-import io.realm.OrderedRealmCollectionChangeListener
-import io.realm.Realm
-import io.realm.RealmQuery
-import io.realm.RealmResults
 
 /**
  * This class is responsible for handling the read receipts for hidden events (check [TimelineSettings] to see filtering).
@@ -152,7 +152,8 @@ internal class TimelineHiddenReadReceipts constructor(private val readReceiptsSu
         beginGroup()
         var needOr = false
         if (settings.filters.filterTypes) {
-            not().`in`("${ReadReceiptsSummaryEntityFields.TIMELINE_EVENT}.${TimelineEventEntityFields.ROOT.TYPE}", settings.filters.allowedTypes.toTypedArray())
+            val allowedTypes = settings.filters.allowedTypes.toTypedArray()
+            not().`in`("${ReadReceiptsSummaryEntityFields.TIMELINE_EVENT}.${TimelineEventEntityFields.ROOT.TYPE}", allowedTypes)
             needOr = true
         }
         if (settings.filters.filterUseless) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineHiddenReadReceipts.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineHiddenReadReceipts.kt
@@ -151,23 +151,23 @@ internal class TimelineHiddenReadReceipts constructor(private val readReceiptsSu
     private fun RealmQuery<ReadReceiptsSummaryEntity>.filterReceiptsWithSettings(): RealmQuery<ReadReceiptsSummaryEntity> {
         beginGroup()
         var needOr = false
-        if (settings.filterTypes) {
-            not().`in`("${ReadReceiptsSummaryEntityFields.TIMELINE_EVENT}.${TimelineEventEntityFields.ROOT.TYPE}", settings.allowedTypes.toTypedArray())
+        if (settings.filters.filterTypes) {
+            not().`in`("${ReadReceiptsSummaryEntityFields.TIMELINE_EVENT}.${TimelineEventEntityFields.ROOT.TYPE}", settings.filters.allowedTypes.toTypedArray())
             needOr = true
         }
-        if (settings.filterUseless) {
+        if (settings.filters.filterUseless) {
             if (needOr) or()
             equalTo("${ReadReceiptsSummaryEntityFields.TIMELINE_EVENT}.${TimelineEventEntityFields.ROOT.IS_USELESS}", true)
             needOr = true
         }
-        if (settings.filterEdits) {
+        if (settings.filters.filterEdits) {
             if (needOr) or()
             like("${ReadReceiptsSummaryEntityFields.TIMELINE_EVENT}.${TimelineEventEntityFields.ROOT.CONTENT}", TimelineEventFilter.Content.EDIT)
             or()
             like("${ReadReceiptsSummaryEntityFields.TIMELINE_EVENT}.${TimelineEventEntityFields.ROOT.CONTENT}", TimelineEventFilter.Content.RESPONSE)
             needOr = true
         }
-        if (settings.filterRedacted) {
+        if (settings.filters.filterRedacted) {
             if (needOr) or()
             like("${ReadReceiptsSummaryEntityFields.TIMELINE_EVENT}.${TimelineEventEntityFields.ROOT.UNSIGNED_DATA}", TimelineEventFilter.Unsigned.REDACTED)
         }

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -41,7 +41,7 @@ def getVersionCode() {
     if (gitBranchName() == "develop") {
         return generateVersionCodeFromTimestamp()
     } else {
-        return generateVersionCodeFromTimestamp()
+        return generateVersionCodeFromVersionName()
     }
 }
 

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -41,7 +41,7 @@ def getVersionCode() {
     if (gitBranchName() == "develop") {
         return generateVersionCodeFromTimestamp()
     } else {
-        return generateVersionCodeFromVersionName()
+        return generateVersionCodeFromTimestamp()
     }
 }
 

--- a/vector/src/main/java/im/vector/app/core/resources/UserPreferencesProvider.kt
+++ b/vector/src/main/java/im/vector/app/core/resources/UserPreferencesProvider.kt
@@ -44,5 +44,4 @@ class UserPreferencesProvider @Inject constructor(private val vectorPreferences:
     fun shouldShowRoomMemberStateEvents(): Boolean {
         return vectorPreferences.showRoomMemberStateEvents()
     }
-
 }

--- a/vector/src/main/java/im/vector/app/core/resources/UserPreferencesProvider.kt
+++ b/vector/src/main/java/im/vector/app/core/resources/UserPreferencesProvider.kt
@@ -40,4 +40,9 @@ class UserPreferencesProvider @Inject constructor(private val vectorPreferences:
     fun neverShowLongClickOnRoomHelpAgain() {
         vectorPreferences.neverShowLongClickOnRoomHelpAgain()
     }
+
+    fun shouldShowRoomMemberStateEvents(): Boolean {
+        return vectorPreferences.showRoomMemberStateEvents()
+    }
+
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
@@ -31,7 +31,6 @@ import im.vector.app.R
 import im.vector.app.core.extensions.exhaustive
 import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.core.resources.StringProvider
-import im.vector.app.core.resources.UserPreferencesProvider
 import im.vector.app.core.utils.subscribeLogError
 import im.vector.app.features.call.WebRtcPeerConnectionManager
 import im.vector.app.features.command.CommandParser
@@ -40,7 +39,6 @@ import im.vector.app.features.crypto.verification.SupportedVerificationMethodsPr
 import im.vector.app.features.home.room.detail.composer.rainbow.RainbowGenerator
 import im.vector.app.features.home.room.detail.sticker.StickerPickerActionHandler
 import im.vector.app.features.home.room.detail.timeline.helper.RoomSummaryHolder
-import im.vector.app.features.home.room.detail.timeline.helper.TimelineDisplayableEvents
 import im.vector.app.features.home.room.detail.timeline.helper.TimelineSettingsFactory
 import im.vector.app.features.home.room.typing.TypingHelper
 import im.vector.app.features.powerlevel.PowerLevelsObservableFactory
@@ -87,8 +85,6 @@ import org.matrix.android.sdk.api.session.room.read.ReadService
 import org.matrix.android.sdk.api.session.room.send.UserDraft
 import org.matrix.android.sdk.api.session.room.timeline.Timeline
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
-import org.matrix.android.sdk.api.session.room.timeline.TimelineEventFilters
-import org.matrix.android.sdk.api.session.room.timeline.TimelineSettings
 import org.matrix.android.sdk.api.session.room.timeline.getTextEditableContent
 import org.matrix.android.sdk.api.session.widgets.model.Widget
 import org.matrix.android.sdk.api.session.widgets.model.WidgetType

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
@@ -62,8 +62,8 @@ import org.matrix.android.sdk.api.query.QueryStringValue
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.crypto.MXCryptoError
 import org.matrix.android.sdk.api.session.events.model.EventType
-import org.matrix.android.sdk.api.session.events.model.isAttachmentMessage
 import org.matrix.android.sdk.api.session.events.model.LocalEcho
+import org.matrix.android.sdk.api.session.events.model.isAttachmentMessage
 import org.matrix.android.sdk.api.session.events.model.isTextMessage
 import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.events.model.toModel
@@ -86,6 +86,7 @@ import org.matrix.android.sdk.api.session.room.read.ReadService
 import org.matrix.android.sdk.api.session.room.send.UserDraft
 import org.matrix.android.sdk.api.session.room.timeline.Timeline
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
+import org.matrix.android.sdk.api.session.room.timeline.TimelineEventFilters
 import org.matrix.android.sdk.api.session.room.timeline.TimelineSettings
 import org.matrix.android.sdk.api.session.room.timeline.getTextEditableContent
 import org.matrix.android.sdk.api.session.widgets.model.Widget
@@ -122,19 +123,23 @@ class RoomDetailViewModel @AssistedInject constructor(
     private val invisibleEventsObservable = BehaviorRelay.create<RoomDetailAction.TimelineEventTurnsInvisible>()
     private val visibleEventsObservable = BehaviorRelay.create<RoomDetailAction.TimelineEventTurnsVisible>()
     private val timelineSettings = if (userPreferencesProvider.shouldShowHiddenEvents()) {
-        TimelineSettings(30,
-                filterEdits = false,
-                filterRedacted = userPreferencesProvider.shouldShowRedactedMessages().not(),
-                filterUseless = false,
-                filterTypes = false,
+        TimelineSettings(
+                initialSize = 30,
+                filters = TimelineEventFilters(
+                        filterEdits = false,
+                        filterRedacted = userPreferencesProvider.shouldShowRedactedMessages().not(),
+                        filterUseless = false,
+                        filterTypes = false),
                 buildReadReceipts = userPreferencesProvider.shouldShowReadReceipts())
     } else {
-        TimelineSettings(30,
-                filterEdits = true,
-                filterRedacted = userPreferencesProvider.shouldShowRedactedMessages().not(),
-                filterUseless = true,
-                filterTypes = true,
-                allowedTypes = TimelineDisplayableEvents.DISPLAYABLE_TYPES,
+        TimelineSettings(
+                initialSize = 30,
+                filters = TimelineEventFilters(
+                        filterEdits = true,
+                        filterRedacted = userPreferencesProvider.shouldShowRedactedMessages().not(),
+                        filterUseless = true,
+                        filterTypes = true,
+                        allowedTypes = TimelineDisplayableEvents.DISPLAYABLE_TYPES),
                 buildReadReceipts = userPreferencesProvider.shouldShowReadReceipts())
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineSettingsFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineSettingsFactory.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home.room.detail.timeline.helper
+
+import im.vector.app.core.resources.UserPreferencesProvider
+import org.matrix.android.sdk.api.session.events.model.EventType
+import org.matrix.android.sdk.api.session.room.timeline.TimelineEventFilters
+import org.matrix.android.sdk.api.session.room.timeline.TimelineSettings
+import javax.inject.Inject
+
+class TimelineSettingsFactory @Inject constructor(private val userPreferencesProvider: UserPreferencesProvider) {
+
+    fun create(): TimelineSettings {
+        return if (userPreferencesProvider.shouldShowHiddenEvents()) {
+            TimelineSettings(
+                    initialSize = 30,
+                    filters = TimelineEventFilters(
+                            filterEdits = false,
+                            filterRedacted = userPreferencesProvider.shouldShowRedactedMessages().not(),
+                            filterUseless = false,
+                            filterTypes = false),
+                    buildReadReceipts = userPreferencesProvider.shouldShowReadReceipts())
+        } else {
+            val allowedTypes = TimelineDisplayableEvents.DISPLAYABLE_TYPES.filterDisplayableTypes()
+            TimelineSettings(
+                    initialSize = 30,
+                    filters = TimelineEventFilters(
+                            filterEdits = true,
+                            filterRedacted = userPreferencesProvider.shouldShowRedactedMessages().not(),
+                            filterUseless = true,
+                            filterTypes = true,
+                            allowedTypes = allowedTypes),
+                    buildReadReceipts = userPreferencesProvider.shouldShowReadReceipts())
+        }
+    }
+
+    private fun List<String>.filterDisplayableTypes(): List<String> {
+        return filter { type ->
+            when (type) {
+                EventType.STATE_ROOM_MEMBER -> userPreferencesProvider.shouldShowRoomMemberStateEvents()
+                else                        -> true
+            }
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -93,6 +93,7 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         private const val SETTINGS_12_24_TIMESTAMPS_KEY = "SETTINGS_12_24_TIMESTAMPS_KEY"
         private const val SETTINGS_SHOW_READ_RECEIPTS_KEY = "SETTINGS_SHOW_READ_RECEIPTS_KEY"
         private const val SETTINGS_SHOW_REDACTED_KEY = "SETTINGS_SHOW_REDACTED_KEY"
+        private const val SETTINGS_SHOW_ROOM_MEMBER_STATE_EVENTS_KEY = "SETTINGS_SHOW_ROOM_MEMBER_STATE_EVENTS_KEY"
         private const val SETTINGS_SHOW_JOIN_LEAVE_MESSAGES_KEY = "SETTINGS_SHOW_JOIN_LEAVE_MESSAGES_KEY"
         private const val SETTINGS_SHOW_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY = "SETTINGS_SHOW_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY"
         private const val SETTINGS_VIBRATE_ON_MENTION_KEY = "SETTINGS_VIBRATE_ON_MENTION_KEY"
@@ -195,6 +196,7 @@ class VectorPreferences @Inject constructor(private val context: Context) {
                 SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY,
                 SETTINGS_12_24_TIMESTAMPS_KEY,
                 SETTINGS_SHOW_READ_RECEIPTS_KEY,
+                SETTINGS_SHOW_ROOM_MEMBER_STATE_EVENTS_KEY,
                 SETTINGS_SHOW_JOIN_LEAVE_MESSAGES_KEY,
                 SETTINGS_SHOW_AVATAR_DISPLAY_NAME_CHANGES_MESSAGES_KEY,
                 SETTINGS_MEDIA_SAVING_PERIOD_KEY,
@@ -341,6 +343,15 @@ class VectorPreferences @Inject constructor(private val context: Context) {
      */
     fun displayTimeIn12hFormat(): Boolean {
         return defaultPrefs.getBoolean(SETTINGS_12_24_TIMESTAMPS_KEY, false)
+    }
+
+    /**
+     * Tells if all room member state events should be shown in the messages list.
+     *
+     * @return true all room member state events should be shown in the messages list.
+     */
+    fun showRoomMemberStateEvents(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_SHOW_ROOM_MEMBER_STATE_EVENTS_KEY, true)
     }
 
     /**

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -857,6 +857,8 @@
     <string name="settings_12_24_timestamps">Show timestamps in 12-hour format</string>
     <string name="settings_show_read_receipts">Show read receipts</string>
     <string name="settings_show_read_receipts_summary">Click on the read receipts for a detailed list.</string>
+    <string name="settings_show_room_member_state_events">Show room member state events</string>
+    <string name="settings_show_room_member_state_events_summary">Includes invite/join/left/kick/ban events and avatar/display name changes.</string>
     <string name="settings_show_join_leave_messages">Show join and leave events</string>
     <string name="settings_show_join_leave_messages_summary">Invites, kicks, and bans are unaffected.</string>
     <string name="settings_show_avatar_display_name_changes_messages">Show account events</string>

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -78,6 +78,12 @@
 
         <im.vector.app.core.preference.VectorSwitchPreference
             android:defaultValue="true"
+            android:key="SETTINGS_SHOW_ROOM_MEMBER_STATE_EVENTS_KEY"
+            android:summary="@string/settings_show_room_member_state_events_summary"
+            android:title="@string/settings_show_room_member_state_events" />
+
+        <im.vector.app.core.preference.VectorSwitchPreference
+            android:defaultValue="true"
             android:key="SETTINGS_SHOW_JOIN_LEAVE_MESSAGES_KEY"
             android:summary="@string/settings_show_join_leave_messages_summary"
             android:title="@string/settings_show_join_leave_messages"


### PR DESCRIPTION
This PR changes filtering for RoomSummary unread/preview and allow users to show/hide room member state events. 
This is a simple one waiting for filtering to be fully reworked.

Related to theses issues: 
 - Rooms incorrectly marked as unread (#588)
 - Option to hide joins/parts (#1231) 