### PR TITLE
Create parent class for all MatrixWorker

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/pushers/AddHttpPusherWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/pushers/AddHttpPusherWorker.kt
@@ -17,10 +17,10 @@
 package org.matrix.android.sdk.internal.session.pushers
 
 import android.content.Context
-import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.squareup.moshi.JsonClass
 import com.zhuinden.monarchy.Monarchy
+import org.greenrobot.eventbus.EventBus
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.session.pushers.PusherState
 import org.matrix.android.sdk.internal.database.mapper.toEntity
@@ -28,16 +28,14 @@ import org.matrix.android.sdk.internal.database.model.PusherEntity
 import org.matrix.android.sdk.internal.database.query.where
 import org.matrix.android.sdk.internal.di.SessionDatabase
 import org.matrix.android.sdk.internal.network.executeRequest
+import org.matrix.android.sdk.internal.session.SessionComponent
 import org.matrix.android.sdk.internal.util.awaitTransaction
+import org.matrix.android.sdk.internal.worker.SessionSafeCoroutineWorker
 import org.matrix.android.sdk.internal.worker.SessionWorkerParams
-import org.matrix.android.sdk.internal.worker.WorkerParamsFactory
-import org.matrix.android.sdk.internal.worker.getSessionComponent
-import org.greenrobot.eventbus.EventBus
-import timber.log.Timber
 import javax.inject.Inject
 
 internal class AddHttpPusherWorker(context: Context, params: WorkerParameters)
-    : CoroutineWorker(context, params) {
+    : SessionSafeCoroutineWorker<AddHttpPusherWorker.Params>(context, params, Params::class.java) {
 
     @JsonClass(generateAdapter = true)
     internal data class Params(
@@ -50,14 +48,11 @@ internal class AddHttpPusherWorker(context: Context, params: WorkerParameters)
     @Inject @SessionDatabase lateinit var monarchy: Monarchy
     @Inject lateinit var eventBus: EventBus
 
-    override suspend fun doWork(): Result {
-        val params = WorkerParamsFactory.fromData<Params>(inputData)
-                ?: return Result.failure()
-                        .also { Timber.e("Unable to parse work parameters") }
+    override fun injectWith(injector: SessionComponent) {
+        injector.inject(this)
+    }
 
-        val sessionComponent = getSessionComponent(params.sessionId) ?: return Result.success()
-        sessionComponent.inject(this)
-
+    override suspend fun doSafeWork(params: Params): Result {
         val pusher = params.pusher
 
         if (pusher.pushKey.isBlank()) {
@@ -80,6 +75,10 @@ internal class AddHttpPusherWorker(context: Context, params: WorkerParameters)
                 }
             }
         }
+    }
+
+    override fun buildErrorParams(params: Params, message: String): Params {
+        return params.copy(lastFailureMessage = params.lastFailureMessage ?: message)
     }
 
     private suspend fun setPusher(pusher: JsonPusher) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/relation/SendRelationWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/relation/SendRelationWorker.kt
@@ -17,7 +17,6 @@
 package org.matrix.android.sdk.internal.session.room.relation
 
 import android.content.Context
-import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.squareup.moshi.JsonClass
 import org.greenrobot.eventbus.EventBus
@@ -27,17 +26,17 @@ import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.room.model.relation.ReactionContent
 import org.matrix.android.sdk.api.session.room.model.relation.ReactionInfo
 import org.matrix.android.sdk.internal.network.executeRequest
+import org.matrix.android.sdk.internal.session.SessionComponent
 import org.matrix.android.sdk.internal.session.room.RoomAPI
 import org.matrix.android.sdk.internal.session.room.send.LocalEchoRepository
 import org.matrix.android.sdk.internal.session.room.send.SendResponse
+import org.matrix.android.sdk.internal.worker.SessionSafeCoroutineWorker
 import org.matrix.android.sdk.internal.worker.SessionWorkerParams
-import org.matrix.android.sdk.internal.worker.WorkerParamsFactory
-import org.matrix.android.sdk.internal.worker.getSessionComponent
-import timber.log.Timber
 import javax.inject.Inject
 
 // TODO This is not used. Delete?
-internal class SendRelationWorker(context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
+internal class SendRelationWorker(context: Context, params: WorkerParameters)
+    : SessionSafeCoroutineWorker<SendRelationWorker.Params>(context, params, Params::class.java) {
 
     @JsonClass(generateAdapter = true)
     internal data class Params(
@@ -52,19 +51,11 @@ internal class SendRelationWorker(context: Context, params: WorkerParameters) : 
     @Inject lateinit var eventBus: EventBus
     @Inject lateinit var localEchoRepository: LocalEchoRepository
 
-    override suspend fun doWork(): Result {
-        val params = WorkerParamsFactory.fromData<Params>(inputData)
-                ?: return Result.failure()
+    override fun injectWith(injector: SessionComponent) {
+        injector.inject(this)
+    }
 
-        if (params.lastFailureMessage != null) {
-            // Transmit the error
-            return Result.success(inputData)
-                    .also { Timber.e("Work cancelled due to input error from parent") }
-        }
-
-        val sessionComponent = getSessionComponent(params.sessionId) ?: return Result.success()
-        sessionComponent.inject(this)
-
+    override suspend fun doSafeWork(params: Params): Result {
         val localEvent = localEchoRepository.getUpToDateEcho(params.eventId)
         if (localEvent?.eventId == null) {
             return Result.failure()
@@ -87,6 +78,10 @@ internal class SendRelationWorker(context: Context, params: WorkerParameters) : 
                 }
             }
         }
+    }
+
+    override fun buildErrorParams(params: Params, message: String): Params {
+        return params.copy(lastFailureMessage = params.lastFailureMessage ?: message)
     }
 
     private suspend fun sendRelation(roomId: String, relationType: String, relatedEventId: String, localEvent: Event) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/EncryptEventWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/EncryptEventWorker.kt
@@ -18,7 +18,6 @@
 package org.matrix.android.sdk.internal.session.room.send
 
 import android.content.Context
-import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.squareup.moshi.JsonClass
 import org.matrix.android.sdk.api.failure.Failure
@@ -31,10 +30,11 @@ import org.matrix.android.sdk.internal.crypto.MXCRYPTO_ALGORITHM_MEGOLM
 import org.matrix.android.sdk.internal.crypto.MXEventDecryptionResult
 import org.matrix.android.sdk.internal.crypto.model.MXEncryptEventContentResult
 import org.matrix.android.sdk.internal.database.mapper.ContentMapper
+import org.matrix.android.sdk.internal.session.SessionComponent
 import org.matrix.android.sdk.internal.util.awaitCallback
+import org.matrix.android.sdk.internal.worker.SessionSafeCoroutineWorker
 import org.matrix.android.sdk.internal.worker.SessionWorkerParams
 import org.matrix.android.sdk.internal.worker.WorkerParamsFactory
-import org.matrix.android.sdk.internal.worker.getSessionComponent
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -43,7 +43,7 @@ import javax.inject.Inject
  * Possible next worker    : Always [SendEventWorker]
  */
 internal class EncryptEventWorker(context: Context, params: WorkerParameters)
-    : CoroutineWorker(context, params) {
+    : SessionSafeCoroutineWorker<EncryptEventWorker.Params>(context, params, Params::class.java) {
 
     @JsonClass(generateAdapter = true)
     internal data class Params(
@@ -58,20 +58,12 @@ internal class EncryptEventWorker(context: Context, params: WorkerParameters)
     @Inject lateinit var localEchoRepository: LocalEchoRepository
     @Inject lateinit var cancelSendTracker: CancelSendTracker
 
-    override suspend fun doWork(): Result {
-        Timber.v("Start Encrypt work")
-        val params = WorkerParamsFactory.fromData<Params>(inputData)
-                ?: return Result.success()
+    override fun injectWith(injector: SessionComponent) {
+        injector.inject(this)
+    }
 
-        if (params.lastFailureMessage != null) {
-            // Transmit the error
-            return Result.success(inputData)
-                    .also { Timber.e("Work cancelled due to input error from parent") }
-        }
-
+    override suspend fun doSafeWork(params: Params): Result {
         Timber.v("## SendEvent: Start Encrypt work for event ${params.eventId}")
-        val sessionComponent = getSessionComponent(params.sessionId) ?: return Result.success()
-        sessionComponent.inject(this)
 
         val localEvent = localEchoRepository.getUpToDateEcho(params.eventId)
         if (localEvent?.eventId == null) {
@@ -147,5 +139,9 @@ internal class EncryptEventWorker(context: Context, params: WorkerParameters)
             )
             return Result.success(WorkerParamsFactory.toData(nextWorkerParams))
         }
+    }
+
+    override fun buildErrorParams(params: Params, message: String): Params {
+        return params.copy(lastFailureMessage = params.lastFailureMessage ?: message)
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/RedactEventWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/RedactEventWorker.kt
@@ -17,24 +17,24 @@
 package org.matrix.android.sdk.internal.session.room.send
 
 import android.content.Context
-import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.squareup.moshi.JsonClass
+import org.greenrobot.eventbus.EventBus
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.internal.network.executeRequest
+import org.matrix.android.sdk.internal.session.SessionComponent
 import org.matrix.android.sdk.internal.session.room.RoomAPI
+import org.matrix.android.sdk.internal.worker.SessionSafeCoroutineWorker
 import org.matrix.android.sdk.internal.worker.SessionWorkerParams
 import org.matrix.android.sdk.internal.worker.WorkerParamsFactory
-import org.matrix.android.sdk.internal.worker.getSessionComponent
-import org.greenrobot.eventbus.EventBus
-import timber.log.Timber
 import javax.inject.Inject
 
 /**
  * Possible previous worker: None
  * Possible next worker    : None
  */
-internal class RedactEventWorker(context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
+internal class RedactEventWorker(context: Context, params: WorkerParameters)
+    : SessionSafeCoroutineWorker<RedactEventWorker.Params>(context, params, Params::class.java) {
 
     @JsonClass(generateAdapter = true)
     internal data class Params(
@@ -49,19 +49,11 @@ internal class RedactEventWorker(context: Context, params: WorkerParameters) : C
     @Inject lateinit var roomAPI: RoomAPI
     @Inject lateinit var eventBus: EventBus
 
-    override suspend fun doWork(): Result {
-        val params = WorkerParamsFactory.fromData<Params>(inputData)
-                ?: return Result.failure()
+    override fun injectWith(injector: SessionComponent) {
+        injector.inject(this)
+    }
 
-        if (params.lastFailureMessage != null) {
-            // Transmit the error
-            return Result.success(inputData)
-                    .also { Timber.e("Work cancelled due to input error from parent") }
-        }
-
-        val sessionComponent = getSessionComponent(params.sessionId) ?: return Result.success()
-        sessionComponent.inject(this)
-
+    override suspend fun doSafeWork(params: Params): Result {
         val eventId = params.eventId
         return runCatching {
             executeRequest<SendResponse>(eventBus) {
@@ -89,5 +81,9 @@ internal class RedactEventWorker(context: Context, params: WorkerParameters) : C
                     }
                 }
         )
+    }
+
+    override fun buildErrorParams(params: Params, message: String): Params {
+        return params.copy(lastFailureMessage = params.lastFailureMessage ?: message)
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
@@ -131,7 +131,7 @@ internal class SyncResponseHandler @Inject constructor(@SessionDatabase private 
 
     /**
      * At the moment we don't get any group data through the sync, so we poll where every hour.
-       You can also force to refetch group data using [Group] API.
+     * You can also force to refetch group data using [Group] API.
      */
     private fun scheduleGroupDataFetchingIfNeeded(groupsSyncResponse: GroupsSyncResponse) {
         val groupIds = ArrayList<String>()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/worker/SessionSafeCoroutineWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/worker/SessionSafeCoroutineWorker.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.worker
+
+import android.content.Context
+import androidx.annotation.CallSuper
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import com.squareup.moshi.JsonClass
+import org.matrix.android.sdk.internal.session.SessionComponent
+import timber.log.Timber
+
+/**
+ * This worker should only sends Result.Success when added to a unique queue to avoid breaking the unique queue.
+ * This abstract class handle the cases of problem when parsing parameter, and forward the error if any to
+ * the next workers.
+ */
+internal abstract class SessionSafeCoroutineWorker<PARAM : SessionWorkerParams>(
+        context: Context,
+        workerParameters: WorkerParameters,
+        private val paramClass: Class<PARAM>
+) : CoroutineWorker(context, workerParameters) {
+
+    @JsonClass(generateAdapter = true)
+    internal data class ErrorData(
+            override val sessionId: String,
+            override val lastFailureMessage: String? = null
+    ) : SessionWorkerParams
+
+    final override suspend fun doWork(): Result {
+        val params = WorkerParamsFactory.fromData(paramClass, inputData)
+                ?: return buildErrorResult(null, "Unable to parse work parameters")
+                        .also { Timber.e("Unable to parse work parameters") }
+
+        return try {
+            val sessionComponent = getSessionComponent(params.sessionId)
+                    ?: return buildErrorResult(params, "No session")
+
+            // Make sure to inject before handling error as you may need some dependencies to process them.
+            injectWith(sessionComponent)
+            if (params.lastFailureMessage != null) {
+                // Forward error to the next workers
+                doOnError(params)
+            } else {
+                doSafeWork(params)
+            }
+        } catch (throwable: Throwable) {
+            buildErrorResult(params, throwable.localizedMessage ?: "error")
+        }
+    }
+
+    abstract fun injectWith(injector: SessionComponent)
+
+    /**
+     * Should only return Result.Success for workers added to a unique queue
+     */
+    abstract suspend fun doSafeWork(params: PARAM): Result
+
+    protected fun buildErrorResult(params: PARAM?, message: String): Result {
+        return Result.success(
+                if (params != null) {
+                    WorkerParamsFactory.toData(paramClass, buildErrorParams(params, message))
+                } else {
+                    WorkerParamsFactory.toData(ErrorData::class.java, ErrorData(sessionId = "", lastFailureMessage = message))
+                }
+        )
+    }
+
+    abstract fun buildErrorParams(params: PARAM, message: String): PARAM
+
+    /**
+     * This is called when the input parameters are correct, but contain an error from the previous worker.
+     */
+    @CallSuper
+    open fun doOnError(params: PARAM): Result {
+        // Forward the error
+        return Result.success(inputData)
+                .also { Timber.e("Work cancelled due to input error from parent") }
+    }
+
+    companion object {
+        fun hasFailed(outputData: Data): Boolean {
+            return WorkerParamsFactory.fromData(ErrorData::class.java, outputData)
+                    .let { it?.lastFailureMessage != null }
+        }
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/worker/WorkerParamsFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/worker/WorkerParamsFactory.kt
@@ -18,13 +18,14 @@
 package org.matrix.android.sdk.internal.worker
 
 import androidx.work.Data
+import com.squareup.moshi.Moshi
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.internal.di.MoshiProvider
 import org.matrix.android.sdk.internal.network.parsing.CheckNumberType
 
 internal object WorkerParamsFactory {
 
-    val moshi by lazy {
+    private val moshi: Moshi by lazy {
         // We are adding the CheckNumberType as we are serializing/deserializing multiple time in a row
         // and we lost typing information doing so.
         // We don't want this check to be done on all adapters, so we just add it here.
@@ -34,20 +35,24 @@ internal object WorkerParamsFactory {
                 .build()
     }
 
-    const val KEY = "WORKER_PARAMS_JSON"
+    private const val KEY = "WORKER_PARAMS_JSON"
 
-    inline fun <reified T> toData(params: T): Data {
-        val adapter = moshi.adapter(T::class.java)
+    inline fun <reified T> toData(params: T) = toData(T::class.java, params)
+
+    fun <T> toData(clazz: Class<T>, params: T): Data {
+        val adapter = moshi.adapter(clazz)
         val json = adapter.toJson(params)
         return Data.Builder().putString(KEY, json).build()
     }
 
-    inline fun <reified T> fromData(data: Data): T? = tryOrNull("Unable to parse work parameters") {
+    inline fun <reified T> fromData(data: Data) = fromData(T::class.java, data)
+
+    fun <T> fromData(clazz: Class<T>, data: Data): T? = tryOrNull("Unable to parse work parameters") {
         val json = data.getString(KEY)
         return if (json == null) {
             null
         } else {
-            val adapter = moshi.adapter(T::class.java)
+            val adapter = moshi.adapter(clazz)
             adapter.fromJson(json)
         }
     }


### PR DESCRIPTION
Trying to normalize the way we use worker, and also try to catch all possible Exception to avoid breaking worker chains.

Parsing Exception is dealt in @ganfra 's PR #2129 

This is really dirty, I cannot to parsing and buildErrorResult() in the parent class, so many duplicated code... Not very proud of it.