### PR TITLE
Basic filtering for "nsfw" keyword

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomDirectoryService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomDirectoryService.kt
@@ -16,11 +16,9 @@
 
 package org.matrix.android.sdk.api.session.room
 
-import org.matrix.android.sdk.api.MatrixCallback
 import org.matrix.android.sdk.api.session.room.model.RoomDirectoryVisibility
 import org.matrix.android.sdk.api.session.room.model.roomdirectory.PublicRoomsParams
 import org.matrix.android.sdk.api.session.room.model.roomdirectory.PublicRoomsResponse
-import org.matrix.android.sdk.api.util.Cancelable
 
 /**
  * This interface defines methods to get and join public rooms. It's implemented at the session level.
@@ -30,9 +28,8 @@ interface RoomDirectoryService {
     /**
      * Get rooms from directory
      */
-    fun getPublicRooms(server: String?,
-                       publicRoomsParams: PublicRoomsParams,
-                       callback: MatrixCallback<PublicRoomsResponse>): Cancelable
+    suspend fun getPublicRooms(server: String?,
+                               publicRoomsParams: PublicRoomsParams): PublicRoomsResponse
 
     /**
      * Get the visibility of a room in the directory

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoomDirectoryService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoomDirectoryService.kt
@@ -16,33 +16,24 @@
 
 package org.matrix.android.sdk.internal.session.room
 
-import org.matrix.android.sdk.api.MatrixCallback
 import org.matrix.android.sdk.api.session.room.RoomDirectoryService
 import org.matrix.android.sdk.api.session.room.model.RoomDirectoryVisibility
 import org.matrix.android.sdk.api.session.room.model.roomdirectory.PublicRoomsParams
 import org.matrix.android.sdk.api.session.room.model.roomdirectory.PublicRoomsResponse
-import org.matrix.android.sdk.api.util.Cancelable
 import org.matrix.android.sdk.internal.session.room.directory.GetPublicRoomTask
 import org.matrix.android.sdk.internal.session.room.directory.GetRoomDirectoryVisibilityTask
 import org.matrix.android.sdk.internal.session.room.directory.SetRoomDirectoryVisibilityTask
-import org.matrix.android.sdk.internal.task.TaskExecutor
-import org.matrix.android.sdk.internal.task.configureWith
 import javax.inject.Inject
 
 internal class DefaultRoomDirectoryService @Inject constructor(
         private val getPublicRoomTask: GetPublicRoomTask,
         private val getRoomDirectoryVisibilityTask: GetRoomDirectoryVisibilityTask,
-        private val setRoomDirectoryVisibilityTask: SetRoomDirectoryVisibilityTask,
-        private val taskExecutor: TaskExecutor) : RoomDirectoryService {
+        private val setRoomDirectoryVisibilityTask: SetRoomDirectoryVisibilityTask
+) : RoomDirectoryService {
 
-    override fun getPublicRooms(server: String?,
-                                publicRoomsParams: PublicRoomsParams,
-                                callback: MatrixCallback<PublicRoomsResponse>): Cancelable {
-        return getPublicRoomTask
-                .configureWith(GetPublicRoomTask.Params(server, publicRoomsParams)) {
-                    this.callback = callback
-                }
-                .executeBy(taskExecutor)
+    override suspend fun getPublicRooms(server: String?,
+                                        publicRoomsParams: PublicRoomsParams): PublicRoomsResponse {
+        return getPublicRoomTask.execute(GetPublicRoomTask.Params(server, publicRoomsParams))
     }
 
     override suspend fun getRoomDirectoryVisibility(roomId: String): RoomDirectoryVisibility {

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/PublicRoomsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/PublicRoomsViewState.kt
@@ -29,7 +29,7 @@ data class PublicRoomsViewState(
         // Store cumul of pagination result
         val publicRooms: List<PublicRoom> = emptyList(),
         // Current pagination request
-        val asyncPublicRoomsRequest: Async<List<PublicRoom>> = Uninitialized,
+        val asyncPublicRoomsRequest: Async<Unit> = Uninitialized,
         // True if more result are available server side
         val hasMore: Boolean = false,
         // Set of joined roomId,

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/RoomDirectoryViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/RoomDirectoryViewModel.kt
@@ -203,7 +203,7 @@ class RoomDirectoryViewModel @AssistedInject constructor(
             val newPublicRooms = data.chunk.orEmpty()
                     .filter {
                         showAllRooms
-                                || "${it.name} ${it.topic}".toLowerCase(Locale.ROOT)
+                                || "${it.name.orEmpty()} ${it.topic.orEmpty()} ${it.canonicalAlias.orEmpty()}".toLowerCase(Locale.ROOT)
                                 .let { str ->
                                     explicitContentTerms.all { term -> term !in str }
                                 }

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/RoomDirectoryViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/RoomDirectoryViewModel.kt
@@ -171,7 +171,7 @@ class RoomDirectoryViewModel @AssistedInject constructor(@Assisted initialState:
 
                         setState {
                             copy(
-                                    asyncPublicRoomsRequest = Success(data.chunk!!),
+                                    asyncPublicRoomsRequest = Success(Unit),
                                     // It's ok to append at the end of the list, so I use publicRooms.size()
                                     publicRooms = publicRooms.appendAt(data.chunk!!, publicRooms.size)
                                             // Rageshake #8206 tells that we can have several times the same room

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -100,6 +100,9 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         private const val SETTINGS_ENABLE_CHAT_EFFECTS = "SETTINGS_ENABLE_CHAT_EFFECTS"
         private const val SETTINGS_SHOW_EMOJI_KEYBOARD = "SETTINGS_SHOW_EMOJI_KEYBOARD"
 
+        // Room directory
+        private const val SETTINGS_ROOM_DIRECTORY_SHOW_ALL_PUBLIC_ROOMS = "SETTINGS_ROOM_DIRECTORY_SHOW_ALL_PUBLIC_ROOMS"
+
         // Help
         private const val SETTINGS_SHOULD_SHOW_HELP_ON_ROOM_LIST_KEY = "SETTINGS_SHOULD_SHOW_HELP_ON_ROOM_LIST_KEY"
 
@@ -397,6 +400,13 @@ class VectorPreferences @Inject constructor(private val context: Context) {
      */
     fun isSendVoiceFeatureEnabled(): Boolean {
         return defaultPrefs.getBoolean(SETTINGS_ENABLE_SEND_VOICE_FEATURE_PREFERENCE_KEY, false)
+    }
+
+    /**
+     * Show all rooms in room directory
+     */
+    fun showAllPublicRooms(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_ROOM_DIRECTORY_SHOW_ALL_PUBLIC_ROOMS, false)
     }
 
     /**

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -498,8 +498,8 @@
     </plurals>
 
     <string name="settings_category_room_directory">Room directory</string>
-    <string name="settings_room_directory_show_all_rooms">Show all rooms in the room directory</string>
-    <string name="settings_room_directory_show_all_rooms_summary">Show all rooms, including rooms with explicit content.</string>
+    <string name="settings_room_directory_show_all_rooms">Show rooms with explicit content</string>
+    <string name="settings_room_directory_show_all_rooms_summary">Show all rooms in the room directory, including rooms with explicit content.</string>
 
     <!-- Groups fragment -->
     <string name="groups_invite_header">Invite</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -497,6 +497,10 @@
         <item quantity="other">%d users</item>
     </plurals>
 
+    <string name="settings_category_room_directory">Room directory</string>
+    <string name="settings_room_directory_show_all_rooms">Show all rooms in the room directory</string>
+    <string name="settings_room_directory_show_all_rooms_summary">Show all rooms, including rooms with explicit content.</string>
+
     <!-- Groups fragment -->
     <string name="groups_invite_header">Invite</string>
     <string name="groups_header">Communities</string>

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -177,4 +177,12 @@
 
     </im.vector.app.core.preference.VectorPreferenceCategory>
 
+    <im.vector.app.core.preference.VectorPreferenceCategory android:title="@string/settings_category_room_directory">
+
+    <im.vector.app.core.preference.VectorSwitchPreference
+        android:key="SETTINGS_ROOM_DIRECTORY_SHOW_ALL_PUBLIC_ROOMS"
+        android:summary="@string/settings_room_directory_show_all_rooms_summary"
+        android:title="@string/settings_room_directory_show_all_rooms" />
+
+    </im.vector.app.core.preference.VectorPreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
New settings, in Settings/Preferences screen, off by default:

(Edit: wording has been updated, see new screenshot below)
<img width="413" alt="image" src="https://user-images.githubusercontent.com/3940906/110324743-ab822100-8016-11eb-9e23-76ffa262802d.png">

Filtering room directory

<img width="404" alt="image" src="https://user-images.githubusercontent.com/3940906/110324840-d40a1b00-8016-11eb-836b-a3bfe2cdb18a.png">


Also migrate RoomDirectoryService to coroutines (#2449)