### PR TITLE
Feature/bma/search highlight

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Improvements 🙌:
 
 Bugfix 🐛:
  - Messages encrypted with no way to decrypt after SDK update from 0.18 to 1.0.0 (#2252)
+ - Search Result | scroll jumps after pagination (#2238)
 
 Translations 🗣:
  -

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Improvements 🙌:
  - Edit and remove icons are now visible on image attachment preview screen (#2294)
  - Room profile: BigImageViewerActivity now only display the image. Use the room setting to change or delete the room Avatar
  - Room member profile: Add action to create (or open) a DM (#2310)
+ - Highlight text in the body of the displayed result (#2200)
 
 Bugfix 🐛:
  - Messages encrypted with no way to decrypt after SDK update from 0.18 to 1.0.0 (#2252)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchFragment.kt
@@ -52,8 +52,6 @@ class SearchFragment @Inject constructor(
     private val fragmentArgs: SearchArgs by args()
     private val searchViewModel: SearchViewModel by fragmentViewModel()
 
-    private var pendingScrollToPosition: Int? = null
-
     override fun getLayoutResId() = R.layout.fragment_search
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -70,12 +68,6 @@ class SearchFragment @Inject constructor(
         searchResultRecycler.configureWith(controller, showDivider = false)
         (searchResultRecycler.layoutManager as? LinearLayoutManager)?.stackFromEnd = true
         controller.listener = this
-
-        controller.addModelBuildListener {
-            pendingScrollToPosition?.let {
-                searchResultRecycler.smoothScrollToPosition(it)
-            }
-        }
     }
 
     override fun onDestroy() {
@@ -100,8 +92,6 @@ class SearchFragment @Inject constructor(
                 }
             }
         } else {
-            pendingScrollToPosition = (state.lastBatchSize - 1).coerceAtLeast(0)
-
             stateView.state = StateView.State.Content
             controller.setData(state)
         }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchFragment.kt
@@ -92,8 +92,8 @@ class SearchFragment @Inject constructor(
                 }
             }
         } else {
-            stateView.state = StateView.State.Content
             controller.setData(state)
+            stateView.state = StateView.State.Content
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchResultController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchResultController.kt
@@ -92,7 +92,7 @@ class SearchResultController @Inject constructor(
     }
 
     /**
-     * @return true if some item has been added
+     * @return the list of EpoxyModel (date items and search result items), or an empty list if all items have been filtered out
      */
     private fun buildSearchResultItems(data: SearchViewState): List<EpoxyModel<*>> {
         var lastDate: Calendar? = null

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchResultItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchResultItem.kt
@@ -21,24 +21,20 @@ import android.widget.TextView
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
-import im.vector.app.core.date.DateFormatKind
-import im.vector.app.core.date.VectorDateFormatter
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 import im.vector.app.features.home.AvatarRenderer
-import org.matrix.android.sdk.api.session.events.model.Content
-import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.util.MatrixItem
 
 @EpoxyModelClass(layout = R.layout.item_search_result)
 abstract class SearchResultItem : VectorEpoxyModel<SearchResultItem.Holder>() {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
-    @EpoxyAttribute var dateFormatter: VectorDateFormatter? = null
-    @EpoxyAttribute lateinit var event: Event
+    @EpoxyAttribute var formattedDate: String? = null
+    @EpoxyAttribute lateinit var spannable: CharSequence
     @EpoxyAttribute var sender: MatrixItem? = null
     @EpoxyAttribute var listener: ClickListener? = null
 
@@ -48,11 +44,8 @@ abstract class SearchResultItem : VectorEpoxyModel<SearchResultItem.Holder>() {
         holder.view.onClick(listener)
         sender?.let { avatarRenderer.render(it, holder.avatarImageView) }
         holder.memberNameView.setTextOrHide(sender?.getBestName())
-        holder.timeView.text = dateFormatter?.format(event.originServerTs, DateFormatKind.MESSAGE_SIMPLE)
-        // TODO Improve that (use formattedBody, etc.)
-        @Suppress("UNCHECKED_CAST")
-        // Take new content first
-        holder.contentView.text = ((event.content?.get("m.new_content") as? Content) ?: event.content)?.get("body") as? String
+        holder.timeView.text = formattedDate
+        holder.contentView.text = spannable
     }
 
     class Holder : VectorEpoxyHolder() {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchResultItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchResultItem.kt
@@ -29,6 +29,7 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 import im.vector.app.features.home.AvatarRenderer
+import org.matrix.android.sdk.api.session.events.model.Content
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.util.MatrixItem
 
@@ -49,7 +50,9 @@ abstract class SearchResultItem : VectorEpoxyModel<SearchResultItem.Holder>() {
         holder.memberNameView.setTextOrHide(sender?.getBestName())
         holder.timeView.text = dateFormatter?.format(event.originServerTs, DateFormatKind.MESSAGE_SIMPLE)
         // TODO Improve that (use formattedBody, etc.)
-        holder.contentView.text = event.content?.get("body") as? String
+        @Suppress("UNCHECKED_CAST")
+        // Take new content first
+        holder.contentView.text = ((event.content?.get("m.new_content") as? Content) ?: event.content)?.get("body") as? String
     }
 
     class Holder : VectorEpoxyHolder() {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchViewModel.kt
@@ -145,6 +145,7 @@ class SearchViewModel @AssistedInject constructor(
         setState {
             copy(
                     searchResult = accumulatedResult,
+                    highlights = searchResult.highlights.orEmpty(),
                     hasMoreResult = !nextBatch.isNullOrEmpty(),
                     lastBatchSize = searchResult.results.orEmpty().size,
                     asyncSearchRequest = Success(Unit)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchViewState.kt
@@ -24,6 +24,7 @@ import org.matrix.android.sdk.api.session.search.EventAndSender
 data class SearchViewState(
         // Accumulated search result
         val searchResult: List<EventAndSender> = emptyList(),
+        val highlights: List<String> = emptyList(),
         val hasMoreResult: Boolean = false,
         // Last batch size, will help RecyclerView to position itself
         val lastBatchSize: Int = 0,

--- a/vector/src/main/res/layout/fragment_search.xml
+++ b/vector/src/main/res/layout/fragment_search.xml
@@ -8,8 +8,10 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/searchResultRecycler"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
         android:overScrollMode="always"
+        tools:itemCount="2"
         tools:listitem="@layout/item_search_result" />
 
 </im.vector.app.core.platform.StateView>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -173,6 +173,7 @@
     <string name="no_conversation_placeholder">No conversations</string>
     <string name="no_contact_access_placeholder">You didn’t allow Element to access your local contacts</string>
     <string name="no_result_placeholder">No results</string>
+    <string name="no_more_results">No more results</string>
     <string name="people_no_identity_server">No identity server configured.</string>
 
     <!-- Rooms fragment -->


### PR DESCRIPTION
Improvements on Search screen:

- fixes #2238 by modifying the layout and removing the previous trick
- implements #2200: make the search terms in bold in the result
- take new content for edited event
- add "No more result" item (iso web)

<img width="321" alt="image" src="https://user-images.githubusercontent.com/3940906/97678450-18e3db00-1a94-11eb-93da-6699b6c9cdd5.png">


#2307 is still a thing but less urgent, and related to something strange from Synapse