### PR TITLE
Fix request too large Uri error when joining a room

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Bugfix 🐛:
  - Tapping drawer having more than 1 room in notifications gives "malformed link" error (#2605)
  - Sent image not displayed when opened immediately after sending (#409)
  - Initial sync is not retried correctly when there is some network error. (#2632)
+ - Fix request too large Uri error when joining a room
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/joining/JoinRoomTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/joining/JoinRoomTask.kt
@@ -55,7 +55,11 @@ internal class DefaultJoinRoomTask @Inject constructor(
         roomChangeMembershipStateDataSource.updateState(params.roomIdOrAlias, ChangeMembershipState.Joining)
         val joinRoomResponse = try {
             executeRequest<JoinRoomResponse>(globalErrorReceiver) {
-                apiCall = roomAPI.join(params.roomIdOrAlias, params.viaServers, mapOf("reason" to params.reason))
+                apiCall = roomAPI.join(
+                        roomIdOrAlias = params.roomIdOrAlias,
+                        viaServers = params.viaServers.take(3),
+                        params = mapOf("reason" to params.reason)
+                )
             }
         } catch (failure: Throwable) {
             roomChangeMembershipStateDataSource.updateState(params.roomIdOrAlias, ChangeMembershipState.FailedJoining(failure))

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/roompreview/RoomPreviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/roompreview/RoomPreviewViewModel.kt
@@ -84,22 +84,34 @@ class RoomPreviewViewModel @AssistedInject constructor(@Assisted private val ini
             when (peekResult) {
                 is PeekResult.Success           -> {
                     setState {
+                        // Do not override what we had from the permalink
+                        val newHomeServers = if (homeServers.isEmpty()) {
+                            peekResult.viaServers.take(3)
+                        } else {
+                            homeServers
+                        }
                         copy(
                                 roomId = peekResult.roomId,
                                 avatarUrl = peekResult.avatarUrl,
                                 roomAlias = peekResult.alias ?: initialState.roomAlias,
                                 roomTopic = peekResult.topic,
-                                homeServers = peekResult.viaServers,
+                                homeServers = newHomeServers,
                                 peekingState = Success(PeekingState.FOUND)
                         )
                     }
                 }
                 is PeekResult.PeekingNotAllowed -> {
                     setState {
+                        // Do not override what we had from the permalink
+                        val newHomeServers = if (homeServers.isEmpty()) {
+                            peekResult.viaServers.take(3)
+                        } else {
+                            homeServers
+                        }
                         copy(
                                 roomId = peekResult.roomId,
                                 roomAlias = peekResult.alias ?: initialState.roomAlias,
-                                homeServers = peekResult.viaServers,
+                                homeServers = newHomeServers,
                                 peekingState = Success(PeekingState.NO_ACCESS)
                         )
                     }


### PR DESCRIPTION
This PR fix the pb of using too many servers when joining a room.
By default we now use what was provided in the permalink (via parameter).

Also the SDK enforces that there is no more than 3 servers in the join request

You can reproduce the current problem with this permalink: https://matrix.to/#/#matrix:matrix.org?via=matrix.org&via=t2bot.io&via=gnome.org