### PR TITLE
Drawer layout width limit for landscape and tablets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Improvements 🙌:
  -
 
 Bugfix 🐛:
- -
+ - Sidebar too large in horizontal orientation or tablets (#475)
 
 Translations 🗣:
  -

--- a/vector/src/main/res/layout/activity_home.xml
+++ b/vector/src/main/res/layout/activity_home.xml
@@ -25,7 +25,7 @@
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/homeDrawerFragmentContainer"
-        android:layout_width="match_parent"
+        android:layout_width="@dimen/navigation_drawer_max_width"
         android:layout_height="match_parent"
         android:layout_gravity="start" />
 

--- a/vector/src/main/res/values-sw600dp/dimens.xml
+++ b/vector/src/main/res/values-sw600dp/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Navigation Drawer -->
+    <dimen name="navigation_drawer_max_width">400dp</dimen>
+</resources>

--- a/vector/src/main/res/values/dimens.xml
+++ b/vector/src/main/res/values/dimens.xml
@@ -33,4 +33,7 @@
     <!-- Max width for some buttons -->
     <dimen name="button_max_width">280dp</dimen>
 
+    <!-- Navigation Drawer -->
+    <dimen name="navigation_drawer_max_width">320dp</dimen>
+
 </resources>


### PR DESCRIPTION
Fixes #475

<img width="726" alt="Screen Shot 2021-01-19 at 15 32 54" src="https://user-images.githubusercontent.com/1254401/105035531-2e055000-5a6c-11eb-8e12-7d037052f1f1.png">
