### PR TITLE
Fix member state filter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Improvements 🙌:
 
 Bugfix 🐛:
  - Url previews sometimes attached to wrong message (#2561)
+ - Fix the "Show room member state events" setting (#2581)
 
 Translations 🗣:
  -

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineSettingsFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineSettingsFactory.kt
@@ -54,11 +54,15 @@ class TimelineSettingsFactory @Inject constructor(
     }
 
     private fun List<String>.createAllowedEventTypeFilters(): List<EventTypeFilter> {
-        return map {
+        var result = map {
             EventTypeFilter(
                     eventType = it,
-                    stateKey = if (it == EventType.STATE_ROOM_MEMBER && userPreferencesProvider.shouldShowRoomMemberStateEvents()) session.myUserId else null
+                    stateKey = null
             )
         }
+        if (!userPreferencesProvider.shouldShowRoomMemberStateEvents()) {
+            result = result.filter { it.eventType != EventType.STATE_ROOM_MEMBER }
+        }
+        return result
     }
 }


### PR DESCRIPTION
Fixes the "Show room member state events" setting.

What we want with that setting:
- When enabled, include all member state events
- When disabled, exclude all member state events

What it did:
- When enabled, exclude all member state events except from the
  logged-in user
- When disabled, include all member state events

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>

### Pull Request Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
~~- [ ] UI change has been tested on both light and dark themes~~
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
~~- [ ] Pull request includes screenshots or videos if containing UI changes~~
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
