### PR TITLE
Fix EW-EA compatibility for verification

### DIFF
--- a/vector/src/main/java/im/vector/app/features/crypto/verification/IncomingVerificationRequestHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/IncomingVerificationRequestHandler.kt
@@ -60,7 +60,7 @@ class IncomingVerificationRequestHandler @Inject constructor(
         // TODO maybe check also if
         val uid = "kvr_${tx.transactionId}"
         when (tx.state) {
-            is VerificationTxState.OnStarted       -> {
+            is VerificationTxState.OnStarted -> {
                 // Add a notification for every incoming request
                 val user = session?.getUser(tx.otherUserId)
                 val name = user?.getBestName() ?: tx.otherUserId
@@ -119,6 +119,14 @@ class IncomingVerificationRequestHandler @Inject constructor(
         Timber.v("## SAS verificationRequestCreated ${pr.transactionId}")
         // For incoming request we should prompt (if not in activity where this request apply)
         if (pr.isIncoming) {
+
+            // if it's a self verification for my devices, we can discard the review login alert
+            // if not this request will be underneath and not visible by the user...
+            // it will re-appear later
+            if (pr.otherUserId == session?.myUserId) {
+                // XXX this is a bit hard coded :/
+                popupAlertManager.cancelAlert("review_login")
+            }
             val user = session?.getUser(pr.otherUserId)?.toMatrixItem()
             val name = user?.getBestName() ?: pr.otherUserId
             val description = if (name == pr.otherUserId) {

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -203,9 +203,8 @@ class HomeActivityViewModel @AssistedInject constructor(
                     _viewEvents.post(
                             HomeActivityViewEvents.OnNewSession(
                                     session.getUser(session.myUserId)?.toMatrixItem(),
-                                    // If it's an old unverified, we should send requests
-                                    // instead of waiting for an incoming one
-                                    reAuthHelper.data != null
+                                    //Always send request instead of waiting for an incoming as per recent EW changes
+                                    false
                             )
                     )
                 }


### PR DESCRIPTION
The recent EW [rework](https://github.com/matrix-org/matrix-react-sdk/pull/5727) on verification flow are not compatible with mobile implementation.

Two main issues:
- When login a new web session and trying to verify with EA:
      When you type on 'Use anothe login' on web, nothing appears on mobile; And if from EA you type 'verify the new login' you will have a infinite loading

- When login in a new EA and trying to verify with EW:
    EA is waiting for an incoming verification request, and this will never happen with EW recent re-work


Quick Fix

For 1: Actually the EA alert for the request from EW is there but under the 'verify this new login' green popup. to fix it EA will dismiss the green alert so that the user can see the verification request alert

For 2: EA now always send a verification request (instead of waiting for an incoming one)

