### PR TITLE
Fix problem when updating trust shield in big e2e rooms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Bugfix 🐛:
  - UrlPreview should be updated when the url is edited and changed (#2678)
  - When receiving a new pepper from identity server, use it on the next hash lookup (#2708)
  - Crashes reported by PlayStore (new in 1.0.14) (#2707)
+ - Data for Worker overload (#2721)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/Extensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/Extensions.kt
@@ -21,11 +21,11 @@ import org.matrix.android.sdk.internal.crypto.model.CryptoDeviceInfo
 import org.matrix.android.sdk.internal.util.JsonCanonicalizer
 import timber.log.Timber
 
-fun CryptoDeviceInfo.canonicalSignable(): String {
+internal fun CryptoDeviceInfo.canonicalSignable(): String {
     return JsonCanonicalizer.getCanonicalJson(Map::class.java, signalableJSONDictionary())
 }
 
-fun CryptoCrossSigningKey.canonicalSignable(): String {
+internal fun CryptoCrossSigningKey.canonicalSignable(): String {
     return JsonCanonicalizer.getCanonicalJson(Map::class.java, signalableJSONDictionary())
 }
 
@@ -40,7 +40,7 @@ fun String.fromBase64(): ByteArray {
 /**
  * Decode the base 64. Return null in case of bad format. Should be used when parsing received data from external source
  */
-fun String.fromBase64Safe(): ByteArray? {
+internal fun String.fromBase64Safe(): ByteArray? {
     return try {
         Base64.decode(this, Base64.DEFAULT)
     } catch (throwable: Throwable) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/UpdateTrustWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/UpdateTrustWorker.kt
@@ -84,6 +84,12 @@ internal class UpdateTrustWorker(context: Context,
             // Get current other userIds for this room
             getOtherUserIds(roomId)
         }
+
+        if (userList.isEmpty()) {
+            // This should not happen, but let's avoid go further in case of empty list
+            return Result.success()
+        }
+
         // Unfortunately we don't have much info on what did exactly changed (is it the cross signing keys of that user,
         // or a new device?) So we check all again :/
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/UpdateTrustWorkerDataRepository.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/UpdateTrustWorkerDataRepository.kt
@@ -22,6 +22,7 @@ import org.matrix.android.sdk.internal.di.MoshiProvider
 import org.matrix.android.sdk.internal.di.SessionFilesDirectory
 import java.io.File
 import java.util.UUID
+import javax.inject.Inject
 
 @JsonClass(generateAdapter = true)
 internal data class UpdateTrustWorkerData(
@@ -29,7 +30,7 @@ internal data class UpdateTrustWorkerData(
         val userIds: List<String>
 )
 
-internal class UpdateTrustWorkerDataRepository(
+internal class UpdateTrustWorkerDataRepository @Inject constructor(
         @SessionFilesDirectory parentDir: File
 ) {
     private val workingDirectory = File(parentDir, "tw")

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/UpdateTrustWorkerDataRepository.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/UpdateTrustWorkerDataRepository.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.crypto.crosssigning
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import org.matrix.android.sdk.internal.di.MoshiProvider
+import org.matrix.android.sdk.internal.di.SessionFilesDirectory
+import java.io.File
+import java.util.UUID
+
+@JsonClass(generateAdapter = true)
+internal data class UpdateTrustWorkerData(
+        @Json(name = "userIds")
+        val userIds: List<String>
+)
+
+internal class UpdateTrustWorkerDataRepository(
+        @SessionFilesDirectory parentDir: File
+) {
+    private val workingDirectory = File(parentDir, "tw")
+    private val jsonAdapter = MoshiProvider.providesMoshi().adapter(UpdateTrustWorkerData::class.java)
+
+    // Return the path of the created file
+    fun createParam(userIds: List<String>): String {
+        val filename = "${UUID.randomUUID()}.json"
+        workingDirectory.mkdirs()
+        val file = File(workingDirectory, filename)
+
+        UpdateTrustWorkerData(userIds = userIds)
+                .let { jsonAdapter.toJson(it) }
+                .let { file.writeText(it) }
+
+        return filename
+    }
+
+    fun getParam(filename: String): UpdateTrustWorkerData? {
+        return File(workingDirectory, filename)
+                .takeIf { it.exists() }
+                ?.let { it.readText() }
+                ?.let { jsonAdapter.fromJson(it) }
+    }
+
+    fun delete(filename: String) {
+        File(workingDirectory, filename).delete()
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/CryptoCrossSigningKey.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/CryptoCrossSigningKey.kt
@@ -63,7 +63,7 @@ data class CryptoCrossSigningKey(
         )
     }
 
-    data class Builder(
+    internal data class Builder(
             val userId: String,
             val usage: KeyUsage,
             private var base64Pkey: String? = null,
@@ -97,7 +97,7 @@ data class CryptoCrossSigningKey(
     }
 }
 
-enum class KeyUsage(val value: String) {
+internal enum class KeyUsage(val value: String) {
     MASTER("master"),
     SELF_SIGNING("self_signing"),
     USER_SIGNING("user_signing")

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -293,7 +293,7 @@ internal class RealmCryptoStore @Inject constructor(
                                 realm.insertOrUpdate(entity)
                             }
                             // Ensure all other devices are deleted
-                            u.devices.forEach { it.deleteOnCascade() }
+                            u.devices.toList().forEach { it.deleteOnCascade() }
                             u.devices.clear()
                             u.devices.addAll(new)
                         }
@@ -1634,7 +1634,7 @@ internal class RealmCryptoStore @Inject constructor(
         } else {
             // Just override existing, caller should check and untrust id needed
             val existing = CrossSigningInfoEntity.getOrCreate(realm, userId)
-            existing.crossSigningKeys.forEach { it.deleteOnCascade() }
+            existing.crossSigningKeys.toList().forEach { it.deleteOnCascade() }
             existing.crossSigningKeys.clear()
             existing.crossSigningKeys.addAll(
                     info.crossSigningKeys.map {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -293,7 +293,8 @@ internal class RealmCryptoStore @Inject constructor(
                                 realm.insertOrUpdate(entity)
                             }
                             // Ensure all other devices are deleted
-                            u.devices.deleteAllFromRealm()
+                            u.devices.forEach { it.deleteOnCascade() }
+                            u.devices.clear()
                             u.devices.addAll(new)
                         }
             }
@@ -309,7 +310,7 @@ internal class RealmCryptoStore @Inject constructor(
                     .let { userEntity ->
                         if (masterKey == null || selfSigningKey == null) {
                             // The user has disabled cross signing?
-                            userEntity.crossSigningInfoEntity?.deleteFromRealm()
+                            userEntity.crossSigningInfoEntity?.deleteOnCascade()
                             userEntity.crossSigningInfoEntity = null
                         } else {
                             var shouldResetMyDevicesLocalTrust = false
@@ -1633,7 +1634,8 @@ internal class RealmCryptoStore @Inject constructor(
         } else {
             // Just override existing, caller should check and untrust id needed
             val existing = CrossSigningInfoEntity.getOrCreate(realm, userId)
-            existing.crossSigningKeys.deleteAllFromRealm()
+            existing.crossSigningKeys.forEach { it.deleteOnCascade() }
+            existing.crossSigningKeys.clear()
             existing.crossSigningKeys.addAll(
                     info.crossSigningKeys.map {
                         crossSigningKeysMapper.map(it)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/CrossSigningInfoEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/CrossSigningInfoEntity.kt
@@ -30,7 +30,7 @@ internal open class CrossSigningInfoEntity(
     companion object
 
     fun deleteOnCascade() {
-        crossSigningKeys.forEach { it.deleteOnCascade() }
+        crossSigningKeys.toList().forEach { it.deleteOnCascade() }
         deleteFromRealm()
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/CrossSigningInfoEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/CrossSigningInfoEntity.kt
@@ -16,10 +16,10 @@
 
 package org.matrix.android.sdk.internal.crypto.store.db.model
 
-import org.matrix.android.sdk.internal.crypto.model.KeyUsage
 import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
+import org.matrix.android.sdk.internal.crypto.model.KeyUsage
 
 internal open class CrossSigningInfoEntity(
         @PrimaryKey
@@ -28,6 +28,11 @@ internal open class CrossSigningInfoEntity(
 ) : RealmObject() {
 
     companion object
+
+    fun deleteOnCascade() {
+        crossSigningKeys.forEach { it.deleteOnCascade() }
+        deleteFromRealm()
+    }
 
     fun getMasterKey() = crossSigningKeys.firstOrNull { it.usages.contains(KeyUsage.MASTER.value) }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/DeviceInfoEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/DeviceInfoEntity.kt
@@ -46,4 +46,9 @@ internal open class DeviceInfoEntity(
     val users: RealmResults<UserEntity>? = null
 
     companion object
+
+    fun deleteOnCascade() {
+        trustLevelEntity?.deleteFromRealm()
+        deleteFromRealm()
+    }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/KeyInfoEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/KeyInfoEntity.kt
@@ -29,4 +29,10 @@ internal open class KeyInfoEntity(
          */
         var signatures: String? = null,
         var trustLevelEntity: TrustLevelEntity? = null
-) : RealmObject()
+) : RealmObject() {
+
+    fun deleteOnCascade() {
+        trustLevelEntity?.deleteFromRealm()
+        deleteFromRealm()
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/UserEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/UserEntity.kt
@@ -30,7 +30,7 @@ internal open class UserEntity(
     companion object
 
     fun deleteOnCascade() {
-        devices.forEach { it.deleteOnCascade() }
+        devices.toList().forEach { it.deleteOnCascade() }
         crossSigningInfoEntity?.deleteOnCascade()
         deleteFromRealm()
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/UserEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/UserEntity.kt
@@ -24,8 +24,14 @@ internal open class UserEntity(
         @PrimaryKey var userId: String? = null,
         var devices: RealmList<DeviceInfoEntity> = RealmList(),
         var crossSigningInfoEntity: CrossSigningInfoEntity? = null,
-        var deviceTrackingStatus: Int = 0)
-    : RealmObject() {
+        var deviceTrackingStatus: Int = 0
+) : RealmObject() {
 
     companion object
+
+    fun deleteOnCascade() {
+        devices.forEach { it.deleteOnCascade() }
+        crossSigningInfoEntity?.deleteOnCascade()
+        deleteFromRealm()
+    }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/query/UserEntitiesQueries.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/query/UserEntitiesQueries.kt
@@ -16,11 +16,11 @@
 
 package org.matrix.android.sdk.internal.crypto.store.db.query
 
-import org.matrix.android.sdk.internal.crypto.store.db.model.UserEntity
-import org.matrix.android.sdk.internal.crypto.store.db.model.UserEntityFields
 import io.realm.Realm
 import io.realm.kotlin.createObject
 import io.realm.kotlin.where
+import org.matrix.android.sdk.internal.crypto.store.db.model.UserEntity
+import org.matrix.android.sdk.internal.crypto.store.db.model.UserEntityFields
 
 /**
  * Get or create a user
@@ -39,5 +39,5 @@ internal fun UserEntity.Companion.delete(realm: Realm, userId: String) {
     realm.where<UserEntity>()
             .equalTo(UserEntityFields.USER_ID, userId)
             .findFirst()
-            ?.deleteFromRealm()
+            ?.deleteOnCascade()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tools/Tools.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tools/Tools.kt
@@ -21,7 +21,7 @@ import org.matrix.olm.OlmPkEncryption
 import org.matrix.olm.OlmPkSigning
 import org.matrix.olm.OlmUtility
 
-fun <T> withOlmEncryption(block: (OlmPkEncryption) -> T): T {
+internal fun <T> withOlmEncryption(block: (OlmPkEncryption) -> T): T {
     val olmPkEncryption = OlmPkEncryption()
     try {
         return block(olmPkEncryption)
@@ -30,7 +30,7 @@ fun <T> withOlmEncryption(block: (OlmPkEncryption) -> T): T {
     }
 }
 
-fun <T> withOlmDecryption(block: (OlmPkDecryption) -> T): T {
+internal fun <T> withOlmDecryption(block: (OlmPkDecryption) -> T): T {
     val olmPkDecryption = OlmPkDecryption()
     try {
         return block(olmPkDecryption)
@@ -39,7 +39,7 @@ fun <T> withOlmDecryption(block: (OlmPkDecryption) -> T): T {
     }
 }
 
-fun <T> withOlmSigning(block: (OlmPkSigning) -> T): T {
+internal fun <T> withOlmSigning(block: (OlmPkSigning) -> T): T {
     val olmPkSigning = OlmPkSigning()
     try {
         return block(olmPkSigning)
@@ -48,7 +48,7 @@ fun <T> withOlmSigning(block: (OlmPkSigning) -> T): T {
     }
 }
 
-fun <T> withOlmUtility(block: (OlmUtility) -> T): T {
+internal fun <T> withOlmUtility(block: (OlmUtility) -> T): T {
     val olmUtility = OlmUtility()
     try {
         return block(olmUtility)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/DatabaseCleaner.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/DatabaseCleaner.kt
@@ -56,7 +56,7 @@ internal class DatabaseCleaner @Inject constructor(@SessionDatabase private val 
         }
     }
 
-    private suspend fun cleanUp(realm: Realm, threshold: Long) {
+    private fun cleanUp(realm: Realm, threshold: Long) {
         val numberOfEvents = realm.where(EventEntity::class.java).findAll().size
         val numberOfTimelineEvents = realm.where(TimelineEventEntity::class.java).findAll().size
         Timber.v("Number of events in db: $numberOfEvents | Number of timeline events in db: $numberOfTimelineEvents")
@@ -76,20 +76,7 @@ internal class DatabaseCleaner @Inject constructor(@SessionDatabase private val 
                 chunk.numberOfTimelineEvents = chunk.numberOfTimelineEvents - eventsToRemove.size
                 eventsToRemove.forEach {
                     val canDeleteRoot = it.root?.stateKey == null
-                    if (canDeleteRoot) {
-                        it.root?.deleteFromRealm()
-                    }
-                    it.readReceipts?.readReceipts?.deleteAllFromRealm()
-                    it.readReceipts?.deleteFromRealm()
-                    it.annotations?.apply {
-                        editSummary?.deleteFromRealm()
-                        pollResponseSummary?.deleteFromRealm()
-                        referencesSummaryEntity?.deleteFromRealm()
-                        reactionsSummary.deleteAllFromRealm()
-                    }
-                    it.annotations?.deleteFromRealm()
-                    it.readReceipts?.deleteFromRealm()
-                    it.deleteFromRealm()
+                    it.deleteOnCascade(canDeleteRoot)
                 }
                 // We reset the prevToken so we will need to fetch again.
                 chunk.prevToken = null

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ChunkEntityHelper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ChunkEntityHelper.kt
@@ -38,12 +38,6 @@ import io.realm.Sort
 import io.realm.kotlin.createObject
 import timber.log.Timber
 
-internal fun ChunkEntity.deleteOnCascade() {
-    assertIsManaged()
-    this.timelineEvents.deleteAllFromRealm()
-    this.deleteFromRealm()
-}
-
 internal fun ChunkEntity.merge(roomId: String, chunkToMerge: ChunkEntity, direction: PaginationDirection) {
     assertIsManaged()
     val localRealm = this.realm

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/RoomEntityHelper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/RoomEntityHelper.kt
@@ -19,11 +19,6 @@ package org.matrix.android.sdk.internal.database.helper
 import org.matrix.android.sdk.internal.database.model.ChunkEntity
 import org.matrix.android.sdk.internal.database.model.RoomEntity
 
-internal fun RoomEntity.deleteOnCascade(chunkEntity: ChunkEntity) {
-    chunks.remove(chunkEntity)
-    chunkEntity.deleteOnCascade()
-}
-
 internal fun RoomEntity.addOrUpdate(chunkEntity: ChunkEntity) {
     if (!chunks.contains(chunkEntity)) {
         chunks.add(chunkEntity)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/RoomEntityHelper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/RoomEntityHelper.kt
@@ -19,7 +19,7 @@ package org.matrix.android.sdk.internal.database.helper
 import org.matrix.android.sdk.internal.database.model.ChunkEntity
 import org.matrix.android.sdk.internal.database.model.RoomEntity
 
-internal fun RoomEntity.addOrUpdate(chunkEntity: ChunkEntity) {
+internal fun RoomEntity.addIfNecessary(chunkEntity: ChunkEntity) {
     if (!chunks.contains(chunkEntity)) {
         chunks.add(chunkEntity)
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/TimelineEventEntityHelper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/TimelineEventEntityHelper.kt
@@ -18,7 +18,6 @@ package org.matrix.android.sdk.internal.database.helper
 
 import org.matrix.android.sdk.internal.database.model.TimelineEventEntity
 import org.matrix.android.sdk.internal.database.model.TimelineEventEntityFields
-import org.matrix.android.sdk.internal.extensions.assertIsManaged
 import io.realm.Realm
 
 internal fun TimelineEventEntity.Companion.nextId(realm: Realm): Long {
@@ -28,12 +27,4 @@ internal fun TimelineEventEntity.Companion.nextId(realm: Realm): Long {
     } else {
         currentIdNum.toLong() + 1
     }
-}
-
-internal fun TimelineEventEntity.deleteOnCascade() {
-    assertIsManaged()
-    root?.deleteFromRealm()
-    annotations?.deleteFromRealm()
-    readReceipts?.deleteFromRealm()
-    deleteFromRealm()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/ChunkEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/ChunkEntity.kt
@@ -21,6 +21,8 @@ import io.realm.RealmObject
 import io.realm.RealmResults
 import io.realm.annotations.Index
 import io.realm.annotations.LinkingObjects
+import org.matrix.android.sdk.internal.database.helper.deleteOnCascade
+import org.matrix.android.sdk.internal.extensions.assertIsManaged
 
 internal open class ChunkEntity(@Index var prevToken: String? = null,
         // Because of gaps we can have several chunks with nextToken == null
@@ -42,4 +44,11 @@ internal open class ChunkEntity(@Index var prevToken: String? = null,
     val room: RealmResults<RoomEntity>? = null
 
     companion object
+
+    fun deleteOnCascade() {
+        assertIsManaged()
+        stateEvents.deleteAllFromRealm()
+        timelineEvents.forEach { it.deleteOnCascade() }
+        deleteFromRealm()
+    }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/ChunkEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/ChunkEntity.kt
@@ -21,7 +21,6 @@ import io.realm.RealmObject
 import io.realm.RealmResults
 import io.realm.annotations.Index
 import io.realm.annotations.LinkingObjects
-import org.matrix.android.sdk.internal.database.helper.deleteOnCascade
 import org.matrix.android.sdk.internal.extensions.assertIsManaged
 
 internal open class ChunkEntity(@Index var prevToken: String? = null,
@@ -45,10 +44,12 @@ internal open class ChunkEntity(@Index var prevToken: String? = null,
 
     companion object
 
-    fun deleteOnCascade() {
+    fun deleteOnCascade(deleteStateEvents: Boolean, canDeleteRoot: Boolean) {
         assertIsManaged()
-        stateEvents.deleteAllFromRealm()
-        timelineEvents.forEach { it.deleteOnCascade() }
+        if (deleteStateEvents) {
+            stateEvents.deleteAllFromRealm()
+        }
+        timelineEvents.forEach { it.deleteOnCascade(canDeleteRoot) }
         deleteFromRealm()
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/EventAnnotationsSummaryEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/EventAnnotationsSummaryEntity.kt
@@ -30,4 +30,12 @@ internal open class EventAnnotationsSummaryEntity(
 ) : RealmObject() {
 
     companion object
+
+    fun deleteOnCascade() {
+        reactionsSummary.deleteAllFromRealm()
+        editSummary?.deleteFromRealm()
+        referencesSummaryEntity?.deleteFromRealm()
+        pollResponseSummary?.deleteFromRealm()
+        deleteFromRealm()
+    }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/PushRuleEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/PushRuleEntity.kt
@@ -39,4 +39,9 @@ internal open class PushRuleEntity(
     val parent: RealmResults<PushRulesEntity>? = null
 
     companion object
+
+    fun deleteOnCascade() {
+        conditions?.forEach { it.deleteFromRealm() }
+        deleteFromRealm()
+    }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/PushRulesEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/PushRulesEntity.kt
@@ -34,4 +34,9 @@ internal open class PushRulesEntity(
         }
 
     companion object
+
+    fun deleteOnCascade() {
+        pushRules.forEach { it.deleteOnCascade() }
+        deleteFromRealm()
+    }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/PushRulesEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/PushRulesEntity.kt
@@ -36,7 +36,7 @@ internal open class PushRulesEntity(
     companion object
 
     fun deleteOnCascade() {
-        pushRules.forEach { it.deleteOnCascade() }
+        pushRules.toList().forEach { it.deleteOnCascade() }
         deleteFromRealm()
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/PusherEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/PusherEntity.kt
@@ -15,8 +15,8 @@
  */
 package org.matrix.android.sdk.internal.database.model
 
-import org.matrix.android.sdk.api.session.pushers.PusherState
 import io.realm.RealmObject
+import org.matrix.android.sdk.api.session.pushers.PusherState
 
 // TODO
 //        at java.lang.Thread.run(Thread.java:764)
@@ -53,4 +53,9 @@ internal open class PusherEntity(
         }
 
     companion object
+
+    fun deleteOnCascade() {
+        data?.deleteFromRealm()
+        deleteFromRealm()
+    }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/ReadReceiptsSummaryEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/ReadReceiptsSummaryEntity.kt
@@ -33,4 +33,9 @@ internal open class ReadReceiptsSummaryEntity(
     val timelineEvent: RealmResults<TimelineEventEntity>? = null
 
     companion object
+
+    fun deleteOnCascade() {
+        readReceipts.deleteAllFromRealm()
+        deleteFromRealm()
+    }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/TimelineEventEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/TimelineEventEntity.kt
@@ -42,7 +42,7 @@ internal open class TimelineEventEntity(var localId: Long = 0,
 
     fun deleteOnCascade(canDeleteRoot: Boolean) {
         assertIsManaged()
-        if(canDeleteRoot) {
+        if (canDeleteRoot) {
             root?.deleteFromRealm()
         }
         annotations?.deleteOnCascade()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/TimelineEventEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/TimelineEventEntity.kt
@@ -20,6 +20,7 @@ import io.realm.RealmObject
 import io.realm.RealmResults
 import io.realm.annotations.Index
 import io.realm.annotations.LinkingObjects
+import org.matrix.android.sdk.internal.extensions.assertIsManaged
 
 internal open class TimelineEventEntity(var localId: Long = 0,
                                         @Index var eventId: String = "",
@@ -38,4 +39,14 @@ internal open class TimelineEventEntity(var localId: Long = 0,
     val chunk: RealmResults<ChunkEntity>? = null
 
     companion object
+
+    fun deleteOnCascade(canDeleteRoot: Boolean) {
+        assertIsManaged()
+        if(canDeleteRoot) {
+            root?.deleteFromRealm()
+        }
+        annotations?.deleteOnCascade()
+        readReceipts?.deleteOnCascade()
+        deleteFromRealm()
+    }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/pushers/GetPushersTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/pushers/GetPushersTask.kt
@@ -41,7 +41,8 @@ internal class DefaultGetPushersTask @Inject constructor(
         monarchy.awaitTransaction { realm ->
             // clear existings?
             realm.where(PusherEntity::class.java)
-                    .findAll().deleteAllFromRealm()
+                    .findAll()
+                    .forEach { it.deleteOnCascade() }
             response.pushers?.forEach { jsonPusher ->
                 jsonPusher.toEntity().also {
                     it.state = PusherState.REGISTERED

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/pushers/SavePushRulesTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/pushers/SavePushRulesTask.kt
@@ -40,7 +40,7 @@ internal class DefaultSavePushRulesTask @Inject constructor(@SessionDatabase pri
             // clear current push rules
             realm.where(PushRulesEntity::class.java)
                     .findAll()
-                    .deleteAllFromRealm()
+                    .forEach { it.deleteOnCascade() }
 
             // Save only global rules for the moment
             val globalRules = params.pushRules.global

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
@@ -140,14 +140,13 @@ internal class RoomSummaryUpdater @Inject constructor(
                     .queryActiveRoomMembersEvent()
                     .notEqualTo(RoomMemberSummaryEntityFields.USER_ID, userId)
                     .findAll()
-                    .asSequence()
                     .map { it.userId }
 
             roomSummaryEntity.otherMemberIds.clear()
             roomSummaryEntity.otherMemberIds.addAll(otherRoomMembers)
             if (roomSummaryEntity.isEncrypted) {
                 // mmm maybe we could only refresh shield instead of checking trust also?
-                crossSigningService.onUsersDeviceUpdateForRoom(roomId)
+                crossSigningService.onUsersDeviceUpdate(otherRoomMembers)
             }
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
@@ -147,7 +147,7 @@ internal class RoomSummaryUpdater @Inject constructor(
             roomSummaryEntity.otherMemberIds.addAll(otherRoomMembers)
             if (roomSummaryEntity.isEncrypted) {
                 // mmm maybe we could only refresh shield instead of checking trust also?
-                crossSigningService.onUsersDeviceUpdate(roomSummaryEntity.otherMemberIds.toList())
+                crossSigningService.onUsersDeviceUpdateForRoom(roomId)
             }
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEventPersistor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEventPersistor.kt
@@ -22,10 +22,9 @@ import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.room.model.RoomMemberContent
 import org.matrix.android.sdk.api.session.room.send.SendState
-import org.matrix.android.sdk.internal.database.helper.addOrUpdate
+import org.matrix.android.sdk.internal.database.helper.addIfNecessary
 import org.matrix.android.sdk.internal.database.helper.addStateEvent
 import org.matrix.android.sdk.internal.database.helper.addTimelineEvent
-import org.matrix.android.sdk.internal.database.helper.deleteOnCascade
 import org.matrix.android.sdk.internal.database.helper.merge
 import org.matrix.android.sdk.internal.database.mapper.toEntity
 import org.matrix.android.sdk.internal.database.model.ChunkEntity
@@ -172,7 +171,7 @@ internal class TokenChunkEventPersistor @Inject constructor(@SessionDatabase pri
             val currentLastForwardChunk = ChunkEntity.findLastForwardChunkOfRoom(realm, roomId)
             if (currentChunk != currentLastForwardChunk) {
                 currentChunk.isLastForward = true
-                currentLastForwardChunk?.deleteOnCascade()
+                currentLastForwardChunk?.deleteOnCascade(deleteStateEvents = false, canDeleteRoot = false)
                 RoomSummaryEntity.where(realm, roomId).findFirst()?.apply {
                     latestPreviewableEvent = RoomSummaryEventsHelper.getLatestPreviewableEvent(realm, roomId)
                 }
@@ -235,7 +234,7 @@ internal class TokenChunkEventPersistor @Inject constructor(@SessionDatabase pri
             }
         }
         chunksToDelete.forEach {
-            it.deleteOnCascade()
+            it.deleteOnCascade(deleteStateEvents = false, canDeleteRoot = false)
         }
         val roomSummaryEntity = RoomSummaryEntity.getOrCreate(realm, roomId)
         val shouldUpdateSummary = roomSummaryEntity.latestPreviewableEvent == null
@@ -244,7 +243,7 @@ internal class TokenChunkEventPersistor @Inject constructor(@SessionDatabase pri
             roomSummaryEntity.latestPreviewableEvent = RoomSummaryEventsHelper.getLatestPreviewableEvent(realm, roomId)
         }
         if (currentChunk.isValid) {
-            RoomEntity.where(realm, roomId).findFirst()?.addOrUpdate(currentChunk)
+            RoomEntity.where(realm, roomId).findFirst()?.addIfNecessary(currentChunk)
         }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
@@ -32,7 +32,6 @@ import org.matrix.android.sdk.internal.crypto.MXCRYPTO_ALGORITHM_MEGOLM
 import org.matrix.android.sdk.internal.crypto.algorithms.olm.OlmDecryptionResult
 import org.matrix.android.sdk.internal.database.helper.addIfNecessary
 import org.matrix.android.sdk.internal.database.helper.addTimelineEvent
-import org.matrix.android.sdk.internal.database.helper.deleteOnCascade
 import org.matrix.android.sdk.internal.database.mapper.asDomain
 import org.matrix.android.sdk.internal.database.mapper.toEntity
 import org.matrix.android.sdk.internal.database.model.ChunkEntity
@@ -263,7 +262,7 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
         val leftMember = RoomMemberSummaryEntity.where(realm, roomId, userId).findFirst()
         val membership = leftMember?.membership ?: Membership.LEAVE
         roomEntity.membership = membership
-        roomEntity.chunks.forEach { it.deleteOnCascade() }
+        roomEntity.chunks.forEach { it.deleteOnCascade(deleteStateEvents = true, canDeleteRoot = true) }
         roomEntity.chunks.clear()
         roomTypingUsersHandler.handle(realm, roomId, null)
         roomChangeMembershipStateDataSource.setMembershipFromSync(roomId, Membership.LEAVE)
@@ -341,7 +340,7 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
                         }
                     }
                     // Finally delete the local echo
-                    sendingEventEntity.deleteOnCascade()
+                    sendingEventEntity.deleteOnCascade(true)
                 } else {
                     Timber.v("Can't find corresponding local echo for tx:$it")
                 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
@@ -30,7 +30,7 @@ import org.matrix.android.sdk.api.session.room.send.SendState
 import org.matrix.android.sdk.internal.crypto.DefaultCryptoService
 import org.matrix.android.sdk.internal.crypto.MXCRYPTO_ALGORITHM_MEGOLM
 import org.matrix.android.sdk.internal.crypto.algorithms.olm.OlmDecryptionResult
-import org.matrix.android.sdk.internal.database.helper.addOrUpdate
+import org.matrix.android.sdk.internal.database.helper.addIfNecessary
 import org.matrix.android.sdk.internal.database.helper.addTimelineEvent
 import org.matrix.android.sdk.internal.database.helper.deleteOnCascade
 import org.matrix.android.sdk.internal.database.mapper.asDomain
@@ -175,7 +175,7 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
                     syncLocalTimestampMillis,
                     isInitialSync
             )
-            roomEntity.addOrUpdate(chunkEntity)
+            roomEntity.addIfNecessary(chunkEntity)
         }
         val hasRoomMember = roomSync.state?.events?.firstOrNull {
             it.type == EventType.STATE_ROOM_MEMBER

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
@@ -263,7 +263,8 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
         val leftMember = RoomMemberSummaryEntity.where(realm, roomId, userId).findFirst()
         val membership = leftMember?.membership ?: Membership.LEAVE
         roomEntity.membership = membership
-        roomEntity.chunks.deleteAllFromRealm()
+        roomEntity.chunks.forEach { it.deleteOnCascade() }
+        roomEntity.chunks.clear()
         roomTypingUsersHandler.handle(realm, roomId, null)
         roomChangeMembershipStateDataSource.setMembershipFromSync(roomId, Membership.LEAVE)
         roomSummaryUpdater.update(realm, roomId, membership, roomSync.summary, roomSync.unreadNotifications)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/UserAccountDataSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/UserAccountDataSyncHandler.kt
@@ -113,7 +113,7 @@ internal class UserAccountDataSyncHandler @Inject constructor(
         val pushRules = event.content.toModel<GetPushRulesResponse>() ?: return
         realm.where(PushRulesEntity::class.java)
                 .findAll()
-                .deleteAllFromRealm()
+                .forEach { it.deleteOnCascade() }
 
         // Save only global rules for the moment
         val globalRules = pushRules.global


### PR DESCRIPTION
Avoid passing a big list of userIds to the worker. Use the roomId in this case

Fixes #2721 