### PR TITLE
Make MSC2858 implementation match the unstable policy of the spec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Improvements 🙌:
  -
 
 Bugfix 🐛:
- -
+ - Fix MSC2858 implementation details (#2540)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/Constants.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/Constants.kt
@@ -33,5 +33,6 @@ const val REGISTER_FALLBACK_PATH = "/_matrix/static/client/register/"
  * Ref: https://matrix.org/docs/spec/client_server/latest#sso-client-login
  */
 const val SSO_REDIRECT_PATH = "/_matrix/client/r0/login/sso/redirect"
+const val MSC2858_SSO_REDIRECT_PATH = "/_matrix/client/unstable/org.matrix.msc2858/login/sso/redirect"
 
 const val SSO_REDIRECT_URL_PARAM = "redirectUrl"

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/data/LoginFlowResponse.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/data/LoginFlowResponse.kt
@@ -42,6 +42,6 @@ internal data class LoginFlow(
          * the client can show a button for each of the supported providers
          * See MSC #2858
          */
-        @Json(name = "identity_providers")
+        @Json(name = "org.matrix.msc2858.identity_providers")
         val ssoIdentityProvider: List<SsoIdentityProvider>?
 )

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewState.kt
@@ -72,9 +72,11 @@ data class LoginViewState(
     fun getSsoUrl(providerId: String?): String {
         return buildString {
             append(homeServerUrl?.trim { it == '/' })
-            append(SSO_REDIRECT_PATH)
             if (providerId != null) {
+                append(MSC2858_SSO_REDIRECT_PATH)
                 append("/$providerId")
+            } else {
+                append(SSO_REDIRECT_PATH)
             }
             // Set a redirect url we will intercept later
             appendParamToUrl(SSO_REDIRECT_URL_PARAM, VECTOR_REDIRECT_URL)


### PR DESCRIPTION
See https://github.com/matrix-org/matrix-doc/pull/2858/files#r543567196
Original implementation in https://github.com/vector-im/element-android/pull/2484

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

I have not tested this, but have no reason to believe it needs to be.
