### PR TITLE
Fix updating read marker automatically

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Bugfix 🐛:
  - Fix issue when opening encrypted files (#3186)
  - Fix wording issue (#3242)
  - Fix missing sender information after edits (#3184)
+ - Fix read marker not updating automatically (#3267)
 
 Translations 🗣:
  -

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
@@ -550,7 +550,7 @@ class RoomDetailViewModel @AssistedInject constructor(
     private fun stopTrackingUnreadMessages() {
         if (trackUnreadMessages.getAndSet(false)) {
             mostRecentDisplayedEvent?.root?.eventId?.also {
-                viewModelScope.launch {
+                session.coroutineScope.launch {
                     tryOrNull { room.setReadMarker(it) }
                 }
             }


### PR DESCRIPTION
Note: I'm not too familiar with kotlin coroutines yet, however, using the NonCancellable dispatcher for setting the read marker seems to fix updating the read marker automatically upon exiting the room.

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request updates [CHANGES.md](https://github.com/vector-im/element-android/blob/develop/CHANGES.md)
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
