### PR TITLE
propagate jitsi LIBRE_BUILD exclusion rules to not pull in gms libs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,7 @@ SDK API changes ⚠️:
  - Removes filtering options on Timeline.
 
 Build 🧱:
- -
+ - Properly exclude gms dependencies in fdroid build flavour which were pulled in through the jitsi SDK (#3125)
 
 Test:
  -

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -442,7 +442,11 @@ dependencies {
     implementation('com.facebook.react:react-native-webrtc:1.87.3-jitsi-6624067@aar')
 
     // Jitsi
-    implementation('org.jitsi.react:jitsi-meet-sdk:3.1.0')
+    implementation('org.jitsi.react:jitsi-meet-sdk:3.1.0') {
+       exclude group: 'com.google.firebase'
+       exclude group: 'com.google.android.gms'
+       exclude group: 'com.android.installreferrer'
+    }
 
     // QR-code
     // Stick to 3.3.3 because of https://github.com/zxing/zxing/issues/1170


### PR DESCRIPTION
Previously jitsi only had optional dependencies being disabled by the
LIBRE build flag but a while ago they introduced optional exclusion
rules which don't transitively propagate to consumers of the library, so
instead we need to mirror the exclusion rules from the jitsi gradle file:
See: https://github.com/jitsi/jitsi-meet/blob/7a64bf006ea027b77564d8847570e1ac46ff0ec0/android/sdk/build.gradle#L53

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
