### PR TITLE
Delete and react to stickers (#3250)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Features ✨:
 
 Improvements 🙌:
  - Add ability to install APK from directly from Element (#2381)
+ - Delete and react to stickers (#3250)
 
 Bugfix 🐛:
  - Message states cosmetic changes (#3007)

--- a/vector/src/main/java/im/vector/app/core/extensions/TimelineEvent.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/TimelineEvent.kt
@@ -21,6 +21,8 @@ import org.matrix.android.sdk.api.session.room.send.SendState
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
 
 fun TimelineEvent.canReact(): Boolean {
-    // Only event of type Event.EVENT_TYPE_MESSAGE are supported for the moment
-    return root.getClearType() == EventType.MESSAGE && root.sendState == SendState.SYNCED && !root.isRedacted()
+    // Only event of type EventType.MESSAGE or EventType.STICKER are supported for the moment
+    return root.getClearType() in listOf(EventType.MESSAGE, EventType.STICKER)
+            && root.sendState == SendState.SYNCED
+            && !root.isRedacted()
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
@@ -394,7 +394,7 @@ class MessageActionsViewModel @AssistedInject constructor(@Assisted
     }
 
     private fun canReply(event: TimelineEvent, messageContent: MessageContent?, actionPermissions: ActionPermissions): Boolean {
-        // Only event of type Event.EVENT_TYPE_MESSAGE are supported for the moment
+        // Only event of type EventType.MESSAGE are supported for the moment
         if (event.root.getClearType() != EventType.MESSAGE) return false
         if (!actionPermissions.canSendMessage) return false
         return when (messageContent?.msgType) {
@@ -410,7 +410,7 @@ class MessageActionsViewModel @AssistedInject constructor(@Assisted
     }
 
     private fun canQuote(event: TimelineEvent, messageContent: MessageContent?, actionPermissions: ActionPermissions): Boolean {
-        // Only event of type Event.EVENT_TYPE_MESSAGE are supported for the moment
+        // Only event of type EventType.MESSAGE are supported for the moment
         if (event.root.getClearType() != EventType.MESSAGE) return false
         if (!actionPermissions.canSendMessage) return false
         return when (messageContent?.msgType) {
@@ -425,8 +425,8 @@ class MessageActionsViewModel @AssistedInject constructor(@Assisted
     }
 
     private fun canRedact(event: TimelineEvent, actionPermissions: ActionPermissions): Boolean {
-        // Only event of type Event.EVENT_TYPE_MESSAGE are supported for the moment
-        if (event.root.getClearType() != EventType.MESSAGE) return false
+        // Only event of type EventType.MESSAGE are supported for the moment
+        if (event.root.getClearType() !in listOf(EventType.MESSAGE, EventType.STICKER)) return false
         // Message sent by the current user can always be redacted
         if (event.root.senderId == session.myUserId) return true
         // Check permission for messages sent by other users
@@ -440,14 +440,13 @@ class MessageActionsViewModel @AssistedInject constructor(@Assisted
     }
 
     private fun canViewReactions(event: TimelineEvent): Boolean {
-        // Only event of type Event.EVENT_TYPE_MESSAGE are supported for the moment
-        if (event.root.getClearType() != EventType.MESSAGE) return false
-        // TODO if user is admin or moderator
+        // Only event of type EventType.MESSAGE and EventType.STICKER are supported for the moment
+        if (event.root.getClearType() !in listOf(EventType.MESSAGE, EventType.STICKER)) return false
         return event.annotations?.reactionsSummary?.isNotEmpty() ?: false
     }
 
     private fun canEdit(event: TimelineEvent, myUserId: String, actionPermissions: ActionPermissions): Boolean {
-        // Only event of type Event.EVENT_TYPE_MESSAGE are supported for the moment
+        // Only event of type EventType.MESSAGE are supported for the moment
         if (event.root.getClearType() != EventType.MESSAGE) return false
         if (!actionPermissions.canSendMessage) return false
         // TODO if user is admin or moderator

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/MessageInformationDataFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/MessageInformationDataFactory.kt
@@ -66,7 +66,7 @@ class MessageInformationDataFactory @Inject constructor(private val session: Ses
                 addDaySeparator
                         || event.senderInfo.avatarUrl != nextEvent?.senderInfo?.avatarUrl
                         || event.senderInfo.disambiguatedDisplayName != nextEvent?.senderInfo?.disambiguatedDisplayName
-                        || (nextEvent.root.getClearType() != EventType.MESSAGE && nextEvent.root.getClearType() != EventType.ENCRYPTED)
+                        || nextEvent.root.getClearType() !in listOf(EventType.MESSAGE, EventType.STICKER, EventType.ENCRYPTED)
                         || isNextMessageReceivedMoreThanOneHourAgo
                         || isTileTypeMessage(nextEvent)
 


### PR DESCRIPTION
Add ability to delete sticker
Add ability to react to sticker and to view the reaction of sticker.

Also do not display user name and avatar again if a message is sent just after the user sent a sticker

Fixes #3250