### PR TITLE
Warn user when he is leaving a not public room (#1460)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,8 @@ Features ✨:
  - Enable url previews for notices (#2562)
 
 Improvements 🙌:
-  - Add System theme option and set as default (#904) (#2387)
+ - Add System theme option and set as default (#904, #2387)
+ - Warn user when he is leaving a not public room (#1460)
 
 Bugfix 🐛:
  - Unspecced msgType field in m.sticker (#2580)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/state/StateServiceExtension.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/state/StateServiceExtension.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.api.session.room.state
+
+import org.matrix.android.sdk.api.query.QueryStringValue
+import org.matrix.android.sdk.api.session.events.model.EventType
+import org.matrix.android.sdk.api.session.events.model.toModel
+import org.matrix.android.sdk.api.session.room.model.RoomJoinRules
+import org.matrix.android.sdk.api.session.room.model.RoomJoinRulesContent
+
+/**
+ * Return true if a room can be joined by anyone (RoomJoinRules.PUBLIC)
+ */
+fun StateService.isPublic(): Boolean {
+    return getStateEvent(EventType.STATE_ROOM_JOIN_RULES, QueryStringValue.NoCondition)
+            ?.content
+            ?.toModel<RoomJoinRulesContent>()
+            ?.joinRules == RoomJoinRules.PUBLIC
+}

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
@@ -33,6 +33,7 @@ import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 import org.matrix.android.sdk.api.session.room.model.tag.RoomTag
+import org.matrix.android.sdk.api.session.room.state.isPublic
 import org.matrix.android.sdk.rx.rx
 import timber.log.Timber
 import java.lang.Exception
@@ -76,6 +77,10 @@ class RoomListViewModel @Inject constructor(initialState: RoomListViewState,
             is RoomListAction.ChangeRoomNotificationState -> handleChangeNotificationMode(action)
             is RoomListAction.ToggleTag                   -> handleToggleTag(action)
         }.exhaustive
+    }
+
+    fun isPublicRoom(roomId: String): Boolean {
+        return session.getRoom(roomId)?.isPublic().orFalse()
     }
 
     // PRIVATE METHODS *****************************************************************************

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileFragment.kt
@@ -17,6 +17,7 @@
 
 package im.vector.app.features.roomprofile
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
@@ -34,6 +35,7 @@ import com.airbnb.mvrx.withState
 import im.vector.app.R
 import im.vector.app.core.animations.AppBarStateChangeListener
 import im.vector.app.core.animations.MatrixItemAppBarStateChangeListener
+import im.vector.app.core.dialogs.withColoredButton
 import im.vector.app.core.extensions.cleanup
 import im.vector.app.core.extensions.configureWith
 import im.vector.app.core.extensions.copyOnLongClick
@@ -247,14 +249,27 @@ class RoomProfileFragment @Inject constructor(
     }
 
     override fun onLeaveRoomClicked() {
+        val isPublicRoom = roomProfileViewModel.isPublicRoom()
+        val message = buildString {
+            append(getString(R.string.room_participants_leave_prompt_msg))
+            if (!isPublicRoom) {
+                append("\n\n")
+                append(getString(R.string.room_participants_leave_private_warning))
+            }
+        }
         AlertDialog.Builder(requireContext())
                 .setTitle(R.string.room_participants_leave_prompt_title)
-                .setMessage(R.string.room_participants_leave_prompt_msg)
+                .setMessage(message)
                 .setPositiveButton(R.string.leave) { _, _ ->
                     roomProfileViewModel.handle(RoomProfileAction.LeaveRoom)
                 }
                 .setNegativeButton(R.string.cancel, null)
                 .show()
+                .apply {
+                    if (!isPublicRoom) {
+                        withColoredButton(DialogInterface.BUTTON_POSITIVE)
+                    }
+                }
     }
 
     override fun onRoomIdClicked() {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileViewModel.kt
@@ -37,6 +37,7 @@ import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.room.members.roomMemberQueryParams
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.powerlevels.PowerLevelsHelper
+import org.matrix.android.sdk.api.session.room.state.isPublic
 import org.matrix.android.sdk.rx.RxRoom
 import org.matrix.android.sdk.rx.rx
 import org.matrix.android.sdk.rx.unwrap
@@ -107,6 +108,10 @@ class RoomProfileViewModel @AssistedInject constructor(
             is RoomProfileAction.ShareRoomProfile            -> handleShareRoomProfile()
             RoomProfileAction.CreateShortcut                 -> handleCreateShortcut()
         }.exhaustive
+    }
+
+    fun isPublicRoom(): Boolean {
+        return room.isPublic()
     }
 
     private fun handleEnableEncryption() {

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -491,6 +491,7 @@
     <!--  Chat participants -->
     <string name="room_participants_leave_prompt_title">Leave room</string>
     <string name="room_participants_leave_prompt_msg">Are you sure you want to leave the room?</string>
+    <string name="room_participants_leave_private_warning">This room is not public. You will not be able to rejoin without an invite.</string>
     <string name="room_participants_remove_prompt_msg">Are you sure you want to remove %s from this chat?</string>
     <string name="room_participants_create">Create</string>
 


### PR DESCRIPTION
Fix #1460 

Add an extra warning, and color the button in red in case of not public room

<img width="313" alt="image" src="https://user-images.githubusercontent.com/3940906/103639084-18613800-4f4e-11eb-88df-fb39ce2b95c1.png">

Applies when leaving room from rooms list or from room profile