### PR TITLE
Add a script to download and install APK from Buildkite

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ SDK API changes ⚠️:
 
 Build 🧱:
  - Update a lot of dependencies, with the help of dependabot.
+ - Add a script to download and install APK from the CI
 
 Test:
  -

--- a/tools/install/androidSelectDevice.sh
+++ b/tools/install/androidSelectDevice.sh
@@ -1,0 +1,116 @@
+#! /bin/bash
+#=====================================================================
+# Selects an android device
+# Copyright (C) 2012-2020 Diego Torres Milano. All rights reserved.
+#
+# See:
+#    - http://dtmilano.blogspot.ca/2013/01/android-select-device.html
+#    - http://dtmilano.blogspot.ca/2012/03/selecting-adb-device.html
+# for details on usage.
+#=====================================================================
+
+# BMA: GIST FROM https://gist.github.com/dtmilano/4537110
+
+get_adb_devices() {
+    adb $ADB_SERVER devices $LONG 2>&1 | tail -n +2 | sed '/^$/d'
+}
+
+git_pull() {
+    [[ "$UNAME" == 'Linux' ]] && OPT=-e
+    ASD=$(readlink $OPT $0)
+    if [[ -n "$ASD" ]]
+    then
+        DIR=$(dirname $ASD)
+        if [[ -n "$DIR" && -d "$DIR/.git" ]]
+        then
+            (cd $DIR && git pull)
+        fi
+    fi
+}
+
+PROGNAME=$(basename $0)
+VERSION="3.3.0"
+UNAME=$(uname)
+DEVICE_OPT=
+LONG=
+ADB_SERVER=
+
+git_pull > /dev/null
+
+for opt in "$@"
+do
+    case "$opt" in
+        -d|-e|-s|-t)
+            DEVICE_OPT=$opt
+            ;;
+
+        -l|--long)
+            LONG=-l
+            ;;
+
+        start-server|kill-server|connect|pair|-help)
+            exit 0
+            ;;
+
+        -V|--version)
+            echo "$PROGNAME version $VERSION"
+            exit 0
+            ;;
+    esac
+done
+[ -n "$DEVICE_OPT" ] && exit 0
+DEV=$(get_adb_devices)
+if [ -z "$DEV" ]
+then
+    echo "$PROGNAME: ERROR: There's no locally connected devices." >&2
+    read -p "Do you want to connect to a remote adb server? [Y/n]: " REPLY
+    case "$REPLY" in
+        n|N)
+            exit 1
+            ;;
+
+        y|Y|"")
+            read -p "ADB server IP: " IP
+            ADB_SERVER="-H $IP"
+            DEV=$(get_adb_devices)
+            ;;
+    esac
+elif echo "$DEV" | grep -q 'daemon started successfully'
+then
+    # try again
+    DEV=$(get_adb_devices)
+fi
+N=$(echo "$DEV" | wc -l | sed 's/ //g')
+
+case $N in
+1)
+    # only one device detected
+    D=$DEV
+    ;;
+
+*)
+    # more than one device detected
+    OLDIFS=$IFS
+    IFS="
+"
+    PS3="Select the device to use, <Q> to quit: "
+    select D in $DEV
+    do
+        [ "$REPLY" = 'q' -o "$REPLY" = 'Q' ] && exit 2
+        [ -n "$D" ] && break
+    done < /dev/tty
+
+    IFS=$OLDIFS
+    ;;
+esac
+
+if [ -z "$D" ]
+then
+    echo "$PROGNAME: ERROR: target device couldn't be determined" >&2
+    exit 1
+fi
+
+# this didn't work on Darwin
+# echo "-s ${D%% *}"
+### BMA Modified printf -- '-s %s\n' "$(echo ${D} | sed 's/ .*$//')"
+printf -- '%s' "$(echo ${D} | sed 's/ .*$//')"

--- a/tools/install/installFromBuildkite.sh
+++ b/tools/install/installFromBuildkite.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Exit on any error
+set -e
+
+if [[ "$#" -ne 1 ]]; then
+  echo "Usage: $0 BUILDKITE_TOKEN" >&2
+  exit 1
+fi
+
+buildkiteToken=$1
+
+# Path where the app is cloned (it's where this project has been cloned)
+appPath=$(dirname $(dirname $(dirname $0)))
+# Path where the APK will be downloaded from Buildkite (it's a dir)
+baseImportPath="${appPath}/tmp/DebugApks"
+
+# Select device
+serialNumber=$(${appPath}/tools/install/androidSelectDevice.sh)
+
+# Detect device architecture
+
+arch=$(adb -s ${serialNumber} shell getprop ro.product.cpu.abi)
+
+# FDroid or Gplay ?
+echo
+read -p "fdroid or gplay (default to gplay)? " fdroidOrGplay
+fdroidOrGplay=${fdroidOrGplay:-gplay}
+
+echo
+echo "Will install ${fdroidOrGplay} version on device ${serialNumber} with arch ${arch}"
+
+# Buildkite build number
+echo
+read -p "Buildkite build number (ex: '1792')? " buildkiteBuildNumber
+
+# Download files
+
+targetPath=${baseImportPath}/${buildkiteBuildNumber}
+
+filename="vector-${fdroidOrGplay}-${arch}-debug.apk"
+
+fullApkPath="${targetPath}/${filename}"
+
+# Check if file already exists
+if test -f "$fullApkPath"; then
+    read -p "$fullApkPath already exists. Override (yes/no) default to no ? " download
+    download=${download:-no}
+else
+    download="yes"
+fi
+
+# Ignore error from now
+set +e
+
+if [ ${download} == "yes" ]; then
+    echo "Downloading ${filename}..."
+    python3 ${appPath}/tools/release/download_buildkite_artifacts.py \
+        --token ${buildkiteToken} \
+        --build ${buildkiteBuildNumber} \
+        --directory ${targetPath} \
+        --filename ${filename} \
+        --ignoreErrors
+fi
+
+echo "Installing ${filename} to device ${serialNumber}..."
+adb -s ${serialNumber} install -r ${fullApkPath}
+
+# Check error and propose to uninstall and retry installing
+if [[ "$?" -ne 0 ]]; then
+    read -p "Error, do you want to uninstall the application then retry (yes/no) default to no ? " retry
+    retry=${retry:-no}
+    if [ ${retry} == "yes" ]; then
+        echo "Uninstalling..."
+        adb -s ${serialNumber} uninstall im.vector.app.debug
+        echo "Installing again..."
+        adb -s ${serialNumber} install -r ${fullApkPath}
+    fi
+fi

--- a/tools/release/download_buildkite_artifacts.py
+++ b/tools/release/download_buildkite_artifacts.py
@@ -81,7 +81,9 @@ base_url = "https://api.buildkite.com/v2/organizations/%s/pipelines/%s/builds/%s
 
 buildkite_build_state_url = base_url
 
-print("Getting build state of project %s/%s build %s" % (ORG_SLUG, PIPELINE_SLUG, build_str))
+buildkite_url = "https://buildkite.com/%s/%s/builds/%s" % (ORG_SLUG, PIPELINE_SLUG, build_str)
+
+print("Getting build state of project %s/%s build %s (%s)" % (ORG_SLUG, PIPELINE_SLUG, build_str, buildkite_url))
 
 if args.verbose:
     print("Url: %s" % buildkite_build_state_url)
@@ -141,7 +143,7 @@ else:
     targetDir = args.directory
 
 if not args.simulate:
-    os.mkdir(targetDir)
+    os.makedirs(targetDir, exist_ok=True)
 
 for elt in data:
     if args.verbose:


### PR DESCRIPTION
Make developers (and power users) happy: install APK from any branches since Buildkite has built it.
It will prompt for the device to install the APK if several device are available. Also will download the correct APK depending on the device architecture.