### PR TITLE
Do not notify again for old events

### DIFF
--- a/changelog.d/1673.bugfix
+++ b/changelog.d/1673.bugfix
@@ -1,0 +1,1 @@
+Avoid resending notifications that are already shown

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
@@ -457,7 +457,7 @@ class NotificationDrawerManager @Inject constructor(private val context: Context
 
             if (eventList.isEmpty() || eventList.all { it.isRedacted }) {
                 notificationUtils.cancelNotificationMessage(null, SUMMARY_NOTIFICATION_ID)
-            } else {
+            } else if (hasNewEvent) {
                 // FIXME roomIdToEventMap.size is not correct, this is the number of rooms
                 val nbEvents = roomIdToEventMap.size + simpleEvents.size
                 val sumTitle = stringProvider.getQuantityString(R.plurals.notification_compat_summary_title, nbEvents, nbEvents)


### PR DESCRIPTION
Resending the notification here can trigger other system components or
apps that listen to new notifications, such as connected smart watches
or automation tools.

Fixes https://github.com/vector-im/element-android/issues/1673

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21 (Note: I haven't tested this thoroughly on pure Element, but this has been included in SchildiChat and Beeper for around a month and didn't seem to cause issues so far)
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
