### PR TITLE
When downloading a file in <= API 29, replace dangerous characters with underscores

### DIFF
--- a/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
@@ -514,7 +514,7 @@ fun selectTxtFileToWrite(
 @Suppress("DEPRECATION")
 fun saveFileIntoLegacy(sourceFile: File, dstDirPath: File, outputFilename: String?): File? {
     // defines another name for the external media
-    val dstFileName: String
+    var dstFileName: String
 
     // build a filename is not provided
     if (null == outputFilename) {
@@ -528,6 +528,9 @@ fun saveFileIntoLegacy(sourceFile: File, dstDirPath: File, outputFilename: Strin
     } else {
         dstFileName = outputFilename
     }
+
+    // remove dangerous characters from the filename
+    dstFileName = dstFileName.replace(Regex("""[/\\]"""), "_")
 
     var dstFile = File(dstDirPath, dstFileName)
 


### PR DESCRIPTION
A small change to make sure that files downloaded on devices with API level below 29 end up in the directory they are meant to end up in. I've previously submitted this as a path traversal vulnerability just in case, but it was not accepted, so I'm submitting it as a public PR instead.

Replacing dangerous path elements with underscores matches the behaviour on devices above API level 29, although this is done implicitly for those.

NOTE: This is a small change, so I didn't modify CHANGES.md, which is why CI is failing. If I should still do that, lmk.

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes have been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

`Signed-off-by: TR_SLimey <tr_slimey@protonmail.com>`