### PR TITLE
Display the room shield in all room setting screens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Features ✨:
  -
 
 Improvements 🙌:
- -
+ - Display the room shield in all room setting screens
 
 Bugfix 🐛:
  -

--- a/vector/src/main/java/im/vector/app/features/roomprofile/alias/RoomAliasFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/alias/RoomAliasFragment.kt
@@ -128,6 +128,7 @@ class RoomAliasFragment @Inject constructor(
         state.roomSummary()?.let {
             views.roomSettingsToolbarTitleView.text = it.displayName
             avatarRenderer.render(it.toMatrixItem(), views.roomSettingsToolbarAvatarImageView)
+            views.roomSettingsDecorationToolbarAvatarImageView.render(it.roomEncryptionTrustLevel)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/roomprofile/banned/RoomBannedMemberListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/banned/RoomBannedMemberListFragment.kt
@@ -117,6 +117,7 @@ class RoomBannedMemberListFragment @Inject constructor(
         state.roomSummary()?.let {
             views.roomSettingsToolbarTitleView.text = it.displayName
             avatarRenderer.render(it.toMatrixItem(), views.roomSettingsToolbarAvatarImageView)
+            views.roomSettingsDecorationToolbarAvatarImageView.render(it.roomEncryptionTrustLevel)
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/members/RoomMemberListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/members/RoomMemberListFragment.kt
@@ -140,6 +140,7 @@ class RoomMemberListFragment @Inject constructor(
         state.roomSummary()?.let {
             views.roomSettingGeneric.roomSettingsToolbarTitleView.text = it.displayName
             avatarRenderer.render(it.toMatrixItem(), views.roomSettingGeneric.roomSettingsToolbarAvatarImageView)
+            views.roomSettingGeneric.roomSettingsDecorationToolbarAvatarImageView.render(it.roomEncryptionTrustLevel)
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/permissions/RoomPermissionsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/permissions/RoomPermissionsFragment.kt
@@ -91,6 +91,7 @@ class RoomPermissionsFragment @Inject constructor(
         state.roomSummary()?.let {
             views.roomSettingsToolbarTitleView.text = it.displayName
             avatarRenderer.render(it.toMatrixItem(), views.roomSettingsToolbarAvatarImageView)
+            views.roomSettingsDecorationToolbarAvatarImageView.render(it.roomEncryptionTrustLevel)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsFragment.kt
@@ -154,6 +154,7 @@ class RoomSettingsFragment @Inject constructor(
         state.roomSummary()?.let {
             views.roomSettingsToolbarTitleView.text = it.displayName
             avatarRenderer.render(it.toMatrixItem(), views.roomSettingsToolbarAvatarImageView)
+            views.roomSettingsDecorationToolbarAvatarImageView.render(it.roomEncryptionTrustLevel)
         }
 
         invalidateOptionsMenu()

--- a/vector/src/main/res/layout/fragment_room_setting_generic.xml
+++ b/vector/src/main/res/layout/fragment_room_setting_generic.xml
@@ -34,6 +34,15 @@
                 app:layout_constraintTop_toTopOf="parent"
                 tools:src="@tools:sample/avatars" />
 
+            <im.vector.app.core.ui.views.ShieldImageView
+                android:id="@+id/roomSettingsDecorationToolbarAvatarImageView"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                app:layout_constraintCircle="@+id/roomSettingsToolbarAvatarImageView"
+                app:layout_constraintCircleAngle="135"
+                app:layout_constraintCircleRadius="20dp"
+                tools:ignore="MissingConstraints" />
+
             <TextView
                 android:id="@+id/roomSettingsToolbarTitleView"
                 android:layout_width="0dp"


### PR DESCRIPTION
Some screen have the room shield (ex: room uploads) and some do not have it. This PR make it uniform.