### PR TITLE
Change ISSUE_TEMPLATE bold lines to proper headers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,27 +7,27 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+#### Describe the bug
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+#### To Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+#### Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+#### Screenshots
 If applicable, add screenshots to help explain your problem.
 
-**Smartphone (please complete the following information):**
+#### Smartphone (please complete the following information):
  - Device: [e.g. Samsung S6]
  - OS: [e.g. Android 6.0]
 
-**Additional context**
+#### Additional context
  - App version and store [e.g. 1.0.0 - F-Droid]
  - Homeserver: [e.g. matrix.org]
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-#### *Is your feature request related to a problem? Please describe.
+#### Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 #### Describe the solution you'd like.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+#### *Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+#### Describe the solution you'd like.
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+#### Describe alternatives you've considered.
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+#### Additional context
 Add any other context or screenshots about the feature request here.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,7 +23,7 @@ Test:
  -
 
 Other changes:
- -
+ - Change formatting on issue templates to proper headings.
 
 Changes in Element 1.1.1 (2021-XX-XX)
 ===================================================


### PR DESCRIPTION
Bugged me for a while, 4-deep headers are equivalent, but they look nicer when editing the pull request itself, and they shift the lines on the PR a tiny bit to make it more readable.

### Pull Request Checklist

- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
  - (sidenote; do I really need to add meta changes such as this to `CHANGES.md`?)
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`