### PR TITLE
Avoid incomplete downloads in cache

### DIFF
--- a/changelog.d/3656.bugfix
+++ b/changelog.d/3656.bugfix
@@ -1,0 +1,1 @@
+Avoid incomplete downloads in cache


### PR DESCRIPTION
### Pull Request Checklist

Previously, when a download was aborted (e.g. due to a bad internet
connection), a partly downloaded file was remaining in cache, which
would then be delivered upon later requests.
This can lead e.g. to chats where images aren't loading.

To avoid this, first download files to a temporary file that is not the
final cache file, and only rename/move it on finish.

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
