### PR TITLE
Make edit and remove image icons visible in attachments preview screen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Improvements 🙌:
  - New room creation screen: set topic and avatar in the room creation form (#2078)
  - Add option to send with enter (#1195)
  - Use Hardware keyboard enter to send message (use shift-enter for new line) (#1881, #1440)
+ - Edit and remove icons are now visible on image attachment preview screen (#2294)
 
 Bugfix 🐛:
  - Messages encrypted with no way to decrypt after SDK update from 0.18 to 1.0.0 (#2252)

--- a/vector/src/main/res/menu/vector_attachments_preview.xml
+++ b/vector/src/main/res/menu/vector_attachments_preview.xml
@@ -8,12 +8,14 @@
         android:id="@+id/attachmentsPreviewRemoveAction"
         android:icon="@drawable/ic_delete"
         android:title="@string/delete"
+        app:iconTint="?vctr_settings_icon_tint_color"
         app:showAsAction="always" />
 
     <item
         android:id="@+id/attachmentsPreviewEditAction"
         android:icon="@drawable/ic_edit"
         android:title="@string/edit"
+        app:iconTint="?vctr_settings_icon_tint_color"
         app:showAsAction="always" />
 
 </menu>


### PR DESCRIPTION
The remove and edit icons were black on a black background on the attachments preview screen so were invisible.

### Before

<img src="https://user-images.githubusercontent.com/3315634/97083047-0722b380-160e-11eb-95ed-ff153deff6d6.png" height="600">

Icon tint was added to the menu xml file for the appropriate menu to make the icons visible

### After

<img src="https://user-images.githubusercontent.com/3315634/97083098-4e10a900-160e-11eb-8aad-f0aaf2a9e783.png" height="600">


### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
