### PR TITLE
Feature/bma/user name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Improvements 🙌:
 Bugfix 🐛:
  - VoIP : fix audio devices output
  - Fix crash after initial sync on Dendrite
+ - myroomnick changes the global name (#1715)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/SessionRealmModule.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/SessionRealmModule.kt
@@ -37,6 +37,7 @@ import io.realm.annotations.RealmModule
             SyncEntity::class,
             PendingThreePidEntity::class,
             UserEntity::class,
+            StringCountedEntity::class,
             IgnoredUserEntity::class,
             BreadcrumbsEntity::class,
             UserThreePidEntity::class,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/StringCountedEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/StringCountedEntity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Matrix.org Foundation C.I.C.
+ * Copyright (c) 2021 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,10 @@
 
 package org.matrix.android.sdk.internal.database.model
 
-import io.realm.RealmList
 import io.realm.RealmObject
-import io.realm.annotations.PrimaryKey
+import io.realm.annotations.RealmClass
 
-internal open class UserEntity(@PrimaryKey var userId: String = "",
-                               var displayName: String = "",
-                               var avatarUrl: String = "",
-                               var displayNameInRoom: RealmList<StringCountedEntity> = RealmList(),
-                               var avatarUrlInRoom: RealmList<StringCountedEntity> = RealmList()
-) : RealmObject() {
-
-    companion object
-}
+@RealmClass(embedded = true)
+internal open class StringCountedEntity(var value: String = "",
+                                        var counter: Int = 0
+) : RealmObject()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/RoomMemberEventHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/RoomMemberEventHandler.kt
@@ -32,18 +32,22 @@ internal class RoomMemberEventHandler @Inject constructor() {
         }
         val userId = event.stateKey ?: return false
         val roomMember = event.content.toModel<RoomMemberContent>()
-        return handle(realm, roomId, userId, roomMember)
+        val previousContent = event.resolvedPrevContent().toModel<RoomMemberContent>()
+        return handle(realm, roomId, userId, roomMember, previousContent)
     }
 
-    fun handle(realm: Realm, roomId: String, userId: String, roomMember: RoomMemberContent?): Boolean {
+    fun handle(realm: Realm,
+               roomId: String,
+               userId: String,
+               roomMember: RoomMemberContent?,
+               previousRoomMember: RoomMemberContent?): Boolean {
         if (roomMember == null) {
             return false
         }
         val roomMemberEntity = RoomMemberEntityFactory.create(roomId, userId, roomMember)
         realm.insertOrUpdate(roomMemberEntity)
         if (roomMember.membership.isActive()) {
-            val userEntity = UserEntityFactory.create(userId, roomMember)
-            realm.insertOrUpdate(userEntity)
+            UserEntityFactory.insertOrUpdate(realm, userId, roomMember, previousRoomMember)
         }
         return true
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
@@ -313,7 +313,13 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
                 if (event.type == EventType.STATE_ROOM_MEMBER) {
                     val fixedContent = event.getFixedRoomMemberContent()
                     roomMemberContentsByUser[event.stateKey] = fixedContent
-                    roomMemberEventHandler.handle(realm, roomEntity.roomId, event.stateKey, fixedContent)
+                    roomMemberEventHandler.handle(
+                            realm,
+                            roomEntity.roomId,
+                            event.stateKey,
+                            fixedContent,
+                            event.resolvedPrevContent().toModel<RoomMemberContent>()
+                    )
                 }
             }
             roomMemberContentsByUser.getOrPut(event.senderId) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/UserEntityFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/UserEntityFactory.kt
@@ -16,16 +16,81 @@
 
 package org.matrix.android.sdk.internal.session.user
 
+import io.realm.Realm
+import io.realm.kotlin.createObject
 import org.matrix.android.sdk.api.session.room.model.RoomMemberContent
+import org.matrix.android.sdk.internal.database.model.StringCountedEntity
 import org.matrix.android.sdk.internal.database.model.UserEntity
+import org.matrix.android.sdk.internal.database.query.where
 
 internal object UserEntityFactory {
 
-    fun create(userId: String, roomMember: RoomMemberContent): UserEntity {
-        return UserEntity(
-                userId = userId,
-                displayName = roomMember.displayName ?: "",
-                avatarUrl = roomMember.avatarUrl ?: ""
-        )
+    /**
+     * The strategy here is to store all the used display name of a user for all rooms.
+     * So we maintain a counter for each display name and then we select the display name which is the most used
+     * as room member name for the user display name.
+     * We make the assumption that the user will not update display name per room (using /myroomnick) for a big number of rooms.
+     *
+     * The same algorithm is used for avatarUrl.
+     */
+    fun insertOrUpdate(realm: Realm,
+                       userId: String,
+                       roomMember: RoomMemberContent,
+                       previousRoomMember: RoomMemberContent?) {
+        val entity = UserEntity.where(realm, userId).findFirst() ?: realm.createObject(userId)
+
+        // Display Name
+        val newDisplayName = roomMember.displayName ?: ""
+        val previousDisplayName = previousRoomMember?.displayName
+
+        if (newDisplayName != previousDisplayName) {
+            if (previousDisplayName != null) {
+                entity.displayNameInRoom.indexOfFirst { it.value == previousDisplayName }
+                        .takeIf { it != -1 }
+                        ?.let { entity.displayNameInRoom[it] }
+                        ?.takeIf { it.counter > 0 }
+                        ?.counter
+                        ?.dec()
+            }
+            entity.displayNameInRoom.indexOfFirst { it.value == newDisplayName }
+                    .let { index ->
+                        if (index == -1) {
+                            entity.displayNameInRoom.add(StringCountedEntity(newDisplayName, 1))
+                        } else {
+                            entity.displayNameInRoom[index]?.counter?.inc()
+                        }
+                    }
+
+            // Update displayName
+            entity.displayNameInRoom.maxByOrNull { it.counter }
+                    ?.let { entity.displayName = it.value }
+        }
+
+        // Avatar
+        val newAvatar = roomMember.avatarUrl ?: ""
+        val previousAvatar = previousRoomMember?.avatarUrl
+
+        if (newAvatar != previousAvatar) {
+            if (previousAvatar != null) {
+                entity.avatarUrlInRoom.indexOfFirst { it.value == previousAvatar }
+                        .takeIf { it != -1 }
+                        ?.let { entity.avatarUrlInRoom[it] }
+                        ?.takeIf { it.counter > 0 }
+                        ?.counter
+                        ?.dec()
+            }
+            entity.avatarUrlInRoom.indexOfFirst { it.value == newAvatar }
+                    .let { index ->
+                        if (index == -1) {
+                            entity.avatarUrlInRoom.add(StringCountedEntity(newAvatar, 1))
+                        } else {
+                            entity.avatarUrlInRoom[index]?.counter?.inc()
+                        }
+                    }
+
+            // Update avatar
+            entity.avatarUrlInRoom.maxByOrNull { it.counter }
+                    ?.let { entity.avatarUrl = it.value }
+        }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/UserEntityFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/UserEntityFactory.kt
@@ -49,15 +49,15 @@ internal object UserEntityFactory {
                         .takeIf { it != -1 }
                         ?.let { entity.displayNameInRoom[it] }
                         ?.takeIf { it.counter > 0 }
-                        ?.counter
-                        ?.dec()
+                        ?.let { it.counter-- }
             }
             entity.displayNameInRoom.indexOfFirst { it.value == newDisplayName }
                     .let { index ->
                         if (index == -1) {
                             entity.displayNameInRoom.add(StringCountedEntity(newDisplayName, 1))
                         } else {
-                            entity.displayNameInRoom[index]?.counter?.inc()
+                            entity.displayNameInRoom[index]
+                                    ?.let { it.counter++ }
                         }
                     }
 
@@ -76,15 +76,15 @@ internal object UserEntityFactory {
                         .takeIf { it != -1 }
                         ?.let { entity.avatarUrlInRoom[it] }
                         ?.takeIf { it.counter > 0 }
-                        ?.counter
-                        ?.dec()
+                        ?.let { it.counter-- }
             }
             entity.avatarUrlInRoom.indexOfFirst { it.value == newAvatar }
                     .let { index ->
                         if (index == -1) {
                             entity.avatarUrlInRoom.add(StringCountedEntity(newAvatar, 1))
                         } else {
-                            entity.avatarUrlInRoom[index]?.counter?.inc()
+                            entity.avatarUrlInRoom[index]
+                                    ?.let { it.counter++ }
                         }
                     }
 

--- a/tools/hs_diag.py
+++ b/tools/hs_diag.py
@@ -57,6 +57,9 @@ items = [
     # Need token , ["Capability", baseUrl + "_matrix/client/r0/capabilities", True]
     # Need token , ["Media config", baseUrl + "_matrix/media/r0/config", True]
     # Need token , ["Turn", baseUrl + "_matrix/client/r0/voip/turnServer", True]
+
+    # Only for Synapse
+    , ["Synapse version", baseUrl + "_synapse/admin/v1/server_version", True]
 ]
 
 for item in items:


### PR DESCRIPTION
Fixes #1715

Replace #2408 

The strategy here is to store all the used display name of a user for all rooms.
So we maintain a counter for each display name and then we select the display name which is the most used
as room member name for the user display name.
We make the assumption that the user will not update display name per room (using /myroomnick) for a big number of rooms.

The same algorithm is used for avatarUrl.

It requires an init sync to properly update the database.