### PR TITLE
Fix mandatory parameter in API (#3065)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Bugfix 🐛:
  - Handle encrypted reactions (#2509)
  - Disable URL preview for some domains (#2995)
  - Fix avatar rendering for DMs, after initial sync (#2693)
+ - Fix mandatory parameter in API (#3065)
 
 Translations 🗣:
  -

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
@@ -154,6 +154,14 @@ internal interface RoomAPI {
                                @Body markers: Map<String, String>)
 
     /**
+     * Send receipt to a room
+     */
+    @POST(NetworkConstants.URI_API_PREFIX_PATH_R0 + "rooms/{roomId}/receipt/{receiptType}/{eventId}")
+    suspend fun sendReceipt(@Path("roomId") roomId: String,
+                            @Path("receiptType") receiptType: String,
+                            @Path("eventId") eventId: String)
+
+    /**
      * Invite a user to the given room.
      * Ref: https://matrix.org/docs/spec/client_server/r0.4.0.html#post-matrix-client-r0-rooms-roomid-invite
      *

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/read/SetReadMarkersTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/read/SetReadMarkersTask.kt
@@ -62,7 +62,7 @@ internal class DefaultSetReadMarkersTask @Inject constructor(
 ) : SetReadMarkersTask {
 
     override suspend fun execute(params: SetReadMarkersTask.Params) {
-        val markers = HashMap<String, String>()
+        val markers = mutableMapOf<String, String>()
         Timber.v("Execute set read marker with params: $params")
         val latestSyncedEventId = latestSyncedEventId(params.roomId)
         val fullyReadEventId = if (params.forceReadMarker) {
@@ -100,7 +100,14 @@ internal class DefaultSetReadMarkersTask @Inject constructor(
                     globalErrorReceiver,
                     canRetry = true
             ) {
-                roomAPI.sendReadMarker(params.roomId, markers)
+                if (markers[READ_MARKER] == null) {
+                    if (readReceiptEventId != null) {
+                        roomAPI.sendReceipt(params.roomId, READ_RECEIPT, readReceiptEventId)
+                    }
+                } else {
+                    // "m.fully_read" value is mandatory to make this call
+                    roomAPI.sendReadMarker(params.roomId, markers)
+                }
             }
         }
     }
@@ -110,7 +117,7 @@ internal class DefaultSetReadMarkersTask @Inject constructor(
                 TimelineEventEntity.latestEvent(realm, roomId = roomId, includesSending = false)?.eventId
             }
 
-    private suspend fun updateDatabase(roomId: String, markers: HashMap<String, String>, shouldUpdateRoomSummary: Boolean) {
+    private suspend fun updateDatabase(roomId: String, markers: Map<String, String>, shouldUpdateRoomSummary: Boolean) {
         monarchy.awaitTransaction { realm ->
             val readMarkerId = markers[READ_MARKER]
             val readReceiptId = markers[READ_RECEIPT]


### PR DESCRIPTION
Fixes #3065.

Use another request when "m.fully_read" does not have to be updated.