### PR TITLE
Room settings ux

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Features ✨:
                                 
 Improvements 🙌:
  - VoIP : new tiles in timeline
+ - Improve room profile UX
 
 Bugfix 🐛:
  - VoIP : fix audio devices output

--- a/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -277,8 +277,23 @@ class UiAllScreensSanityTest {
 
         assertDisplayed(R.id.roomProfileAvatarView)
 
-        // Leave
+        // Room addresses
         clickListItem(R.id.matrixProfileRecyclerView, 13)
+        onView(isRoot()).perform(waitForView(withText(R.string.room_alias_published_alias_title)))
+        pressBack()
+
+        // Room permissions
+        clickListItem(R.id.matrixProfileRecyclerView, 15)
+        onView(isRoot()).perform(waitForView(withText(R.string.room_permissions_title)))
+        clickOn(R.string.room_permissions_change_room_avatar)
+        clickDialogNegativeButton()
+        // Toggle
+        clickOn(R.string.show_advanced)
+        clickOn(R.string.hide_advanced)
+        pressBack()
+
+        // Leave
+        clickListItem(R.id.matrixProfileRecyclerView, 17)
         clickDialogNegativeButton()
 
         // Menu share
@@ -289,27 +304,12 @@ class UiAllScreensSanityTest {
     }
 
     private fun navigateToRoomParameters() {
-        // Room addresses
-        clickListItem(R.id.roomSettingsRecyclerView, 4)
-        onView(isRoot()).perform(waitForView(withText(R.string.room_alias_published_alias_title)))
-        pressBack()
-
-        // Room permissions
-        clickListItem(R.id.roomSettingsRecyclerView, 6)
-        onView(isRoot()).perform(waitForView(withText(R.string.room_permissions_title)))
-        clickOn(R.string.room_permissions_change_room_avatar)
-        clickDialogNegativeButton()
-        // Toggle
-        clickOn(R.string.show_advanced)
-        clickOn(R.string.hide_advanced)
-        pressBack()
-
         // Room history readability
-        clickListItem(R.id.roomSettingsRecyclerView, 8)
+        clickListItem(R.id.roomSettingsRecyclerView, 4)
         pressBack()
 
         // Room access
-        clickListItem(R.id.roomSettingsRecyclerView, 10)
+        clickListItem(R.id.roomSettingsRecyclerView, 6)
         pressBack()
     }
 

--- a/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCall.kt
+++ b/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCall.kt
@@ -476,7 +476,6 @@ class WebRtcCall(val mxCall: MxCall,
 
         if (camera != null) {
             val videoCapturer = cameraIterator.createCapturer(camera.name, object : CameraEventsHandlerAdapter() {
-
                 override fun onFirstFrameAvailable() {
                     super.onFirstFrameAvailable()
                     videoCapturerIsInError = false
@@ -490,7 +489,6 @@ class WebRtcCall(val mxCall: MxCall,
                     videoCapturerIsInError = true
                     val cameraManager = context.getSystemService<CameraManager>()
                     cameraAvailabilityCallback = object : CameraManager.AvailabilityCallback() {
-
                         override fun onCameraUnavailable(cameraId: String) {
                             super.onCameraUnavailable(cameraId)
                             Timber.v("On camera unavailable: $cameraId")

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileController.kt
@@ -54,6 +54,8 @@ class RoomProfileController @Inject constructor(
         fun createShortcut()
         fun onSettingsClicked()
         fun onLeaveRoomClicked()
+        fun onRoomAliasesClicked()
+        fun onRoomPermissionsClicked()
         fun onRoomIdClicked()
         fun onUrlInTopicLongClicked(url: String)
     }
@@ -174,8 +176,29 @@ class RoomProfileController @Inject constructor(
         )
 
         // Advanced
+        buildProfileSection(stringProvider.getString(R.string.room_settings_category_advanced_title))
+
+        buildProfileAction(
+                id = "alias",
+                title = stringProvider.getString(R.string.room_settings_alias_title),
+                subtitle = stringProvider.getString(R.string.room_settings_alias_subtitle),
+                dividerColor = dividerColor,
+                divider = true,
+                editable = true,
+                action = { callback?.onRoomAliasesClicked() }
+        )
+
+        buildProfileAction(
+                id = "permissions",
+                title = stringProvider.getString(R.string.room_settings_permissions_title),
+                subtitle = stringProvider.getString(R.string.room_settings_permissions_subtitle),
+                dividerColor = dividerColor,
+                divider = true,
+                editable = true,
+                action = { callback?.onRoomPermissionsClicked() }
+        )
+
         if (vectorPreferences.developerMode()) {
-            buildProfileSection(stringProvider.getString(R.string.room_settings_category_advanced_title))
             buildProfileAction(
                     id = "roomId",
                     title = stringProvider.getString(R.string.room_settings_room_internal_id),

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileFragment.kt
@@ -116,12 +116,29 @@ class RoomProfileFragment @Inject constructor(
                 .observe()
                 .subscribe { handleQuickActions(it) }
                 .disposeOnDestroyView()
+        setupClicks()
         setupLongClicks()
     }
 
     private fun setupWaitingView() {
         views.waitingView.waitingStatusText.setText(R.string.please_wait)
         views.waitingView.waitingStatusText.isVisible = true
+    }
+
+    private fun setupClicks() {
+        // Shortcut to room settings
+        listOf(
+                headerViews.roomProfileNameView,
+                views.matrixProfileToolbarTitleView,
+        ).forEach {
+            it.setOnClickListener {
+                roomProfileSharedActionViewModel.post(RoomProfileSharedAction.OpenRoomSettings)
+            }
+        }
+        // Shortcut to room alias
+        headerViews.roomProfileAliasView.setOnClickListener {
+            roomProfileSharedActionViewModel.post(RoomProfileSharedAction.OpenRoomAliasesSettings)
+        }
     }
 
     private fun setupLongClicks() {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileFragment.kt
@@ -128,7 +128,7 @@ class RoomProfileFragment @Inject constructor(
         // Shortcut to room settings
         setOf(
                 headerViews.roomProfileNameView,
-                views.matrixProfileToolbarTitleView,
+                views.matrixProfileToolbarTitleView
         ).forEach {
             it.setOnClickListener {
                 roomProfileSharedActionViewModel.post(RoomProfileSharedAction.OpenRoomSettings)

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileFragment.kt
@@ -269,6 +269,14 @@ class RoomProfileFragment @Inject constructor(
                 }
     }
 
+    override fun onRoomAliasesClicked() {
+        roomProfileSharedActionViewModel.post(RoomProfileSharedAction.OpenRoomAliasesSettings)
+    }
+
+    override fun onRoomPermissionsClicked() {
+        roomProfileSharedActionViewModel.post(RoomProfileSharedAction.OpenRoomPermissionsSettings)
+    }
+
     override fun onRoomIdClicked() {
         copyToClipboard(requireContext(), roomProfileArgs.roomId)
     }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsController.kt
@@ -45,8 +45,6 @@ class RoomSettingsController @Inject constructor(
         fun onNameChanged(name: String)
         fun onTopicChanged(topic: String)
         fun onHistoryVisibilityClicked()
-        fun onRoomAliasesClicked()
-        fun onRoomPermissionsClicked()
         fun onJoinRuleClicked()
     }
 
@@ -105,26 +103,6 @@ class RoomSettingsController @Inject constructor(
                 callback?.onTopicChanged(text)
             }
         }
-
-        buildProfileAction(
-                id = "alias",
-                title = stringProvider.getString(R.string.room_settings_alias_title),
-                subtitle = stringProvider.getString(R.string.room_settings_alias_subtitle),
-                dividerColor = dividerColor,
-                divider = true,
-                editable = true,
-                action = { callback?.onRoomAliasesClicked() }
-        )
-
-        buildProfileAction(
-                id = "permissions",
-                title = stringProvider.getString(R.string.room_settings_permissions_title),
-                subtitle = stringProvider.getString(R.string.room_settings_permissions_subtitle),
-                dividerColor = dividerColor,
-                divider = true,
-                editable = true,
-                action = { callback?.onRoomPermissionsClicked() }
-        )
 
         buildProfileAction(
                 id = "historyReadability",

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsFragment.kt
@@ -41,7 +41,6 @@ import im.vector.app.core.utils.toast
 import im.vector.app.databinding.FragmentRoomSettingGenericBinding
 import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.roomprofile.RoomProfileArgs
-import im.vector.app.features.roomprofile.RoomProfileSharedAction
 import im.vector.app.features.roomprofile.RoomProfileSharedActionViewModel
 import im.vector.app.features.roomprofile.settings.historyvisibility.RoomHistoryVisibilitySharedActionViewModel
 import im.vector.app.features.roomprofile.settings.historyvisibility.RoomHistoryVisibilityBottomSheet

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsFragment.kt
@@ -174,14 +174,6 @@ class RoomSettingsFragment @Inject constructor(
                 .show(childFragmentManager, "RoomHistoryVisibilityBottomSheet")
     }
 
-    override fun onRoomAliasesClicked() {
-        roomProfileSharedActionViewModel.post(RoomProfileSharedAction.OpenRoomAliasesSettings)
-    }
-
-    override fun onRoomPermissionsClicked() {
-        roomProfileSharedActionViewModel.post(RoomProfileSharedAction.OpenRoomPermissionsSettings)
-    }
-
     override fun onJoinRuleClicked()  = withState(viewModel) { state ->
         val currentJoinRule = state.newRoomJoinRules.newJoinRules ?: state.currentRoomJoinRules
         val currentGuestAccess = state.newRoomJoinRules.newGuestAccess ?: state.currentGuestAccess


### PR DESCRIPTION
A few changes and improvements in the UX for room settings

- Move "Room addresses" and "Room permissions" entry point from the screen where user can update basic states of the room to the advanced section of the room profile. This is mainly because it's better for non-tech user, and also the room setting screen is a form where all changes are committed at once, so, for the UX it was not ideal to have entry point for other screens here.
- Add some click listener to open specific screens from the settings.