### PR TITLE
Remove empty task affinity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Improvements 🙌:
  -
 
 Bugfix 🐛:
- -
+ - Fix duplicate tasks created on app launch (#2560)
 
 Translations 🗣:
  -

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -63,7 +63,6 @@
 
         <activity
             android:name=".features.MainActivity"
-            android:taskAffinity=""
             android:theme="@style/AppTheme.Launcher" />
 
         <!-- Activity alias for the launcher Activity (must be declared after the Activity it targets) -->


### PR DESCRIPTION
By default, all activities of the app share the same task affinity. By
setting it to "" for this activity, on launch the splash screen and the
home activity are launched as two separate tasks on recent Android
versions (observed on Android 11, not observed on Lollipop).

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
~~- [ ] UI change has been tested on both light and dark themes~~
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
~~- [ ] Pull request includes screenshots or videos if containing UI changes~~
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
