### PR TITLE
Fix crash when setting up key backup

### DIFF
--- a/vector/src/main/res/layout/fragment_keys_backup_setup_step1.xml
+++ b/vector/src/main/res/layout/fragment_keys_backup_setup_step1.xml
@@ -84,6 +84,8 @@
     <Button
         android:id="@+id/keys_backup_setup_step1_manual_export_button"
         style="@style/Widget.Vector.Button.Text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_margin="16dp"
         android:layout_marginStart="@dimen/layout_horizontal_margin"
         android:layout_marginEnd="@dimen/layout_horizontal_margin"


### PR DESCRIPTION
Got a crash when trying to setup keybackup on logout

![image](https://user-images.githubusercontent.com/9841565/122354539-604ea700-cf51-11eb-91e2-0e608b683f35.png)

````
    Thread: main, Exception: android.view.InflateException: Binary XML file line #97 in im.vector.app.debug:layout/fragment_keys_backup_setup_step1: Binary XML file line #97: You must supply a layout_width attribute.
    Caused by: java.lang.UnsupportedOperationException: Binary XML file line #97: You must supply a layout_width attribute.
        at android.content.res.TypedArray.getLayoutDimension(TypedArray.java:829)
        at android.view.ViewGroup$LayoutParams.setBaseAttributes(ViewGroup.java:7932)
        at android.view.ViewGroup$MarginLayoutParams.<init>(ViewGroup.java:8130)
        at androidx.constraintlayout.widget.ConstraintLayout$LayoutParams.<init>(ConstraintLayout.java:2691)
