### PR TITLE
Considerably faster QR-code bitmap generation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,4 +1,4 @@
-A full developer contributors list can be found [here](https://github.com/vector-im/element-android/graphs/contributors). 
+A full developer contributors list can be found [here](https://github.com/vector-im/element-android/graphs/contributors).
 
 # Core team:
 
@@ -33,3 +33,8 @@ First of all, we thank all contributors who use Element and report problems on t
 We do not forget all translators, for their work of translating Element into many languages. They are also the authors of Element.
 
 Feel free to add your name below, when you contribute to the project!
+
+Name    | Matrix ID           | GitHub
+--------|---------------------|--------------------------------------
+gjpower | @gjpower:matrix.org | [gjpower](https://github.com/gjpower)
+

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Improvements 🙌:
  - Prepare changelog for F-Droid (#2296)
  - Add graphic resources for F-Droid (#812, #2220)
  - Highlight text in the body of the displayed result (#2200)
+ - Considerably faster QR-code bitmap generation (#2331)
 
 Bugfix 🐛:
  - Messages encrypted with no way to decrypt after SDK update from 0.18 to 1.0.0 (#2252)

--- a/vector/src/main/java/im/vector/app/core/qrcode/QrCode.kt
+++ b/vector/src/main/java/im/vector/app/core/qrcode/QrCode.kt
@@ -34,12 +34,15 @@ fun String.toBitMatrix(size: Int): BitMatrix {
 
 fun BitMatrix.toBitmap(@ColorInt backgroundColor: Int = Color.WHITE,
                        @ColorInt foregroundColor: Int = Color.BLACK): Bitmap {
-    val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-    for (x in 0 until width) {
-        for (y in 0 until height) {
-            bmp.setPixel(x, y, if (get(x, y)) foregroundColor else backgroundColor)
+    val colorBuffer = IntArray(width*height)
+    var rowOffset = 0
+    for (y in 0 until height) {
+        for (x in 0 until width) {
+            val arrayIndex = x + rowOffset
+            colorBuffer[arrayIndex] = if (get(x, y)) foregroundColor else backgroundColor
         }
+        rowOffset += width
     }
 
-    return bmp
+    return Bitmap.createBitmap(colorBuffer, width, height, Bitmap.Config.ARGB_8888)
 }

--- a/vector/src/main/java/im/vector/app/core/qrcode/QrCode.kt
+++ b/vector/src/main/java/im/vector/app/core/qrcode/QrCode.kt
@@ -34,7 +34,7 @@ fun String.toBitMatrix(size: Int): BitMatrix {
 
 fun BitMatrix.toBitmap(@ColorInt backgroundColor: Int = Color.WHITE,
                        @ColorInt foregroundColor: Int = Color.BLACK): Bitmap {
-    val colorBuffer = IntArray(width*height)
+    val colorBuffer = IntArray(width * height)
     var rowOffset = 0
     for (y in 0 until height) {
         for (x in 0 until width) {


### PR DESCRIPTION
Directly assign colours to a colour buffer then use that buffer to
generate the bitmap. This is much faster than using Bitmap.setPixel for
every pixel.

Roughly 100x speed increase with a sample QR-code when tested on a Motorola G4

### Pull Request Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
