### PR TITLE
Disable native dialler integration on jitsi widget

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Bugfix 🐛:
  - Discard change dialog displayed by mistake when avatar has been updated
  - Try to fix cropped image in timeline (#2126)
  - Registration: annoying error message scares every new user when they add an email (#2391)
+ - Fix jitsi integration for those with non-vanilla dialler frameworks
 
 Translations 🗣:
  -

--- a/vector/src/main/java/im/vector/app/features/call/conference/VectorJitsiActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/conference/VectorJitsiActivity.kt
@@ -109,6 +109,7 @@ class VectorJitsiActivity : VectorBaseActivity(), JitsiMeetActivityInterface, Ji
                 .setFeatureFlag("invite.enabled", false)
                 .setFeatureFlag("add-people.enabled", false)
                 .setFeatureFlag("video-share.enabled", false)
+                .setFeatureFlag("call-integration.enabled", false)
                 .setRoom(viewState.confId)
                 .setSubject(viewState.subject)
                 .build()


### PR DESCRIPTION
Native dialler integration breaks the jitsi widget for those of us with non-vanilla telephony frameworks.

Disabling this integration (as is default on the Jitsi Meet Android app) allows us to also join conference calls, with no adverse effect on those for whom it already works.

Signed-off-by: Ed Geraghty <ed@geraghty.london>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
