### PR TITLE
Visually disable call buttons/prohibit calling on insufficient permissions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Features ✨:
 
 Improvements 🙌:
  - Add "show password" in import Megolm keys dialog
+ - Visually disable call buttons in menu and prohibit calling when permissions are insufficient (#2112)
 
 Bugfix 🐛:
  - Long message cannot be sent/takes infinite time & blocks other messages #1397

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -610,6 +610,16 @@ class RoomDetailFragment @Inject constructor(
             it.isVisible = roomDetailViewModel.isMenuItemVisible(it.itemId)
         }
         withState(roomDetailViewModel) { state ->
+            // Set the visual state of the call buttons (voice/video) to enabled/disabled according to user permissions
+            val callButtonsEnabled = when (state.asyncRoomSummary.invoke()?.joinedMembersCount) {
+                1 -> false
+                2 -> state.isAllowedToStartWebRTCCall
+                else -> state.isAllowedToManageWidgets
+            }
+            setOf(R.id.voice_call, R.id.video_call).forEach {
+                menu.findItem(it).icon?.alpha = if (callButtonsEnabled) 0xFF else 0x40
+            }
+
             val matrixAppsMenuItem = menu.findItem(R.id.open_matrix_apps)
             val widgetsCount = state.activeRoomWidgets.invoke()?.size ?: 0
             if (widgetsCount > 0) {
@@ -687,6 +697,8 @@ class RoomDetailFragment @Inject constructor(
                     //                            webRtcPeerConnectionManager.endCall()
                     //                            safeStartCall(it, isVideoCall)
                     //                        }
+                } else if (!state.isAllowedToStartWebRTCCall) {
+                    showDialogWithMessage(getString(R.string.no_permissions_to_start_webrtc_call))
                 } else {
                     safeStartCall(isVideoCall)
                 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
@@ -181,10 +181,12 @@ class RoomDetailViewModel @AssistedInject constructor(
                 .subscribe {
                     val canSendMessage = PowerLevelsHelper(it).isUserAllowedToSend(session.myUserId, false, EventType.MESSAGE)
                     val isAllowedToManageWidgets = session.widgetService().hasPermissionsToHandleWidgets(room.roomId)
+                    val isAllowedToStartWebRTCCall = PowerLevelsHelper(it).isUserAllowedToSend(session.myUserId, false, EventType.CALL_INVITE)
                     setState {
                         copy(
                                 canSendMessage = canSendMessage,
-                                isAllowedToManageWidgets = isAllowedToManageWidgets
+                                isAllowedToManageWidgets = isAllowedToManageWidgets,
+                                isAllowedToStartWebRTCCall = isAllowedToStartWebRTCCall
                         )
                     }
                 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -67,7 +67,8 @@ data class RoomDetailViewState(
         val canShowJumpToReadMarker: Boolean = true,
         val changeMembershipState: ChangeMembershipState = ChangeMembershipState.Unknown,
         val canSendMessage: Boolean = true,
-        val isAllowedToManageWidgets: Boolean = false
+        val isAllowedToManageWidgets: Boolean = false,
+        val isAllowedToStartWebRTCCall: Boolean = true
 ) : MvRxState {
 
     constructor(args: RoomDetailArgs) : this(

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
     <string name="missing_permissions_error">"Due to missing permissions, this action is not possible.</string>
     <string name="missing_permissions_to_start_conf_call">You need permission to invite to start a conference in this room</string>
     <string name="no_permissions_to_start_conf_call">You do not have permission to start a conference call in this room</string>
+    <string name="no_permissions_to_start_webrtc_call">You do not have permission to start a call in this room</string>
     <string name="conference_call_in_progress">A conference is already in progress!</string>
     <string name="video_meeting">Start video meeting</string>
     <string name="audio_meeting">Start audio meeting</string>


### PR DESCRIPTION
Visually disables call buttons when either
- the room has only one member
- in rooms with 2 participants you have no permission to send `m.call.invite` events
- in rooms with 3 or more participants you don't have permission to manage widgets.
Click/select handlers are still attached.
This is just a suggestion on how to handle #2112 but I am of course open for better ways to deal with call permissions. 

# Pull Request Checklist
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
![image](https://user-images.githubusercontent.com/18017241/93690833-7ec86480-fadd-11ea-86ff-1e6588c3cdee.png)
![image](https://user-images.githubusercontent.com/18017241/93690837-999ad900-fadd-11ea-92ee-8a423379e6ce.png)
