### PR TITLE
[issue-2610] implement client-side override of nick color

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Changes in Element 1.0.14 (2020-XX-XX)
 ===================================================
 
 Features ✨:
+ - Allow changing nick colors (#2610)
  - Enable url previews for notices (#2562)
 
 Improvements 🙌:

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/MessageColorProvider.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/MessageColorProvider.kt
@@ -32,7 +32,7 @@ class MessageColorProvider @Inject constructor(
 
     @ColorInt
     fun getMemberNameTextColor(matrixItem: MatrixItem): Int {
-        return matrixItemColorProvider.getColor(matrixItem)
+        return vectorPreferences.overrideColor(matrixItem.id, matrixItemColorProvider.getColor(matrixItem))
     }
 
     @ColorInt

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.media.RingtoneManager
 import android.net.Uri
 import android.provider.MediaStore
+import androidx.annotation.ColorInt
 import androidx.core.content.edit
 import com.squareup.seismic.ShakeDetector
 import im.vector.app.BuildConfig
@@ -179,6 +180,8 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         private const val DID_ASK_TO_USE_ANALYTICS_TRACKING_KEY = "DID_ASK_TO_USE_ANALYTICS_TRACKING_KEY"
         private const val SETTINGS_DISPLAY_ALL_EVENTS_KEY = "SETTINGS_DISPLAY_ALL_EVENTS_KEY"
 
+        private const val SETTINGS_OVERRIDE_COLOR = "SETTINGS_OVERRIDE_COLOR"
+
         private const val DID_ASK_TO_ENABLE_SESSION_PUSH = "DID_ASK_TO_ENABLE_SESSION_PUSH"
 
         private const val MEDIA_SAVING_3_DAYS = 0
@@ -237,6 +240,7 @@ class VectorPreferences @Inject constructor(private val context: Context) {
     }
 
     private val defaultPrefs = DefaultSharedPreferences.getInstance(context)
+    private val colorOverridePrefs = context.getSharedPreferences(SETTINGS_OVERRIDE_COLOR, Context.MODE_PRIVATE)
 
     /**
      * Clear the preferences.
@@ -929,5 +933,24 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         } catch (e: Throwable) {
             BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_BATTERY
         }
+    }
+
+    fun setOverrideColor(id: String, @ColorInt color: Int) {
+        if (color != 0) {
+            colorOverridePrefs
+                    .edit()
+                    .putInt(id, color)
+                    .apply()
+        } else {
+            colorOverridePrefs
+                    .edit()
+                    .remove(id)
+                    .apply()
+        }
+    }
+
+    @ColorInt
+    fun overrideColor(id: String, @ColorInt defColor: Int): Int {
+        return colorOverridePrefs.getInt(id, defColor)
     }
 }

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2241,6 +2241,8 @@
     <string name="direct_room_profile_section_more_leave">Leave</string>
     <string name="room_profile_leaving_room">"Leaving the room…"</string>
 
+    <string name="room_member_override_color">Override color</string>
+
     <string name="room_member_power_level_admins">Admins</string>
     <string name="room_member_power_level_moderators">Moderators</string>
     <string name="room_member_power_level_custom">Custom</string>


### PR DESCRIPTION
Implement issue #2610 

- allow changing the nick color by clicking the dispay-name in the room
  member details page.
- the ovirride-color can be specified as a hex string (#rrggbb)
- entering an invalid color code or leaving the field blank reverts to
  the default hash-based nick color

- future improvements:
  - replace the text-based color entry with a proper color picker dialog
  - sync the setting server side so it can be reused by other clients
    (although this can cause problems if different themes are used on
    the clients)
  - make the feature more discoverable

Signed-off-by: Radics Péter <mitchnull@gmail.com>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
