### PR TITLE
Registration: annoying error message scares every new user when they add an email (#2391)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Bugfix 🐛:
  - Fix issue when restoring draft after sharing (#2287)
  - Fix issue when updating the avatar of a room (new avatar vanishing)
  - Discard change dialog displayed by mistake when avatar has been updated
+ - Registration: annoying error message scares every new user when they add an email (#2391)
 
 Translations 🗣:
  -

--- a/vector/src/main/java/im/vector/app/features/login/AbstractLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/AbstractLoginFragment.kt
@@ -69,6 +69,11 @@ abstract class AbstractLoginFragment : VectorBaseFragment(), OnBackPressed {
     }
 
     override fun showFailure(throwable: Throwable) {
+        // Only the resumed Fragment can eventually show the error, to avoid multiple dialog display
+        if (!isResumed) {
+            return
+        }
+
         when (throwable) {
             is Failure.Cancelled                      ->
                 /* Ignore this error, user has cancelled the action */

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
@@ -207,7 +207,6 @@ class LoginViewModel @AssistedInject constructor(
     private fun handleCheckIfEmailHasBeenValidated(action: LoginAction.CheckIfEmailHasBeenValidated) {
         // We do not want the common progress bar to be displayed, so we do not change asyncRegistration value in the state
         currentTask?.cancel()
-        currentTask = null
         currentTask = registrationWizard?.checkIfEmailHasBeenValidated(action.delayMillis, registrationCallback)
     }
 


### PR DESCRIPTION
Fixes #2391 
Not sure from where this regression comes from.

Actually those are the other resumed Fragment (ex: `LoginCaptchaFragment`) which show the error dialog by mistake, because they are still listening to the ViewEvents. The (sort of expected) 401 error is correctly ignored by `LoginWaitForEmailFragment`

@ganfra do you have an idea