### PR TITLE
fix: make cross signing work with server names containing :

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@ Bugfix 🐛:
  - Be robust if Event.type is missing (#2946)
  - Snappier message send status
  - Fix MainActivity display (#2927)
+ - Cross signing now works with servers with an explicit port in the servername
 
 Translations 🗣:
  - All string resources and translations have been moved to the application module. Weblate project for the SDK will be removed.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DeviceListManager.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DeviceListManager.kt
@@ -104,7 +104,7 @@ internal class DeviceListManager @Inject constructor(private val cryptoStore: IM
         if (':' in userId) {
             try {
                 synchronized(notReadyToRetryHS) {
-                    res = !notReadyToRetryHS.contains(userId.substringAfterLast(':'))
+                    res = !notReadyToRetryHS.contains(userId.substringAfter(':'))
                 }
             } catch (e: Exception) {
                 Timber.e(e, "## CRYPTO | canRetryKeysDownload() failed")


### PR DESCRIPTION
Server names are allowed to contain ':' to specify a port, see https://matrix.org/docs/spec/appendices#server-name
User ids on the other hand are not allowed to contain ':', even
historical user ids, see https://matrix.org/docs/spec/appendices#historical-user-ids

Therefore we can use the first instance of ':' to split the user
localpart from the server name.

Note: I could not test it yet

Signed-off-by: Timo Kösters <timo@koesters.xyz>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [X] Pull request is based on the develop branch
- [X] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [X] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
