### PR TITLE
Compress thumbnail: change Jpeg quality from 100 to 80 (#3396)

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/ThumbnailExtractor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/ThumbnailExtractor.kt
@@ -52,7 +52,7 @@ internal class ThumbnailExtractor @Inject constructor(
             mediaMetadataRetriever.setDataSource(context, attachment.queryUri)
             mediaMetadataRetriever.frameAtTime?.let { thumbnail ->
                 val outputStream = ByteArrayOutputStream()
-                thumbnail.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+                thumbnail.compress(Bitmap.CompressFormat.JPEG, 80, outputStream)
                 val thumbnailWidth = thumbnail.width
                 val thumbnailHeight = thumbnail.height
                 val thumbnailSize = outputStream.size()

--- a/newsfragment/3396.feature
+++ b/newsfragment/3396.feature
@@ -1,0 +1,1 @@
+Compress thumbnail: change Jpeg quality from 100 to 80


### PR DESCRIPTION
Fix #3396 

### In the timeline

<img width="385" alt="image" src="https://user-images.githubusercontent.com/3940906/119864874-5ff75900-bf1b-11eb-99b9-f4961e29a1d5.png">

### Thumbnail size

Quality 100: 1_032_382 bytes
Quality 80: 134_085

File size is 7 times smaller.