### PR TITLE
Add subscribeToChanges/unsubscribeToChanges to VectorPreferences

### DIFF
--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -239,6 +239,20 @@ class VectorPreferences @Inject constructor(private val context: Context) {
     }
 
     private val defaultPrefs = DefaultSharedPreferences.getInstance(context)
+    
+    /**
+     * Allow subscribing and unsubscribing to configuration changes. This is
+     * particularly useful when you need to be notified of a configuration change
+     * in a background service, e.g. for the P2P demos.
+     */
+    
+    public fun subscribeToChanges(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
+        defaultPrefs.registerOnSharedPreferenceChangeListener(listener)
+    }
+
+    public fun unsubscribeToChanges(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
+        defaultPrefs.unregisterOnSharedPreferenceChangeListener(listener)
+    }
 
     /**
      * Clear the preferences.

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -246,11 +246,9 @@ class VectorPreferences @Inject constructor(private val context: Context) {
      * particularly useful when you need to be notified of a configuration change
      * in a background service, e.g. for the P2P demos.
      */
-    
     fun subscribeToChanges(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
         defaultPrefs.registerOnSharedPreferenceChangeListener(listener)
     }
-
     fun unsubscribeToChanges(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
         defaultPrefs.unregisterOnSharedPreferenceChangeListener(listener)
     }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -16,6 +16,7 @@
 package im.vector.app.features.settings
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.media.RingtoneManager
 import android.net.Uri
 import android.provider.MediaStore
@@ -246,11 +247,11 @@ class VectorPreferences @Inject constructor(private val context: Context) {
      * in a background service, e.g. for the P2P demos.
      */
     
-    public fun subscribeToChanges(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
+    fun subscribeToChanges(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
         defaultPrefs.registerOnSharedPreferenceChangeListener(listener)
     }
 
-    public fun unsubscribeToChanges(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
+    fun unsubscribeToChanges(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
         defaultPrefs.unregisterOnSharedPreferenceChangeListener(listener)
     }
 


### PR DESCRIPTION
This is useful for the P2P demo as we need to subscribe to configuration changes from a background service. The `Service` can implement `SharedPreferences.OnSharedPreferenceChangeListener` and override `onSharedPreferenceChanged` to receive notifications.