### PR TITLE
Change the behaviour of retryNoNetworkTask slightly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Features ✨:
  -
 
 Improvements 🙌:
+ - Improve event processing backoff time on bad networks.
  -
 
 Bugfix 🐛:


### PR DESCRIPTION
This changes the behaviour to "summon" the task the event processor starts, then it'll now continuously check for the homeserver every 10 seconds in the background, possibly reducing the time slightly between a `waitOnNetwork()` call and unblocking.

This'll also possibly improve event send-time on dodgy networks, as it'll try to make a connection every 10 seconds period, sending events will continue until "stopped", and the retry time to test the network will be <10 seconds with the timer already ticking down in the background.

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`