### PR TITLE
Release VectorBaseBottomSheetDialogFragment bindings when view destroyed

### DIFF
--- a/vector/src/main/java/im/vector/app/core/platform/VectorBaseBottomSheetDialogFragment.kt
+++ b/vector/src/main/java/im/vector/app/core/platform/VectorBaseBottomSheetDialogFragment.kt
@@ -114,6 +114,7 @@ abstract class VectorBaseBottomSheetDialogFragment<VB: ViewBinding> : BottomShee
     @CallSuper
     override fun onDestroyView() {
         uiDisposables.clear()
+        _binding = null
         super.onDestroyView()
     }
 


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

Set `_bindings` in VectorBaseBottomSheetDialogFragment to null when view destroyed, as done in VectorBaseFragment and [suggested by View Binding migration guide](https://developer.android.com/topic/libraries/view-binding#fragments) _(minor oversight in ViewBindings migration PR https://github.com/vector-im/element-android/pull/2542)_