### PR TITLE
Improve init sync performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Features ✨:
 Improvements 🙌:
  - Allow non-HTTPS connections to homeservers on Tor (#2941)
  - Fetch homeserver type and version and display in a new setting screen and add info in rageshakes (#2831)
- - Improve initial sync performance (#983)
+ - Improve initial sync performance - split into 2 transactions (#983)
  - PIP support for Jitsi call (#2418)
  - Add tooltip for room quick actions
  - Pre-share session keys when opening a room or start typing (#2771)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/sync/FilterService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/sync/FilterService.kt
@@ -22,9 +22,9 @@ interface FilterService {
         NoFilter,
 
         /**
-         * Filter for Riot, will include only known event type
+         * Filter for Element, will include only known event type
          */
-        RiotFilter
+        ElementFilter
     }
 
     /**

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/di/MoshiProvider.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/di/MoshiProvider.kt
@@ -36,7 +36,7 @@ import org.matrix.android.sdk.internal.network.parsing.ForceToBooleanJsonAdapter
 import org.matrix.android.sdk.internal.network.parsing.RuntimeJsonAdapterFactory
 import org.matrix.android.sdk.internal.network.parsing.TlsVersionMoshiAdapter
 import org.matrix.android.sdk.internal.network.parsing.UriMoshiAdapter
-import org.matrix.android.sdk.internal.session.sync.parsing.DefaultLazyRoomSyncJsonAdapter
+import org.matrix.android.sdk.internal.session.sync.parsing.DefaultLazyRoomSyncEphemeralJsonAdapter
 
 object MoshiProvider {
 
@@ -46,7 +46,7 @@ object MoshiProvider {
             .add(CipherSuiteMoshiAdapter())
             .add(TlsVersionMoshiAdapter())
             // Use addLast here so we can inject a SplitLazyRoomSyncJsonAdapter later to override the default parsing.
-            .addLast(DefaultLazyRoomSyncJsonAdapter())
+            .addLast(DefaultLazyRoomSyncEphemeralJsonAdapter())
             .add(RuntimeJsonAdapterFactory.of(MessageContent::class.java, "msgtype", MessageDefaultContent::class.java)
                     .registerSubtype(MessageTextContent::class.java, MessageType.MSGTYPE_TEXT)
                     .registerSubtype(MessageNoticeContent::class.java, MessageType.MSGTYPE_NOTICE)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/filter/FilterFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/filter/FilterFactory.kt
@@ -56,11 +56,11 @@ internal object FilterFactory {
         )
     }
 
-    private fun createElementTimelineFilter(): RoomEventFilter {
-        return RoomEventFilter().apply {
+    private fun createElementTimelineFilter(): RoomEventFilter? {
+        return null // RoomEventFilter().apply {
             // TODO Enable this for optimization
             // types = listOfSupportedEventTypes.toMutableList()
-        }
+        // }
     }
 
     private fun createElementStateFilter(): RoomEventFilter {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/filter/FilterFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/filter/FilterFactory.kt
@@ -33,11 +33,11 @@ internal object FilterFactory {
         return FilterUtil.enableLazyLoading(Filter(), true)
     }
 
-    fun createRiotFilter(): Filter {
+    fun createElementFilter(): Filter {
         return Filter(
                 room = RoomFilter(
-                        timeline = createRiotTimelineFilter(),
-                        state = createRiotStateFilter()
+                        timeline = createElementTimelineFilter(),
+                        state = createElementStateFilter()
                 )
         )
     }
@@ -48,7 +48,7 @@ internal object FilterFactory {
         )
     }
 
-    fun createRiotRoomFilter(): RoomEventFilter {
+    fun createElementRoomFilter(): RoomEventFilter {
         return RoomEventFilter(
                 lazyLoadMembers = true
                 // TODO Enable this for optimization
@@ -56,26 +56,26 @@ internal object FilterFactory {
         )
     }
 
-    private fun createRiotTimelineFilter(): RoomEventFilter {
+    private fun createElementTimelineFilter(): RoomEventFilter {
         return RoomEventFilter().apply {
             // TODO Enable this for optimization
             // types = listOfSupportedEventTypes.toMutableList()
         }
     }
 
-    private fun createRiotStateFilter(): RoomEventFilter {
+    private fun createElementStateFilter(): RoomEventFilter {
         return RoomEventFilter(
                 lazyLoadMembers = true
         )
     }
 
-    // Get only managed types by Riot
+    // Get only managed types by Element
     private val listOfSupportedEventTypes = listOf(
             // TODO Complete the list
             EventType.MESSAGE
     )
 
-    // Get only managed types by Riot
+    // Get only managed types by Element
     private val listOfSupportedStateEventTypes = listOf(
             // TODO Complete the list
             EventType.STATE_ROOM_MEMBER

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/filter/SaveFilterTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/filter/SaveFilterTask.kt
@@ -42,18 +42,18 @@ internal class DefaultSaveFilterTask @Inject constructor(
 
     override suspend fun execute(params: SaveFilterTask.Params) {
         val filterBody = when (params.filterPreset) {
-            FilterService.FilterPreset.RiotFilter -> {
-                FilterFactory.createRiotFilter()
+            FilterService.FilterPreset.ElementFilter -> {
+                FilterFactory.createElementFilter()
             }
-            FilterService.FilterPreset.NoFilter   -> {
+            FilterService.FilterPreset.NoFilter      -> {
                 FilterFactory.createDefaultFilter()
             }
         }
         val roomFilter = when (params.filterPreset) {
-            FilterService.FilterPreset.RiotFilter -> {
-                FilterFactory.createRiotRoomFilter()
+            FilterService.FilterPreset.ElementFilter -> {
+                FilterFactory.createElementRoomFilter()
             }
-            FilterService.FilterPreset.NoFilter   -> {
+            FilterService.FilterPreset.NoFilter      -> {
                 FilterFactory.createDefaultRoomFilter()
             }
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/ProcessEventForPushTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/ProcessEventForPushTask.kt
@@ -50,7 +50,7 @@ internal class DefaultProcessEventForPushTask @Inject constructor(
         }
         val newJoinEvents = params.syncResponse.join
                 .mapNotNull { (key, value) ->
-                    value.roomSync.timeline?.events?.map { it.copy(roomId = key) }
+                    value.timeline?.events?.map { it.copy(roomId = key) }
                 }
                 .flatten()
         val inviteEvents = params.syncResponse.invite
@@ -80,7 +80,7 @@ internal class DefaultProcessEventForPushTask @Inject constructor(
 
         val allRedactedEvents = params.syncResponse.join
                 .asSequence()
-                .mapNotNull { (_, value) -> value.roomSync.timeline?.events }
+                .mapNotNull { it.value.timeline?.events }
                 .flatten()
                 .filter { it.type == EventType.REDACTION }
                 .mapNotNull { it.redacts }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/InitialSyncStrategy.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/InitialSyncStrategy.kt
@@ -41,10 +41,10 @@ sealed class InitialSyncStrategy {
              */
             val minSizeToSplit: Long = 1024 * 1024,
             /**
-             * Limit per room to reach to decide to store a join room into a file
-             * Empiric value: 10 kilobytes
+             * Limit per room to reach to decide to store a join room ephemeral Events into a file
+             * Empiric value: 6 kilobytes
              */
-            val minSizeToStoreInFile: Long = 10 * 1024,
+            val minSizeToStoreInFile: Long = 6 * 1024,
             /**
              * Max number of rooms to insert at a time in database (to avoid too much RAM usage)
              */

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
@@ -119,7 +119,7 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
         val rooms = when (handlingStrategy) {
             is HandlingStrategy.JOINED  -> {
                 if (isInitialSync && initialSyncStrategy is InitialSyncStrategy.Optimized) {
-                    insertJoinRooms(realm, handlingStrategy, insertType, syncLocalTimeStampMillis, reporter)
+                    insertJoinRoomsFromInitSync(realm, handlingStrategy, insertType, syncLocalTimeStampMillis, reporter)
                     // Rooms are already inserted, return an empty list
                     emptyList()
                 } else {
@@ -142,11 +142,11 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
         realm.insertOrUpdate(rooms)
     }
 
-    private fun insertJoinRooms(realm: Realm,
-                                handlingStrategy: HandlingStrategy.JOINED,
-                                insertType: EventInsertType,
-                                syncLocalTimeStampMillis: Long,
-                                reporter: ProgressReporter?) {
+    private fun insertJoinRoomsFromInitSync(realm: Realm,
+                                            handlingStrategy: HandlingStrategy.JOINED,
+                                            insertType: EventInsertType,
+                                            syncLocalTimeStampMillis: Long,
+                                            reporter: ProgressReporter?) {
         val maxSize = (initialSyncStrategy as? InitialSyncStrategy.Optimized)?.maxRoomsToInsert ?: Int.MAX_VALUE
         val listSize = handlingStrategy.data.keys.size
         val numberOfChunks = ceil(listSize / maxSize.toDouble()).toInt()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
@@ -119,7 +119,7 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
         val rooms = when (handlingStrategy) {
             is HandlingStrategy.JOINED  -> {
                 if (isInitialSync && initialSyncStrategy is InitialSyncStrategy.Optimized) {
-                    insertJoinRoomsFromInitSync(realm, handlingStrategy, insertType, syncLocalTimeStampMillis, reporter)
+                    insertJoinRoomsFromInitSync(realm, handlingStrategy, syncLocalTimeStampMillis, reporter)
                     // Rooms are already inserted, return an empty list
                     emptyList()
                 } else {
@@ -144,7 +144,6 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
 
     private fun insertJoinRoomsFromInitSync(realm: Realm,
                                             handlingStrategy: HandlingStrategy.JOINED,
-                                            insertType: EventInsertType,
                                             syncLocalTimeStampMillis: Long,
                                             reporter: ProgressReporter?) {
         val maxSize = (initialSyncStrategy as? InitialSyncStrategy.Optimized)?.maxRoomsToInsert ?: Int.MAX_VALUE
@@ -167,7 +166,7 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
                                                 roomId = it,
                                                 roomSync = handlingStrategy.data[it] ?: error("Should not happen"),
                                                 handleEphemeralEvents = false,
-                                                insertType = insertType,
+                                                insertType = EventInsertType.INITIAL_SYNC,
                                                 syncLocalTimestampMillis = syncLocalTimeStampMillis
                                         )
                                     }
@@ -178,7 +177,7 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
         } else {
             // No need to split
             val rooms = handlingStrategy.data.mapWithProgress(reporter, InitSyncStep.ImportingAccountJoinedRooms, 0.6f) {
-                handleJoinedRoom(realm, it.key, it.value, false, insertType, syncLocalTimeStampMillis)
+                handleJoinedRoom(realm, it.key, it.value, false, EventInsertType.INITIAL_SYNC, syncLocalTimeStampMillis)
             }
             realm.insertOrUpdate(rooms)
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
@@ -195,7 +195,7 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
         if (handleEphemeralEvents) {
             ephemeralResult = roomSync.ephemeral?.roomSyncEphemeral?.events
                     ?.takeIf { it.isNotEmpty() }
-                    ?.let { handleEphemeral(realm, roomId, it, false) }
+                    ?.let { handleEphemeral(realm, roomId, it, insertType == EventInsertType.INITIAL_SYNC) }
         }
 
         if (roomSync.accountData?.events?.isNotEmpty() == true) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/model/LazyRoomSyncEphemeral.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/model/LazyRoomSyncEphemeral.kt
@@ -24,18 +24,18 @@ import okio.source
 import java.io.File
 
 @JsonClass(generateAdapter = false)
-internal sealed class LazyRoomSync {
-    data class Parsed(val _roomSync: RoomSync) : LazyRoomSync()
-    data class Stored(val roomSyncAdapter: JsonAdapter<RoomSync>, val file: File) : LazyRoomSync()
+internal sealed class LazyRoomSyncEphemeral {
+    data class Parsed(val _roomSyncEphemeral: RoomSyncEphemeral) : LazyRoomSyncEphemeral()
+    data class Stored(val roomSyncEphemeralAdapter: JsonAdapter<RoomSyncEphemeral>, val file: File) : LazyRoomSyncEphemeral()
 
-    val roomSync: RoomSync
+    val roomSyncEphemeral: RoomSyncEphemeral
         get() {
             return when (this) {
-                is Parsed -> _roomSync
+                is Parsed -> _roomSyncEphemeral
                 is Stored -> {
                     // Parse the file now
                     file.inputStream().use { pos ->
-                        roomSyncAdapter.fromJson(JsonReader.of(pos.source().buffer()))!!
+                        roomSyncEphemeralAdapter.fromJson(JsonReader.of(pos.source().buffer()))!!
                     }
                 }
             }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/model/RoomSync.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/model/RoomSync.kt
@@ -34,7 +34,7 @@ internal data class RoomSync(
         /**
          * The ephemeral events in the room that aren't recorded in the timeline or state of the room (e.g. typing, receipts).
          */
-        @Json(name = "ephemeral") val ephemeral: RoomSyncEphemeral? = null,
+        @Json(name = "ephemeral") val ephemeral: LazyRoomSyncEphemeral? = null,
 
         /**
          * The account data events for the room (e.g. tags).

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/model/RoomsSyncResponse.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/model/RoomsSyncResponse.kt
@@ -24,7 +24,7 @@ internal data class RoomsSyncResponse(
         /**
          * Joined rooms: keys are rooms ids.
          */
-        @Json(name = "join") val join: Map<String, LazyRoomSync> = emptyMap(),
+        @Json(name = "join") val join: Map<String, RoomSync> = emptyMap(),
 
         /**
          * Invitations. The rooms that the user has been invited to: keys are rooms ids.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/parsing/DefaultLazyRoomSyncEphemeralJsonAdapter.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/parsing/DefaultLazyRoomSyncEphemeralJsonAdapter.kt
@@ -22,22 +22,22 @@ import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.ToJson
 import org.matrix.android.sdk.internal.session.sync.InitialSyncStrategy
-import org.matrix.android.sdk.internal.session.sync.model.LazyRoomSync
-import org.matrix.android.sdk.internal.session.sync.model.RoomSync
+import org.matrix.android.sdk.internal.session.sync.model.LazyRoomSyncEphemeral
+import org.matrix.android.sdk.internal.session.sync.model.RoomSyncEphemeral
 import timber.log.Timber
 import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
-internal class DefaultLazyRoomSyncJsonAdapter {
+internal class DefaultLazyRoomSyncEphemeralJsonAdapter {
 
     @FromJson
-    fun fromJson(reader: JsonReader, delegate: JsonAdapter<RoomSync>): LazyRoomSync? {
-        val roomSync = delegate.fromJson(reader) ?: return null
-        return LazyRoomSync.Parsed(roomSync)
+    fun fromJson(reader: JsonReader, delegate: JsonAdapter<RoomSyncEphemeral>): LazyRoomSyncEphemeral? {
+        val roomSyncEphemeral = delegate.fromJson(reader) ?: return null
+        return LazyRoomSyncEphemeral.Parsed(roomSyncEphemeral)
     }
 
     @ToJson
-    fun toJson(writer: JsonWriter, value: LazyRoomSync?) {
+    fun toJson(writer: JsonWriter, value: LazyRoomSyncEphemeral?) {
         // This Adapter is not supposed to serialize object
         Timber.v("To json $value with $writer")
         throw UnsupportedOperationException()
@@ -56,7 +56,7 @@ internal class SplitLazyRoomSyncJsonAdapter(
     }
 
     @FromJson
-    fun fromJson(reader: JsonReader, delegate: JsonAdapter<RoomSync>): LazyRoomSync? {
+    fun fromJson(reader: JsonReader, delegate: JsonAdapter<RoomSyncEphemeral>): LazyRoomSyncEphemeral? {
         val path = reader.path
         val json = reader.nextSource().inputStream().bufferedReader().use {
             it.readText()
@@ -67,16 +67,16 @@ internal class SplitLazyRoomSyncJsonAdapter(
             // Copy the source to a file
             val file = createFile()
             file.writeText(json)
-            LazyRoomSync.Stored(delegate, file)
+            LazyRoomSyncEphemeral.Stored(delegate, file)
         } else {
             Timber.v("INIT_SYNC $path content length: ${json.length} parse it now")
             val roomSync = delegate.fromJson(json) ?: return null
-            LazyRoomSync.Parsed(roomSync)
+            LazyRoomSyncEphemeral.Parsed(roomSync)
         }
     }
 
     @ToJson
-    fun toJson(writer: JsonWriter, value: LazyRoomSync?) {
+    fun toJson(writer: JsonWriter, value: LazyRoomSyncEphemeral?) {
         // This Adapter is not supposed to serialize object
         Timber.v("To json $value with $writer")
         throw UnsupportedOperationException()

--- a/vector/src/main/java/im/vector/app/core/extensions/Session.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/Session.kt
@@ -29,7 +29,7 @@ import timber.log.Timber
 fun Session.configureAndStart(context: Context) {
     Timber.i("Configure and start session for $myUserId")
     open()
-    setFilter(FilterService.FilterPreset.RiotFilter)
+    setFilter(FilterService.FilterPreset.ElementFilter)
     startSyncing(context)
     refreshPushers()
 }


### PR DESCRIPTION
This PR reduce the delay to see the room list and be able to open a room and send a message to it.
On my account (about 300 rooms) I can see the room list after 55 seconds. With this PR, it is reduced to 35 seconds, including 12 seconds to let the server compute the response and the client to download the data.