### PR TITLE
stable prefix for msc1772

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/EventType.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/EventType.kt
@@ -52,11 +52,9 @@ object EventType {
     const val STATE_ROOM_GUEST_ACCESS = "m.room.guest_access"
     const val STATE_ROOM_POWER_LEVELS = "m.room.power_levels"
 
-    //    const val STATE_SPACE_CHILD = "m.space.child"
-    const val STATE_SPACE_CHILD = "org.matrix.msc1772.space.child"
+    const val STATE_SPACE_CHILD = "m.space.child"
 
-    //    const val STATE_SPACE_PARENT = "m.space.parent"
-    const val STATE_SPACE_PARENT = "org.matrix.msc1772.space.parent"
+    const val STATE_SPACE_PARENT = "m.space.parent"
 
     /**
      * Note that this Event has been deprecated, see

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomType.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomType.kt
@@ -18,6 +18,5 @@ package org.matrix.android.sdk.api.session.room.model
 
 object RoomType {
 
-    const val SPACE = "org.matrix.msc1772.space" // "m.space"
-//    const val MESSAGING = "org.matrix.msc1840.messaging"
+    const val SPACE = "m.space"
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/create/CreateRoomParams.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/create/CreateRoomParams.kt
@@ -160,6 +160,6 @@ open class CreateRoomParams {
 
     companion object {
         private const val CREATION_CONTENT_KEY_M_FEDERATE = "m.federate"
-        private const val CREATION_CONTENT_KEY_ROOM_TYPE = "org.matrix.msc1772.type"
+        private const val CREATION_CONTENT_KEY_ROOM_TYPE = "type"
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/create/RoomCreateContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/create/RoomCreateContent.kt
@@ -28,5 +28,5 @@ data class RoomCreateContent(
         @Json(name = "room_version") val roomVersion: String? = null,
         @Json(name = "predecessor") val predecessor: Predecessor? = null,
         // Defines the room type, see #RoomType (user extensible)
-        @Json(name = "org.matrix.msc1772.type") val type: String? = null
+        @Json(name = "type") val type: String? = null
 )


### PR DESCRIPTION
Use stable prefixes as msc1772 has been merged

Proposed final identifier       | Purpose | Development identifier
------------------------------- | ------- | ----
`type` | property in `m.room.create` | `org.matrix.msc1772.type`
`m.space` | value of `type` in `m.room.create` | `org.matrix.msc1772.space`
`m.space.child` | event type | `org.matrix.msc1772.space.child`
`m.space.parent` | event type | `org.matrix.msc1772.space.parent`