### PR TITLE
Get event

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Improvements 🙌:
  - Add better support for empty room name fallback (#3106)
  - Room list improvements (paging)
  - Fix quick click action (#3127)
+ - Get Event after a Push for a faster notification display in some conditions
 
 Bugfix 🐛:
  - Fix bad theme change for the MainActivity

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/pushrules/PushRuleService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/pushrules/PushRuleService.kt
@@ -39,6 +39,8 @@ interface PushRuleService {
 
     fun removePushRuleListener(listener: PushRuleListener)
 
+    fun getActions(event: Event): List<Action>
+
 //    fun fulfilledBingRule(event: Event, rules: List<PushRule>): PushRule?
 
     interface PushRuleListener {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/Session.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/Session.kt
@@ -30,6 +30,7 @@ import org.matrix.android.sdk.api.session.call.CallSignalingService
 import org.matrix.android.sdk.api.session.content.ContentUploadStateTracker
 import org.matrix.android.sdk.api.session.content.ContentUrlResolver
 import org.matrix.android.sdk.api.session.crypto.CryptoService
+import org.matrix.android.sdk.api.session.events.EventService
 import org.matrix.android.sdk.api.session.file.ContentDownloadStateTracker
 import org.matrix.android.sdk.api.session.file.FileService
 import org.matrix.android.sdk.api.session.group.GroupService
@@ -68,6 +69,7 @@ interface Session :
         SignOutService,
         FilterService,
         TermsService,
+        EventService,
         ProfileService,
         PushRuleService,
         PushersService,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/EventService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/EventService.kt
@@ -23,6 +23,10 @@ interface EventService {
     /**
      * Ask the homeserver for an event content. The SDK will try to decrypt it if it is possible
      * The result will not be stored into cache
+     * @param onlyOnWifi if true and if WiFi is not available, no request will be done,
+     * and null will be returned
      */
-    suspend fun getEvent(roomId: String, eventId: String): Event
+    suspend fun getEvent(roomId: String,
+                         eventId: String,
+                         onlyOnWifi: Boolean): Event?
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/EventService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/EventService.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.api.session.events
+
+import org.matrix.android.sdk.api.session.events.model.Event
+
+interface EventService {
+
+    /**
+     * Ask the homeserver for an event content. The SDK will try to decrypt it if it is possible
+     * The result will not be stored into cache
+     */
+    suspend fun getEvent(roomId: String, eventId: String): Event
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/EventService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/EventService.kt
@@ -23,10 +23,7 @@ interface EventService {
     /**
      * Ask the homeserver for an event content. The SDK will try to decrypt it if it is possible
      * The result will not be stored into cache
-     * @param onlyOnWifi if true and if WiFi is not available, no request will be done,
-     * and null will be returned
      */
     suspend fun getEvent(roomId: String,
-                         eventId: String,
-                         onlyOnWifi: Boolean): Event?
+                         eventId: String): Event
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
@@ -289,3 +289,7 @@ fun Event.getRelationContent(): RelationDefaultContent? {
 fun Event.isReply(): Boolean {
     return getRelationContent()?.inReplyTo?.eventId != null
 }
+
+fun Event.isEdition(): Boolean {
+    return getRelationContent()?.takeIf { it.type == RelationType.REPLACE }?.eventId != null
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/WifiDetector.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/WifiDetector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 New Vector Ltd
+ * Copyright (c) 2021 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/WifiDetector.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/WifiDetector.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import androidx.core.content.getSystemService
+import org.matrix.android.sdk.api.extensions.orFalse
+import timber.log.Timber
+import javax.inject.Inject
+
+internal class WifiDetector @Inject constructor(
+        context: Context
+) {
+    private val connectivityManager = context.getSystemService<ConnectivityManager>()!!
+
+    fun isConnectedToWifi(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            connectivityManager.activeNetwork
+                    ?.let { connectivityManager.getNetworkCapabilities(it) }
+                    ?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+                    .orFalse()
+        } else {
+            @Suppress("DEPRECATION")
+            connectivityManager.activeNetworkInfo?.type == ConnectivityManager.TYPE_WIFI
+        }
+                .also { Timber.d("isConnected to WiFi: $it") }
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
@@ -33,6 +33,7 @@ import org.matrix.android.sdk.api.session.call.CallSignalingService
 import org.matrix.android.sdk.api.session.content.ContentUploadStateTracker
 import org.matrix.android.sdk.api.session.content.ContentUrlResolver
 import org.matrix.android.sdk.api.session.crypto.CryptoService
+import org.matrix.android.sdk.api.session.events.EventService
 import org.matrix.android.sdk.api.session.file.ContentDownloadStateTracker
 import org.matrix.android.sdk.api.session.file.FileService
 import org.matrix.android.sdk.api.session.group.GroupService
@@ -114,6 +115,7 @@ internal class DefaultSession @Inject constructor(
         private val accountDataService: Lazy<AccountDataService>,
         private val _sharedSecretStorageService: Lazy<SharedSecretStorageService>,
         private val accountService: Lazy<AccountService>,
+        private val eventService: Lazy<EventService>,
         private val defaultIdentityService: DefaultIdentityService,
         private val integrationManagerService: IntegrationManagerService,
         private val thirdPartyService: Lazy<ThirdPartyService>,
@@ -129,6 +131,7 @@ internal class DefaultSession @Inject constructor(
         FilterService by filterService.get(),
         PushRuleService by pushRuleService.get(),
         PushersService by pushersService.get(),
+        EventService by eventService.get(),
         TermsService by termsService.get(),
         InitialSyncProgressService by initialSyncProgressService.get(),
         SecureStorageService by secureStorageService.get(),

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionModule.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionModule.kt
@@ -32,10 +32,11 @@ import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
 import org.matrix.android.sdk.api.auth.data.SessionParams
 import org.matrix.android.sdk.api.auth.data.sessionId
 import org.matrix.android.sdk.api.crypto.MXCryptoConfig
-import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.accountdata.AccountDataService
+import org.matrix.android.sdk.api.session.events.EventService
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilitiesService
+import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService
 import org.matrix.android.sdk.api.session.securestorage.SecureStorageService
 import org.matrix.android.sdk.api.session.securestorage.SharedSecretStorageService
@@ -75,6 +76,7 @@ import org.matrix.android.sdk.internal.network.token.AccessTokenProvider
 import org.matrix.android.sdk.internal.network.token.HomeserverAccessTokenProvider
 import org.matrix.android.sdk.internal.session.call.CallEventProcessor
 import org.matrix.android.sdk.internal.session.download.DownloadProgressInterceptor
+import org.matrix.android.sdk.internal.session.events.DefaultEventService
 import org.matrix.android.sdk.internal.session.homeserver.DefaultHomeServerCapabilitiesService
 import org.matrix.android.sdk.internal.session.identity.DefaultIdentityService
 import org.matrix.android.sdk.internal.session.initsync.DefaultInitialSyncProgressService
@@ -356,6 +358,9 @@ internal abstract class SessionModule {
 
     @Binds
     abstract fun bindAccountDataService(service: DefaultAccountDataService): AccountDataService
+
+    @Binds
+    abstract fun bindEventService(service: DefaultEventService): EventService
 
     @Binds
     abstract fun bindSharedSecretStorageService(service: DefaultSharedSecretStorageService): SharedSecretStorageService

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/call/CallSignalingHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/call/CallSignalingHandler.kt
@@ -56,25 +56,25 @@ internal class CallSignalingHandler @Inject constructor(private val activeCallHa
 
     fun onCallEvent(event: Event) {
         when (event.getClearType()) {
-            EventType.CALL_ANSWER -> {
+            EventType.CALL_ANSWER        -> {
                 handleCallAnswerEvent(event)
             }
-            EventType.CALL_INVITE -> {
+            EventType.CALL_INVITE        -> {
                 handleCallInviteEvent(event)
             }
-            EventType.CALL_HANGUP -> {
+            EventType.CALL_HANGUP        -> {
                 handleCallHangupEvent(event)
             }
-            EventType.CALL_REJECT -> {
+            EventType.CALL_REJECT        -> {
                 handleCallRejectEvent(event)
             }
-            EventType.CALL_CANDIDATES -> {
+            EventType.CALL_CANDIDATES    -> {
                 handleCallCandidatesEvent(event)
             }
             EventType.CALL_SELECT_ANSWER -> {
                 handleCallSelectAnswerEvent(event)
             }
-            EventType.CALL_NEGOTIATE -> {
+            EventType.CALL_NEGOTIATE     -> {
                 handleCallNegotiateEvent(event)
             }
         }
@@ -168,6 +168,14 @@ internal class CallSignalingHandler @Inject constructor(private val activeCallHa
             return
         }
         val content = event.getClearContent().toModel<CallInviteContent>() ?: return
+
+        content.callId ?: return
+        if (activeCallHandler.getCallWithId(content.callId) != null) {
+            // Call is already known, maybe due to fast lane. Ignore
+            Timber.d("Ignoring already known call invite")
+            return
+        }
+
         val incomingCall = mxCallFactory.createIncomingCall(
                 roomId = event.roomId,
                 opponentUserId = event.senderId,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/events/DefaultEventService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/events/DefaultEventService.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.events
+
+import org.matrix.android.sdk.api.session.events.EventService
+import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.internal.session.call.CallEventProcessor
+import org.matrix.android.sdk.internal.session.room.timeline.GetEventTask
+import javax.inject.Inject
+
+internal class DefaultEventService @Inject constructor(
+        private val getEventTask: GetEventTask,
+        private val callEventProcessor: CallEventProcessor
+) : EventService {
+
+    override suspend fun getEvent(roomId: String, eventId: String): Event {
+        val event = getEventTask.execute(GetEventTask.Params(roomId, eventId))
+
+        // Fast lane to the call event processors: try to make the incoming call ring faster
+        if (callEventProcessor.shouldProcessFastLane(event.getClearType())) {
+            callEventProcessor.processFastLane(event)
+        }
+
+        return event
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/events/DefaultEventService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/events/DefaultEventService.kt
@@ -18,16 +18,24 @@ package org.matrix.android.sdk.internal.session.events
 
 import org.matrix.android.sdk.api.session.events.EventService
 import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.internal.network.WifiDetector
 import org.matrix.android.sdk.internal.session.call.CallEventProcessor
 import org.matrix.android.sdk.internal.session.room.timeline.GetEventTask
+import timber.log.Timber
 import javax.inject.Inject
 
 internal class DefaultEventService @Inject constructor(
         private val getEventTask: GetEventTask,
-        private val callEventProcessor: CallEventProcessor
+        private val callEventProcessor: CallEventProcessor,
+        private val wifiDetector: WifiDetector
 ) : EventService {
 
-    override suspend fun getEvent(roomId: String, eventId: String): Event {
+    override suspend fun getEvent(roomId: String, eventId: String, onlyOnWifi: Boolean): Event? {
+        if (onlyOnWifi && !wifiDetector.isConnectedToWifi()) {
+            Timber.d("No WiFi network, do not get Event")
+            return null
+        }
+
         val event = getEventTask.execute(GetEventTask.Params(roomId, eventId))
 
         // Fast lane to the call event processors: try to make the incoming call ring faster

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/events/DefaultEventService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/events/DefaultEventService.kt
@@ -18,24 +18,16 @@ package org.matrix.android.sdk.internal.session.events
 
 import org.matrix.android.sdk.api.session.events.EventService
 import org.matrix.android.sdk.api.session.events.model.Event
-import org.matrix.android.sdk.internal.network.WifiDetector
 import org.matrix.android.sdk.internal.session.call.CallEventProcessor
 import org.matrix.android.sdk.internal.session.room.timeline.GetEventTask
-import timber.log.Timber
 import javax.inject.Inject
 
 internal class DefaultEventService @Inject constructor(
         private val getEventTask: GetEventTask,
-        private val callEventProcessor: CallEventProcessor,
-        private val wifiDetector: WifiDetector
+        private val callEventProcessor: CallEventProcessor
 ) : EventService {
 
-    override suspend fun getEvent(roomId: String, eventId: String, onlyOnWifi: Boolean): Event? {
-        if (onlyOnWifi && !wifiDetector.isConnectedToWifi()) {
-            Timber.d("No WiFi network, do not get Event")
-            return null
-        }
-
+    override suspend fun getEvent(roomId: String, eventId: String): Event {
         val event = getEventTask.execute(GetEventTask.Params(roomId, eventId))
 
         // Fast lane to the call event processors: try to make the incoming call ring faster

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/DefaultPushRuleService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/DefaultPushRuleService.kt
@@ -16,8 +16,11 @@
 package org.matrix.android.sdk.internal.session.notification
 
 import com.zhuinden.monarchy.Monarchy
+import org.matrix.android.sdk.api.pushrules.Action
+import org.matrix.android.sdk.api.pushrules.ConditionResolver
 import org.matrix.android.sdk.api.pushrules.PushRuleService
 import org.matrix.android.sdk.api.pushrules.RuleKind
+import org.matrix.android.sdk.api.pushrules.RuleScope
 import org.matrix.android.sdk.api.pushrules.RuleSetKey
 import org.matrix.android.sdk.api.pushrules.getActions
 import org.matrix.android.sdk.api.pushrules.rest.PushRule
@@ -45,6 +48,7 @@ internal class DefaultPushRuleService @Inject constructor(
         private val addPushRuleTask: AddPushRuleTask,
         private val updatePushRuleActionsTask: UpdatePushRuleActionsTask,
         private val removePushRuleTask: RemovePushRuleTask,
+        private val conditionResolver: ConditionResolver,
         private val taskExecutor: TaskExecutor,
         @SessionDatabase private val monarchy: Monarchy
 ) : PushRuleService {
@@ -127,6 +131,22 @@ internal class DefaultPushRuleService @Inject constructor(
     override fun addPushRuleListener(listener: PushRuleService.PushRuleListener) {
         synchronized(listeners) {
             listeners.add(listener)
+        }
+    }
+
+    override fun getActions(event: Event): List<Action> {
+        val rules = getPushRules(RuleScope.GLOBAL).getAllRules()
+
+        return fulfilledBingRule(event, rules)?.getActions().orEmpty()
+    }
+
+    // TODO This is a copy paste, try to have only once this code
+    private fun fulfilledBingRule(event: Event, rules: List<PushRule>): PushRule? {
+        return rules.firstOrNull { rule ->
+            // All conditions must hold true for an event in order to apply the action for the event.
+            rule.enabled && rule.conditions?.all {
+                it.asExecutableCondition(rule)?.isSatisfied(event, conditionResolver) ?: false
+            } ?: false
         }
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/DefaultPushRuleService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/DefaultPushRuleService.kt
@@ -17,7 +17,6 @@ package org.matrix.android.sdk.internal.session.notification
 
 import com.zhuinden.monarchy.Monarchy
 import org.matrix.android.sdk.api.pushrules.Action
-import org.matrix.android.sdk.api.pushrules.ConditionResolver
 import org.matrix.android.sdk.api.pushrules.PushRuleService
 import org.matrix.android.sdk.api.pushrules.RuleKind
 import org.matrix.android.sdk.api.pushrules.RuleScope
@@ -48,7 +47,7 @@ internal class DefaultPushRuleService @Inject constructor(
         private val addPushRuleTask: AddPushRuleTask,
         private val updatePushRuleActionsTask: UpdatePushRuleActionsTask,
         private val removePushRuleTask: RemovePushRuleTask,
-        private val conditionResolver: ConditionResolver,
+        private val pushRuleFinder: PushRuleFinder,
         private val taskExecutor: TaskExecutor,
         @SessionDatabase private val monarchy: Monarchy
 ) : PushRuleService {
@@ -137,17 +136,7 @@ internal class DefaultPushRuleService @Inject constructor(
     override fun getActions(event: Event): List<Action> {
         val rules = getPushRules(RuleScope.GLOBAL).getAllRules()
 
-        return fulfilledBingRule(event, rules)?.getActions().orEmpty()
-    }
-
-    // TODO This is a copy paste, try to have only once this code
-    private fun fulfilledBingRule(event: Event, rules: List<PushRule>): PushRule? {
-        return rules.firstOrNull { rule ->
-            // All conditions must hold true for an event in order to apply the action for the event.
-            rule.enabled && rule.conditions?.all {
-                it.asExecutableCondition(rule)?.isSatisfied(event, conditionResolver) ?: false
-            } ?: false
-        }
+        return pushRuleFinder.fulfilledBingRule(event, rules)?.getActions().orEmpty()
     }
 
 //    fun processEvents(events: List<Event>) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/PushRuleFinder.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/PushRuleFinder.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.notification
+
+import org.matrix.android.sdk.api.pushrules.ConditionResolver
+import org.matrix.android.sdk.api.pushrules.rest.PushRule
+import org.matrix.android.sdk.api.session.events.model.Event
+import javax.inject.Inject
+
+internal class PushRuleFinder @Inject constructor(
+        private val conditionResolver: ConditionResolver
+) {
+    fun fulfilledBingRule(event: Event, rules: List<PushRule>): PushRule? {
+        return rules.firstOrNull { rule ->
+            // All conditions must hold true for an event in order to apply the action for the event.
+            rule.enabled && rule.conditions?.all {
+                it.asExecutableCondition(rule)?.isSatisfied(event, conditionResolver) ?: false
+            } ?: false
+        }
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomModule.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomModule.kt
@@ -79,9 +79,11 @@ import org.matrix.android.sdk.internal.session.room.tags.DefaultDeleteTagFromRoo
 import org.matrix.android.sdk.internal.session.room.tags.DeleteTagFromRoomTask
 import org.matrix.android.sdk.internal.session.room.timeline.DefaultFetchTokenAndPaginateTask
 import org.matrix.android.sdk.internal.session.room.timeline.DefaultGetContextOfEventTask
+import org.matrix.android.sdk.internal.session.room.timeline.DefaultGetEventTask
 import org.matrix.android.sdk.internal.session.room.timeline.DefaultPaginationTask
 import org.matrix.android.sdk.internal.session.room.timeline.FetchTokenAndPaginateTask
 import org.matrix.android.sdk.internal.session.room.timeline.GetContextOfEventTask
+import org.matrix.android.sdk.internal.session.room.timeline.GetEventTask
 import org.matrix.android.sdk.internal.session.room.timeline.PaginationTask
 import org.matrix.android.sdk.internal.session.room.typing.DefaultSendTypingTask
 import org.matrix.android.sdk.internal.session.room.typing.SendTypingTask
@@ -228,4 +230,7 @@ internal abstract class RoomModule {
 
     @Binds
     abstract fun bindPeekRoomTask(task: DefaultPeekRoomTask): PeekRoomTask
+
+    @Binds
+    abstract fun bindGetEventTask(task: DefaultGetEventTask): GetEventTask
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/GetEventTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/GetEventTask.kt
@@ -16,28 +16,49 @@
 
 package org.matrix.android.sdk.internal.session.room.timeline
 
+import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.internal.crypto.EventDecryptor
+import org.matrix.android.sdk.internal.crypto.algorithms.olm.OlmDecryptionResult
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.session.room.RoomAPI
 import org.matrix.android.sdk.internal.task.Task
 import javax.inject.Inject
 
-// TODO Add parent task
-
-internal class GetEventTask @Inject constructor(
-        private val roomAPI: RoomAPI,
-        private val globalErrorReceiver: GlobalErrorReceiver
-) : Task<GetEventTask.Params, Event> {
-
-    internal data class Params(
+internal interface GetEventTask : Task<GetEventTask.Params, Event> {
+    data class Params(
             val roomId: String,
-            val eventId: String
+            val eventId: String,
     )
+}
 
-    override suspend fun execute(params: Params): Event {
-        return executeRequest(globalErrorReceiver) {
+internal class DefaultGetEventTask @Inject constructor(
+        private val roomAPI: RoomAPI,
+        private val globalErrorReceiver: GlobalErrorReceiver,
+        private val eventDecryptor: EventDecryptor
+) : GetEventTask {
+
+    override suspend fun execute(params: GetEventTask.Params): Event {
+        val event = executeRequest(globalErrorReceiver) {
             roomAPI.getEvent(params.roomId, params.eventId)
         }
+
+        // Try to decrypt the Event
+        if (event.isEncrypted()) {
+            tryOrNull(message = "Unable to decrypt the event") {
+                eventDecryptor.decryptEvent(event, "")
+            }
+                    ?.let { result ->
+                        event.mxDecryptionResult = OlmDecryptionResult(
+                                payload = result.clearEvent,
+                                senderKey = result.senderCurve25519Key,
+                                keysClaimed = result.claimedEd25519Key?.let { mapOf("ed25519" to it) },
+                                forwardingCurve25519KeyChain = result.forwardingCurve25519KeyChain
+                        )
+                    }
+        }
+
+        return event
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/GetEventTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/GetEventTask.kt
@@ -29,7 +29,7 @@ import javax.inject.Inject
 internal interface GetEventTask : Task<GetEventTask.Params, Event> {
     data class Params(
             val roomId: String,
-            val eventId: String,
+            val eventId: String
     )
 }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/RoomSyncHandler.kt
@@ -408,6 +408,7 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
 
     private fun decryptIfNeeded(event: Event, roomId: String) {
         try {
+            // Event from sync does not have roomId, so add it to the event first
             val result = cryptoService.decryptEvent(event.copy(roomId = roomId), "")
             event.mxDecryptionResult = OlmDecryptionResult(
                     payload = result.clearEvent,

--- a/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
@@ -194,7 +194,6 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
 
             val resolvedEvent = notifiableEventResolver.resolveInMemoryEvent(session, event)
 
-            // TODO Test the Event against the push rules
             resolvedEvent
                     ?.also { Timber.d("Fast lane: notify drawer") }
                     ?.let {

--- a/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
@@ -190,7 +190,7 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
 
         coroutineScope.launch {
             Timber.d("Fast lane: start request")
-            val event = session.getEvent(roomId, eventId, onlyOnWifi = true)?: return@launch
+            val event = session.getEvent(roomId, eventId, onlyOnWifi = true) ?: return@launch
 
             val resolvedEvent = notifiableEventResolver.resolveInMemoryEvent(session, event)
 

--- a/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
@@ -190,7 +190,7 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
 
         coroutineScope.launch {
             Timber.d("Fast lane: start request")
-            val event = session.getEvent(roomId, eventId)
+            val event = session.getEvent(roomId, eventId, onlyOnWifi = true)?: return@launch
 
             val resolvedEvent = notifiableEventResolver.resolveInMemoryEvent(session, event)
 

--- a/vector/src/main/java/im/vector/app/core/di/VectorComponent.kt
+++ b/vector/src/main/java/im/vector/app/core/di/VectorComponent.kt
@@ -26,6 +26,7 @@ import im.vector.app.EmojiCompatWrapper
 import im.vector.app.VectorApplication
 import im.vector.app.core.dialogs.UnrecognizedCertificateDialog
 import im.vector.app.core.error.ErrorFormatter
+import im.vector.app.core.network.WifiDetector
 import im.vector.app.core.pushers.PushersManager
 import im.vector.app.core.utils.AssetReader
 import im.vector.app.core.utils.DimensionConverter
@@ -139,6 +140,8 @@ interface VectorComponent {
     fun notifiableEventResolver(): NotifiableEventResolver
 
     fun vectorPreferences(): VectorPreferences
+
+    fun wifiDetector(): WifiDetector
 
     fun vectorFileLogger(): VectorFileLogger
 

--- a/vector/src/main/java/im/vector/app/core/extensions/LiveData.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/LiveData.kt
@@ -39,7 +39,7 @@ inline fun <T> LiveData<LiveEvent<T>>.observeEventFirstThrottle(owner: Lifecycle
     val firstThrottler = FirstThrottler(minimumInterval)
 
     this.observe(owner, EventObserver {
-        if (firstThrottler.canHandle()) {
+        if (firstThrottler.canHandle() is FirstThrottler.CanHandlerResult.Yes) {
             it.run(observer)
         }
     })

--- a/vector/src/main/java/im/vector/app/core/network/WifiDetector.kt
+++ b/vector/src/main/java/im/vector/app/core/network/WifiDetector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 The Matrix.org Foundation C.I.C.
+ * Copyright (c) 2021 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.matrix.android.sdk.internal.network
+package im.vector.app.core.network
 
 import android.content.Context
 import android.net.ConnectivityManager
@@ -25,7 +25,7 @@ import org.matrix.android.sdk.api.extensions.orFalse
 import timber.log.Timber
 import javax.inject.Inject
 
-internal class WifiDetector @Inject constructor(
+class WifiDetector @Inject constructor(
         context: Context
 ) {
     private val connectivityManager = context.getSystemService<ConnectivityManager>()!!

--- a/vector/src/main/java/im/vector/app/core/utils/FirstThrottler.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/FirstThrottler.kt
@@ -24,14 +24,27 @@ import android.os.SystemClock
 class FirstThrottler(private val minimumInterval: Long = 800) {
     private var lastDate = 0L
 
-    fun canHandle(): Boolean {
+    sealed class CanHandlerResult {
+        object Yes : CanHandlerResult()
+        data class No(val shouldWaitMillis: Long) : CanHandlerResult()
+
+        fun waitMillis(): Long {
+            return when (this) {
+                Yes   -> 0
+                is No -> shouldWaitMillis
+            }
+        }
+    }
+
+    fun canHandle(): CanHandlerResult {
         val now = SystemClock.elapsedRealtime()
-        if (now > lastDate + minimumInterval) {
+        val delaySinceLast = now - lastDate
+        if (delaySinceLast > minimumInterval) {
             lastDate = now
-            return true
+            return CanHandlerResult.Yes
         }
 
         // Too soon
-        return false
+        return CanHandlerResult.No(minimumInterval - delaySinceLast)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
@@ -26,6 +26,7 @@ import org.matrix.android.sdk.api.session.content.ContentUrlResolver
 import org.matrix.android.sdk.api.session.crypto.MXCryptoError
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
+import org.matrix.android.sdk.api.session.events.model.isEdition
 import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.model.RoomMemberContent
@@ -89,7 +90,9 @@ class NotifiableEventResolver @Inject constructor(
     fun resolveInMemoryEvent(session: Session, event: Event): NotifiableEvent? {
         if (event.getClearType() != EventType.MESSAGE) return null
 
-        // TODO Ignore message edition
+        // Ignore message edition
+        if (event.isEdition()) return null
+
         val user = session.getUser(event.senderId!!) ?: return null
 
         val timelineEvent = TimelineEvent(

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
@@ -89,7 +89,9 @@ class NotificationDrawerManager @Inject constructor(private val context: Context
         // If we support multi session, event list should be per userId
         // Currently only manage single session
         if (BuildConfig.LOW_PRIVACY_LOG_ENABLE) {
-            Timber.v("%%%%%%%% onNotifiableEventReceived $notifiableEvent")
+            Timber.d("onNotifiableEventReceived(): $notifiableEvent")
+        } else {
+            Timber.d("onNotifiableEventReceived(): is push: ${notifiableEvent.isPushGatewayEvent}")
         }
         synchronized(eventList) {
             val existing = eventList.firstOrNull { it.eventId == notifiableEvent.eventId }
@@ -550,7 +552,7 @@ class NotificationDrawerManager @Inject constructor(private val context: Context
         return bitmapLoader.getRoomBitmap(roomAvatarPath)
     }
 
-    private fun shouldIgnoreMessageEventInRoom(roomId: String?): Boolean {
+    fun shouldIgnoreMessageEventInRoom(roomId: String?): Boolean {
         return currentRoomId != null && roomId == currentRoomId
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsHelpAboutFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsHelpAboutFragment.kt
@@ -101,7 +101,7 @@ class VectorSettingsHelpAboutFragment @Inject constructor(
         // third party notice
         findPreference<VectorPreference>(VectorPreferences.SETTINGS_THIRD_PARTY_NOTICES_PREFERENCE_KEY)!!
                 .onPreferenceClickListener = Preference.OnPreferenceClickListener {
-            if (firstThrottler.canHandle()) {
+            if (firstThrottler.canHandle() is FirstThrottler.CanHandlerResult.Yes) {
                 activity?.displayInWebView(VectorSettingsUrls.THIRD_PARTY_LICENSES)
             }
             false


### PR DESCRIPTION
Try to get event faster after receiving a Push by retrieving the event directly. A background sync is run as usual.

Also give this event to the CallEventProcessor for faster incoming call treatment.

TODO:

- [x] Test all cases
- [x] Handle push rules
- [x] Ignore message edition
- [x] Do this also when app is in foreground? -> NO
- [x] Do not do this if not on WiFi network because of the network data overhead (the event will be downloaded 2 times)