### PR TITLE
Fix Dendrite sync response support

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/EventContextResponse.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/EventContextResponse.kt
@@ -24,13 +24,17 @@ import org.matrix.android.sdk.api.session.events.model.Event
 data class EventContextResponse(
         @Json(name = "event") val event: Event,
         @Json(name = "start") override val start: String? = null,
-        @Json(name = "events_before") val eventsBefore: List<Event> = emptyList(),
-        @Json(name = "events_after") val eventsAfter: List<Event> = emptyList(),
+        @Json(name = "events_before") val eventsBefore: List<Event>? = emptyList(),
+        @Json(name = "events_after") val eventsAfter: List<Event>? = emptyList(),
         @Json(name = "end") override val end: String? = null,
-        @Json(name = "state") override val stateEvents: List<Event> = emptyList()
+        @Json(name = "state") override val stateEvents: List<Event>? = emptyList()
 ) : TokenChunkEvent {
 
     override val events: List<Event> by lazy {
-        eventsAfter.reversed() + listOf(event) + eventsBefore
+        mutableListOf<Event>().apply {
+            eventsAfter?.let { addAll(it.reversed()) }
+            add(event)
+            eventsBefore?.let { addAll(it) }
+        }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/EventContextResponse.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/EventContextResponse.kt
@@ -21,20 +21,34 @@ import com.squareup.moshi.JsonClass
 import org.matrix.android.sdk.api.session.events.model.Event
 
 @JsonClass(generateAdapter = true)
-data class EventContextResponse(
+internal data class EventContextResponse(
+        /**
+         * Details of the requested event.
+         */
         @Json(name = "event") val event: Event,
+        /**
+         * A token that can be used to paginate backwards with.
+         */
         @Json(name = "start") override val start: String? = null,
-        @Json(name = "events_before") val eventsBefore: List<Event>? = emptyList(),
-        @Json(name = "events_after") val eventsAfter: List<Event>? = emptyList(),
+        /**
+         * A list of room events that happened just before the requested event, in reverse-chronological order.
+         */
+        @Json(name = "events_before") val eventsBefore: List<Event>? = null,
+        /**
+         * A list of room events that happened just after the requested event, in chronological order.
+         */
+        @Json(name = "events_after") val eventsAfter: List<Event>? = null,
+        /**
+         * A token that can be used to paginate forwards with.
+         */
         @Json(name = "end") override val end: String? = null,
-        @Json(name = "state") override val stateEvents: List<Event>? = emptyList()
+        /**
+         * The state of the room at the last event returned.
+         */
+        @Json(name = "state") override val stateEvents: List<Event>? = null
 ) : TokenChunkEvent {
 
     override val events: List<Event> by lazy {
-        mutableListOf<Event>().apply {
-            eventsAfter?.let { addAll(it.reversed()) }
-            add(event)
-            eventsBefore?.let { addAll(it) }
-        }
+        eventsAfter.orEmpty().reversed() + event + eventsBefore.orEmpty()
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/PaginationResponse.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/PaginationResponse.kt
@@ -22,8 +22,28 @@ import org.matrix.android.sdk.api.session.events.model.Event
 
 @JsonClass(generateAdapter = true)
 internal data class PaginationResponse(
+        /**
+         * The token the pagination starts from. If dir=b this will be the token supplied in from.
+         */
         @Json(name = "start") override val start: String? = null,
+        /**
+         * The token the pagination ends at. If dir=b this token should be used again to request even earlier events.
+         */
         @Json(name = "end") override val end: String? = null,
-        @Json(name = "chunk") override val events: List<Event>? = emptyList(),
-        @Json(name = "state") override val stateEvents: List<Event>? = emptyList()
-) : TokenChunkEvent
+        /**
+         * A list of room events. The order depends on the dir parameter. For dir=b events will be in
+         * reverse-chronological order, for dir=f in chronological order, so that events start at the from point.
+         */
+        @Json(name = "chunk") val chunk: List<Event>? = null,
+        /**
+         * A list of state events relevant to showing the chunk. For example, if lazy_load_members is enabled
+         * in the filter then this may contain the membership events for the senders of events in the chunk.
+         *
+         * Unless include_redundant_members is true, the server may remove membership events which would have
+         * already been sent to the client in prior calls to this endpoint, assuming the membership of those members has not changed.
+         */
+        @Json(name = "state") override val stateEvents: List<Event>? = null
+) : TokenChunkEvent {
+    override val events: List<Event>
+        get() = chunk.orEmpty()
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/PaginationResponse.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/PaginationResponse.kt
@@ -24,6 +24,6 @@ import org.matrix.android.sdk.api.session.events.model.Event
 internal data class PaginationResponse(
         @Json(name = "start") override val start: String? = null,
         @Json(name = "end") override val end: String? = null,
-        @Json(name = "chunk") override val events: List<Event> = emptyList(),
-        @Json(name = "state") override val stateEvents: List<Event> = emptyList()
+        @Json(name = "chunk") override val events: List<Event>? = emptyList(),
+        @Json(name = "state") override val stateEvents: List<Event>? = emptyList()
 ) : TokenChunkEvent

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEvent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEvent.kt
@@ -21,7 +21,7 @@ import org.matrix.android.sdk.api.session.events.model.Event
 internal interface TokenChunkEvent {
     val start: String?
     val end: String?
-    val events: List<Event>?
+    val events: List<Event>
     val stateEvents: List<Event>?
 
     fun hasMore() = start != end

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEvent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEvent.kt
@@ -21,8 +21,8 @@ import org.matrix.android.sdk.api.session.events.model.Event
 internal interface TokenChunkEvent {
     val start: String?
     val end: String?
-    val events: List<Event>
-    val stateEvents: List<Event>
+    val events: List<Event>?
+    val stateEvents: List<Event>?
 
     fun hasMore() = start != end
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/uploads/GetUploadsTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/uploads/GetUploadsTask.kt
@@ -56,8 +56,8 @@ internal class DefaultGetUploadsTask @Inject constructor(
         private val roomAPI: RoomAPI,
         private val tokenStore: SyncTokenStore,
         @SessionDatabase private val monarchy: Monarchy,
-        private val globalErrorReceiver: GlobalErrorReceiver)
-    : GetUploadsTask {
+        private val globalErrorReceiver: GlobalErrorReceiver
+) : GetUploadsTask {
 
     override suspend fun execute(params: GetUploadsTask.Params): GetUploadsResult {
         val result: GetUploadsResult
@@ -95,7 +95,7 @@ internal class DefaultGetUploadsTask @Inject constructor(
                     nextToken = chunk.end ?: "",
                     hasMore = chunk.hasMore()
             )
-            events = chunk.events ?: emptyList()
+            events = chunk.events
         }
 
         var uploadEvents = listOf<UploadEvent>()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/uploads/GetUploadsTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/uploads/GetUploadsTask.kt
@@ -95,7 +95,7 @@ internal class DefaultGetUploadsTask @Inject constructor(
                     nextToken = chunk.end ?: "",
                     hasMore = chunk.hasMore()
             )
-            events = chunk.events
+            events = chunk.events ?: emptyList()
         }
 
         var uploadEvents = listOf<UploadEvent>()


### PR DESCRIPTION
Fixes issues when syncing and back paginating with Dendrite:
EA didn't support null event list (dendrite behavior) , expected it to be an empty array (synapse behavior)

Back pagination depends on this dendrite fix https://github.com/matrix-org/dendrite/pull/1708
