### PR TITLE
[WIP] Convert RelationService to suspend functions

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/relation/RelationService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/relation/RelationService.kt
@@ -19,7 +19,6 @@ import androidx.lifecycle.LiveData
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.room.model.EventAnnotationsSummary
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
-import org.matrix.android.sdk.api.util.Cancelable
 import org.matrix.android.sdk.api.util.Optional
 
 /**
@@ -53,16 +52,14 @@ interface RelationService {
      * @param targetEventId the id of the event being reacted
      * @param reaction the reaction (preferably emoji)
      */
-    fun sendReaction(targetEventId: String,
-                     reaction: String): Cancelable
+    suspend fun sendReaction(targetEventId: String, reaction: String)
 
     /**
      * Undo a reaction (emoji) to the targetedEvent.
      * @param targetEventId the id of the event being reacted
      * @param reaction the reaction (preferably emoji)
      */
-    fun undoReaction(targetEventId: String,
-                     reaction: String): Cancelable
+    suspend fun undoReaction(targetEventId: String, reaction: String)
 
     /**
      * Edit a text message body. Limited to "m.text" contentType
@@ -70,11 +67,11 @@ interface RelationService {
      * @param newBodyText The edited body
      * @param compatibilityBodyText The text that will appear on clients that don't support yet edition
      */
-    fun editTextMessage(targetEvent: TimelineEvent,
-                        msgType: String,
-                        newBodyText: CharSequence,
-                        newBodyAutoMarkdown: Boolean,
-                        compatibilityBodyText: String = "* $newBodyText"): Cancelable
+    suspend fun editTextMessage(targetEvent: TimelineEvent,
+                                msgType: String,
+                                newBodyText: CharSequence,
+                                newBodyAutoMarkdown: Boolean,
+                                compatibilityBodyText: String = "* $newBodyText")
 
     /**
      * Edit a reply. This is a special case because replies contains fallback text as a prefix.
@@ -84,10 +81,10 @@ interface RelationService {
      * @param newBodyText The edited body (stripped from in reply to content)
      * @param compatibilityBodyText The text that will appear on clients that don't support yet edition
      */
-    fun editReply(replyToEdit: TimelineEvent,
-                  originalTimelineEvent: TimelineEvent,
-                  newBodyText: String,
-                  compatibilityBodyText: String = "* $newBodyText"): Cancelable
+    suspend fun editReply(replyToEdit: TimelineEvent,
+                          originalTimelineEvent: TimelineEvent,
+                          newBodyText: String,
+                          compatibilityBodyText: String = "* $newBodyText")
 
     /**
      * Get the edit history of the given event
@@ -106,9 +103,9 @@ interface RelationService {
      * @param replyText the reply text
      * @param autoMarkdown If true, the SDK will generate a formatted HTML message from the body text if markdown syntax is present
      */
-    fun replyToMessage(eventReplied: TimelineEvent,
-                       replyText: CharSequence,
-                       autoMarkdown: Boolean = false): Cancelable?
+    suspend fun replyToMessage(eventReplied: TimelineEvent,
+                               replyText: CharSequence,
+                               autoMarkdown: Boolean = false)
 
     /**
      * Get the current EventAnnotationsSummary

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
@@ -822,16 +822,20 @@ class RoomDetailViewModel @AssistedInject constructor(
                     if (inReplyTo != null) {
                         // TODO check if same content?
                         room.getTimeLineEvent(inReplyTo)?.let {
-                            room.editReply(state.sendMode.timelineEvent, it, action.text.toString())
+                            viewModelScope.launch {
+                                room.editReply(state.sendMode.timelineEvent, it, action.text.toString())
+                            }
                         }
                     } else {
                         val messageContent = state.sendMode.timelineEvent.getLastMessageContent()
                         val existingBody = messageContent?.body ?: ""
                         if (existingBody != action.text) {
-                            room.editTextMessage(state.sendMode.timelineEvent,
-                                    messageContent?.msgType ?: MessageType.MSGTYPE_TEXT,
-                                    action.text,
-                                    action.autoMarkdown)
+                            viewModelScope.launch {
+                                room.editTextMessage(state.sendMode.timelineEvent,
+                                        messageContent?.msgType ?: MessageType.MSGTYPE_TEXT,
+                                        action.text,
+                                        action.autoMarkdown)
+                            }
                         } else {
                             Timber.w("Same message content, do not send edition")
                         }
@@ -862,7 +866,9 @@ class RoomDetailViewModel @AssistedInject constructor(
                 }
                 is SendMode.REPLY   -> {
                     state.sendMode.timelineEvent.let {
-                        room.replyToMessage(it, action.text.toString(), action.autoMarkdown)
+                        viewModelScope.launch {
+                            room.replyToMessage(it, action.text.toString(), action.autoMarkdown)
+                        }
                         _viewEvents.post(RoomDetailViewEvents.MessageSent)
                         popDraft()
                     }
@@ -1016,7 +1022,9 @@ class RoomDetailViewModel @AssistedInject constructor(
     }
 
     private fun handleSendReaction(action: RoomDetailAction.SendReaction) {
-        room.sendReaction(action.targetEventId, action.reaction)
+        viewModelScope.launch {
+            room.sendReaction(action.targetEventId, action.reaction)
+        }
     }
 
     private fun handleRedactEvent(action: RoomDetailAction.RedactAction) {
@@ -1025,14 +1033,20 @@ class RoomDetailViewModel @AssistedInject constructor(
     }
 
     private fun handleUndoReact(action: RoomDetailAction.UndoReaction) {
-        room.undoReaction(action.targetEventId, action.reaction)
+        viewModelScope.launch {
+            room.undoReaction(action.targetEventId, action.reaction)
+        }
     }
 
     private fun handleUpdateQuickReaction(action: RoomDetailAction.UpdateQuickReactAction) {
         if (action.add) {
-            room.sendReaction(action.targetEventId, action.selectedReaction)
+            viewModelScope.launch {
+                room.sendReaction(action.targetEventId, action.selectedReaction)
+            }
         } else {
-            room.undoReaction(action.targetEventId, action.selectedReaction)
+            viewModelScope.launch {
+                room.undoReaction(action.targetEventId, action.selectedReaction)
+            }
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Dominic Fischer <dominicfischer7@gmail.com>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

I cheated a bit in this one. It just so happens that we don't touch the `Cancellable` so I was able to get away without refactoring.
The `EventSenderProcessor` is going to need to be refactored to support suspension.