### PR TITLE
remove enum from rest model

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomHistoryVisibility.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomHistoryVisibility.kt
@@ -16,35 +16,31 @@
 
 package org.matrix.android.sdk.api.session.room.model
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
-
 /**
  * Ref: https://matrix.org/docs/spec/client_server/latest#room-history-visibility
  */
-@JsonClass(generateAdapter = false)
 enum class RoomHistoryVisibility {
     /**
      * All events while this is the m.room.history_visibility value may be shared by any
      * participating homeserver with anyone, regardless of whether they have ever joined the room.
      */
-    @Json(name = "world_readable") WORLD_READABLE,
+    WORLD_READABLE,
 
     /**
      * Previous events are always accessible to newly joined members. All events in the
      * room are accessible, even those sent when the member was not a part of the room.
      */
-    @Json(name = "shared") SHARED,
+    SHARED,
 
     /**
      * Events are accessible to newly joined members from the point they were invited onwards.
      * Events stop being accessible when the member's state changes to something other than invite or join.
      */
-    @Json(name = "invited") INVITED,
+    INVITED,
 
     /**
      * Events are accessible to newly joined members from the point they joined the room onwards.
      * Events stop being accessible when the member's state changes to something other than join.
      */
-    @Json(name = "joined") JOINED
+    JOINED
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomHistoryVisibilityContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomHistoryVisibilityContent.kt
@@ -21,5 +21,16 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class RoomHistoryVisibilityContent(
-        @Json(name = "history_visibility") val historyVisibility: RoomHistoryVisibility? = null
-)
+        @Json(name = "history_visibility") val historyVisibility: String? = null
+) {
+
+    fun safeHistoryVisibility(): RoomHistoryVisibility? {
+        return when (historyVisibility) {
+            "world_readable" -> RoomHistoryVisibility.WORLD_READABLE
+            "shared" -> RoomHistoryVisibility.SHARED
+            "invited" -> RoomHistoryVisibility.INVITED
+            "joined" -> RoomHistoryVisibility.JOINED
+            else             -> null
+        }
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -894,9 +894,9 @@ internal class DefaultCryptoService @Inject constructor(
         }
     }
 
-    private fun onRoomHistoryVisibilityEvent(roomId: String, event: Event) {
+    private fun  onRoomHistoryVisibilityEvent(roomId: String, event: Event) {
         val eventContent = event.content.toModel<RoomHistoryVisibilityContent>()
-        eventContent?.historyVisibility?.let {
+        eventContent?.safeHistoryVisibility()?.let {
             cryptoStore.setShouldEncryptForInvitedMembers(roomId, it != RoomHistoryVisibility.JOINED)
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/format/NoticeEventFormatter.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/format/NoticeEventFormatter.kt
@@ -271,7 +271,7 @@ class NoticeEventFormatter @Inject constructor(
     }
 
     private fun formatRoomHistoryVisibilityEvent(event: Event, senderName: String?, rs: RoomSummary?): CharSequence? {
-        val historyVisibility = event.getClearContent().toModel<RoomHistoryVisibilityContent>()?.historyVisibility ?: return null
+        val historyVisibility = event.getClearContent().toModel<RoomHistoryVisibilityContent>()?.safeHistoryVisibility() ?: return null
 
         val historyVisibilitySuffix = roomHistoryVisibilityFormatter.getNoticeSuffix(historyVisibility)
         return if (event.isSentByCurrentUser()) {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsViewModel.kt
@@ -136,7 +136,7 @@ class RoomSettingsViewModel @AssistedInject constructor(@Assisted initialState: 
                 .mapOptional { it.content.toModel<RoomHistoryVisibilityContent>() }
                 .unwrap()
                 .subscribe {
-                    it.historyVisibility?.let {
+                    it.safeHistoryVisibility()?.let {
                         setState { copy(currentHistoryVisibility = it) }
                     }
                 }


### PR DESCRIPTION
Avoid using enum in rest model

````
To model failed : com.squareup.moshi.JsonDataException: Expected one of [world_readable, shared, invited, joined] but was anyone at path $.history_visibility