### PR TITLE
Feature/fix filtering redacted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Bugfix 🐛:
  - Long message cannot be sent/takes infinite time & blocks other messages #1397
  - User Verification in DM not working
  - Manual import of Megolm keys does back up the imported keys
+ - Auto scrolling to the latest message when sending (#2094)
 
 Translations 🗣:
  -


### PR DESCRIPTION
There was an issue with the filtering condition of redacted events in timeline. It was causing this issue => https://github.com/vector-im/element-android/issues/2094

Also, filtering was not working for changes on already built events.