### PR TITLE
Regression: Video will not play upon tap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Improvements 🙌:
 Bugfix 🐛:
  - Add option to cancel stuck messages at bottom of timeline see #516
  - Ensure message are decrypted in the room list after a clear cache
+ - Regression: Video will not play upon tap, but only after swipe #2928
 
 Translations 🗣:
  -

--- a/vector/src/main/java/im/vector/app/features/media/VectorAttachmentViewerActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/media/VectorAttachmentViewerActivity.kt
@@ -29,7 +29,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
 import androidx.transition.Transition
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
@@ -132,7 +131,7 @@ class VectorAttachmentViewerActivity : AttachmentViewerActivity(), BaseAttachmen
         if (savedInstanceState == null) {
             pager2.setCurrentItem(initialIndex, false)
             // The page change listener is not notified of the change...
-            lifecycleScope.launchWhenResumed {
+            pager2.post {
                 onSelectedPositionChanged(initialIndex)
             }
         }


### PR DESCRIPTION
Fixes #2928 (Regression: Video will not play upon tap, but only after swipe)