### PR TITLE
Split key request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Features ✨:
  -
 
 Improvements 🙌:
- -
+ - Split network request `/keys/query` into smaller requests (250 users max) (#2925)
 
 Bugfix 🐛:
  -

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/DownloadKeysForUsersTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/DownloadKeysForUsersTask.kt
@@ -29,7 +29,7 @@ import org.matrix.android.sdk.internal.crypto.model.rest.RestKeyInfo
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.task.Task
-import org.matrix.android.sdk.internal.util.getBetsChunkSize
+import org.matrix.android.sdk.internal.util.computeBestChunkSize
 import javax.inject.Inject
 
 internal interface DownloadKeysForUsersTask : Task<DownloadKeysForUsersTask.Params, KeysQueryResponse> {
@@ -47,7 +47,7 @@ internal class DefaultDownloadKeysForUsers @Inject constructor(
 ) : DownloadKeysForUsersTask {
 
     override suspend fun execute(params: DownloadKeysForUsersTask.Params): KeysQueryResponse {
-        val bestChunkSize = getBetsChunkSize(params.userIds.size, LIMIT)
+        val bestChunkSize = computeBestChunkSize(params.userIds.size, LIMIT)
 
         // Store server results in these mutable maps
         val deviceKeys = mutableMapOf<String, Map<String, DeviceKeysWithUnsigned>>()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
@@ -64,7 +64,7 @@ import org.matrix.android.sdk.internal.session.sync.model.LazyRoomSyncEphemeral
 import org.matrix.android.sdk.internal.session.sync.model.RoomSync
 import org.matrix.android.sdk.internal.session.sync.model.RoomSyncAccountData
 import org.matrix.android.sdk.internal.session.sync.model.RoomsSyncResponse
-import org.matrix.android.sdk.internal.util.getBetsChunkSize
+import org.matrix.android.sdk.internal.util.computeBestChunkSize
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -140,12 +140,12 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
                                             syncLocalTimeStampMillis: Long,
                                             aggregator: SyncResponsePostTreatmentAggregator,
                                             reporter: ProgressReporter?) {
-        val bestChunkSize = getBetsChunkSize(
+        val bestChunkSize = computeBestChunkSize(
                 listSize = handlingStrategy.data.keys.size,
                 limit = (initialSyncStrategy as? InitialSyncStrategy.Optimized)?.maxRoomsToInsert ?: Int.MAX_VALUE
         )
 
-        if (bestChunkSize.shouldSplit()) {
+        if (bestChunkSize.shouldChunk()) {
             reportSubtask(reporter, InitSyncStep.ImportingAccountJoinedRooms, bestChunkSize.numberOfChunks, 0.6f) {
                 Timber.d("INIT_SYNC ${handlingStrategy.data.keys.size} rooms to insert, split with $bestChunkSize")
                 // I cannot find a better way to chunk a map, so chunk the keys and then create new maps

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/MathUtils.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/MathUtils.kt
@@ -33,7 +33,8 @@ internal fun getBetsChunkSize(listSize: Int, limit: Int): BestChunkSize {
         )
     } else {
         val numberOfChunks = ceil(listSize / limit.toDouble()).toInt()
-        val chunkSize = listSize / numberOfChunks
+        // Round on next Int
+        val chunkSize = ceil(listSize / numberOfChunks.toDouble()).toInt()
 
         BestChunkSize(
                 numberOfChunks = numberOfChunks,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/MathUtils.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/MathUtils.kt
@@ -22,10 +22,10 @@ internal data class BestChunkSize(
         val numberOfChunks: Int,
         val chunkSize: Int
 ) {
-    fun shouldSplit() = numberOfChunks > 1
+    fun shouldChunk() = numberOfChunks > 1
 }
 
-internal fun getBetsChunkSize(listSize: Int, limit: Int): BestChunkSize {
+internal fun computeBestChunkSize(listSize: Int, limit: Int): BestChunkSize {
     return if (listSize <= limit) {
         BestChunkSize(
                 numberOfChunks = 1,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/MathUtils.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/MathUtils.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.util
+
+import kotlin.math.ceil
+
+internal data class BestChunkSize(
+        val numberOfChunks: Int,
+        val chunkSize: Int
+) {
+    fun shouldSplit() = numberOfChunks > 1
+}
+
+internal fun getBetsChunkSize(listSize: Int, limit: Int): BestChunkSize {
+    return if (listSize <= limit) {
+        BestChunkSize(
+                numberOfChunks = 1,
+                chunkSize = listSize
+        )
+    } else {
+        val numberOfChunks = ceil(listSize / limit.toDouble()).toInt()
+        val chunkSize = listSize / numberOfChunks
+
+        BestChunkSize(
+                numberOfChunks = numberOfChunks,
+                chunkSize = chunkSize
+        )
+    }
+}

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/util/MathUtilTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/util/MathUtilTest.kt
@@ -27,35 +27,35 @@ import org.matrix.android.sdk.MatrixTest
 class MathUtilTest : MatrixTest {
 
     @Test
-    fun testGetBestChunkSize0() = doTest(0, 100, 1, 0)
+    fun testComputeBestChunkSize0() = doTest(0, 100, 1, 0)
 
     @Test
-    fun testGetBestChunkSize1to99() {
+    fun testComputeBestChunkSize1to99() {
         for (i in 1..99) {
             doTest(i, 100, 1, i)
         }
     }
 
     @Test
-    fun testGetBestChunkSize100() = doTest(100, 100, 1, 100)
+    fun testComputeBestChunkSize100() = doTest(100, 100, 1, 100)
 
     @Test
-    fun testGetBestChunkSize101() = doTest(101, 100, 2, 51)
+    fun testComputeBestChunkSize101() = doTest(101, 100, 2, 51)
 
     @Test
-    fun testGetBestChunkSize199() = doTest(199, 100, 2, 100)
+    fun testComputeBestChunkSize199() = doTest(199, 100, 2, 100)
 
     @Test
-    fun testGetBestChunkSize200() = doTest(200, 100, 2, 100)
+    fun testComputeBestChunkSize200() = doTest(200, 100, 2, 100)
 
     @Test
-    fun testGetBestChunkSize201() = doTest(201, 100, 3, 67)
+    fun testComputeBestChunkSize201() = doTest(201, 100, 3, 67)
 
     @Test
-    fun testGetBestChunkSize240() = doTest(240, 100, 3, 80)
+    fun testComputeBestChunkSize240() = doTest(240, 100, 3, 80)
 
     private fun doTest(listSize: Int, limit: Int, expectedNumberOfChunks: Int, expectedChunkSize: Int) {
-        val result = getBetsChunkSize(listSize, limit)
+        val result = computeBestChunkSize(listSize, limit)
 
         result.numberOfChunks shouldBeEqualTo expectedNumberOfChunks
         result.chunkSize shouldBeEqualTo expectedChunkSize

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/util/MathUtilTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/util/MathUtilTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.util
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldHaveSize
+import org.junit.FixMethodOrder
+import org.junit.Test
+import org.junit.runners.MethodSorters
+import org.matrix.android.sdk.MatrixTest
+
+@FixMethodOrder(MethodSorters.JVM)
+class MathUtilTest : MatrixTest {
+
+    @Test
+    fun testGetBestChunkSize0() = doTest(0, 100, 1, 0)
+
+    @Test
+    fun testGetBestChunkSize1() = doTest(1, 100, 1, 1)
+
+    @Test
+    fun testGetBestChunkSize5() = doTest(5, 100, 1, 5)
+
+    @Test
+    fun testGetBestChunkSize99() = doTest(99, 100, 1, 99)
+
+    @Test
+    fun testGetBestChunkSize100() = doTest(100, 100, 1, 100)
+
+    @Test
+    fun testGetBestChunkSize101() = doTest(101, 100, 2, 50)
+
+    @Test
+    fun testGetBestChunkSize199() = doTest(199, 100, 2, 99)
+
+    @Test
+    fun testGetBestChunkSize200() = doTest(200, 100, 2, 100)
+
+    @Test
+    fun testGetBestChunkSize201() = doTest(201, 100, 3, 67)
+
+    @Test
+    fun testGetBestChunkSize240() = doTest(240, 100, 3, 80)
+
+    private fun doTest(listSize: Int, limit: Int, expectedNumberOfChunks: Int, expectedChunkSize: Int) {
+        val result = getBetsChunkSize(listSize, limit)
+
+        result.numberOfChunks shouldBeEqualTo expectedNumberOfChunks
+        result.chunkSize shouldBeEqualTo expectedChunkSize
+
+        // Test that the result make sense, when we use chunked()
+        if (result.chunkSize > 0) {
+            generateSequence { "a" }
+                    .take(listSize)
+                    .chunked(result.chunkSize)
+                    .shouldHaveSize(result.numberOfChunks)
+        }
+    }
+}

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/util/MathUtilTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/util/MathUtilTest.kt
@@ -42,10 +42,10 @@ class MathUtilTest : MatrixTest {
     fun testGetBestChunkSize100() = doTest(100, 100, 1, 100)
 
     @Test
-    fun testGetBestChunkSize101() = doTest(101, 100, 2, 50)
+    fun testGetBestChunkSize101() = doTest(101, 100, 2, 51)
 
     @Test
-    fun testGetBestChunkSize199() = doTest(199, 100, 2, 99)
+    fun testGetBestChunkSize199() = doTest(199, 100, 2, 100)
 
     @Test
     fun testGetBestChunkSize200() = doTest(200, 100, 2, 100)

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/util/MathUtilTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/util/MathUtilTest.kt
@@ -30,13 +30,11 @@ class MathUtilTest : MatrixTest {
     fun testGetBestChunkSize0() = doTest(0, 100, 1, 0)
 
     @Test
-    fun testGetBestChunkSize1() = doTest(1, 100, 1, 1)
-
-    @Test
-    fun testGetBestChunkSize5() = doTest(5, 100, 1, 5)
-
-    @Test
-    fun testGetBestChunkSize99() = doTest(99, 100, 1, 99)
+    fun testGetBestChunkSize1to99() {
+        for (i in 1..99) {
+            doTest(i, 100, 1, i)
+        }
+    }
 
     @Test
     fun testGetBestChunkSize100() = doTest(100, 100, 1, 100)


### PR DESCRIPTION
Fixes #2925

Limit the number of user to max 250 per request.

If there is 251 users, the request will be cut into 2 requests, one with 125 users and one with 126 users