### PR TITLE
Add "jump to read receipt" and "mention" actions from room member detail screen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Improvements 🙌:
  - Add a menu item in the timeline as a shortcut to invite user (#2171)
  - Drawer: move settings access and add sign out action (#2171)
  - Filter room member (and banned users) by name (#2184)
+ - Implement "Jump to read receipt" and "Mention" actions on the room member profile screen
 
 Bugfix 🐛:
  - Improve support for image/audio/video/file selection with intent changes (#1376)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/read/ReadService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/read/ReadService.kt
@@ -65,11 +65,11 @@ interface ReadService {
 
     /**
      * Get the eventId where the read receipt for the provided user is
-     * @param otherUserId the userId param to look for
+     * @param userId the id of the user to look for
      *
      * @return the eventId where the read receipt for the provided user is attached, or null if not found
      */
-    fun getUserReadReceipt(otherUserId: String): String?
+    fun getUserReadReceipt(userId: String): String?
 
     /**
      * Returns a live list of read receipts for a given event

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/read/ReadService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/read/ReadService.kt
@@ -64,6 +64,14 @@ interface ReadService {
     fun getMyReadReceiptLive(): LiveData<Optional<String>>
 
     /**
+     * Get the eventId where the read receipt for the provided user is
+     * @param otherUserId the userId param to look for
+     *
+     * @return the eventId where the read receipt for the provided user is attached, or null if not found
+     */
+    fun getUserReadReceipt(otherUserId: String): String?
+
+    /**
      * Returns a live list of read receipts for a given event
      * @param eventId: the event
      */

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/read/DefaultReadService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/read/DefaultReadService.kt
@@ -107,10 +107,10 @@ internal class DefaultReadService @AssistedInject constructor(
         }
     }
 
-    override fun getUserReadReceipt(otherUserId: String): String? {
+    override fun getUserReadReceipt(userId: String): String? {
         var eventId: String? = null
         monarchy.doWithRealm {
-            eventId = ReadReceiptEntity.where(it, roomId = roomId, userId = otherUserId)
+            eventId = ReadReceiptEntity.where(it, roomId = roomId, userId = userId)
                     .findFirst()
                     ?.eventId
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/read/DefaultReadService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/read/DefaultReadService.kt
@@ -107,6 +107,16 @@ internal class DefaultReadService @AssistedInject constructor(
         }
     }
 
+    override fun getUserReadReceipt(otherUserId: String): String? {
+        var eventId: String? = null
+        monarchy.doWithRealm {
+            eventId = ReadReceiptEntity.where(it, roomId = roomId, userId = otherUserId)
+                    .findFirst()
+                    ?.eventId
+        }
+        return eventId
+    }
+
     override fun getEventReadReceiptsLive(eventId: String): LiveData<List<ReadReceipt>> {
         val liveRealmData = monarchy.findAllMappedWithChanges(
                 { ReadReceiptsSummaryEntity.where(it, eventId) },

--- a/vector/src/main/java/im/vector/app/core/di/VectorComponent.kt
+++ b/vector/src/main/java/im/vector/app/core/di/VectorComponent.kt
@@ -36,6 +36,7 @@ import im.vector.app.features.crypto.verification.IncomingVerificationRequestHan
 import im.vector.app.features.grouplist.SelectedGroupDataSource
 import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.HomeRoomListDataSource
+import im.vector.app.features.home.room.detail.RoomDetailPendingActionStore
 import im.vector.app.features.home.room.detail.timeline.helper.MatrixItemColorProvider
 import im.vector.app.features.html.EventHtmlRenderer
 import im.vector.app.features.html.VectorHtmlCompressor
@@ -113,6 +114,8 @@ interface VectorComponent {
     fun homeRoomListObservableStore(): HomeRoomListDataSource
 
     fun selectedGroupStore(): SelectedGroupDataSource
+
+    fun roomDetailPendingActionStore(): RoomDetailPendingActionStore
 
     fun activeSessionObservableStore(): ActiveSessionDataSource
 

--- a/vector/src/main/java/im/vector/app/core/utils/TemporaryStore.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/TemporaryStore.kt
@@ -23,6 +23,7 @@ const val THREE_MINUTES = 3 * 60_000L
 
 /**
  * Store an object T for a specific period of time
+ * @param delay delay to keep the data, in millis
  */
 open class TemporaryStore<T>(private val delay: Long = THREE_MINUTES) {
 
@@ -30,14 +31,16 @@ open class TemporaryStore<T>(private val delay: Long = THREE_MINUTES) {
 
     var data: T? = null
         set(value) {
-            field = value
             timer?.cancel()
-            timer = Timer().also {
-                it.schedule(object : TimerTask() {
-                    override fun run() {
-                        field = null
-                    }
-                }, delay)
+            field = value
+            if (value != null) {
+                timer = Timer().also {
+                    it.schedule(object : TimerTask() {
+                        override fun run() {
+                            field = null
+                        }
+                    }, delay)
+                }
             }
         }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
@@ -88,4 +88,6 @@ sealed class RoomDetailAction : VectorViewModelAction {
     data class EnsureNativeWidgetAllowed(val widget: Widget,
                                          val userJustAccepted: Boolean,
                                          val grantedEvents: RoomDetailViewEvents) : RoomDetailAction()
+
+    data class JumpToReadReceipt(val userId: String) : RoomDetailAction()
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -216,7 +216,8 @@ class RoomDetailFragment @Inject constructor(
         private val notificationUtils: NotificationUtils,
         private val webRtcPeerConnectionManager: WebRtcPeerConnectionManager,
         private val matrixItemColorProvider: MatrixItemColorProvider,
-        private val imageContentRenderer: ImageContentRenderer
+        private val imageContentRenderer: ImageContentRenderer,
+        private val roomDetailPendingActionStore: RoomDetailPendingActionStore
 ) :
         VectorBaseFragment(),
         TimelineEventController.Callback,
@@ -878,6 +879,17 @@ class RoomDetailFragment @Inject constructor(
     override fun onResume() {
         super.onResume()
         notificationDrawerManager.setCurrentRoom(roomDetailArgs.roomId)
+        roomDetailPendingActionStore.data?.let { handlePendingAction(it) }
+        roomDetailPendingActionStore.data = null
+    }
+
+    private fun handlePendingAction(roomDetailPendingAction: RoomDetailPendingAction) {
+        when (roomDetailPendingAction) {
+            is RoomDetailPendingAction.JumpToReadReceipt ->
+                roomDetailViewModel.handle(RoomDetailAction.JumpToReadReceipt(roomDetailPendingAction.userId))
+            is RoomDetailPendingAction.MentionUser       ->
+                insertUserDisplayNameInTextEditor(roomDetailPendingAction.userId)
+        }.exhaustive
     }
 
     override fun onPause() {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailPendingAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailPendingAction.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home.room.detail
+
+sealed class RoomDetailPendingAction {
+    data class JumpToReadReceipt(val userId: String) : RoomDetailPendingAction()
+    data class MentionUser(val userId: String) : RoomDetailPendingAction()
+}

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailPendingActionStore.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailPendingActionStore.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home.room.detail
+
+import im.vector.app.core.utils.TemporaryStore
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// Store to keep a pending action from sub screen of a room detail
+@Singleton
+class RoomDetailPendingActionStore @Inject constructor() : TemporaryStore<RoomDetailPendingAction>(10_000)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
@@ -274,7 +274,13 @@ class RoomDetailViewModel @AssistedInject constructor(
             is RoomDetailAction.RemoveWidget -> handleDeleteWidget(action.widgetId)
             is RoomDetailAction.EnsureNativeWidgetAllowed -> handleCheckWidgetAllowed(action)
             is RoomDetailAction.CancelSend -> handleCancel(action)
+            is RoomDetailAction.JumpToReadReceipt -> handleJumpToReadReceipt(action)
         }.exhaustive
+    }
+
+    private fun handleJumpToReadReceipt(action: RoomDetailAction.JumpToReadReceipt) {
+        room.getUserReadReceipt(action.userId)
+                ?.let { handleNavigateToEvent(RoomDetailAction.NavigateToEvent(it, true)) }
     }
 
     private fun handleSendSticker(action: RoomDetailAction.SendSticker) {

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileController.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileController.kt
@@ -173,7 +173,7 @@ class RoomMemberProfileController @Inject constructor(
 
             buildProfileSection(stringProvider.getString(R.string.room_profile_section_more))
 
-            if (membership == Membership.JOIN) {
+            if (state.hasReadReceipt) {
                 buildProfileAction(
                         id = "read_receipt",
                         editable = false,

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileController.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileController.kt
@@ -172,13 +172,16 @@ class RoomMemberProfileController @Inject constructor(
             val membership = state.asyncMembership() ?: return
 
             buildProfileSection(stringProvider.getString(R.string.room_profile_section_more))
-            buildProfileAction(
-                    id = "read_receipt",
-                    editable = false,
-                    title = stringProvider.getString(R.string.room_member_jump_to_read_receipt),
-                    dividerColor = dividerColor,
-                    action = { callback?.onJumpToReadReceiptClicked() }
-            )
+
+            if (membership == Membership.JOIN) {
+                buildProfileAction(
+                        id = "read_receipt",
+                        editable = false,
+                        title = stringProvider.getString(R.string.room_member_jump_to_read_receipt),
+                        dividerColor = dividerColor,
+                        action = { callback?.onJumpToReadReceiptClicked() }
+                )
+            }
 
             val ignoreActionTitle = state.buildIgnoreActionTitle()
 

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
@@ -43,6 +43,8 @@ import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.core.utils.startSharePlainTextIntent
 import im.vector.app.features.crypto.verification.VerificationBottomSheet
 import im.vector.app.features.home.AvatarRenderer
+import im.vector.app.features.home.room.detail.RoomDetailPendingAction
+import im.vector.app.features.home.room.detail.RoomDetailPendingActionStore
 import im.vector.app.features.roommemberprofile.devices.DeviceListBottomSheet
 import im.vector.app.features.roommemberprofile.powerlevel.EditPowerLevelDialogs
 import kotlinx.android.parcel.Parcelize
@@ -61,7 +63,8 @@ data class RoomMemberProfileArgs(
 class RoomMemberProfileFragment @Inject constructor(
         val viewModelFactory: RoomMemberProfileViewModel.Factory,
         private val roomMemberProfileController: RoomMemberProfileController,
-        private val avatarRenderer: AvatarRenderer
+        private val avatarRenderer: AvatarRenderer,
+        private val roomDetailPendingActionStore: RoomDetailPendingActionStore
 ) : VectorBaseFragment(), RoomMemberProfileController.Callback {
 
     private val fragmentArgs: RoomMemberProfileArgs by args()
@@ -276,11 +279,13 @@ class RoomMemberProfileFragment @Inject constructor(
     }
 
     override fun onJumpToReadReceiptClicked() {
-        vectorBaseActivity.notImplemented("Jump to read receipts")
+        roomDetailPendingActionStore.data = RoomDetailPendingAction.JumpToReadReceipt(fragmentArgs.userId)
+        vectorBaseActivity.finish()
     }
 
     override fun onMentionClicked() {
-        vectorBaseActivity.notImplemented("Mention")
+        roomDetailPendingActionStore.data = RoomDetailPendingAction.MentionUser(fragmentArgs.userId)
+        vectorBaseActivity.finish()
     }
 
     private fun handleShareRoomMemberProfile(permalink: String) {

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewModel.kt
@@ -85,7 +85,8 @@ class RoomMemberProfileViewModel @AssistedInject constructor(@Assisted private v
         setState {
             copy(
                     isMine = session.myUserId == this.userId,
-                    userMatrixItem = room?.getRoomMember(initialState.userId)?.toMatrixItem()?.let { Success(it) } ?: Uninitialized
+                    userMatrixItem = room?.getRoomMember(initialState.userId)?.toMatrixItem()?.let { Success(it) } ?: Uninitialized,
+                    hasReadReceipt = room?.getUserReadReceipt(initialState.userId) != null
             )
         }
         observeIgnoredState()

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewState.kt
@@ -39,6 +39,7 @@ data class RoomMemberProfileViewState(
         val allDevicesAreTrusted: Boolean = false,
         val allDevicesAreCrossSignedTrusted: Boolean = false,
         val asyncMembership: Async<Membership> = Uninitialized,
+        val hasReadReceipt: Boolean = false,
         val actionPermissions: ActionPermissions = ActionPermissions()
 ) : MvRxState {
 

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileActivity.kt
@@ -29,6 +29,7 @@ import im.vector.app.core.extensions.addFragment
 import im.vector.app.core.extensions.addFragmentToBackstack
 import im.vector.app.core.platform.ToolbarConfigurable
 import im.vector.app.core.platform.VectorBaseActivity
+import im.vector.app.features.home.room.detail.RoomDetailPendingActionStore
 import im.vector.app.features.room.RequireActiveMembershipViewEvents
 import im.vector.app.features.room.RequireActiveMembershipViewModel
 import im.vector.app.features.room.RequireActiveMembershipViewState
@@ -60,6 +61,9 @@ class RoomProfileActivity :
 
     @Inject
     lateinit var requireActiveMembershipViewModelFactory: RequireActiveMembershipViewModel.Factory
+
+    @Inject
+    lateinit var roomDetailPendingActionStore: RoomDetailPendingActionStore
 
     override fun create(initialState: RequireActiveMembershipViewState): RequireActiveMembershipViewModel {
         return requireActiveMembershipViewModelFactory.create(initialState)
@@ -94,6 +98,13 @@ class RoomProfileActivity :
             when (it) {
                 is RequireActiveMembershipViewEvents.RoomLeft -> handleRoomLeft(it)
             }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (roomDetailPendingActionStore.data != null) {
+            finish()
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/roomprofile/members/RoomMemberListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/members/RoomMemberListFragment.kt
@@ -36,6 +36,7 @@ import im.vector.app.core.extensions.cleanup
 import im.vector.app.core.extensions.configureWith
 import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.features.home.AvatarRenderer
+import im.vector.app.features.home.room.detail.RoomDetailPendingActionStore
 import im.vector.app.features.roomprofile.RoomProfileArgs
 import kotlinx.android.synthetic.main.fragment_room_setting_generic.*
 import javax.inject.Inject
@@ -43,7 +44,8 @@ import javax.inject.Inject
 class RoomMemberListFragment @Inject constructor(
         val viewModelFactory: RoomMemberListViewModel.Factory,
         private val roomMemberListController: RoomMemberListController,
-        private val avatarRenderer: AvatarRenderer
+        private val avatarRenderer: AvatarRenderer,
+        private val roomDetailPendingActionStore: RoomDetailPendingActionStore
 ) : VectorBaseFragment(), RoomMemberListController.Callback {
 
     private val viewModel: RoomMemberListViewModel by fragmentViewModel()
@@ -94,6 +96,13 @@ class RoomMemberListFragment @Inject constructor(
                 return true
             }
         })
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (roomDetailPendingActionStore.data != null) {
+            vectorBaseActivity.finish()
+        }
     }
 
     override fun onDestroyView() {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/members/RoomMemberListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/members/RoomMemberListFragment.kt
@@ -36,7 +36,6 @@ import im.vector.app.core.extensions.cleanup
 import im.vector.app.core.extensions.configureWith
 import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.features.home.AvatarRenderer
-import im.vector.app.features.home.room.detail.RoomDetailPendingActionStore
 import im.vector.app.features.roomprofile.RoomProfileArgs
 import kotlinx.android.synthetic.main.fragment_room_setting_generic.*
 import javax.inject.Inject
@@ -44,8 +43,7 @@ import javax.inject.Inject
 class RoomMemberListFragment @Inject constructor(
         val viewModelFactory: RoomMemberListViewModel.Factory,
         private val roomMemberListController: RoomMemberListController,
-        private val avatarRenderer: AvatarRenderer,
-        private val roomDetailPendingActionStore: RoomDetailPendingActionStore
+        private val avatarRenderer: AvatarRenderer
 ) : VectorBaseFragment(), RoomMemberListController.Callback {
 
     private val viewModel: RoomMemberListViewModel by fragmentViewModel()
@@ -96,13 +94,6 @@ class RoomMemberListFragment @Inject constructor(
                 return true
             }
         })
-    }
-
-    override fun onResume() {
-        super.onResume()
-        if (roomDetailPendingActionStore.data != null) {
-            vectorBaseActivity.finish()
-        }
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
Using a trick to avoid messing up with ActivityResult: we store the pending action in a singleton.

Also I created https://github.com/vector-im/element-web/issues/15380