### PR TITLE
Identity: Recompute hashes after M_INVALID_PEPPER

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Improvements 🙌:
 Bugfix 🐛:
  - Fix clear cache issue: sometimes, after a clear cache, there is still a token, so the init sync service is not started.
  - Sidebar too large in horizontal orientation or tablets (#475)
+ - When receiving a new pepper from identity server, use it on the next hash lookup (#2708)
 
 Translations 🗣:
  -


### PR DESCRIPTION
When a new pepper is retrieved after an M_INVALID_PEPPER response,
recompute hashes with that pepper, and send those new hashes in the next
lookup attempt instead of reusing the original hashes.

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
