### PR TITLE
Add preference to send with enter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Features ✨:
 Improvements 🙌:
  - Rework sending Event management (#154)
  - New room creation screen: set topic and avatar in the room creation form (#2078)
+ - Add option to send with enter (#1195)
+ - Use Hardware keyboard enter to send message (use shift-enter for new line) (#1881, #1440)
 
 Bugfix 🐛:
  - Messages encrypted with no way to decrypt after SDK update from 0.18 to 1.0.0 (#2252)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.DialogInterface
 import android.content.Intent
+import android.content.res.Configuration
 import android.graphics.Typeface
 import android.net.Uri
 import android.os.Build
@@ -27,11 +28,13 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.text.Spannable
 import android.view.HapticFeedbackConstants
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
@@ -1058,9 +1061,32 @@ class RoomDetailFragment @Inject constructor(
     }
 
     private fun setupComposer() {
-        autoCompleter.setup(composerLayout.composerEditText)
+        val composerEditText = composerLayout.composerEditText
+        autoCompleter.setup(composerEditText)
 
         observerUserTyping()
+
+        if (vectorPreferences.sendMessageWithEnter()) {
+            // imeOptions="actionSend" only works with single line, so we remove multiline inputType
+            composerEditText.inputType = composerEditText.inputType and EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE.inv()
+            composerEditText.imeOptions = EditorInfo.IME_ACTION_SEND
+        }
+
+        composerEditText.setOnEditorActionListener { v, actionId, keyEvent ->
+            val imeActionId = actionId and EditorInfo.IME_MASK_ACTION
+            if (EditorInfo.IME_ACTION_DONE == imeActionId || EditorInfo.IME_ACTION_SEND == imeActionId) {
+                sendTextMessage(v.text)
+                true
+            }
+            // Add external keyboard functionality (to send messages)
+            else if (null != keyEvent
+                    && !keyEvent.isShiftPressed
+                    && keyEvent.keyCode == KeyEvent.KEYCODE_ENTER
+                    && resources.configuration.keyboard != Configuration.KEYBOARD_NOKEYS) {
+                sendTextMessage(v.text)
+                true
+            } else false
+        }
 
         composerLayout.callback = object : TextComposerView.Callback {
             override fun onAddAttachment() {
@@ -1071,16 +1097,7 @@ class RoomDetailFragment @Inject constructor(
             }
 
             override fun onSendMessage(text: CharSequence) {
-                if (lockSendButton) {
-                    Timber.w("Send button is locked")
-                    return
-                }
-                if (text.isNotBlank()) {
-                    // We collapse ASAP, if not there will be a slight anoying delay
-                    composerLayout.collapse(true)
-                    lockSendButton = true
-                    roomDetailViewModel.handle(RoomDetailAction.SendMessage(text, vectorPreferences.isMarkdownEnabled()))
-                }
+                sendTextMessage(text)
             }
 
             override fun onCloseRelatedMessage() {
@@ -1097,6 +1114,19 @@ class RoomDetailFragment @Inject constructor(
                     true
                 }
             }
+        }
+    }
+
+    private fun sendTextMessage(text: CharSequence) {
+        if (lockSendButton) {
+            Timber.w("Send button is locked")
+            return
+        }
+        if (text.isNotBlank()) {
+            // We collapse ASAP, if not there will be a slight anoying delay
+            composerLayout.collapse(true)
+            lockSendButton = true
+            roomDetailViewModel.handle(RoomDetailAction.SendMessage(text, vectorPreferences.isMarkdownEnabled()))
         }
     }
 

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -43,6 +43,12 @@
             android:summary="@string/settings_send_typing_notifs_summary"
             android:title="@string/settings_send_typing_notifs" />
 
+        <im.vector.app.core.preference.VectorSwitchPreference
+            android:defaultValue="false"
+            android:key="SETTINGS_SEND_MESSAGE_WITH_ENTER"
+            android:summary="@string/settings_send_message_with_enter_summary"
+            android:title="@string/settings_send_message_with_enter" />
+
     </im.vector.app.core.preference.VectorPreferenceCategory>
 
     <im.vector.app.core.preference.VectorPreferenceCategory android:title="@string/settings_category_timeline">
@@ -98,12 +104,6 @@
         <im.vector.app.core.preference.VectorSwitchPreference
             android:key="SETTINGS_VIBRATE_ON_MENTION_KEY"
             android:title="@string/settings_vibrate_on_mention"
-            app:isPreferenceVisible="@bool/false_not_implemented" />
-
-        <im.vector.app.core.preference.VectorSwitchPreference
-            android:key="SETTINGS_SEND_MESSAGE_WITH_ENTER"
-            android:summary="@string/settings_send_message_with_enter_summary"
-            android:title="@string/settings_send_message_with_enter"
             app:isPreferenceVisible="@bool/false_not_implemented" />
 
         <im.vector.app.core.preference.VectorListPreference


### PR DESCRIPTION
 - Add preference settings to send message by pressing the soft keyboard enter key (instead of new line)
 - Add support for external keyboard send (currently can only break line)

=> I imported back the old app code https://github.com/vector-im/riot-android/blob/af848a04704b8a286c39ce75b23894f63de53cfa/vector/src/main/java/im/vector/activity/VectorRoomActivity.java#L733

Fixes #1195
Fixes #1881
Fixes #1440

<img width="462" alt="image" src="https://user-images.githubusercontent.com/9841565/97299206-e6986a80-1854-11eb-984d-fed3da431ff9.png">

