### PR TITLE
Fix unread messages marker being hidden in collapsed membership item

### DIFF
--- a/changelog.d/3655.bugfix
+++ b/changelog.d/3655.bugfix
@@ -1,0 +1,1 @@
+Fix unread messages marker being hidden in collapsed membership item

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineControllerInterceptorHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineControllerInterceptorHelper.kt
@@ -73,7 +73,8 @@ class TimelineControllerInterceptorHelper(private val positionOfReadMarker: KMut
                 }
                 epoxyModel.getEventIds().forEach { eventId ->
                     adapterPositionMapping[eventId] = index
-                    appendReadMarker = epoxyModel.canAppendReadMarker() && eventId == firstUnreadEventId && atLeastOneVisibleItemsBeforeReadMarker
+                    appendReadMarker = appendReadMarker
+                            || (epoxyModel.canAppendReadMarker() && eventId == firstUnreadEventId && atLeastOneVisibleItemsBeforeReadMarker)
                 }
             }
             if (epoxyModel is DaySeparatorItem) {


### PR DESCRIPTION
Scenario: the last read event in a chat is a membership change. After
that, at least two new membership changes were added, followed by normal
messages. Due to the membership changes being collapsed by default, in
this scenario the read marker would not show, since in the loop, we
would overwrite the appendReadMarker with the value for the last eventId
of the merged item, instead of showing it if any of the items matched.

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
