### PR TITLE
Properly hide preview URLs for messages that don't support previews

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Improvements 🙌:
  -
 
 Bugfix 🐛:
- -
+ - Url previews sometimes attached to wrong message (#2561)
 
 Translations 🗣:
  -

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.home.room.detail.timeline.item
 import android.text.method.MovementMethod
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.text.PrecomputedTextCompat
+import androidx.core.view.isVisible
 import androidx.core.widget.TextViewCompat
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
@@ -60,7 +61,12 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
         // Preview URL
         previewUrlViewUpdater.previewUrlView = holder.previewUrlView
         previewUrlViewUpdater.imageContentRenderer = imageContentRenderer
-        previewUrlRetriever?.addListener(attributes.informationData.eventId, previewUrlViewUpdater)
+        val safePreviewUrlRetriever = previewUrlRetriever
+        if (safePreviewUrlRetriever == null) {
+            holder.previewUrlView.isVisible = false
+        } else {
+            safePreviewUrlRetriever.addListener(attributes.informationData.eventId, previewUrlViewUpdater)
+        }
         holder.previewUrlView.delegate = previewUrlCallback
 
         if (useBigFont) {
@@ -106,7 +112,11 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
         var imageContentRenderer: ImageContentRenderer? = null
 
         override fun onStateUpdated(state: PreviewUrlUiState) {
-            val safeImageContentRenderer = imageContentRenderer ?: return
+            val safeImageContentRenderer = imageContentRenderer
+            if (safeImageContentRenderer == null) {
+                previewUrlView?.isVisible = false
+                return
+            }
             previewUrlView?.render(state, safeImageContentRenderer)
         }
     }


### PR DESCRIPTION
Notices and formatted messages don't have imageContentRenderer and
previewUrlRetriever set.
Accordingly, when recycling messages that previously had an URL preview,
we do not want to keep that preview, but actually hide it, instead of
returning early (without rendering any update).

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
~~- [ ] UI change has been tested on both light and dark themes~~
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
~~- [ ] Pull request includes screenshots or videos if containing UI changes~~
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
