### PR TITLE
Feature/bca/crypto db clean

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/Session.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/Session.kt
@@ -242,5 +242,5 @@ interface Session :
     /**
      * Maintenance API, allows to print outs info on DB size to logcat
      */
-    fun dbgTraceDbInfo()
+    fun logDbUsageInfo()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/Session.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/Session.kt
@@ -238,4 +238,9 @@ interface Session :
     }
 
     val sharedSecretStorageService: SharedSecretStorageService
+
+    /**
+     * Maintenance API, allows to print outs info on DB size to logcat
+     */
+    fun dbgTraceDbInfo()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/CryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/CryptoService.kt
@@ -155,4 +155,6 @@ interface CryptoService {
     // For testing shared session
     fun getSharedWithInfo(roomId: String?, sessionId: String): MXUsersDevicesMap<Int>
     fun getWithHeldMegolmSession(roomId: String, sessionId: String): RoomKeyWithHeldContent?
+
+    fun logDbUsageInfo()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -314,6 +314,10 @@ internal class DefaultCryptoService @Inject constructor(
         }
         // Just update
         fetchDevicesList(NoOpMatrixCallback())
+
+        cryptoCoroutineScope.launch(coroutineDispatchers.crypto) {
+            cryptoStore.tidyUpDataBase()
+        }
     }
 
     fun ensureDevice() {
@@ -1291,6 +1295,11 @@ internal class DefaultCryptoService @Inject constructor(
     override fun getWithHeldMegolmSession(roomId: String, sessionId: String): RoomKeyWithHeldContent? {
         return cryptoStore.getWithHeldMegolmSession(roomId, sessionId)
     }
+
+    override fun logDbUsageInfo() {
+        cryptoStore.logDbUsageInfo()
+    }
+
     /* ==========================================================================================
      * For test only
      * ========================================================================================== */

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
@@ -456,4 +456,6 @@ internal interface IMXCryptoStore {
 
     fun setDeviceKeysUploaded(uploaded: Boolean)
     fun getDeviceKeysUploaded(): Boolean
+    fun tidyUpDataBase()
+    fun logDbUsageInfo()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -87,6 +87,7 @@ import org.matrix.android.sdk.internal.crypto.store.db.query.get
 import org.matrix.android.sdk.internal.crypto.store.db.query.getById
 import org.matrix.android.sdk.internal.crypto.store.db.query.getOrCreate
 import org.matrix.android.sdk.internal.database.mapper.ContentMapper
+import org.matrix.android.sdk.internal.database.tools.RealmDebugTools
 import org.matrix.android.sdk.internal.di.CryptoDatabase
 import org.matrix.android.sdk.internal.di.DeviceId
 import org.matrix.android.sdk.internal.di.MoshiProvider
@@ -95,7 +96,6 @@ import org.matrix.android.sdk.internal.session.SessionScope
 import org.matrix.olm.OlmAccount
 import org.matrix.olm.OlmException
 import timber.log.Timber
-import java.lang.StringBuilder
 import javax.inject.Inject
 import kotlin.collections.set
 
@@ -1709,19 +1709,6 @@ internal class RealmCryptoStore @Inject constructor(
      * Prints out database info
      */
     override fun logDbUsageInfo() {
-        Realm.getInstance(realmConfiguration).use { realm ->
-            val info = StringBuilder()
-            // Check if we have data
-            info.append("\n==============================================")
-            info.append("\n==============================================")
-            info.append("\nCrypto Realm is empty: ${realm.isEmpty}")
-            realmConfiguration.realmObjectClasses.forEach { modelClazz ->
-                val count = realm.where(modelClazz).count()
-                info.append("\nCrypto Realm - count ${modelClazz.simpleName}: $count")
-            }
-            info.append("\n==============================================")
-            info.append("\n==============================================")
-            Timber.i(info.toString())
-        }
+        RealmDebugTools(realmConfiguration).logInfo("Crypto")
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/tools/RealmDebugTools.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/tools/RealmDebugTools.kt
@@ -42,10 +42,11 @@ internal class RealmDebugTools(
                 separator()
                 append("\n$baseName Realm is empty: ${realm.isEmpty}")
                 var total = 0L
+                val maxNameLength = realmConfiguration.realmObjectClasses.maxOf { it.simpleName.length }
                 realmConfiguration.realmObjectClasses.forEach { modelClazz ->
                     val count = realm.where(modelClazz).count()
                     total += count
-                    append("\n$baseName Realm - count ${modelClazz.simpleName}: $count")
+                    append("\n$baseName Realm - count ${modelClazz.simpleName.padEnd(maxNameLength)} : $count")
                 }
                 separator()
                 append("\n$baseName Realm - total count: $total")
@@ -56,5 +57,5 @@ internal class RealmDebugTools(
                 .let { Timber.i(it) }
     }
 
-    internal fun StringBuilder.separator() = append("\n==============================================")
+    private fun StringBuilder.separator() = append("\n==============================================")
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/tools/RealmDebugTools.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/tools/RealmDebugTools.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.matrix.android.sdk.internal.database
+package org.matrix.android.sdk.internal.database.tools
 
 import org.matrix.android.sdk.internal.crypto.store.db.model.CrossSigningInfoEntity
 import org.matrix.android.sdk.internal.crypto.store.db.model.CryptoMetadataEntity
@@ -35,17 +35,19 @@ import io.realm.RealmConfiguration
 import io.realm.kotlin.where
 import timber.log.Timber
 
-object RealmDebugTools {
+internal class RealmDebugTools(
+        private val realmConfiguration: RealmConfiguration
+) {
     /**
-     * Log info about the crypto DB
+     * Log info about the DB
      */
-    fun dumpCryptoDb(realmConfiguration: RealmConfiguration) {
+    fun logInfo() {
+        Timber.d("Realm located at : ${realmConfiguration.realmDirectory}/${realmConfiguration.realmFileName}")
+
+        val key = realmConfiguration.encryptionKey.joinToString("") { byte -> "%02x".format(byte) }
+        Timber.d("Realm encryption key : $key")
+
         Realm.getInstance(realmConfiguration).use {
-            Timber.d("Realm located at : ${realmConfiguration.realmDirectory}/${realmConfiguration.realmFileName}")
-
-            val key = realmConfiguration.encryptionKey.joinToString("") { byte -> "%02x".format(byte) }
-            Timber.d("Realm encryption key : $key")
-
             // Check if we have data
             Timber.e("Realm is empty: ${it.isEmpty}")
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
@@ -18,7 +18,9 @@ package org.matrix.android.sdk.internal.session
 
 import androidx.annotation.MainThread
 import dagger.Lazy
+import io.realm.Realm
 import io.realm.RealmConfiguration
+import io.realm.kotlin.where
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
@@ -197,7 +199,7 @@ internal class DefaultSession @Inject constructor(
     override fun close() {
         assert(isOpen)
         stopSync()
-       // timelineEventDecryptor.destroy()
+        // timelineEventDecryptor.destroy()
         uiHandler.post {
             lifecycleObservers.forEach { it.onStop() }
         }
@@ -283,5 +285,23 @@ internal class DefaultSession @Inject constructor(
     // For easy debugging
     override fun toString(): String {
         return "$myUserId - ${sessionParams.deviceId}"
+    }
+
+    override fun dbgTraceDbInfo() {
+        Realm.getInstance(realmConfiguration).use { realm ->
+            val info = StringBuilder()
+
+            // Check if we have data
+            info.append("\n==============================================")
+            info.append("\n==============================================")
+            info.append("\nSession Realm is empty: ${realm.isEmpty}")
+            realmConfiguration.realmObjectClasses.forEach { modelClazz ->
+                val count = realm.where(modelClazz).count()
+                info.append("\nSession Realm - count ${modelClazz.simpleName}: $count")
+            }
+            info.append("\n==============================================")
+            info.append("\n==============================================")
+            Timber.i(info.toString())
+        }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
@@ -18,9 +18,7 @@ package org.matrix.android.sdk.internal.session
 
 import androidx.annotation.MainThread
 import dagger.Lazy
-import io.realm.Realm
 import io.realm.RealmConfiguration
-import io.realm.kotlin.where
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
@@ -61,6 +59,7 @@ import org.matrix.android.sdk.api.session.user.UserService
 import org.matrix.android.sdk.api.session.widgets.WidgetService
 import org.matrix.android.sdk.internal.auth.SessionParamsStore
 import org.matrix.android.sdk.internal.crypto.DefaultCryptoService
+import org.matrix.android.sdk.internal.database.tools.RealmDebugTools
 import org.matrix.android.sdk.internal.di.SessionDatabase
 import org.matrix.android.sdk.internal.di.SessionId
 import org.matrix.android.sdk.internal.di.UnauthenticatedWithCertificate
@@ -288,20 +287,6 @@ internal class DefaultSession @Inject constructor(
     }
 
     override fun logDbUsageInfo() {
-        Realm.getInstance(realmConfiguration).use { realm ->
-            val info = StringBuilder()
-
-            // Check if we have data
-            info.append("\n==============================================")
-            info.append("\n==============================================")
-            info.append("\nSession Realm is empty: ${realm.isEmpty}")
-            realmConfiguration.realmObjectClasses.forEach { modelClazz ->
-                val count = realm.where(modelClazz).count()
-                info.append("\nSession Realm - count ${modelClazz.simpleName}: $count")
-            }
-            info.append("\n==============================================")
-            info.append("\n==============================================")
-            Timber.i(info.toString())
-        }
+        RealmDebugTools(realmConfiguration).logInfo("Session")
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
@@ -287,7 +287,7 @@ internal class DefaultSession @Inject constructor(
         return "$myUserId - ${sessionParams.deviceId}"
     }
 
-    override fun dbgTraceDbInfo() {
+    override fun logDbUsageInfo() {
         Realm.getInstance(realmConfiguration).use { realm ->
             val info = StringBuilder()
 

--- a/vector/src/main/java/im/vector/app/features/rageshake/BugReporter.kt
+++ b/vector/src/main/java/im/vector/app/features/rageshake/BugReporter.kt
@@ -446,6 +446,8 @@ class BugReporter @Inject constructor(
      */
     fun openBugReportScreen(activity: FragmentActivity, forSuggestion: Boolean = false) {
         screenshot = takeScreenshot(activity)
+        activeSessionHolder.getSafeActiveSession()?.dbgTraceDbInfo()
+        activeSessionHolder.getSafeActiveSession()?.cryptoService()?.logDbUsageInfo()
 
         val intent = Intent(activity, BugReportActivity::class.java)
         intent.putExtra("FOR_SUGGESTION", forSuggestion)

--- a/vector/src/main/java/im/vector/app/features/rageshake/BugReporter.kt
+++ b/vector/src/main/java/im/vector/app/features/rageshake/BugReporter.kt
@@ -212,20 +212,20 @@ class BugReporter @Inject constructor(
                 }
 
                 activeSessionHolder.getSafeActiveSession()
-                            ?.takeIf { !mIsCancelled && withKeyRequestHistory }
-                            ?.cryptoService()
-                            ?.getGossipingEvents()
-                            ?.let { GossipingEventsSerializer().serialize(it) }
-                            ?.toByteArray()
-                            ?.let { rawByteArray ->
-                                File(context.cacheDir.absolutePath, KEY_REQUESTS_FILENAME)
-                                        .also {
-                                            it.outputStream()
+                        ?.takeIf { !mIsCancelled && withKeyRequestHistory }
+                        ?.cryptoService()
+                        ?.getGossipingEvents()
+                        ?.let { GossipingEventsSerializer().serialize(it) }
+                        ?.toByteArray()
+                        ?.let { rawByteArray ->
+                            File(context.cacheDir.absolutePath, KEY_REQUESTS_FILENAME)
+                                    .also {
+                                        it.outputStream()
                                                 .use { os -> os.write(rawByteArray) }
-                                        }
-                            }
-                            ?.let { compressFile(it) }
-                            ?.let { gzippedFiles.add(it) }
+                                    }
+                        }
+                        ?.let { compressFile(it) }
+                        ?.let { gzippedFiles.add(it) }
 
                 var deviceId = "undefined"
                 var userId = "undefined"
@@ -446,8 +446,10 @@ class BugReporter @Inject constructor(
      */
     fun openBugReportScreen(activity: FragmentActivity, forSuggestion: Boolean = false) {
         screenshot = takeScreenshot(activity)
-        activeSessionHolder.getSafeActiveSession()?.dbgTraceDbInfo()
-        activeSessionHolder.getSafeActiveSession()?.cryptoService()?.logDbUsageInfo()
+        activeSessionHolder.getSafeActiveSession()?.let {
+            it.logDbUsageInfo()
+            it.cryptoService().logDbUsageInfo()
+        }
 
         val intent = Intent(activity, BugReportActivity::class.java)
         intent.putExtra("FOR_SUGGESTION", forSuggestion)

--- a/vector/src/main/java/im/vector/app/features/rageshake/VectorFileLogger.kt
+++ b/vector/src/main/java/im/vector/app/features/rageshake/VectorFileLogger.kt
@@ -102,8 +102,8 @@ class VectorFileLogger @Inject constructor(val context: Context, private val vec
         return if (vectorPreferences.labAllowedExtendedLogging()) {
             false
         } else {
-            // Exclude debug and verbose logs
-            priority <= Log.DEBUG
+            // Exclude verbose logs
+            priority < Log.DEBUG
         }
     }
 


### PR DESCRIPTION
# Clean 

3 simple changes:
 - Reduce FileLogger level to debug to ease debugging from rageshake
 - Prints in logs some info regarding databases (number of entries per entity)
 - On open delete gossiping related entities that are one week older or more (to avoid these table to grow endlessly)


Benoit: Example of output:
```text
2020-11-03 09:56:49.358 13782-13782/im.vector.app.debug I/RealmDebugTools: Session Realm located at : /data/user/0/im.vector.app.debug/files/bc1a52d626a85c1f8e0ca5a325e3794c/disk_store.realm
    Session Realm encryption key : ONLY_IF__LOG_PRIVATE_DATA__IS_SET_TO_TRUE
    ==============================================
    ==============================================
    Session Realm is empty: false
    Session Realm - count PushRuleEntity                         : 15
    Session Realm - count ReadReceiptsSummaryEntity              : 3412
    Session Realm - count ChunkEntity                            : 34
    Session Realm - count HomeServerCapabilitiesEntity           : 1
    Session Realm - count RoomEntity                             : 22
    Session Realm - count UserAccountDataEntity                  : 27
    Session Realm - count PusherDataEntity                       : 171
    Session Realm - count BreadcrumbsEntity                      : 1
    Session Realm - count RoomTagEntity                          : 2
    Session Realm - count RoomMemberSummaryEntity                : 338
    Session Realm - count WellknownIntegrationManagerConfigEntity: 0
    Session Realm - count EventInsertEntity                      : 0
    Session Realm - count EventAnnotationsSummaryEntity          : 4
    Session Realm - count IgnoredUserEntity                      : 0
    Session Realm - count ReactionAggregatedSummaryEntity        : 3
    Session Realm - count PusherEntity                           : 6
    Session Realm - count SyncEntity                             : 1
    Session Realm - count EventEntity                            : 1242
    Session Realm - count FilterEntity                           : 1
    Session Realm - count RoomSummaryEntity                      : 23
    Session Realm - count GroupSummaryEntity                     : 0
    Session Realm - count PushRulesEntity                        : 5
    Session Realm - count ScalarTokenEntity                      : 0
    Session Realm - count ReadReceiptEntity                      : 2741
    Session Realm - count ReadMarkerEntity                       : 17
    Session Realm - count DraftEntity                            : 0
    Session Realm - count UserEntity                             : 285
    Session Realm - count CurrentStateEventEntity                : 496
    Session Realm - count UserThreePidEntity                     : 0
    Session Realm - count PushConditionEntity                    : 18
    Session Realm - count PollResponseAggregatedSummaryEntity    : 0
    Session Realm - count ReferencesAggregatedSummaryEntity      : 0
    Session Realm - count PendingThreePidEntity                  : 0
    Session Realm - count GroupEntity                            : 0
    Session Realm - count EditAggregatedSummaryEntity            : 3
    Session Realm - count UserDraftsEntity                       : 4
    Session Realm - count TimelineEventEntity                    : 957
    ==============================================
    Session Realm - total count: 9829
    ==============================================
    ==============================================
2020-11-03 09:56:49.380 13782-13782/im.vector.app.debug I/RealmDebugTools: Crypto Realm located at : /data/user/0/im.vector.app.debug/files/bc1a52d626a85c1f8e0ca5a325e3794c/crypto_store.realm
    Crypto Realm encryption key : ONLY_IF__LOG_PRIVATE_DATA__IS_SET_TO_TRUE
    ==============================================
    ==============================================
    Crypto Realm is empty: false
    Crypto Realm - count OutgoingGossipingRequestEntity: 39
    Crypto Realm - count MyDeviceLastSeenInfoEntity    : 2
    Crypto Realm - count SharedSessionEntity           : 2
    Crypto Realm - count CryptoRoomEntity              : 20
    Crypto Realm - count TrustLevelEntity              : 208
    Crypto Realm - count DeviceInfoEntity              : 26
    Crypto Realm - count KeysBackupDataEntity          : 1
    Crypto Realm - count GossipingEventEntity          : 106
    Crypto Realm - count OlmSessionEntity              : 2
    Crypto Realm - count WithHeldSessionEntity         : 0
    Crypto Realm - count OlmInboundGroupSessionEntity  : 3
    Crypto Realm - count KeyInfoEntity                 : 11
    Crypto Realm - count CryptoMetadataEntity          : 1
    Crypto Realm - count IncomingGossipingRequestEntity: 26
    Crypto Realm - count UserEntity                    : 5
    Crypto Realm - count CrossSigningInfoEntity        : 5
    ==============================================
    Crypto Realm - total count: 457
    ==============================================
    ==============================================
```
