### PR TITLE
Use different copy for self verification

### DIFF
--- a/changelog.d/3624.bugfix
+++ b/changelog.d/3624.bugfix
@@ -1,0 +1,1 @@
+Use different copy for self verification.

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodController.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodController.kt
@@ -45,9 +45,19 @@ class VerificationChooseMethodController @Inject constructor(
         val host = this
 
         if (state.otherCanScanQrCode || state.otherCanShowQrCode) {
+            var scanCodeInstructions: String
+            var scanOtherCodeTitle: String
+            if (state.isMe) {
+                scanCodeInstructions = host.stringProvider.getString(R.string.verification_scan_self_notice)
+                scanOtherCodeTitle = host.stringProvider.getString(R.string.verification_scan_with_this_device)
+            } else {
+                scanCodeInstructions = host.stringProvider.getString(R.string.verification_scan_notice)
+                scanOtherCodeTitle = host.stringProvider.getString(R.string.verification_scan_their_code)
+            }
+
             bottomSheetVerificationNoticeItem {
                 id("notice")
-                notice(host.stringProvider.getString(R.string.verification_scan_notice))
+                notice(scanCodeInstructions)
             }
 
             if (state.otherCanScanQrCode && !state.qrCodeText.isNullOrBlank()) {
@@ -64,7 +74,7 @@ class VerificationChooseMethodController @Inject constructor(
             if (state.otherCanShowQrCode) {
                 bottomSheetVerificationActionItem {
                     id("openCamera")
-                    title(host.stringProvider.getString(R.string.verification_scan_their_code))
+                    title(scanOtherCodeTitle)
                     titleColor(host.colorProvider.getColorFromAttribute(R.attr.colorPrimary))
                     iconRes(R.drawable.ic_camera)
                     iconColor(host.colorProvider.getColorFromAttribute(R.attr.colorPrimary))

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodController.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodController.kt
@@ -47,12 +47,15 @@ class VerificationChooseMethodController @Inject constructor(
         if (state.otherCanScanQrCode || state.otherCanShowQrCode) {
             var scanCodeInstructions: String
             var scanOtherCodeTitle: String
+            var compareEmojiSubtitle: String
             if (state.isMe) {
                 scanCodeInstructions = host.stringProvider.getString(R.string.verification_scan_self_notice)
                 scanOtherCodeTitle = host.stringProvider.getString(R.string.verification_scan_with_this_device)
+                compareEmojiSubtitle = host.stringProvider.getString(R.string.verification_scan_self_emoji_subtitle)
             } else {
                 scanCodeInstructions = host.stringProvider.getString(R.string.verification_scan_notice)
                 scanOtherCodeTitle = host.stringProvider.getString(R.string.verification_scan_their_code)
+                compareEmojiSubtitle = host.stringProvider.getString(R.string.verification_scan_emoji_subtitle)
             }
 
             bottomSheetVerificationNoticeItem {
@@ -90,7 +93,7 @@ class VerificationChooseMethodController @Inject constructor(
                 id("openEmoji")
                 title(host.stringProvider.getString(R.string.verification_scan_emoji_title))
                 titleColor(host.colorProvider.getColorFromAttribute(R.attr.vctr_content_primary))
-                subTitle(host.stringProvider.getString(R.string.verification_scan_emoji_subtitle))
+                subTitle(compareEmojiSubtitle)
                 iconRes(R.drawable.ic_arrow_right)
                 iconColor(host.colorProvider.getColorFromAttribute(R.attr.vctr_content_primary))
                 listener { host.listener?.doVerifyBySas() }

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2630,7 +2630,9 @@
     <string name="you">You</string>
 
     <string name="verification_scan_notice">Scan the code with the other user\'s device to securely verify each other</string>
+    <string name="verification_scan_self_notice">Scan the code with your other device to securely verify each other</string>
     <string name="verification_scan_their_code">Scan their code</string>
+    <string name="verification_scan_with_this_device">Scan with this device</string>
     <string name="verification_scan_emoji_title">Can\'t scan</string>
     <string name="verification_scan_emoji_subtitle">If you\'re not in person, compare emoji instead</string>
 

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2630,11 +2630,12 @@
     <string name="you">You</string>
 
     <string name="verification_scan_notice">Scan the code with the other user\'s device to securely verify each other</string>
-    <string name="verification_scan_self_notice">Scan the code with your other device to securely verify each other</string>
+    <string name="verification_scan_self_notice">Scan the code with your other device or switch and scan with this device</string>
     <string name="verification_scan_their_code">Scan their code</string>
     <string name="verification_scan_with_this_device">Scan with this device</string>
     <string name="verification_scan_emoji_title">Can\'t scan</string>
     <string name="verification_scan_emoji_subtitle">If you\'re not in person, compare emoji instead</string>
+    <string name="verification_scan_self_emoji_subtitle">Verify by comparing emoji instead</string>
 
     <string name="verification_no_scan_emoji_title">Verify by comparing emojis</string>
 


### PR DESCRIPTION
The copy all refers to 'their' device for when you're verifying
someone else. Update it to refer to your own devices in the case
where you're verifying one of your own devices.

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes (Hopefully not necessary for a string change...)
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

![Screenshot_2021-07-05-19-48-43-131_im vector app debug](https://user-images.githubusercontent.com/986903/124509695-4a066f00-ddca-11eb-90e7-bfd48961e8a1.jpg)

Equivalent for iOS: https://github.com/vector-im/element-ios/pull/4525