### PR TITLE
Related to #1793, allow cleartext to LAN domains

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@ git branch -u origin/main main
 # And optionally
 git remote prune origin
 ```
+ - Allow cleartext (non-SSL) connections to Matrix servers on LAN hosts (#3166)
 
 Changes in Element 1.1.6 (2021-04-16)
 ===================================================

--- a/vector/src/main/res/xml/network_security_config.xml
+++ b/vector/src/main/res/xml/network_security_config.xml
@@ -13,6 +13,16 @@
         <domain includeSubdomains="true">10.0.2.2</domain>
         <!-- Onion services -->
         <domain includeSubdomains="true">onion</domain>
+
+        <!-- Domains that are used for LANs -->
+        <!-- These are IANA recognized special use domain names, see https://www.iana.org/assignments/special-use-domain-names/special-use-domain-names.xhtml -->
+        <domain includeSubdomains="true">home.arpa</domain>
+        <domain includeSubdomains="true">local</domain> <!-- Note this has been reserved for use with mDNS -->
+        <domain includeSubdomains="true">test</domain>
+        <!-- These are observed in the wild either by convention or RFCs that have not been accepted, and are not currently TLDs -->
+        <domain includeSubdomains="true">home</domain>
+        <domain includeSubdomains="true">lan</domain>
+        <domain includeSubdomains="true">localdomain</domain>
     </domain-config>
 
     <debug-overrides>


### PR DESCRIPTION
This functionality exists in the desktop client, so hoping to mirror that. 

This addresses a number of the use cases touched on in #1793. `localdomain` is a conventional domain that is an equivalent of the `localhost` host. Enabling clear text to `*.localdomain` means it's easier to develop the Android application, as a Matrix server can be deployed locally without much fuss anywhere on the developer's LAN. This can reduce the reliance on a DNS or SSL certificates when neither are really relevant to the interaction of the client/server. In particular, managing SSL certs without a public domain is a pain in the butt.

At the same time, this does not significantly diminish the security of Element Android, as `*.localdomain` is not a TLD so any "real" deployment still needs SSL.

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

Signed-off-by: Toby Murray <toby.murray@protonmail.com>
