### PR TITLE
Periodic sync to re-kick-off rapid sync

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/Session.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/Session.kt
@@ -111,10 +111,9 @@ interface Session :
 
     /**
      * Launches infinite periodic background syncs
-     * This does not work in doze mode :/
-     * If battery optimization is on it can work in app standby but that's all :/
+     * Doze mode will probably interrupt rapid sync, but it should start up again the next time we run a periodic sync
      */
-    fun startAutomaticBackgroundSync(timeOutInSeconds: Long, repeatDelayInSeconds: Long)
+    fun startAutomaticBackgroundSync(timeOutInSeconds: Long, rapidSync: Boolean, repeatDelayInSeconds: Long)
 
     fun stopAnyBackgroundSync()
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/di/WorkManagerProvider.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/di/WorkManagerProvider.kt
@@ -50,6 +50,16 @@ internal class WorkManagerProvider @Inject constructor(
                     .addTag(tag)
 
     /**
+     * Create a PeriodicWorkRequestBuilder, with the Matrix SDK tag
+     */
+    inline fun <reified W : ListenableWorker> matrixPeriodicWorkRequestBuilder(repeatInterval: Long,
+                                                                               repeatIntervalTimeUnit: TimeUnit,
+                                                                               flexTimeInterval: Long,
+                                                                               flexTimeIntervalUnit: TimeUnit) =
+            PeriodicWorkRequestBuilder<W>(repeatInterval, repeatIntervalTimeUnit, flexTimeInterval, flexTimeIntervalUnit)
+                    .addTag(tag)
+
+    /**
      * Cancel all works instantiated by the Matrix SDK for the current session, and not those from the SDK client, or for other sessions
      */
     fun cancelAllWorks() {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
@@ -168,8 +168,8 @@ internal class DefaultSession @Inject constructor(
         SyncWorker.requireBackgroundSync(workManagerProvider, sessionId)
     }
 
-    override fun startAutomaticBackgroundSync(timeOutInSeconds: Long, repeatDelayInSeconds: Long) {
-        SyncWorker.automaticallyBackgroundSync(workManagerProvider, sessionId, timeOutInSeconds, repeatDelayInSeconds)
+    override fun startAutomaticBackgroundSync(timeOutInSeconds: Long, rapidSync: Boolean, repeatDelayInSeconds: Long) {
+        SyncWorker.automaticallyPeriodicBackgroundSync(workManagerProvider, sessionId, timeOutInSeconds, rapidSync, repeatDelayInSeconds)
     }
 
     override fun stopAnyBackgroundSync() {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncWorker.kt
@@ -17,7 +17,9 @@ package org.matrix.android.sdk.internal.session.sync.job
 
 import android.content.Context
 import androidx.work.BackoffPolicy
+import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
+import androidx.work.WorkRequest
 import androidx.work.WorkerParameters
 import com.squareup.moshi.JsonClass
 import org.matrix.android.sdk.api.failure.isTokenError
@@ -73,7 +75,7 @@ internal class SyncWorker(context: Context,
                     Result.success().also {
                         if (params.periodic) {
                             // we want to schedule another one after delay
-                            automaticallyBackgroundSync(workManagerProvider, params.sessionId, params.timeout, params.delay)
+                            automaticallyRapidBackgroundSync(workManagerProvider, params.sessionId, params.timeout, params.delay)
                         }
                     }
                 },
@@ -101,34 +103,53 @@ internal class SyncWorker(context: Context,
 
     companion object {
         private const val BG_SYNC_WORK_NAME = "BG_SYNCP"
+        private const val BG_RAPID_SYNC_WORK_NAME = "BG_RAPID_SYNCP"
+        private const val BG_PERIODIC_SYNC_WORK_NAME = "BG_PERIODIC_SYNCP"
 
         fun requireBackgroundSync(workManagerProvider: WorkManagerProvider, sessionId: String, serverTimeout: Long = 0) {
             val data = WorkerParamsFactory.toData(Params(sessionId, serverTimeout, 0L, false))
             val workRequest = workManagerProvider.matrixOneTimeWorkRequestBuilder<SyncWorker>()
                     .setConstraints(WorkManagerProvider.workConstraints)
-                    .setBackoffCriteria(BackoffPolicy.LINEAR, 1_000, TimeUnit.MILLISECONDS)
+                    .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, WorkRequest.MIN_BACKOFF_MILLIS, TimeUnit.MILLISECONDS)
                     .setInputData(data)
                     .build()
+            // If we've already scheduled a sync that's not yet run, defer to the existing one
             workManagerProvider.workManager
-                    .enqueueUniqueWork(BG_SYNC_WORK_NAME, ExistingWorkPolicy.APPEND_OR_REPLACE, workRequest)
+                    .enqueueUniqueWork(BG_SYNC_WORK_NAME, ExistingWorkPolicy.KEEP, workRequest)
         }
 
-        fun automaticallyBackgroundSync(workManagerProvider: WorkManagerProvider, sessionId: String, serverTimeout: Long = 0, delayInSeconds: Long = 30) {
+        fun automaticallyRapidBackgroundSync(workManagerProvider: WorkManagerProvider, sessionId: String, serverTimeout: Long = 0, delayInSeconds: Long = 30) {
             val data = WorkerParamsFactory.toData(Params(sessionId, serverTimeout, delayInSeconds, true))
             val workRequest = workManagerProvider.matrixOneTimeWorkRequestBuilder<SyncWorker>()
                     .setConstraints(WorkManagerProvider.workConstraints)
                     .setInputData(data)
-                    .setBackoffCriteria(BackoffPolicy.LINEAR, 1_000, TimeUnit.MILLISECONDS)
+                    .setBackoffCriteria(BackoffPolicy.LINEAR, WorkRequest.MIN_BACKOFF_MILLIS, TimeUnit.MILLISECONDS)
                     .setInitialDelay(delayInSeconds, TimeUnit.SECONDS)
+                    .build()
+            // Avoid risking multiple chains of syncs by replacing the existing chain
+            workManagerProvider.workManager
+                    .enqueueUniqueWork(BG_RAPID_SYNC_WORK_NAME, ExistingWorkPolicy.REPLACE, workRequest)
+        }
+
+        fun automaticallyPeriodicBackgroundSync(workManagerProvider: WorkManagerProvider, sessionId: String, serverTimeout: Long = 0, restartRapidSync: Boolean = true, delayInSeconds: Long = 30) {
+            val data = WorkerParamsFactory.toData(Params(sessionId, serverTimeout, delayInSeconds, restartRapidSync))
+            val workRequest = workManagerProvider.matrixPeriodicWorkRequestBuilder<SyncWorker>(1, TimeUnit.HOURS, 15, TimeUnit.MINUTES)
+                    .setConstraints(WorkManagerProvider.workConstraints)
+                    .setInputData(data)
+                    .setBackoffCriteria(BackoffPolicy.LINEAR, WorkRequest.MIN_BACKOFF_MILLIS, TimeUnit.MILLISECONDS)
                     .build()
 
             workManagerProvider.workManager
-                    .enqueueUniqueWork(BG_SYNC_WORK_NAME, ExistingWorkPolicy.APPEND_OR_REPLACE, workRequest)
+                    .enqueueUniquePeriodicWork(BG_PERIODIC_SYNC_WORK_NAME, ExistingPeriodicWorkPolicy.KEEP, workRequest)
         }
 
         fun stopAnyBackgroundSync(workManagerProvider: WorkManagerProvider) {
             workManagerProvider.workManager
                     .cancelUniqueWork(BG_SYNC_WORK_NAME)
+            workManagerProvider.workManager
+                    .cancelUniqueWork(BG_RAPID_SYNC_WORK_NAME)
+            workManagerProvider.workManager
+                    .cancelUniqueWork(BG_PERIODIC_SYNC_WORK_NAME)
         }
     }
 }

--- a/vector/src/fdroid/java/im/vector/app/fdroid/BackgroundSyncStarter.kt
+++ b/vector/src/fdroid/java/im/vector/app/fdroid/BackgroundSyncStarter.kt
@@ -34,6 +34,7 @@ object BackgroundSyncStarter {
                     Timber.i("## Sync: Work scheduled to periodically sync in ${vectorPreferences.backgroundSyncDelay()}s")
                     activeSession.startAutomaticBackgroundSync(
                             vectorPreferences.backgroundSyncTimeOut().toLong(),
+                            true,
                             vectorPreferences.backgroundSyncDelay().toLong()
                     )
                 }

--- a/vector/src/gplay/java/im/vector/app/push/fcm/FcmHelper.kt
+++ b/vector/src/gplay/java/im/vector/app/push/fcm/FcmHelper.kt
@@ -108,6 +108,11 @@ object FcmHelper {
 
     @Suppress("UNUSED_PARAMETER")
     fun onEnterBackground(context: Context, vectorPreferences: VectorPreferences, activeSessionHolder: ActiveSessionHolder) {
-        // TODO FCM fallback
+        val activeSession = activeSessionHolder.getSafeActiveSession() ?: return
+        activeSession.startAutomaticBackgroundSync(
+                vectorPreferences.backgroundSyncTimeOut().toLong(),
+                false,
+                vectorPreferences.backgroundSyncDelay().toLong()
+        )
     }
 }


### PR DESCRIPTION
### Pull Request Checklist

WIP attempt to periodically kick off sync in case it's been cancelled by battery optimisation.

I'm unsure this is the right approach, but I'm pushing a branch + draft PR in order to refer to it in a comment.

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [X] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
