### PR TITLE
Feature/bma/rtl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Improvements 🙌:
 Bugfix 🐛:
  - Duplicate thumbs | Mobile reactions for 👍 and 👎 are not the same as web (#2776)
  - Join room by alias other federation error (#2778)
+ - RTL: some arrows should be rotated in RTL (#2757)
 
 Translations 🗣:
  -

--- a/vector/src/main/res/drawable-ldrtl/ic_arrow_right.xml
+++ b/vector/src/main/res/drawable-ldrtl/ic_arrow_right.xml
@@ -7,7 +7,7 @@
     <path
         android:fillColor="#00000000"
         android:fillType="evenOdd"
-        android:pathData="M1,11l5,-5 -5,-5"
+        android:pathData="M6,11l-5,-5 5,-5"
         android:strokeWidth="2"
         android:strokeColor="#2E2F32"
         android:strokeLineCap="round"

--- a/vector/src/main/res/layout/fragment_home_drawer.xml
+++ b/vector/src/main/res/layout/fragment_home_drawer.xml
@@ -84,6 +84,7 @@
             android:insetRight="0dp"
             android:insetBottom="0dp"
             android:padding="0dp"
+            android:rotationY="@integer/rtl_mirror_flip"
             app:cornerRadius="17dp"
             app:icon="@drawable/ic_qr_code_add"
             app:iconGravity="textStart"


### PR DESCRIPTION
Fix #2757

## Add  by QR code icon

(ignore new translation)

Before:

<img width="291" alt="image" src="https://user-images.githubusercontent.com/3940906/107077565-55d71080-67ed-11eb-8d55-3b56e05d3714.png">

After:

<img width="292" alt="image" src="https://user-images.githubusercontent.com/3940906/107077398-127ca200-67ed-11eb-8ade-68dba518185a.png">

## Right arrow

Before

<img width="189" alt="image" src="https://user-images.githubusercontent.com/3940906/107077612-6b4c3a80-67ed-11eb-9db7-a9d0f10997b8.png">

<img width="388" alt="image" src="https://user-images.githubusercontent.com/3940906/107077653-7a32ed00-67ed-11eb-9f22-1fc81e8f1154.png">

<img width="390" alt="image" src="https://user-images.githubusercontent.com/3940906/107077684-8454eb80-67ed-11eb-93f6-6e71d0fa5fe7.png">

After

<img width="296" alt="image" src="https://user-images.githubusercontent.com/3940906/107077713-8dde5380-67ed-11eb-8071-2a1b7fa4a4ed.png">

<img width="393" alt="image" src="https://user-images.githubusercontent.com/3940906/107077759-9d5d9c80-67ed-11eb-9ddf-a104b5cfbb5a.png">

<img width="388" alt="image" src="https://user-images.githubusercontent.com/3940906/107077782-a51d4100-67ed-11eb-94bd-5ae2ebaf269c.png">


And many other places
