### PR TITLE
Bugfix for #2593

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomTask.kt
@@ -117,7 +117,7 @@ internal class DefaultCreateRoomTask @Inject constructor(
     }
 
     private suspend fun handleDirectChatCreation(roomId: String, otherUserId: String) {
-        monarchy.awaitTransaction { realm ->
+        monarchy.runTransactionSync { realm ->
             RoomSummaryEntity.where(realm, roomId).findFirst()?.apply {
                 this.directUserId = otherUserId
                 this.isDirect = true

--- a/newsfragment/2593.bugfix
+++ b/newsfragment/2593.bugfix
@@ -1,0 +1,1 @@
+Fixed the issue with DMs listed as a room, if created via user's profile


### PR DESCRIPTION
Wait for DM is written in the local Realm database before storing the DM list in user's account data. 

closes vector-im/element-android#2593

Signed-off-by: Artjom König <artkoenig@gmail.com>

### Pull Request Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./newsfragment. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
