### PR TITLE
Improve wellknown usage

### DIFF
--- a/.idea/dictionaries/bmarty.xml
+++ b/.idea/dictionaries/bmarty.xml
@@ -38,6 +38,7 @@
       <w>unpublish</w>
       <w>unwedging</w>
       <w>vctr</w>
+      <w>wellknown</w>
     </words>
   </dictionary>
 </component>

--- a/changelog.d/2843.bugfix
+++ b/changelog.d/2843.bugfix
@@ -1,0 +1,1 @@
+Perform .well-known request first, even if the entered URL is a valid homeserver base url

--- a/changelog.d/3572.misc
+++ b/changelog.d/3572.misc
@@ -1,0 +1,1 @@
+RawService.getWellknown() now takes a domain instead of a matrixId as parameter

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/MatrixPatterns.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/MatrixPatterns.kt
@@ -16,6 +16,8 @@
 
 package org.matrix.android.sdk.api
 
+import org.matrix.android.sdk.BuildConfig
+
 /**
  * This class contains pattern to match the different Matrix ids
  */
@@ -154,7 +156,7 @@ object MatrixPatterns {
      * Orders which are not strings, or do not consist solely of ascii characters in the range \x20 (space) to \x7E (~),
      * or consist of more than 50 characters, are forbidden and the field should be ignored if received.
      */
-    fun isValidOrderString(order: String?) : Boolean {
+    fun isValidOrderString(order: String?): Boolean {
         return order != null && order.length < 50 && order matches ORDER_STRING_REGEX
     }
 
@@ -162,5 +164,18 @@ object MatrixPatterns {
         return Regex("\\s").replace(name.lowercase(), "_").let {
             "[^a-z0-9._%#@=+-]".toRegex().replace(it, "")
         }
+    }
+
+    /**
+     * Return the domain form a userId
+     * Examples:
+     * - "@alice:domain.org".getDomain() will return "domain.org"
+     * - "@bob:domain.org:3455".getDomain() will return "domain.org:3455"
+     */
+    fun String.getDomain(): String {
+        if (BuildConfig.DEBUG) {
+            assert(isUserId(this))
+        }
+        return substringAfter(":")
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/data/HomeServerConnectionConfig.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/data/HomeServerConnectionConfig.kt
@@ -30,8 +30,13 @@ import okhttp3.TlsVersion
  * You should use the [Builder] to create one.
  */
 @JsonClass(generateAdapter = true)
-data class HomeServerConnectionConfig(
+data class HomeServerConnectionConfig constructor(
+        // This is the homeserver URL entered by the user
         val homeServerUri: Uri,
+        // This is the homeserver base URL for the client-server API. Default to homeServerUri,
+        // but can be updated with data from .Well-Known before login, and/or with the data
+        // included in the login response
+        val homeServerUriBase: Uri = homeServerUri,
         val identityServerUri: Uri? = null,
         val antiVirusServerUri: Uri? = null,
         val allowedFingerprints: List<Fingerprint> = emptyList(),
@@ -47,7 +52,6 @@ data class HomeServerConnectionConfig(
      * This builder should be use to create a [HomeServerConnectionConfig] instance.
      */
     class Builder {
-
         private lateinit var homeServerUri: Uri
         private var identityServerUri: Uri? = null
         private var antiVirusServerUri: Uri? = null
@@ -234,16 +238,16 @@ data class HomeServerConnectionConfig(
          */
         fun build(): HomeServerConnectionConfig {
             return HomeServerConnectionConfig(
-                    homeServerUri,
-                    identityServerUri,
-                    antiVirusServerUri,
-                    allowedFingerprints,
-                    shouldPin,
-                    tlsVersions,
-                    tlsCipherSuites,
-                    shouldAcceptTlsExtensions,
-                    allowHttpExtension,
-                    forceUsageTlsVersions
+                    homeServerUri = homeServerUri,
+                    identityServerUri = identityServerUri,
+                    antiVirusServerUri = antiVirusServerUri,
+                    allowedFingerprints = allowedFingerprints,
+                    shouldPin = shouldPin,
+                    tlsVersions = tlsVersions,
+                    tlsCipherSuites = tlsCipherSuites,
+                    shouldAcceptTlsExtensions = shouldAcceptTlsExtensions,
+                    allowHttpExtension = allowHttpExtension,
+                    forceUsageTlsVersions = forceUsageTlsVersions
             )
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/data/HomeServerConnectionConfig.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/data/HomeServerConnectionConfig.kt
@@ -18,11 +18,11 @@ package org.matrix.android.sdk.api.auth.data
 
 import android.net.Uri
 import com.squareup.moshi.JsonClass
+import okhttp3.CipherSuite
+import okhttp3.TlsVersion
 import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig.Builder
 import org.matrix.android.sdk.internal.network.ssl.Fingerprint
 import org.matrix.android.sdk.internal.util.ensureTrailingSlash
-import okhttp3.CipherSuite
-import okhttp3.TlsVersion
 
 /**
  * This data class holds how to connect to a specific Homeserver.
@@ -30,7 +30,7 @@ import okhttp3.TlsVersion
  * You should use the [Builder] to create one.
  */
 @JsonClass(generateAdapter = true)
-data class HomeServerConnectionConfig constructor(
+data class HomeServerConnectionConfig(
         // This is the homeserver URL entered by the user
         val homeServerUri: Uri,
         // This is the homeserver base URL for the client-server API. Default to homeServerUri,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/data/SessionParams.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/data/SessionParams.kt
@@ -51,13 +51,18 @@ data class SessionParams(
     val deviceId = credentials.deviceId
 
     /**
-     * The current homeserver Url. It can be different that the homeserver url entered
-     * during login phase, because a redirection may have occurred
+     * The homeserver Url entered by the user during the login phase.
      */
     val homeServerUrl = homeServerConnectionConfig.homeServerUri.toString()
 
     /**
-     * The current homeserver host
+     * The current homeserver Url for client-server API. It can be different that the homeserver url entered
+     * during login phase, because a redirection may have occurred
+     */
+    val homeServerUrlBase = homeServerConnectionConfig.homeServerUriBase.toString()
+
+    /**
+     * The current homeserver host, using what has been entered by the user during login phase
      */
     val homeServerHost = homeServerConnectionConfig.homeServerUri.host
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/wellknown/WellknownResult.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/wellknown/WellknownResult.kt
@@ -23,11 +23,6 @@ import org.matrix.android.sdk.api.auth.data.WellKnown
  */
 sealed class WellknownResult {
     /**
-     * The provided matrixId is no valid. Unable to extract a domain name.
-     */
-    object InvalidMatrixId : WellknownResult()
-
-    /**
      * Retrieve the specific piece of information from the user in a way which fits within the existing client user experience,
      * if the client is inclined to do so. Failure can take place instead if no good user experience for this is possible at this point.
      */

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/MatrixIdFailure.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/MatrixIdFailure.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.api.failure
+
+sealed class MatrixIdFailure : Failure.FeatureFailure() {
+    object InvalidMatrixId : MatrixIdFailure()
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/raw/RawService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/raw/RawService.kt
@@ -29,8 +29,10 @@ interface RawService {
 
     /**
      * Specific case for the well-known file. Cache validity is 8 hours
+     * @param domain the domain to get the .well-known file, for instance "matrix.org".
+     * The URL will be "https://{domain}/.well-known/matrix/client"
      */
-    suspend fun getWellknown(userId: String): String
+    suspend fun getWellknown(domain: String): String
 
     /**
      * Clear all the cache data

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/AuthAPI.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/AuthAPI.kt
@@ -21,8 +21,8 @@ import org.matrix.android.sdk.api.util.JsonDict
 import org.matrix.android.sdk.internal.auth.data.Availability
 import org.matrix.android.sdk.internal.auth.data.LoginFlowResponse
 import org.matrix.android.sdk.internal.auth.data.PasswordLoginParams
-import org.matrix.android.sdk.internal.auth.data.RiotConfig
 import org.matrix.android.sdk.internal.auth.data.TokenLoginParams
+import org.matrix.android.sdk.internal.auth.data.WebClientConfig
 import org.matrix.android.sdk.internal.auth.login.ResetPasswordMailConfirmed
 import org.matrix.android.sdk.internal.auth.registration.AddThreePidRegistrationParams
 import org.matrix.android.sdk.internal.auth.registration.AddThreePidRegistrationResponse
@@ -44,16 +44,16 @@ import retrofit2.http.Url
  */
 internal interface AuthAPI {
     /**
-     * Get a Riot config file, using the name including the domain
+     * Get a Web client config file, using the name including the domain
      */
     @GET("config.{domain}.json")
-    suspend fun getRiotConfigDomain(@Path("domain") domain: String): RiotConfig
+    suspend fun getWebClientConfigDomain(@Path("domain") domain: String): WebClientConfig
 
     /**
-     * Get a Riot config file
+     * Get a Web client default config file
      */
     @GET("config.json")
-    suspend fun getRiotConfig(): RiotConfig
+    suspend fun getWebClientConfig(): WebClientConfig
 
     /**
      * Get the version information of the homeserver

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/DefaultAuthenticationService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/DefaultAuthenticationService.kt
@@ -20,6 +20,7 @@ import android.net.Uri
 import dagger.Lazy
 import okhttp3.OkHttpClient
 import org.matrix.android.sdk.api.MatrixPatterns
+import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.auth.AuthenticationService
 import org.matrix.android.sdk.api.auth.data.Credentials
 import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
@@ -379,7 +380,7 @@ internal class DefaultAuthenticationService @Inject constructor(
         }
 
         return getWellknownTask.execute(GetWellknownTask.Params(
-                domain = matrixId.substringAfter(":"),
+                domain = matrixId.getDomain(),
                 homeServerConnectionConfig = homeServerConnectionConfig)
         )
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/IsValidClientServerApiTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/IsValidClientServerApiTask.kt
@@ -42,7 +42,7 @@ internal class DefaultIsValidClientServerApiTask @Inject constructor(
 
     override suspend fun execute(params: IsValidClientServerApiTask.Params): Boolean {
         val client = buildClient(params.homeServerConnectionConfig)
-        val homeServerUrl = params.homeServerConnectionConfig.homeServerUri.toString()
+        val homeServerUrl = params.homeServerConnectionConfig.homeServerUriBase.toString()
 
         val authAPI = retrofitFactory.create(client, homeServerUrl)
                 .create(AuthAPI::class.java)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/SessionCreator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/SessionCreator.kt
@@ -56,7 +56,7 @@ internal class DefaultSessionCreator @Inject constructor(
                     tryOrNull {
                         isValidClientServerApiTask.execute(
                                 IsValidClientServerApiTask.Params(
-                                        homeServerConnectionConfig.copy(homeServerUri = it)
+                                        homeServerConnectionConfig.copy(homeServerUriBase = it)
                                 )
                         )
                                 .also { Timber.d("Overriding homeserver url: $it") }
@@ -66,7 +66,7 @@ internal class DefaultSessionCreator @Inject constructor(
         val sessionParams = SessionParams(
                 credentials = credentials,
                 homeServerConnectionConfig = homeServerConnectionConfig.copy(
-                        homeServerUri = overriddenUrl ?: homeServerConnectionConfig.homeServerUri,
+                        homeServerUriBase = overriddenUrl ?: homeServerConnectionConfig.homeServerUriBase,
                         identityServerUri = credentials.discoveryInformation?.identityServer?.baseURL
                                 // remove trailing "/"
                                 ?.trim { it == '/' }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/data/WebClientConfig.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/data/WebClientConfig.kt
@@ -20,7 +20,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-internal data class RiotConfig(
+internal data class WebClientConfig(
         /**
          * This is now deprecated, but still used first, rather than value from "default_server_config"
          */
@@ -28,7 +28,7 @@ internal data class RiotConfig(
         val defaultHomeServerUrl: String?,
 
         @Json(name = "default_server_config")
-        val defaultServerConfig: RiotConfigDefaultServerConfig?
+        val defaultServerConfig: WebClientConfigDefaultServerConfig?
 ) {
     fun getPreferredHomeServerUrl(): String? {
         return defaultHomeServerUrl
@@ -38,13 +38,13 @@ internal data class RiotConfig(
 }
 
 @JsonClass(generateAdapter = true)
-internal data class RiotConfigDefaultServerConfig(
+internal data class WebClientConfigDefaultServerConfig(
         @Json(name = "m.homeserver")
-        val homeServer: RiotConfigBaseConfig? = null
+        val homeServer: WebClientConfigBaseConfig? = null
 )
 
 @JsonClass(generateAdapter = true)
-internal data class RiotConfigBaseConfig(
+internal data class WebClientConfigBaseConfig(
         @Json(name = "base_url")
         val baseURL: String? = null
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/DirectLoginTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/DirectLoginTask.kt
@@ -50,7 +50,7 @@ internal class DefaultDirectLoginTask @Inject constructor(
 
     override suspend fun execute(params: DirectLoginTask.Params): Session {
         val client = buildClient(params.homeServerConnectionConfig)
-        val homeServerUrl = params.homeServerConnectionConfig.homeServerUri.toString()
+        val homeServerUrl = params.homeServerConnectionConfig.homeServerUriBase.toString()
 
         val authAPI = retrofitFactory.create(client, homeServerUrl)
                 .create(AuthAPI::class.java)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/federation/FederationModule.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/federation/FederationModule.kt
@@ -37,7 +37,8 @@ internal abstract class FederationModule {
         fun providesFederationAPI(@Unauthenticated okHttpClient: Lazy<OkHttpClient>,
                                   sessionParams: SessionParams,
                                   retrofitFactory: RetrofitFactory): FederationAPI {
-            return retrofitFactory.create(okHttpClient, sessionParams.homeServerUrl).create(FederationAPI::class.java)
+            return retrofitFactory.create(okHttpClient, sessionParams.homeServerUrlBase)
+                    .create(FederationAPI::class.java)
         }
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/ssl/CertUtil.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/ssl/CertUtil.kt
@@ -253,7 +253,7 @@ internal object CertUtil {
         val list = ArrayList<ConnectionSpec>()
         list.add(builder.build())
         // TODO: we should display a warning if user enter an http url
-        if (hsConfig.allowHttpExtension || hsConfig.homeServerUri.toString().startsWith("http://")) {
+        if (hsConfig.allowHttpExtension || hsConfig.homeServerUriBase.toString().startsWith("http://")) {
             list.add(ConnectionSpec.CLEARTEXT)
         }
         return list

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/raw/DefaultRawService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/raw/DefaultRawService.kt
@@ -29,10 +29,9 @@ internal class DefaultRawService @Inject constructor(
         return getUrlTask.execute(GetUrlTask.Params(url, cacheStrategy))
     }
 
-    override suspend fun getWellknown(userId: String): String {
-        val homeServerDomain = userId.substringAfter(":")
+    override suspend fun getWellknown(domain: String): String {
         return getUrl(
-                "https://$homeServerDomain/.well-known/matrix/client",
+                "https://$domain/.well-known/matrix/client",
                 CacheStrategy.TtlCache(TimeUnit.HOURS.toMillis(8), false)
         )
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
@@ -313,7 +313,7 @@ internal class DefaultSession @Inject constructor(
 
     override fun getUiaSsoFallbackUrl(authenticationSessionId: String): String {
         val hsBas = sessionParams.homeServerConnectionConfig
-                .homeServerUri
+                .homeServerUriBase
                 .toString()
                 .trim { it == '/' }
         return buildString {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionModule.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionModule.kt
@@ -261,7 +261,7 @@ internal abstract class SessionModule {
                              sessionParams: SessionParams,
                              retrofitFactory: RetrofitFactory): Retrofit {
             return retrofitFactory
-                    .create(okHttpClient, sessionParams.homeServerConnectionConfig.homeServerUri.toString())
+                    .create(okHttpClient, sessionParams.homeServerConnectionConfig.homeServerUriBase.toString())
         }
 
         @JvmStatic

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/DefaultContentUrlResolver.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/DefaultContentUrlResolver.kt
@@ -26,7 +26,7 @@ private const val MATRIX_CONTENT_URI_SCHEME = "mxc://"
 
 internal class DefaultContentUrlResolver @Inject constructor(homeServerConnectionConfig: HomeServerConnectionConfig) : ContentUrlResolver {
 
-    private val baseUrl = homeServerConnectionConfig.homeServerUri.toString().ensureTrailingSlash()
+    private val baseUrl = homeServerConnectionConfig.homeServerUriBase.toString().ensureTrailingSlash()
 
     override val uploadUrl = baseUrl + NetworkConstants.URI_API_MEDIA_PREFIX_PATH_R0 + "upload"
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetHomeServerCapabilitiesTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetHomeServerCapabilitiesTask.kt
@@ -89,7 +89,10 @@ internal class DefaultGetHomeServerCapabilitiesTask @Inject constructor(
         }.getOrNull()
 
         val wellknownResult = runCatching {
-            getWellknownTask.execute(GetWellknownTask.Params(userId, homeServerConnectionConfig))
+            getWellknownTask.execute(GetWellknownTask.Params(
+                    domain = userId.substringAfter(":"),
+                    homeServerConnectionConfig = homeServerConnectionConfig
+            ))
         }.getOrNull()
 
         insertInDb(capabilities, mediaConfig, versions, wellknownResult)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetHomeServerCapabilitiesTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetHomeServerCapabilitiesTask.kt
@@ -17,6 +17,7 @@
 package org.matrix.android.sdk.internal.session.homeserver
 
 import com.zhuinden.monarchy.Monarchy
+import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
 import org.matrix.android.sdk.api.auth.wellknown.WellknownResult
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilities
@@ -90,7 +91,7 @@ internal class DefaultGetHomeServerCapabilitiesTask @Inject constructor(
 
         val wellknownResult = runCatching {
             getWellknownTask.execute(GetWellknownTask.Params(
-                    domain = userId.substringAfter(":"),
+                    domain = userId.getDomain(),
                     homeServerConnectionConfig = homeServerConnectionConfig
             ))
         }.getOrNull()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/ViaParameterFinder.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/ViaParameterFinder.kt
@@ -16,6 +16,7 @@
 
 package org.matrix.android.sdk.internal.session.permalinks
 
+import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.session.room.members.roomMemberQueryParams
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.internal.di.UserId
@@ -47,9 +48,9 @@ internal class ViaParameterFinder @Inject constructor(
     }
 
     fun computeViaParams(userId: String, roomId: String, max: Int): List<String> {
-        val userHomeserver = userId.substringAfter(":")
+        val userHomeserver = userId.getDomain()
         return getUserIdsOfJoinedMembers(roomId)
-                .map { it.substringAfter(":") }
+                .map { it.getDomain() }
                 .groupBy { it }
                 .mapValues { it.value.size }
                 .toMutableMap()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/alias/RoomAliasAvailabilityChecker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/alias/RoomAliasAvailabilityChecker.kt
@@ -16,6 +16,7 @@
 
 package org.matrix.android.sdk.internal.session.room.alias
 
+import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.session.room.alias.RoomAliasError
 import org.matrix.android.sdk.internal.di.UserId
@@ -64,6 +65,6 @@ internal class RoomAliasAvailabilityChecker @Inject constructor(
     }
 
     companion object {
-        internal fun String.toFullLocalAlias(userId: String) = "#" + this + ":" + userId.substringAfter(":")
+        internal fun String.toFullLocalAlias(userId: String) = "#" + this + ":" + userId.getDomain()
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/queue/HomeServerAvailabilityChecker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/queue/HomeServerAvailabilityChecker.kt
@@ -26,8 +26,8 @@ import java.net.Socket
 internal class HomeServerAvailabilityChecker(val sessionParams: SessionParams) {
 
     fun check(): Boolean {
-        val host = sessionParams.homeServerConnectionConfig.homeServerUri.host ?: return false
-        val port = sessionParams.homeServerConnectionConfig.homeServerUri.port.takeIf { it != -1 } ?: 80
+        val host = sessionParams.homeServerConnectionConfig.homeServerUriBase.host ?: return false
+        val port = sessionParams.homeServerConnectionConfig.homeServerUriBase.port.takeIf { it != -1 } ?: 80
         val timeout = 30_000
         try {
             Socket().use { socket ->

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/wellknown/GetWellknownTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/wellknown/GetWellknownTask.kt
@@ -39,7 +39,11 @@ import javax.net.ssl.HttpsURLConnection
 
 internal interface GetWellknownTask : Task<GetWellknownTask.Params, WellknownResult> {
     data class Params(
-            val matrixId: String,
+            /**
+             * domain, for instance "matrix.org"
+             * the URL will be https://{domain}/.well-known/matrix/client
+             */
+            val domain: String,
             val homeServerConnectionConfig: HomeServerConnectionConfig?
     )
 }
@@ -54,14 +58,8 @@ internal class DefaultGetWellknownTask @Inject constructor(
 ) : GetWellknownTask {
 
     override suspend fun execute(params: GetWellknownTask.Params): WellknownResult {
-        if (!MatrixPatterns.isUserId(params.matrixId)) {
-            return WellknownResult.InvalidMatrixId
-        }
-
-        val homeServerDomain = params.matrixId.substringAfter(":")
-
         val client = buildClient(params.homeServerConnectionConfig)
-        return findClientConfig(homeServerDomain, client)
+        return findClientConfig(params.domain, client)
     }
 
     private fun buildClient(homeServerConnectionConfig: HomeServerConnectionConfig?): OkHttpClient {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/wellknown/GetWellknownTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/wellknown/GetWellknownTask.kt
@@ -18,7 +18,6 @@ package org.matrix.android.sdk.internal.wellknown
 
 import android.util.MalformedJsonException
 import dagger.Lazy
-import org.matrix.android.sdk.api.MatrixPatterns
 import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
 import org.matrix.android.sdk.api.auth.data.WellKnown
 import org.matrix.android.sdk.api.auth.wellknown.WellknownResult

--- a/vector/src/main/java/im/vector/app/core/dialogs/UnrecognizedCertificateDialog.kt
+++ b/vector/src/main/java/im/vector/app/core/dialogs/UnrecognizedCertificateDialog.kt
@@ -50,7 +50,15 @@ class UnrecognizedCertificateDialog @Inject constructor(
         val userId = activeSessionHolder.getSafeActiveSession()?.myUserId
         val hsConfig = activeSessionHolder.getSafeActiveSession()?.sessionParams?.homeServerConnectionConfig ?: return
 
-        internalShow(activity, unrecognizedFingerprint, true, callback, userId, hsConfig.homeServerUriBase.toString(), hsConfig.allowedFingerprints.isNotEmpty())
+        internalShow(
+                activity = activity,
+                unrecognizedFingerprint = unrecognizedFingerprint,
+                existing = true,
+                callback = callback,
+                userId = userId,
+                homeServerUrl = hsConfig.homeServerUriBase.toString(),
+                homeServerConnectionConfigHasFingerprints = hsConfig.allowedFingerprints.isNotEmpty()
+        )
     }
 
     /**
@@ -60,7 +68,15 @@ class UnrecognizedCertificateDialog @Inject constructor(
              unrecognizedFingerprint: Fingerprint,
              homeServerUrl: String,
              callback: Callback) {
-        internalShow(activity, unrecognizedFingerprint, false, callback, null, homeServerUrl, false)
+        internalShow(
+                activity = activity,
+                unrecognizedFingerprint = unrecognizedFingerprint,
+                existing = false,
+                callback = callback,
+                userId = null,
+                homeServerUrl = homeServerUrl,
+                homeServerConnectionConfigHasFingerprints = false
+        )
     }
 
     /**

--- a/vector/src/main/java/im/vector/app/core/dialogs/UnrecognizedCertificateDialog.kt
+++ b/vector/src/main/java/im/vector/app/core/dialogs/UnrecognizedCertificateDialog.kt
@@ -50,7 +50,7 @@ class UnrecognizedCertificateDialog @Inject constructor(
         val userId = activeSessionHolder.getSafeActiveSession()?.myUserId
         val hsConfig = activeSessionHolder.getSafeActiveSession()?.sessionParams?.homeServerConnectionConfig ?: return
 
-        internalShow(activity, unrecognizedFingerprint, true, callback, userId, hsConfig.homeServerUri.toString(), hsConfig.allowedFingerprints.isNotEmpty())
+        internalShow(activity, unrecognizedFingerprint, true, callback, userId, hsConfig.homeServerUriBase.toString(), hsConfig.allowedFingerprints.isNotEmpty())
     }
 
     /**

--- a/vector/src/main/java/im/vector/app/core/error/ErrorFormatter.kt
+++ b/vector/src/main/java/im/vector/app/core/error/ErrorFormatter.kt
@@ -21,6 +21,7 @@ import im.vector.app.core.resources.StringProvider
 import im.vector.app.features.call.dialpad.DialPadLookup
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.failure.MatrixError
+import org.matrix.android.sdk.api.failure.MatrixIdFailure
 import org.matrix.android.sdk.api.failure.isInvalidPassword
 import org.matrix.android.sdk.api.session.identity.IdentityServiceError
 import java.net.HttpURLConnection
@@ -39,9 +40,9 @@ class DefaultErrorFormatter @Inject constructor(
 
     override fun toHumanReadable(throwable: Throwable?): String {
         return when (throwable) {
-            null                         -> null
-            is IdentityServiceError      -> identityServerError(throwable)
-            is Failure.NetworkConnection -> {
+            null                                   -> null
+            is IdentityServiceError                -> identityServerError(throwable)
+            is Failure.NetworkConnection           -> {
                 when (throwable.ioException) {
                     is SocketTimeoutException     ->
                         stringProvider.getString(R.string.error_network_timeout)
@@ -54,7 +55,7 @@ class DefaultErrorFormatter @Inject constructor(
                         stringProvider.getString(R.string.error_no_network)
                 }
             }
-            is Failure.ServerError       -> {
+            is Failure.ServerError                 -> {
                 when {
                     throwable.error.code == MatrixError.M_CONSENT_NOT_GIVEN          -> {
                         // Special case for terms and conditions
@@ -104,23 +105,25 @@ class DefaultErrorFormatter @Inject constructor(
                     }
                 }
             }
-            is Failure.OtherServerError -> {
+            is Failure.OtherServerError            -> {
                 when (throwable.httpCode) {
-                    HttpURLConnection.HTTP_NOT_FOUND ->
+                    HttpURLConnection.HTTP_NOT_FOUND    ->
                         // homeserver not found
                         stringProvider.getString(R.string.login_error_no_homeserver_found)
                     HttpURLConnection.HTTP_UNAUTHORIZED ->
                         // uia errors?
                         stringProvider.getString(R.string.error_unauthorized)
-                    else                             ->
+                    else                                ->
                         throwable.localizedMessage
                 }
             }
-            is DialPadLookup.Failure.NumberIsYours    ->
+            is DialPadLookup.Failure.NumberIsYours ->
                 stringProvider.getString(R.string.cannot_call_yourself)
-            is DialPadLookup.Failure.NoResult    ->
+            is DialPadLookup.Failure.NoResult      ->
                 stringProvider.getString(R.string.call_dial_pad_lookup_error)
-            else                        -> throwable.localizedMessage
+            is MatrixIdFailure.InvalidMatrixId     ->
+                stringProvider.getString(R.string.login_signin_matrix_id_error_invalid_matrix_id)
+            else                                   -> throwable.localizedMessage
         }
                 ?: stringProvider.getString(R.string.unknown_error)
     }

--- a/vector/src/main/java/im/vector/app/features/call/conference/JitsiService.kt
+++ b/vector/src/main/java/im/vector/app/features/call/conference/JitsiService.kt
@@ -56,7 +56,7 @@ class JitsiService @Inject constructor(
         // Build data for a jitsi widget
         val widgetId: String = WidgetType.Jitsi.preferred + "_" + session.myUserId + "_" + System.currentTimeMillis()
         val preferredJitsiDomain = tryOrNull {
-            rawService.getElementWellknown(session.myUserId)
+            rawService.getElementWellknown(session.sessionParams)
                     ?.jitsiServer
                     ?.preferredDomain
         }

--- a/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomViewModel.kt
@@ -86,7 +86,7 @@ class CreateDirectRoomViewModel @AssistedInject constructor(@Assisted
         setState { copy(createAndInviteState = Loading()) }
 
         viewModelScope.launch(Dispatchers.IO) {
-            val adminE2EByDefault = rawService.getElementWellknown(session.myUserId)
+            val adminE2EByDefault = rawService.getElementWellknown(session.sessionParams)
                     ?.isE2EByDefault()
                     ?: true
 

--- a/vector/src/main/java/im/vector/app/features/createdirect/DirectRoomHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/DirectRoomHelper.kt
@@ -35,7 +35,7 @@ class DirectRoomHelper @Inject constructor(
         if (existingRoomId != null) {
             roomId = existingRoomId
         } else {
-            val adminE2EByDefault = rawService.getElementWellknown(session.myUserId)
+            val adminE2EByDefault = rawService.getElementWellknown(session.sessionParams)
                     ?.isE2EByDefault()
                     ?: true
 

--- a/vector/src/main/java/im/vector/app/features/homeserver/HomeServerCapabilitiesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/homeserver/HomeServerCapabilitiesViewModel.kt
@@ -70,7 +70,7 @@ class HomeServerCapabilitiesViewModel @AssistedInject constructor(
     private fun initAdminE2eByDefault() {
         viewModelScope.launch(Dispatchers.IO) {
             val adminE2EByDefault = tryOrNull {
-                rawService.getElementWellknown(session.myUserId)
+                rawService.getElementWellknown(session.sessionParams)
                         ?.isE2EByDefault()
                         ?: true
             } ?: true

--- a/vector/src/main/java/im/vector/app/features/login/LoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginFragment.kt
@@ -174,7 +174,7 @@ class LoginFragment @Inject constructor() : AbstractSSOLoginFragment<FragmentLog
                 ServerType.MatrixOrg -> {
                     views.loginServerIcon.isVisible = true
                     views.loginServerIcon.setImageResource(R.drawable.ic_logo_matrix_org)
-                    views.loginTitle.text = getString(resId, state.homeServerUrl.toReducedUrl())
+                    views.loginTitle.text = getString(resId, state.homeServerUrlFromUser.toReducedUrl())
                     views.loginNotice.text = getString(R.string.login_server_matrix_org_text)
                 }
                 ServerType.EMS       -> {
@@ -185,7 +185,7 @@ class LoginFragment @Inject constructor() : AbstractSSOLoginFragment<FragmentLog
                 }
                 ServerType.Other     -> {
                     views.loginServerIcon.isVisible = false
-                    views.loginTitle.text = getString(resId, state.homeServerUrl.toReducedUrl())
+                    views.loginTitle.text = getString(resId, state.homeServerUrlFromUser.toReducedUrl())
                     views.loginNotice.text = getString(R.string.login_server_other_text)
                 }
                 ServerType.Unknown   -> Unit /* Should not happen */

--- a/vector/src/main/java/im/vector/app/features/login/LoginResetPasswordFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginResetPasswordFragment.kt
@@ -55,7 +55,7 @@ class LoginResetPasswordFragment @Inject constructor() : AbstractLoginFragment<F
     }
 
     private fun setupUi(state: LoginViewState) {
-        views.resetPasswordTitle.text = getString(R.string.login_reset_password_on, state.homeServerUrl.toReducedUrl())
+        views.resetPasswordTitle.text = getString(R.string.login_reset_password_on, state.homeServerUrlFromUser.toReducedUrl())
     }
 
     private fun setupSubmitButton() {

--- a/vector/src/main/java/im/vector/app/features/login/LoginSignUpSignInSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginSignUpSignInSelectionFragment.kt
@@ -53,19 +53,19 @@ class LoginSignUpSignInSelectionFragment @Inject constructor() : AbstractSSOLogi
             ServerType.MatrixOrg -> {
                 views.loginSignupSigninServerIcon.setImageResource(R.drawable.ic_logo_matrix_org)
                 views.loginSignupSigninServerIcon.isVisible = true
-                views.loginSignupSigninTitle.text = getString(R.string.login_connect_to, state.homeServerUrl.toReducedUrl())
+                views.loginSignupSigninTitle.text = getString(R.string.login_connect_to, state.homeServerUrlFromUser.toReducedUrl())
                 views.loginSignupSigninText.text = getString(R.string.login_server_matrix_org_text)
             }
             ServerType.EMS       -> {
                 views.loginSignupSigninServerIcon.setImageResource(R.drawable.ic_logo_element_matrix_services)
                 views.loginSignupSigninServerIcon.isVisible = true
                 views.loginSignupSigninTitle.text = getString(R.string.login_connect_to_modular)
-                views.loginSignupSigninText.text = state.homeServerUrl.toReducedUrl()
+                views.loginSignupSigninText.text = state.homeServerUrlFromUser.toReducedUrl()
             }
             ServerType.Other     -> {
                 views.loginSignupSigninServerIcon.isVisible = false
                 views.loginSignupSigninTitle.text = getString(R.string.login_server_other_title)
-                views.loginSignupSigninText.text = getString(R.string.login_connect_to, state.homeServerUrl.toReducedUrl())
+                views.loginSignupSigninText.text = getString(R.string.login_connect_to, state.homeServerUrlFromUser.toReducedUrl())
             }
             ServerType.Unknown   -> Unit /* Should not happen */
         }

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
@@ -563,16 +563,16 @@ class LoginViewModel @AssistedInject constructor(
                 return@launch
             }
             when (data) {
-                is WellknownResult.Prompt          ->
+                is WellknownResult.Prompt     ->
                     onWellknownSuccess(action, data, homeServerConnectionConfig)
-                is WellknownResult.FailPrompt      ->
+                is WellknownResult.FailPrompt ->
                     // Relax on IS discovery if home server is valid
                     if (data.homeServerUrl != null && data.wellKnown != null) {
                         onWellknownSuccess(action, WellknownResult.Prompt(data.homeServerUrl!!, null, data.wellKnown!!), homeServerConnectionConfig)
                     } else {
                         onWellKnownError()
                     }
-                else                               -> {
+                else                          -> {
                     onWellKnownError()
                 }
             }.exhaustive
@@ -597,7 +597,8 @@ class LoginViewModel @AssistedInject constructor(
                         identityServerUri = wellKnownPrompt.identityServerUrl?.let { Uri.parse(it) }
                 )
                 ?: HomeServerConnectionConfig(
-                        homeServerUri = Uri.parse(wellKnownPrompt.homeServerUrl),
+                        homeServerUri = Uri.parse("https://${action.username.substringAfter(":")}"),
+                        homeServerUriBase = Uri.parse(wellKnownPrompt.homeServerUrl),
                         identityServerUri = wellKnownPrompt.identityServerUrl?.let { Uri.parse(it) }
                 )
 

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
@@ -40,6 +40,7 @@ import im.vector.app.core.utils.ensureTrailingSlash
 import im.vector.app.features.signout.soft.SoftLogoutActivity
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.auth.AuthenticationService
 import org.matrix.android.sdk.api.auth.HomeServerHistoryService
 import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
@@ -597,7 +598,7 @@ class LoginViewModel @AssistedInject constructor(
                         identityServerUri = wellKnownPrompt.identityServerUrl?.let { Uri.parse(it) }
                 )
                 ?: HomeServerConnectionConfig(
-                        homeServerUri = Uri.parse("https://${action.username.substringAfter(":")}"),
+                        homeServerUri = Uri.parse("https://${action.username.getDomain()}"),
                         homeServerUriBase = Uri.parse(wellKnownPrompt.homeServerUrl),
                         identityServerUri = wellKnownPrompt.identityServerUrl?.let { Uri.parse(it) }
                 )

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
@@ -591,7 +591,7 @@ class LoginViewModel @AssistedInject constructor(
                                            homeServerConnectionConfig: HomeServerConnectionConfig?) {
         val alteredHomeServerConnectionConfig = homeServerConnectionConfig
                 ?.copy(
-                        homeServerUri = Uri.parse(wellKnownPrompt.homeServerUrl),
+                        homeServerUriBase = Uri.parse(wellKnownPrompt.homeServerUrl),
                         identityServerUri = wellKnownPrompt.identityServerUrl?.let { Uri.parse(it) }
                 )
                 ?: HomeServerConnectionConfig(
@@ -772,7 +772,7 @@ class LoginViewModel @AssistedInject constructor(
             data ?: return@launch
 
             // Valid Homeserver, add it to the history.
-            // Note: we add what the user has input, data.homeServerUrl can be different
+            // Note: we add what the user has input, data.homeServerUrlBase can be different
             rememberHomeServer(homeServerConnectionConfig.homeServerUri.toString())
 
             val loginMode = when {

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
@@ -214,6 +214,7 @@ class LoginViewModel @AssistedInject constructor(
             copy(
                     signMode = SignMode.SignIn,
                     loginMode = LoginMode.Sso(action.ssoIdentityProviders),
+                    homeServerUrlFromUser = action.homeServerUrl,
                     homeServerUrl = action.homeServerUrl,
                     deviceId = action.deviceId
             )
@@ -365,6 +366,7 @@ class LoginViewModel @AssistedInject constructor(
                     setState {
                         copy(
                                 asyncHomeServerLoginFlowRequest = Uninitialized,
+                                homeServerUrlFromUser = null,
                                 homeServerUrl = null,
                                 loginMode = LoginMode.Unknown,
                                 serverType = ServerType.Unknown,
@@ -788,6 +790,7 @@ class LoginViewModel @AssistedInject constructor(
             setState {
                 copy(
                         asyncHomeServerLoginFlowRequest = Uninitialized,
+                        homeServerUrlFromUser = homeServerConnectionConfig.homeServerUri.toString(),
                         homeServerUrl = data.homeServerUrl,
                         loginMode = loginMode,
                         loginModeSupportedTypes = data.supportedLoginTypes.toList()

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewState.kt
@@ -38,7 +38,12 @@ data class LoginViewState(
         @PersistState
         val resetPasswordEmail: String? = null,
         @PersistState
+        val homeServerUrlFromUser: String? = null,
+
+        // Can be modified after a Wellknown request
+        @PersistState
         val homeServerUrl: String? = null,
+
         // For SSO session recovery
         @PersistState
         val deviceId: String? = null,

--- a/vector/src/main/java/im/vector/app/features/login/terms/LoginTermsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/terms/LoginTermsFragment.kt
@@ -112,7 +112,7 @@ class LoginTermsFragment @Inject constructor(
     }
 
     override fun updateWithState(state: LoginViewState) {
-        policyController.homeServer = state.homeServerUrl.toReducedUrl()
+        policyController.homeServer = state.homeServerUrlFromUser.toReducedUrl()
         renderState()
     }
 

--- a/vector/src/main/java/im/vector/app/features/login2/LoginViewModel2.kt
+++ b/vector/src/main/java/im/vector/app/features/login2/LoginViewModel2.kt
@@ -41,6 +41,7 @@ import im.vector.app.features.login.LoginMode
 import im.vector.app.features.login.ReAuthHelper
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.auth.AuthenticationService
 import org.matrix.android.sdk.api.auth.HomeServerHistoryService
 import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
@@ -651,7 +652,7 @@ class LoginViewModel2 @AssistedInject constructor(
         }
         viewEvent?.let { _viewEvents.post(it) }
 
-        val urlFromUser = action.username.substringAfter(":")
+        val urlFromUser = action.username.getDomain()
         setState {
             copy(
                     isLoading = false,

--- a/vector/src/main/java/im/vector/app/features/login2/LoginViewModel2.kt
+++ b/vector/src/main/java/im/vector/app/features/login2/LoginViewModel2.kt
@@ -612,7 +612,7 @@ class LoginViewModel2 @AssistedInject constructor(
                                            homeServerConnectionConfig: HomeServerConnectionConfig?) {
         val alteredHomeServerConnectionConfig = homeServerConnectionConfig
                 ?.copy(
-                        homeServerUri = Uri.parse(wellKnownPrompt.homeServerUrl),
+                        homeServerUriBase = Uri.parse(wellKnownPrompt.homeServerUrl),
                         identityServerUri = wellKnownPrompt.identityServerUrl?.let { Uri.parse(it) }
                 )
                 ?: HomeServerConnectionConfig(
@@ -752,7 +752,7 @@ class LoginViewModel2 @AssistedInject constructor(
             } ?: return@launch
 
             // Valid Homeserver, add it to the history.
-            // Note: we add what the user has input, data.homeServerUrl can be different
+            // Note: we add what the user has input, data.homeServerUrlBase can be different
             rememberHomeServer(homeServerConnectionConfig.homeServerUri.toString())
 
             val loginMode = when {

--- a/vector/src/main/java/im/vector/app/features/login2/LoginViewModel2.kt
+++ b/vector/src/main/java/im/vector/app/features/login2/LoginViewModel2.kt
@@ -595,10 +595,6 @@ class LoginViewModel2 @AssistedInject constructor(
                     } else {
                         onWellKnownError()
                     }
-                is WellknownResult.InvalidMatrixId -> {
-                    setState { copy(isLoading = false) }
-                    _viewEvents.post(LoginViewEvents2.Failure(Exception(stringProvider.getString(R.string.login_signin_matrix_id_error_invalid_matrix_id))))
-                }
                 else                               -> {
                     onWellKnownError()
                 }

--- a/vector/src/main/java/im/vector/app/features/raw/wellknown/ElementWellKnownExt.kt
+++ b/vector/src/main/java/im/vector/app/features/raw/wellknown/ElementWellKnownExt.kt
@@ -16,11 +16,14 @@
 
 package im.vector.app.features.raw.wellknown
 
+import org.matrix.android.sdk.api.auth.data.SessionParams
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.raw.RawService
 
-suspend fun RawService.getElementWellknown(userId: String): ElementWellKnown? {
-    return tryOrNull { getWellknown(userId) }
+suspend fun RawService.getElementWellknown(sessionParams: SessionParams): ElementWellKnown? {
+    // By default we use the domain of the userId to retrieve the .well-known data
+    val domain = sessionParams.userId.substringAfter(":")
+    return tryOrNull { getWellknown(domain) }
             ?.let { ElementWellKnownMapper.from(it) }
 }
 

--- a/vector/src/main/java/im/vector/app/features/raw/wellknown/ElementWellKnownExt.kt
+++ b/vector/src/main/java/im/vector/app/features/raw/wellknown/ElementWellKnownExt.kt
@@ -16,13 +16,14 @@
 
 package im.vector.app.features.raw.wellknown
 
+import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.auth.data.SessionParams
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.raw.RawService
 
 suspend fun RawService.getElementWellknown(sessionParams: SessionParams): ElementWellKnown? {
     // By default we use the domain of the userId to retrieve the .well-known data
-    val domain = sessionParams.userId.substringAfter(":")
+    val domain = sessionParams.userId.getDomain()
     return tryOrNull { getWellknown(domain) }
             ?.let { ElementWellKnownMapper.from(it) }
 }

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
@@ -34,6 +34,7 @@ import im.vector.app.features.raw.wellknown.getElementWellknown
 import im.vector.app.features.raw.wellknown.isE2EByDefault
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.raw.RawService
 import org.matrix.android.sdk.api.session.Session
@@ -62,7 +63,7 @@ class CreateRoomViewModel @AssistedInject constructor(@Assisted private val init
     private fun initHomeServerName() {
         setState {
             copy(
-                    homeServerName = session.myUserId.substringAfter(":")
+                    homeServerName = session.myUserId.getDomain()
             )
         }
     }

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
@@ -72,7 +72,7 @@ class CreateRoomViewModel @AssistedInject constructor(@Assisted private val init
     private fun initAdminE2eByDefault() {
         viewModelScope.launch(Dispatchers.IO) {
             adminE2EByDefault = tryOrNull {
-                rawService.getElementWellknown(session.myUserId)
+                rawService.getElementWellknown(session.sessionParams)
                         ?.isE2EByDefault()
                         ?: true
             } ?: true

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/picker/RoomDirectoryListCreator.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/picker/RoomDirectoryListCreator.kt
@@ -20,6 +20,7 @@ import im.vector.app.R
 import im.vector.app.core.resources.StringArrayProvider
 import im.vector.app.features.roomdirectory.RoomDirectoryData
 import im.vector.app.features.roomdirectory.RoomDirectoryServer
+import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.room.model.thirdparty.ThirdPartyProtocol
 import javax.inject.Inject
@@ -36,7 +37,7 @@ class RoomDirectoryListCreator @Inject constructor(
         val protocols = ArrayList<RoomDirectoryData>()
 
         // Add user homeserver name
-        val userHsName = session.myUserId.substringAfter(":")
+        val userHsName = session.myUserId.getDomain()
 
         // Add default protocol
         protocols.add(

--- a/vector/src/main/java/im/vector/app/features/roomprofile/alias/RoomAliasViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/alias/RoomAliasViewModel.kt
@@ -31,6 +31,7 @@ import im.vector.app.core.extensions.exhaustive
 import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.features.powerlevel.PowerLevelsObservableFactory
 import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.query.QueryStringValue
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.events.model.EventType
@@ -101,7 +102,7 @@ class RoomAliasViewModel @AssistedInject constructor(@Assisted initialState: Roo
     private fun initHomeServerName() {
         setState {
             copy(
-                    homeServerName = session.myUserId.substringAfter(":")
+                    homeServerName = session.myUserId.getDomain()
             )
         }
     }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
@@ -157,7 +157,7 @@ class VectorSettingsSecurityPrivacyFragment @Inject constructor(
             findPreference<VectorPreference>(VectorPreferences.SETTINGS_CRYPTOGRAPHY_HS_ADMIN_DISABLED_E2E_DEFAULT)?.isVisible =
                     vectorActivity.getVectorComponent()
                             .rawService()
-                            .getElementWellknown(session.myUserId)
+                            .getElementWellknown(session.sessionParams)
                             ?.isE2EByDefault() == false
         }
     }

--- a/vector/src/main/java/im/vector/app/features/settings/homeserver/HomeServerSettingsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/homeserver/HomeServerSettingsViewState.kt
@@ -23,7 +23,8 @@ import org.matrix.android.sdk.api.federation.FederationVersion
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilities
 
 data class HomeServerSettingsViewState(
-        val baseUrl: String = "",
+        val homeserverUrl: String = "",
+        val homeserverClientServerApiUrl: String = "",
         val homeServerCapabilities: HomeServerCapabilities = HomeServerCapabilities(),
         val federationVersion: Async<FederationVersion> = Uninitialized
 ) : MvRxState

--- a/vector/src/main/java/im/vector/app/features/settings/homeserver/HomeserverSettingsController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/homeserver/HomeserverSettingsController.kt
@@ -29,13 +29,15 @@ import im.vector.app.core.resources.StringProvider
 import im.vector.app.features.discovery.settingsCenteredImageItem
 import im.vector.app.features.discovery.settingsInfoItem
 import im.vector.app.features.discovery.settingsSectionTitleItem
+import im.vector.app.features.settings.VectorPreferences
 import org.matrix.android.sdk.api.federation.FederationVersion
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilities
 import javax.inject.Inject
 
 class HomeserverSettingsController @Inject constructor(
         private val stringProvider: StringProvider,
-        private val errorFormatter: ErrorFormatter
+        private val errorFormatter: ErrorFormatter,
+        private val vectorPreferences: VectorPreferences
 ) : TypedEpoxyController<HomeServerSettingsViewState>() {
 
     var callback: Callback? = null
@@ -78,7 +80,17 @@ class HomeserverSettingsController @Inject constructor(
         }
         settingsInfoItem {
             id("urlValue")
-            helperText(state.baseUrl)
+            helperText(state.homeserverUrl)
+        }
+        if (vectorPreferences.developerMode()) {
+            settingsSectionTitleItem {
+                id("urlApiTitle")
+                titleResId(R.string.hs_client_url)
+            }
+            settingsInfoItem {
+                id("urlApiValue")
+                helperText(state.homeserverClientServerApiUrl)
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/homeserver/HomeserverSettingsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/homeserver/HomeserverSettingsViewModel.kt
@@ -53,7 +53,8 @@ class HomeserverSettingsViewModel @AssistedInject constructor(
     init {
         setState {
             copy(
-                    baseUrl = session.sessionParams.homeServerUrl,
+                    homeserverUrl = session.sessionParams.homeServerUrl,
+                    homeserverClientServerApiUrl = session.sessionParams.homeServerUrlBase,
                     homeServerCapabilities = session.getHomeServerCapabilities()
             )
         }

--- a/vector/src/main/java/im/vector/app/features/spaces/create/CreateSpaceViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/create/CreateSpaceViewModel.kt
@@ -36,6 +36,7 @@ import im.vector.app.core.resources.StringProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.MatrixPatterns
+import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.room.AliasAvailabilityResult
 import org.matrix.android.sdk.api.session.room.failure.CreateRoomFailure
@@ -51,7 +52,7 @@ class CreateSpaceViewModel @AssistedInject constructor(
     init {
         setState {
             copy(
-                    homeServerName = session.myUserId.substringAfter(":")
+                    homeServerName = session.myUserId.getDomain()
             )
         }
     }

--- a/vector/src/main/java/im/vector/app/features/spaces/create/CreateSpaceViewModelTask.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/create/CreateSpaceViewModelTask.kt
@@ -75,7 +75,7 @@ class CreateSpaceViewModelTask @Inject constructor(
         val childIds = mutableListOf<String>()
 
         val e2eByDefault = tryOrNull {
-            rawService.getElementWellknown(session.myUserId)
+            rawService.getElementWellknown(session.sessionParams)
                     ?.isE2EByDefault()
                     ?: true
         } ?: true

--- a/vector/src/main/java/im/vector/app/features/spaces/people/SpacePeopleViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/people/SpacePeopleViewModel.kt
@@ -81,7 +81,7 @@ class SpacePeopleViewModel @AssistedInject constructor(
         setState { copy(createAndInviteState = Loading()) }
 
         viewModelScope.launch(Dispatchers.IO) {
-            val adminE2EByDefault = rawService.getElementWellknown(session.myUserId)
+            val adminE2EByDefault = rawService.getElementWellknown(session.sessionParams)
                     ?.isE2EByDefault()
                     ?: true
 

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -538,6 +538,7 @@
     <string name="login">Log in</string>
     <string name="logout">Sign out</string>
     <string name="hs_url">Homeserver URL</string>
+    <string name="hs_client_url">Homeserver API URL</string>
     <string name="identity_url">Identity Server URL</string>
     <string name="search">Search</string>
 


### PR DESCRIPTION
This PR fixes several issues:

Fixes #2843 : we now first perform a .well-known request, even if the entered URL is a valid Matrix API

Fixes #3572: we now store the url entered at session creation (Auth database migration required to add the new field), for further reference. Settings screen is updated:

<img width="312" alt="image" src="https://user-images.githubusercontent.com/3940906/123944375-5b501580-d99d-11eb-8ea2-2d230a20cb4f.png">

and

<img width="329" alt="image" src="https://user-images.githubusercontent.com/3940906/123944430-66a34100-d99d-11eb-831f-0bef2444f448.png">

API URL is only displayed in developer mode (see the diff with https://user-images.githubusercontent.com/3940906/123458079-e79cba00-d5e4-11eb-825e-4d481662b418.png).

Some change in the SDK API, wellknown now takes a domain instead of a matrixId.

### Tested OK

- sign in on matrix.org
- sign up on matrix.org
- SSO on matrix.org (using a GitHub account, see the screenshots)
- sign in on mozilla.modular.im (other SSO)
- sign in using a matrixId
- use element web url (develop.element.io) to retrieve config file

### Limitation

If the user enter the matrix API url, for instance "matrix-client.matrix.org", there is no way to deduce the domain matrix.org. So every further wellknow request will fail.