### PR TITLE
Fix top row of emoji reaction picker on small displays

### DIFF
--- a/changelog.d/3661.bugfix
+++ b/changelog.d/3661.bugfix
@@ -1,0 +1,1 @@
+Ensure reaction emoji picker tabs look fine on small displays

--- a/vector/src/main/res/layout/activity_emoji_reaction_picker.xml
+++ b/vector/src/main/res/layout/activity_emoji_reaction_picker.xml
@@ -39,7 +39,9 @@
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tabs"
             android:layout_width="match_parent"
-            android:layout_height="40dp" />
+            android:layout_height="40dp"
+            app:tabPaddingEnd="0dp"
+            app:tabPaddingStart="0dp" />
 
     </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
Emojis were not showing if not enough space, so allow scrolling there.

Before:
![device-2021-07-11-111443](https://user-images.githubusercontent.com/12481742/125189798-3760bf80-e23a-11eb-958d-905fcf4a7b08.png)

After:
![device-2021-07-11-111657](https://user-images.githubusercontent.com/12481742/125189802-3d56a080-e23a-11eb-98b1-c92d1b972d7f.png)



Signed-off-by: Tobias Büttner <dev@spiritcroc.de>

### Pull Request Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
