### PR TITLE
Quick Work around to remove stuck messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Improvements 🙌:
  -
 
 Bugfix 🐛:
- -
+ - Add option to cancel stuck messages at bottom of timeline see #516
 
 Translations 🗣:
  -

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
@@ -58,7 +58,7 @@ sealed class RoomDetailAction : VectorViewModelAction {
 
     data class ResendMessage(val eventId: String) : RoomDetailAction()
     data class RemoveFailedEcho(val eventId: String) : RoomDetailAction()
-    data class CancelSend(val eventId: String) : RoomDetailAction()
+    data class CancelSend(val eventId: String, val force: Boolean) : RoomDetailAction()
 
     data class ReplyToOptions(val eventId: String, val optionIndex: Int, val optionValue: String) : RoomDetailAction()
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -1570,14 +1570,18 @@ class RoomDetailFragment @Inject constructor(
     }
 
     private fun handleCancelSend(action: EventSharedAction.Cancel) {
-        AlertDialog.Builder(requireContext())
-                .setTitle(R.string.dialog_title_confirmation)
-                .setMessage(getString(R.string.event_status_cancel_sending_dialog_message))
-                .setNegativeButton(R.string.no, null)
-                .setPositiveButton(R.string.yes) { _, _ ->
-                    roomDetailViewModel.handle(RoomDetailAction.CancelSend(action.eventId))
-                }
-                .show()
+        if (action.force) {
+            roomDetailViewModel.handle(RoomDetailAction.CancelSend(action.eventId, true))
+        } else {
+            AlertDialog.Builder(requireContext())
+                    .setTitle(R.string.dialog_title_confirmation)
+                    .setMessage(getString(R.string.event_status_cancel_sending_dialog_message))
+                    .setNegativeButton(R.string.no, null)
+                    .setPositiveButton(R.string.yes) { _, _ ->
+                        roomDetailViewModel.handle(RoomDetailAction.CancelSend(action.eventId, false))
+                    }
+                    .show()
+        }
     }
 
     override fun onAvatarClicked(informationData: MessageInformationData) {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
@@ -1208,6 +1208,10 @@ class RoomDetailViewModel @AssistedInject constructor(
     }
 
     private fun handleCancel(action: RoomDetailAction.CancelSend) {
+        if (action.force) {
+            room.cancelSend(action.eventId)
+            return
+        }
         val targetEventId = action.eventId
         room.getTimeLineEvent(targetEventId)?.let {
             // State must be in one of the sending states

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/EventSharedAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/EventSharedAction.kt
@@ -63,7 +63,7 @@ sealed class EventSharedAction(@StringRes val titleRes: Int,
     data class Redact(val eventId: String, val askForReason: Boolean) :
             EventSharedAction(R.string.message_action_item_redact, R.drawable.ic_delete, true)
 
-    data class Cancel(val eventId: String) :
+    data class Cancel(val eventId: String, val force: Boolean) :
             EventSharedAction(R.string.cancel, R.drawable.ic_close_round)
 
     data class ViewSource(val content: String) :

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
@@ -251,7 +251,7 @@ class MessageActionsViewModel @AssistedInject constructor(@Assisted
                     addActionsForSyncedState(timelineEvent, actionPermissions, messageContent, msgType)
                 }
                 timelineEvent.root.sendState == SendState.SENT   -> {
-                    addActionsForSentNotSyncedState(timelineEvent, actionPermissions, messageContent, msgType)
+                    addActionsForSentNotSyncedState(timelineEvent)
                 }
             }
         }
@@ -294,21 +294,16 @@ class MessageActionsViewModel @AssistedInject constructor(@Assisted
         }
     }
 
-    private fun ArrayList<EventSharedAction>.addActionsForSentNotSyncedState(timelineEvent: TimelineEvent,
-                                                                             actionPermissions: ActionPermissions,
-                                                                             messageContent: MessageContent?,
-                                                                             msgType: String?) {
-        if (timelineEvent.root.sendState == SendState.SENT) {
-            // If sent but not synced (synapse stuck at bottom bug)
-            // Still offer action to cancel (will only remove local echo)
-            timelineEvent.root.eventId?.let {
-                add(EventSharedAction.Cancel(it, true))
-            }
-
-            // TODO Can be redacted
-
-            // TODO sent by me or sufficient power level
+    private fun ArrayList<EventSharedAction>.addActionsForSentNotSyncedState(timelineEvent: TimelineEvent) {
+        // If sent but not synced (synapse stuck at bottom bug)
+        // Still offer action to cancel (will only remove local echo)
+        timelineEvent.root.eventId?.let {
+            add(EventSharedAction.Cancel(it, true))
         }
+
+        // TODO Can be redacted
+
+        // TODO sent by me or sufficient power level
     }
 
     private fun ArrayList<EventSharedAction>.addActionsForSyncedState(timelineEvent: TimelineEvent,


### PR DESCRIPTION
Quick work around to remove stuck messages at the bottom of timeline.
Currently only choice is to clear cache and do a full initial sync.
This PR is just adding an option to cancel sent but not synced message, only effect is that it will delete the local echo.

<img width="809" alt="image" src="https://user-images.githubusercontent.com/9841565/111300631-9712d980-8651-11eb-9ba9-14c96e8aa585.png">

This does not fix the root issues, See:
https://github.com/vector-im/element-android/issues/516
https://github.com/matrix-org/synapse/issues/9424
https://github.com/matrix-org/synapse/issues/9624

