### PR TITLE
Fix ui echo isues

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/DefaultTimeline.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/DefaultTimeline.kt
@@ -819,7 +819,7 @@ internal class DefaultTimeline(
         private val inMemorySendingEvents = Collections.synchronizedList<TimelineEvent>(ArrayList())
 
         fun getInMemorySendingEvents(): List<TimelineEvent> {
-            return inMemorySendingEvents
+            return inMemorySendingEvents.toList()
         }
 
         /**


### PR DESCRIPTION
Fix issues with ui local echo (introduced with send re-work), visible when adding a reaction that would be counted twice

We had several issues with UI echos
    - We were listening only to filtered sending events, which is annoying as relations events filtered but their updates are needed to update ui echo. Changed this and delayed the filtering at the time of event building
    - There was an issue with update of reaction (was looking at reference event instead of local id of the reaction)
    - We also had an issue in the event filtering that was not checking on clear type , clear content (for sending event post encrypt)