### PR TITLE
RegistrationWizard.createAccount() parameters are now all optional

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ Translations 🗣:
  -
 
 SDK API changes ⚠️:
- -
+ - RegistrationWizard.createAccount() parameters are now all optional, following Matrix spec (#3205)
 
 Build 🧱:
  - Upgrade to gradle 7

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/registration/RegistrationWizard.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/registration/RegistrationWizard.kt
@@ -20,7 +20,9 @@ interface RegistrationWizard {
 
     suspend fun getRegistrationFlow(): RegistrationResult
 
-    suspend fun createAccount(userName: String, password: String, initialDeviceDisplayName: String?): RegistrationResult
+    suspend fun createAccount(userName: String?,
+                              password: String?,
+                              initialDeviceDisplayName: String?): RegistrationResult
 
     suspend fun performReCaptcha(response: String): RegistrationResult
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/registration/DefaultRegistrationWizard.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/registration/DefaultRegistrationWizard.kt
@@ -66,8 +66,8 @@ internal class DefaultRegistrationWizard(
         return performRegistrationRequest(params)
     }
 
-    override suspend fun createAccount(userName: String,
-                                       password: String,
+    override suspend fun createAccount(userName: String?,
+                                       password: String?,
                                        initialDeviceDisplayName: String?): RegistrationResult {
         val params = RegistrationParams(
                 username = userName,


### PR DESCRIPTION
Following Matrix spec (Fixes #3205)