### PR TITLE
Add System theme option and set as default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Features ✨:
  - Enable url previews for notices (#2562)
 
 Improvements 🙌:
- -
+  - Add System theme option and set as default (#904) (#2387)
 
 Bugfix 🐛:
  - Url previews sometimes attached to wrong message (#2561)

--- a/vector/src/main/java/im/vector/app/features/themes/ThemeUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/themes/ThemeUtils.kt
@@ -102,7 +102,7 @@ object ThemeUtils {
     fun setApplicationTheme(context: Context, aTheme: String) {
         currentTheme.set(aTheme)
         when (aTheme) {
-            SYSTEM_THEME_VALUE -> context.setTheme(if(isSystemDarkTheme(context.resources)) R.style.AppTheme_Dark else R.style.AppTheme_Light)
+            SYSTEM_THEME_VALUE -> context.setTheme(if (isSystemDarkTheme(context.resources)) R.style.AppTheme_Dark else R.style.AppTheme_Light)
             THEME_DARK_VALUE   -> context.setTheme(R.style.AppTheme_Dark)
             THEME_BLACK_VALUE  -> context.setTheme(R.style.AppTheme_Black)
             else               -> context.setTheme(R.style.AppTheme_Light)
@@ -119,7 +119,7 @@ object ThemeUtils {
      */
     fun setActivityTheme(activity: Activity, otherThemes: ActivityOtherThemes) {
         when (getApplicationTheme(activity)) {
-            SYSTEM_THEME_VALUE -> if(isSystemDarkTheme(activity.resources)) activity.setTheme(otherThemes.dark)
+            SYSTEM_THEME_VALUE -> if (isSystemDarkTheme(activity.resources)) activity.setTheme(otherThemes.dark)
             THEME_DARK_VALUE   -> activity.setTheme(otherThemes.dark)
             THEME_BLACK_VALUE  -> activity.setTheme(otherThemes.black)
         }

--- a/vector/src/main/res/values/array.xml
+++ b/vector/src/main/res/values/array.xml
@@ -92,12 +92,14 @@
 
     <!-- Theme -->
     <string-array name="theme_entries">
+        <item>@string/system_theme</item>
         <item>@string/light_theme</item>
         <item>@string/dark_theme</item>
         <item>@string/black_them</item>
     </string-array>
 
     <string-array name="theme_values">
+        <item>system</item>
         <item>light</item>
         <item>dark</item>
         <item>black</item>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="resources_script">Latn</string>
 
     <!-- theme -->
+    <string name="system_theme">System Default</string>
     <string name="light_theme">Light Theme</string>
     <string name="dark_theme">Dark Theme</string>
     <string name="black_them">Black Theme</string>

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -13,7 +13,7 @@
             app:fragment="im.vector.app.features.settings.locale.LocalePickerFragment" />
 
         <im.vector.app.core.preference.VectorListPreference
-            android:defaultValue="light"
+            android:defaultValue="system"
             android:entries="@array/theme_entries"
             android:entryValues="@array/theme_values"
             android:key="APPLICATION_THEME_KEY"


### PR DESCRIPTION
This adds an option to use the system theme as the app theme. It is enabled by default and works on API 21+. 

### Screenshots
Login screen with system theme option (dark theme as system default)
![](https://i.tigr.dev/kj9k7dnq.png)
Settings dialog to choose themes
![](https://i.tigr.dev/kj9kaoeh.png)

Signed-off-by: Tigermouthbear <tigermouthbear@tigr.dev>

### Pull Request Checklist
- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
