### PR TITLE
Fix Splash screen layout, especially on small screens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Improvements 🙌:
  -
 
 Bugfix 🐛:
- -
+ - Fix Splash layout on small screens
 
 Translations 🗣:
  -

--- a/vector/src/main/java/im/vector/app/features/login/LoginActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginActivity.kt
@@ -146,8 +146,10 @@ open class LoginActivity : VectorBaseActivity(), ToolbarConfigurable, UnlockedAc
                         LoginServerSelectionFragment::class.java,
                         option = { ft ->
                             findViewById<View?>(R.id.loginSplashLogo)?.let { ft.addSharedElement(it, ViewCompat.getTransitionName(it) ?: "") }
-                            findViewById<View?>(R.id.loginSplashTitle)?.let { ft.addSharedElement(it, ViewCompat.getTransitionName(it) ?: "") }
-                            findViewById<View?>(R.id.loginSplashSubmit)?.let { ft.addSharedElement(it, ViewCompat.getTransitionName(it) ?: "") }
+                            // Disable transition of text
+                            // findViewById<View?>(R.id.loginSplashTitle)?.let { ft.addSharedElement(it, ViewCompat.getTransitionName(it) ?: "") }
+                            // No transition here now actually
+                            // findViewById<View?>(R.id.loginSplashSubmit)?.let { ft.addSharedElement(it, ViewCompat.getTransitionName(it) ?: "") }
                             // TODO Disabled because it provokes a flickering
                             // ft.setCustomAnimations(enterAnim, exitAnim, popEnterAnim, popExitAnim)
                         })

--- a/vector/src/main/res/layout/fragment_login_splash.xml
+++ b/vector/src/main/res/layout/fragment_login_splash.xml
@@ -3,144 +3,187 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?riotx_background">
+    android:background="?riotx_background"
+    android:paddingStart="36dp"
+    android:paddingTop="@dimen/layout_vertical_margin"
+    android:paddingEnd="36dp"
+    android:paddingBottom="@dimen/layout_vertical_margin">
 
-    <androidx.core.widget.NestedScrollView
+    <!-- Strategy: 5 Spaces are used to spread the remaining space, using weight -->
+
+    <Space
+        android:id="@+id/loginSplashSpace1"
         android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/loginSplashLogoContainer"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="spread_inside"
+        app:layout_constraintVertical_weight="4" />
+
+    <LinearLayout
+        android:id="@+id/loginSplashLogoContainer"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toTopOf="@+id/loginSplashSpace2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@+id/loginSplashSpace1">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            style="@style/LoginContainer"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+        <ImageView
+            android:id="@+id/loginSplashLogo"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:src="@drawable/element_logo_green"
+            android:transitionName="loginLogoTransition" />
 
-            <ImageView
-                android:id="@+id/loginSplashLogo"
-                android:layout_width="64dp"
-                android:layout_height="64dp"
-                android:src="@drawable/element_logo_green"
-                android:transitionName="loginLogoTransition"
-                app:layout_constraintBottom_toTopOf="@+id/logoType"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_chainStyle="packed" />
+        <ImageView
+            android:id="@+id/logoType"
+            android:layout_width="wrap_content"
+            android:layout_height="44dp"
+            android:layout_marginTop="8dp"
+            android:src="@drawable/element_logotype"
+            android:tint="?colorAccent" />
 
-            <ImageView
-                android:id="@+id/logoType"
-                android:layout_width="wrap_content"
-                android:layout_height="44dp"
-                android:layout_marginTop="8dp"
-                android:src="@drawable/element_logotype"
-                android:tint="?colorAccent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/loginSplashLogo" />
+    </LinearLayout>
 
-            <TextView
-                android:id="@+id/loginSplashTitle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="32dp"
-                android:gravity="center"
-                android:text="@string/login_splash_title"
-                android:textAppearance="@style/TextAppearance.Vector.Login.Title"
-                android:transitionName="loginTitleTransition"
-                app:layout_constraintBottom_toTopOf="@+id/loginSplashText1"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/logoType" />
+    <Space
+        android:id="@+id/loginSplashSpace2"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/loginSplashTitle"
+        app:layout_constraintTop_toBottomOf="@+id/loginSplashLogoContainer"
+        app:layout_constraintVertical_weight="1" />
 
-            <ImageView
-                android:id="@+id/loginSplashPicto1"
-                android:layout_width="32dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="2dp"
-                android:importantForAccessibility="no"
-                android:src="@drawable/ic_login_splash_message_circle"
-                android:tint="?riotx_text_secondary"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/loginSplashText1" />
+    <TextView
+        android:id="@+id/loginSplashTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/login_splash_title"
+        android:textAppearance="@style/TextAppearance.Vector.Login.Title"
+        android:transitionName="loginTitleTransition"
+        app:layout_constraintBottom_toTopOf="@+id/loginSplashSpace3"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/loginSplashSpace2" />
 
-            <TextView
-                android:id="@+id/loginSplashText1"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="96dp"
-                android:gravity="start"
-                android:text="@string/login_splash_text1"
-                android:textAppearance="@style/TextAppearance.Vector.Login.Text"
-                app:layout_constraintBottom_toTopOf="@+id/loginSplashText2"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/loginSplashPicto1"
-                app:layout_constraintTop_toBottomOf="@+id/loginSplashTitle" />
+    <Space
+        android:id="@+id/loginSplashSpace3"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/loginSplashContent"
+        app:layout_constraintTop_toBottomOf="@+id/loginSplashTitle"
+        app:layout_constraintVertical_weight="2" />
 
-            <ImageView
-                android:id="@+id/loginSplashPicto2"
-                android:layout_width="32dp"
-                android:layout_height="wrap_content"
-                android:importantForAccessibility="no"
-                android:src="@drawable/ic_login_splash_lock"
-                android:tint="?riotx_text_secondary"
-                app:layout_constraintStart_toStartOf="@id/loginSplashPicto1"
-                app:layout_constraintTop_toTopOf="@+id/loginSplashText2" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/loginSplashContent"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@+id/loginSplashSpace4"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/loginSplashSpace3">
 
-            <TextView
-                android:id="@+id/loginSplashText2"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:gravity="start"
-                android:text="@string/login_splash_text2"
-                android:textAppearance="@style/TextAppearance.Vector.Login.Text"
-                app:layout_constraintBottom_toTopOf="@id/loginSplashText3"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@id/loginSplashText1"
-                app:layout_constraintTop_toBottomOf="@+id/loginSplashText1" />
+        <ImageView
+            android:id="@+id/loginSplashPicto1"
+            android:layout_width="32dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="2dp"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_login_splash_message_circle"
+            android:tint="?riotx_text_secondary"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/loginSplashText1" />
 
-            <ImageView
-                android:id="@+id/loginSplashPicto3"
-                android:layout_width="32dp"
-                android:layout_height="wrap_content"
-                android:importantForAccessibility="no"
-                android:src="@drawable/ic_login_splash_sliders"
-                android:tint="?riotx_text_secondary"
-                app:layout_constraintStart_toStartOf="@+id/loginSplashPicto1"
-                app:layout_constraintTop_toTopOf="@+id/loginSplashText3" />
+        <TextView
+            android:id="@+id/loginSplashText1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:gravity="start"
+            android:text="@string/login_splash_text1"
+            android:textAppearance="@style/TextAppearance.Vector.Login.Text"
+            app:layout_constraintBottom_toTopOf="@+id/loginSplashText2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/loginSplashPicto1"
+            app:layout_constraintTop_toTopOf="parent" />
 
-            <TextView
-                android:id="@+id/loginSplashText3"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:gravity="start"
-                android:text="@string/login_splash_text3"
-                android:textAppearance="@style/TextAppearance.Vector.Login.Text"
-                app:layout_constraintBottom_toTopOf="@+id/loginSplashSubmit"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/loginSplashText1"
-                app:layout_constraintTop_toBottomOf="@+id/loginSplashText2" />
+        <ImageView
+            android:id="@+id/loginSplashPicto2"
+            android:layout_width="32dp"
+            android:layout_height="wrap_content"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_login_splash_lock"
+            android:tint="?riotx_text_secondary"
+            app:layout_constraintStart_toStartOf="@id/loginSplashPicto1"
+            app:layout_constraintTop_toTopOf="@+id/loginSplashText2" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/loginSplashSubmit"
-                style="@style/Style.Vector.Login.Button"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="48dp"
-                android:text="@string/login_splash_submit"
-                android:transitionName="loginSubmitTransition"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/loginSplashText3" />
+        <TextView
+            android:id="@+id/loginSplashText2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:gravity="start"
+            android:text="@string/login_splash_text2"
+            android:textAppearance="@style/TextAppearance.Vector.Login.Text"
+            app:layout_constraintBottom_toTopOf="@id/loginSplashText3"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@id/loginSplashText1"
+            app:layout_constraintTop_toBottomOf="@+id/loginSplashText1" />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        <ImageView
+            android:id="@+id/loginSplashPicto3"
+            android:layout_width="32dp"
+            android:layout_height="wrap_content"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_login_splash_sliders"
+            android:tint="?riotx_text_secondary"
+            app:layout_constraintStart_toStartOf="@+id/loginSplashPicto1"
+            app:layout_constraintTop_toTopOf="@+id/loginSplashText3" />
 
-    </androidx.core.widget.NestedScrollView>
+        <TextView
+            android:id="@+id/loginSplashText3"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:gravity="start"
+            android:text="@string/login_splash_text3"
+            android:textAppearance="@style/TextAppearance.Vector.Login.Text"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/loginSplashText1"
+            app:layout_constraintTop_toBottomOf="@+id/loginSplashText2" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <Space
+        android:id="@+id/loginSplashSpace4"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/loginSplashSubmit"
+        app:layout_constraintTop_toBottomOf="@+id/loginSplashContent"
+        app:layout_constraintVertical_weight="2" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/loginSplashSubmit"
+        style="@style/Style.Vector.Login.Button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/login_splash_submit"
+        android:transitionName="loginSubmitTransition"
+        app:layout_constraintBottom_toTopOf="@+id/loginSplashSpace5"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/loginSplashSpace4" />
+
+    <Space
+        android:id="@+id/loginSplashSpace5"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/loginSplashSubmit"
+        app:layout_constraintVertical_weight="4" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/main/res/values/styles_login.xml
+++ b/vector/src/main/res/values/styles_login.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="LoginContainer">
-        <item name="android:paddingTop">32dp</item>
-        <item name="android:paddingBottom">32dp</item>
-        <item name="android:paddingStart">36dp</item>
-        <item name="android:paddingEnd">36dp</item>
-    </style>
-
     <item name="loginLogo" type="id" />
     <item name="loginFormScrollView" type="id" />
     <item name="loginFormContainer" type="id" />


### PR DESCRIPTION
Rely only on ConstraintLayout (no more scroll view) for the first displayed screen of the app.

## On small screen (Nexus One) -> BUG FIX, no need to scroll anymore

Before <img width="239" alt="Screenshot 2020-09-25 at 06 29 03" src="https://user-images.githubusercontent.com/3940906/94231238-e29ac500-ff03-11ea-9bbe-b9475bcd9078.png"> After <img width="242" alt="image" src="https://user-images.githubusercontent.com/3940906/94231284-f6462b80-ff03-11ea-9e94-101f03606e0f.png">

## On big screen (S9+) -> Nearly no impact (sorry screenshot not in the same language)

Before <img width="250" alt="Screenshot 2020-09-25 at 07 28 29" src="https://user-images.githubusercontent.com/3940906/94231418-46bd8900-ff04-11ea-8ef6-1a4325351ecc.png"> After <img width="250" alt="image" src="https://user-images.githubusercontent.com/3940906/94231371-28f02400-ff04-11ea-888c-797375fedf19.png">

### Also rendering OK in landscape, for tablet it could be better, but it's not worth that we we have now