### PR TITLE
Typo in the set-up instructions for the test homeserver

### DIFF
--- a/docs/ui-tests.md
+++ b/docs/ui-tests.md
@@ -27,7 +27,6 @@ $ source env/bin/activate
 Every time you want to launch these test homeservers, type:
 
 ```shell script
-$ virtualenv -p python3 env
 $ source env/bin/activate
 (env) $ demo/start.sh --no-rate-limit
 ```


### PR DESCRIPTION
I think I removed a typo. You probably don't want a new virtualenv every time you start a homeserver?