### PR TITLE
Permission rework

### DIFF
--- a/changelog.d/3667.feature
+++ b/changelog.d/3667.feature
@@ -1,0 +1,1 @@
+Better management of permission requests

--- a/vector/src/debug/AndroidManifest.xml
+++ b/vector/src/debug/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <application>
         <activity android:name=".features.debug.TestLinkifyActivity" />
+        <activity android:name=".features.debug.DebugPermissionActivity" />
         <activity android:name=".features.debug.sas.DebugSasEmojiActivity" />
     </application>
 

--- a/vector/src/debug/java/im/vector/app/features/debug/DebugMenuActivity.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/DebugMenuActivity.kt
@@ -20,20 +20,15 @@ import android.app.Activity
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.os.Build
-import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.Person
-import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.di.ScreenComponent
 import im.vector.app.core.extensions.registerStartForActivityResult
 import im.vector.app.core.platform.VectorBaseActivity
-import im.vector.app.core.utils.PERMISSIONS_ALL
 import im.vector.app.core.utils.PERMISSIONS_FOR_TAKING_PHOTO
 import im.vector.app.core.utils.checkPermissions
 import im.vector.app.core.utils.registerForPermissionsResult
@@ -228,7 +223,7 @@ class DebugMenuActivity : VectorBaseActivity<ActivityDebugMenuBinding>() {
         }
     }
 
-    private val permissionCamera = registerForPermissionsResult { allGranted ->
+    private val permissionCamera = registerForPermissionsResult { allGranted, _ ->
         if (allGranted) {
             doScanQRCode()
         }

--- a/vector/src/debug/java/im/vector/app/features/debug/DebugMenuActivity.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/DebugMenuActivity.kt
@@ -20,15 +20,20 @@ import android.app.Activity
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
+import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.Person
+import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.di.ScreenComponent
 import im.vector.app.core.extensions.registerStartForActivityResult
 import im.vector.app.core.platform.VectorBaseActivity
+import im.vector.app.core.utils.PERMISSIONS_ALL
 import im.vector.app.core.utils.PERMISSIONS_FOR_TAKING_PHOTO
 import im.vector.app.core.utils.checkPermissions
 import im.vector.app.core.utils.registerForPermissionsResult
@@ -113,6 +118,9 @@ class DebugMenuActivity : VectorBaseActivity<ActivityDebugMenuBinding>() {
         }
         views.debugTestCrash.setOnClickListener { testCrash() }
         views.debugScanQrCode.setOnClickListener { scanQRCode() }
+        views.debugPermission.setOnClickListener {
+            startActivity(Intent(this, DebugPermissionActivity::class.java))
+        }
     }
 
     private fun renderQrCode(text: String) {

--- a/vector/src/debug/java/im/vector/app/features/debug/DebugMenuActivity.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/DebugMenuActivity.kt
@@ -30,9 +30,8 @@ import im.vector.app.core.di.ScreenComponent
 import im.vector.app.core.extensions.registerStartForActivityResult
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.core.utils.PERMISSIONS_FOR_TAKING_PHOTO
-import im.vector.app.core.utils.PERMISSION_REQUEST_CODE_LAUNCH_CAMERA
-import im.vector.app.core.utils.allGranted
 import im.vector.app.core.utils.checkPermissions
+import im.vector.app.core.utils.registerForPermissionsResult
 import im.vector.app.core.utils.toast
 import im.vector.app.databinding.ActivityDebugMenuBinding
 import im.vector.app.features.debug.sas.DebugSasEmojiActivity
@@ -48,7 +47,6 @@ import im.vector.lib.ui.styles.debug.DebugVectorButtonStylesLightActivity
 import im.vector.lib.ui.styles.debug.DebugVectorTextViewDarkActivity
 import im.vector.lib.ui.styles.debug.DebugVectorTextViewLightActivity
 import org.matrix.android.sdk.internal.crypto.verification.qrcode.toQrCodeData
-
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -217,15 +215,13 @@ class DebugMenuActivity : VectorBaseActivity<ActivityDebugMenuBinding>() {
     }
 
     private fun scanQRCode() {
-        if (checkPermissions(PERMISSIONS_FOR_TAKING_PHOTO, this, PERMISSION_REQUEST_CODE_LAUNCH_CAMERA)) {
+        if (checkPermissions(PERMISSIONS_FOR_TAKING_PHOTO, this, permissionCamera)) {
             doScanQRCode()
         }
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-
-        if (requestCode == PERMISSION_REQUEST_CODE_LAUNCH_CAMERA && allGranted(grantResults)) {
+    private val permissionCamera = registerForPermissionsResult { allGranted ->
+        if (allGranted) {
             doScanQRCode()
         }
     }

--- a/vector/src/debug/java/im/vector/app/features/debug/DebugMenuActivity.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/DebugMenuActivity.kt
@@ -218,12 +218,12 @@ class DebugMenuActivity : VectorBaseActivity<ActivityDebugMenuBinding>() {
     }
 
     private fun scanQRCode() {
-        if (checkPermissions(PERMISSIONS_FOR_TAKING_PHOTO, this, permissionCamera)) {
+        if (checkPermissions(PERMISSIONS_FOR_TAKING_PHOTO, this, permissionCameraLauncher)) {
             doScanQRCode()
         }
     }
 
-    private val permissionCamera = registerForPermissionsResult { allGranted, _ ->
+    private val permissionCameraLauncher = registerForPermissionsResult { allGranted, _ ->
         if (allGranted) {
             doScanQRCode()
         }

--- a/vector/src/debug/java/im/vector/app/features/debug/DebugPermissionActivity.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/DebugPermissionActivity.kt
@@ -26,6 +26,8 @@ import im.vector.app.R
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.core.utils.PERMISSIONS_ALL
 import im.vector.app.core.utils.checkPermissions
+import im.vector.app.core.utils.onPermissionDeniedDialog
+import im.vector.app.core.utils.onPermissionDeniedSnackbar
 import im.vector.app.core.utils.registerForPermissionsResult
 import im.vector.app.databinding.ActivityDebugPermissionBinding
 import timber.log.Timber
@@ -33,6 +35,8 @@ import timber.log.Timber
 class DebugPermissionActivity : VectorBaseActivity<ActivityDebugPermissionBinding>() {
 
     override fun getBinding() = ActivityDebugPermissionBinding.inflate(layoutInflater)
+
+    override fun getCoordinatorLayout() = views.coordinatorLayout
 
     private var lastPermissions = emptyList<String>()
 
@@ -67,12 +71,19 @@ class DebugPermissionActivity : VectorBaseActivity<ActivityDebugPermissionBindin
         }
     }
 
+    private var dialogOrSnackbar = false
+
     private val launcher = registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
             Toast.makeText(this, "All granted", Toast.LENGTH_SHORT).show()
         } else {
             if (deniedPermanently) {
-                Toast.makeText(this, "Denied forever", Toast.LENGTH_SHORT).show()
+                dialogOrSnackbar = !dialogOrSnackbar
+                if (dialogOrSnackbar) {
+                    onPermissionDeniedDialog(R.string.denied_permission_camera)
+                } else {
+                    onPermissionDeniedSnackbar(R.string.denied_permission_camera)
+                }
             } else {
                 Toast.makeText(this, "Denied", Toast.LENGTH_SHORT).show()
             }

--- a/vector/src/debug/java/im/vector/app/features/debug/DebugPermissionActivity.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/DebugPermissionActivity.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.debug
+
+import android.content.pm.PackageManager
+import android.os.Build
+import android.widget.Toast
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import im.vector.app.R
+import im.vector.app.core.platform.VectorBaseActivity
+import im.vector.app.core.utils.PERMISSIONS_ALL
+import im.vector.app.core.utils.checkPermissions
+import im.vector.app.core.utils.registerForPermissionsResult
+import im.vector.app.databinding.ActivityDebugPermissionBinding
+import timber.log.Timber
+
+class DebugPermissionActivity : VectorBaseActivity<ActivityDebugPermissionBinding>() {
+
+    override fun getBinding() = ActivityDebugPermissionBinding.inflate(layoutInflater)
+
+    override fun initUiAndData() {
+        views.status.setOnClickListener { refresh() }
+
+        listOf(
+                views.audio,
+                views.camera,
+                views.write,
+                views.read,
+                views.contact
+        ).forEach { button ->
+            button.setOnClickListener {
+                checkPermissions(listOf(button.text.toString()), this, launcher, R.string.debug_rationale)
+            }
+        }
+    }
+
+    private val launcher = registerForPermissionsResult { allGranted ->
+        if (allGranted) {
+            Toast.makeText(this, "All granted", Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(this, "Denied", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refresh()
+    }
+
+    private fun refresh() {
+        views.status.text = getStatus()
+    }
+
+    private fun getStatus(): String {
+        return buildString {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                Timber.v("## debugPermission() : log the permissions status used by the app")
+                PERMISSIONS_ALL.forEach { permission ->
+                    append("[$permission] : ")
+                    if (PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(this@DebugPermissionActivity, permission)) {
+                        append("PERMISSION_GRANTED")
+                    } else {
+                        append("PERMISSION_DENIED")
+                    }
+                    append(" show rational: ")
+                    append(ActivityCompat.shouldShowRequestPermissionRationale(this@DebugPermissionActivity, permission))
+                    append("\n")
+                }
+            } else {
+                append("Before M!")
+            }
+            append("\n")
+            append("(Click to refresh)")
+        }
+    }
+}

--- a/vector/src/debug/java/im/vector/app/features/debug/DebugPermissionActivity.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/DebugPermissionActivity.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.features.debug
 
+import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Build
 import android.widget.Toast
@@ -33,27 +34,48 @@ class DebugPermissionActivity : VectorBaseActivity<ActivityDebugPermissionBindin
 
     override fun getBinding() = ActivityDebugPermissionBinding.inflate(layoutInflater)
 
+    private var lastPermissions = emptyList<String>()
+
     override fun initUiAndData() {
         views.status.setOnClickListener { refresh() }
 
-        listOf(
-                views.audio,
-                views.camera,
-                views.write,
-                views.read,
-                views.contact
-        ).forEach { button ->
-            button.setOnClickListener {
-                checkPermissions(listOf(button.text.toString()), this, launcher, R.string.debug_rationale)
-            }
+        views.camera.setOnClickListener {
+            lastPermissions = listOf(Manifest.permission.CAMERA)
+            checkPerm()
+        }
+        views.audio.setOnClickListener {
+            lastPermissions = listOf(Manifest.permission.RECORD_AUDIO)
+            checkPerm()
+        }
+        views.write.setOnClickListener {
+            lastPermissions = listOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            checkPerm()
+        }
+        views.read.setOnClickListener {
+            lastPermissions = listOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+            checkPerm()
+        }
+        views.contact.setOnClickListener {
+            lastPermissions = listOf(Manifest.permission.READ_CONTACTS)
+            checkPerm()
         }
     }
 
-    private val launcher = registerForPermissionsResult { allGranted ->
+    private fun checkPerm() {
+        if (checkPermissions(lastPermissions, this, launcher, R.string.debug_rationale)) {
+            Toast.makeText(this, "Already granted, sync call", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private val launcher = registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
             Toast.makeText(this, "All granted", Toast.LENGTH_SHORT).show()
         } else {
-            Toast.makeText(this, "Denied", Toast.LENGTH_SHORT).show()
+            if (deniedPermanently) {
+                Toast.makeText(this, "Denied forever", Toast.LENGTH_SHORT).show()
+            } else {
+                Toast.makeText(this, "Denied", Toast.LENGTH_SHORT).show()
+            }
         }
     }
 

--- a/vector/src/debug/java/im/vector/app/features/debug/DebugPermissionActivity.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/DebugPermissionActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 New Vector Ltd
+ * Copyright 2021 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import im.vector.app.R
 import im.vector.app.core.platform.VectorBaseActivity
-import im.vector.app.core.utils.PERMISSIONS_ALL
 import im.vector.app.core.utils.checkPermissions
 import im.vector.app.core.utils.onPermissionDeniedDialog
 import im.vector.app.core.utils.onPermissionDeniedSnackbar
@@ -38,6 +37,14 @@ class DebugPermissionActivity : VectorBaseActivity<ActivityDebugPermissionBindin
 
     override fun getCoordinatorLayout() = views.coordinatorLayout
 
+    // For debug
+    private val allPermissions = listOf(
+            Manifest.permission.CAMERA,
+            Manifest.permission.RECORD_AUDIO,
+            Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            Manifest.permission.READ_EXTERNAL_STORAGE,
+            Manifest.permission.READ_CONTACTS)
+
     private var lastPermissions = emptyList<String>()
 
     override fun initUiAndData() {
@@ -49,6 +56,10 @@ class DebugPermissionActivity : VectorBaseActivity<ActivityDebugPermissionBindin
         }
         views.audio.setOnClickListener {
             lastPermissions = listOf(Manifest.permission.RECORD_AUDIO)
+            checkPerm()
+        }
+        views.cameraAudio.setOnClickListener {
+            lastPermissions = listOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)
             checkPerm()
         }
         views.write.setOnClickListener {
@@ -80,9 +91,9 @@ class DebugPermissionActivity : VectorBaseActivity<ActivityDebugPermissionBindin
             if (deniedPermanently) {
                 dialogOrSnackbar = !dialogOrSnackbar
                 if (dialogOrSnackbar) {
-                    onPermissionDeniedDialog(R.string.denied_permission_camera)
+                    onPermissionDeniedDialog(R.string.denied_permission_generic)
                 } else {
-                    onPermissionDeniedSnackbar(R.string.denied_permission_camera)
+                    onPermissionDeniedSnackbar(R.string.denied_permission_generic)
                 }
             } else {
                 Toast.makeText(this, "Denied", Toast.LENGTH_SHORT).show()
@@ -103,9 +114,9 @@ class DebugPermissionActivity : VectorBaseActivity<ActivityDebugPermissionBindin
         return buildString {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 Timber.v("## debugPermission() : log the permissions status used by the app")
-                PERMISSIONS_ALL.forEach { permission ->
+                allPermissions.forEach { permission ->
                     append("[$permission] : ")
-                    if (PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(this@DebugPermissionActivity, permission)) {
+                    if (ContextCompat.checkSelfPermission(this@DebugPermissionActivity, permission) == PackageManager.PERMISSION_GRANTED) {
                         append("PERMISSION_GRANTED")
                     } else {
                         append("PERMISSION_DENIED")

--- a/vector/src/debug/res/layout/activity_debug_menu.xml
+++ b/vector/src/debug/res/layout/activity_debug_menu.xml
@@ -156,7 +156,7 @@
                 android:id="@+id/debug_permission"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Permission status" />
+                android:text="Permissions" />
 
         </LinearLayout>
 

--- a/vector/src/debug/res/layout/activity_debug_menu.xml
+++ b/vector/src/debug/res/layout/activity_debug_menu.xml
@@ -152,6 +152,12 @@
                 android:layout_height="200dp"
                 tools:src="@drawable/ic_qr_code_add" />
 
+            <Button
+                android:id="@+id/debug_permission"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Permission status" />
+
         </LinearLayout>
 
     </ScrollView>

--- a/vector/src/debug/res/layout/activity_debug_permission.xml
+++ b/vector/src/debug/res/layout/activity_debug_permission.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinatorLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".features.debug.DebugPermissionActivity"
+    tools:ignore="HardcodedText">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:divider="@drawable/linear_divider"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:padding="@dimen/layout_horizontal_margin"
+            android:showDividers="middle">
+
+            <TextView
+                android:id="@+id/status"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                tools:text="Status" />
+
+            <Button
+                android:id="@+id/camera"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Manifest.permission.CAMERA"
+                android:textAllCaps="false" />
+
+            <Button
+                android:id="@+id/audio"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Manifest.permission.RECORD_AUDIO"
+                android:textAllCaps="false" />
+
+            <Button
+                android:id="@+id/write"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Manifest.permission.WRITE_EXTERNAL_STORAGE"
+                android:textAllCaps="false" />
+
+            <Button
+                android:id="@+id/read"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Manifest.permission.READ_EXTERNAL_STORAGE"
+                android:textAllCaps="false" />
+
+            <Button
+                android:id="@+id/contact"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Manifest.permission.READ_CONTACTS"
+                android:textAllCaps="false" />
+
+        </LinearLayout>
+
+    </ScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/vector/src/debug/res/layout/activity_debug_permission.xml
+++ b/vector/src/debug/res/layout/activity_debug_permission.xml
@@ -30,35 +30,42 @@
                 android:id="@+id/camera"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Manifest.permission.CAMERA"
+                android:text="CAMERA"
                 android:textAllCaps="false" />
 
             <Button
                 android:id="@+id/audio"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Manifest.permission.RECORD_AUDIO"
+                android:text="RECORD_AUDIO"
+                android:textAllCaps="false" />
+
+            <Button
+                android:id="@+id/camera_audio"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="CAMERA + RECORD_AUDIO"
                 android:textAllCaps="false" />
 
             <Button
                 android:id="@+id/write"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Manifest.permission.WRITE_EXTERNAL_STORAGE"
+                android:text="WRITE_EXTERNAL_STORAGE"
                 android:textAllCaps="false" />
 
             <Button
                 android:id="@+id/read"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Manifest.permission.READ_EXTERNAL_STORAGE"
+                android:text="READ_EXTERNAL_STORAGE"
                 android:textAllCaps="false" />
 
             <Button
                 android:id="@+id/contact"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Manifest.permission.READ_CONTACTS"
+                android:text="READ_CONTACTS"
                 android:textAllCaps="false" />
 
         </LinearLayout>

--- a/vector/src/debug/res/values/strings.xml
+++ b/vector/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="debug_rationale">Rationale!</string>
+</resources>

--- a/vector/src/main/java/im/vector/app/core/dialogs/GalleryOrCameraDialogHelper.kt
+++ b/vector/src/main/java/im/vector/app/core/dialogs/GalleryOrCameraDialogHelper.kt
@@ -29,6 +29,7 @@ import im.vector.app.core.extensions.registerStartForActivityResult
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.utils.PERMISSIONS_FOR_TAKING_PHOTO
 import im.vector.app.core.utils.checkPermissions
+import im.vector.app.core.utils.onPermissionDeniedDialog
 import im.vector.app.core.utils.registerForPermissionsResult
 import im.vector.app.features.media.createUCropWithDefaultSettings
 import im.vector.lib.multipicker.MultiPicker
@@ -55,9 +56,11 @@ class GalleryOrCameraDialogHelper(
 
     private val listener = fragment as? Listener ?: error("Fragment must implement GalleryOrCameraDialogHelper.Listener")
 
-    private val takePhotoPermissionActivityResultLauncher = fragment.registerForPermissionsResult { allGranted ->
+    private val takePhotoPermissionActivityResultLauncher = fragment.registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
             doOpenCamera()
+        } else if (deniedPermanently) {
+            activity.onPermissionDeniedDialog(R.string.denied_permission_camera)
         }
     }
 
@@ -116,7 +119,7 @@ class GalleryOrCameraDialogHelper(
 
     private fun onAvatarTypeSelected(type: Type) {
         when (type) {
-            Type.Camera ->
+            Type.Camera  ->
                 if (checkPermissions(PERMISSIONS_FOR_TAKING_PHOTO, activity, takePhotoPermissionActivityResultLauncher)) {
                     doOpenCamera()
                 }

--- a/vector/src/main/java/im/vector/app/core/platform/VectorBaseActivity.kt
+++ b/vector/src/main/java/im/vector/app/core/platform/VectorBaseActivity.kt
@@ -32,7 +32,6 @@ import androidx.annotation.MainThread
 import androidx.annotation.MenuRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
-import com.google.android.material.appbar.MaterialToolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
@@ -42,6 +41,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewbinding.ViewBinding
 import com.bumptech.glide.util.Util
+import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.snackbar.Snackbar
 import com.jakewharton.rxbinding3.view.clicks
 import im.vector.app.BuildConfig
@@ -82,14 +82,13 @@ import im.vector.app.receivers.DebugReceiver
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
-
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.failure.GlobalError
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import kotlin.system.measureTimeMillis
 
-abstract class VectorBaseActivity<VB: ViewBinding> : AppCompatActivity(), HasScreenInjector {
+abstract class VectorBaseActivity<VB : ViewBinding> : AppCompatActivity(), HasScreenInjector {
     /* ==========================================================================================
      * View
      * ========================================================================================== */
@@ -596,12 +595,19 @@ abstract class VectorBaseActivity<VB: ViewBinding> : AppCompatActivity(), HasScr
     }
 
     fun showSnackbar(message: String, @StringRes withActionTitle: Int?, action: (() -> Unit)?) {
-        getCoordinatorLayout()?.let {
-            Snackbar.make(it, message, Snackbar.LENGTH_LONG).apply {
+        val coordinatorLayout = getCoordinatorLayout()
+        if (coordinatorLayout != null) {
+            Snackbar.make(coordinatorLayout, message, Snackbar.LENGTH_LONG).apply {
                 withActionTitle?.let {
-                    setAction(withActionTitle, { action?.invoke() })
+                    setAction(withActionTitle) { action?.invoke() }
                 }
             }.show()
+        } else {
+            if (vectorPreferences.failFast()) {
+                error("No CoordinatorLayout to display this snackbar!")
+            } else {
+                Timber.w("No CoordinatorLayout to display this snackbar!")
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/core/utils/PermissionsTools.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/PermissionsTools.kt
@@ -18,7 +18,6 @@ package im.vector.app.core.utils
 
 import android.Manifest
 import android.app.Activity
-import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import android.widget.Toast
@@ -45,30 +44,13 @@ val PERMISSIONS_FOR_PICKING_CONTACT = listOf(Manifest.permission.READ_CONTACTS)
 
 val PERMISSIONS_EMPTY = emptyList<String>()
 
-/**
- * Log the used permissions statuses.
- */
-fun logPermissionStatuses(context: Context) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        val permissions = listOf(
-                Manifest.permission.CAMERA,
-                Manifest.permission.RECORD_AUDIO,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                Manifest.permission.READ_EXTERNAL_STORAGE,
-                Manifest.permission.READ_CONTACTS)
-
-        Timber.v("## logPermissionStatuses() : log the permissions status used by the app")
-
-        for (permission in permissions) {
-            Timber.v(("Status of [$permission] : " +
-                    if (PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(context, permission)) {
-                        "PERMISSION_GRANTED"
-                    } else {
-                        "PERMISSION_DENIED"
-                    }))
-        }
-    }
-}
+// For debug
+val PERMISSIONS_ALL = listOf(
+        Manifest.permission.CAMERA,
+        Manifest.permission.RECORD_AUDIO,
+        Manifest.permission.WRITE_EXTERNAL_STORAGE,
+        Manifest.permission.READ_EXTERNAL_STORAGE,
+        Manifest.permission.READ_CONTACTS)
 
 fun ComponentActivity.registerForPermissionsResult(allGranted: (Boolean) -> Unit): ActivityResultLauncher<Array<String>> {
     return registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->

--- a/vector/src/main/java/im/vector/app/core/utils/PermissionsTools.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/PermissionsTools.kt
@@ -42,14 +42,6 @@ val PERMISSIONS_FOR_PICKING_CONTACT = listOf(Manifest.permission.READ_CONTACTS)
 
 val PERMISSIONS_EMPTY = emptyList<String>()
 
-// For debug
-val PERMISSIONS_ALL = listOf(
-        Manifest.permission.CAMERA,
-        Manifest.permission.RECORD_AUDIO,
-        Manifest.permission.WRITE_EXTERNAL_STORAGE,
-        Manifest.permission.READ_EXTERNAL_STORAGE,
-        Manifest.permission.READ_CONTACTS)
-
 // This is not ideal to store the value like that, but it works
 private var permissionDialogDisplayed = false
 
@@ -62,40 +54,31 @@ private var permissionDialogDisplayed = false
 fun ComponentActivity.registerForPermissionsResult(lambda: (allGranted: Boolean, deniedPermanently: Boolean) -> Unit)
         : ActivityResultLauncher<Array<String>> {
     return registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
-        if (result.keys.all { result[it] == true }) {
-            lambda(true, /* not used */ false)
-        } else {
-            if (permissionDialogDisplayed) {
-                // A permission dialog has been displayed, so even if the user has checked the do not ask again button, we do
-                // not tell the user to open the app settings
-                lambda(false, false)
-            } else {
-                // No dialog has been displayed, so tell the user to go to the system setting
-                lambda(false, true)
-            }
-        }
-        // Reset
-        permissionDialogDisplayed = false
+        onPermissionResult(result, lambda)
     }
 }
 
 fun Fragment.registerForPermissionsResult(lambda: (allGranted: Boolean, deniedPermanently: Boolean) -> Unit): ActivityResultLauncher<Array<String>> {
     return registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
-        if (result.keys.all { result[it] == true }) {
-            lambda(true, /* not used */ false)
-        } else {
-            if (permissionDialogDisplayed) {
-                // A permission dialog has been displayed, so even if the user has checked the do not ask again button, we do
-                // not tell the user to open the app settings
-                lambda(false, false)
-            } else {
-                // No dialog has been displayed, so tell the user to go to the system setting
-                lambda(false, true)
-            }
-        }
-        // Reset
-        permissionDialogDisplayed = false
+        onPermissionResult(result, lambda)
     }
+}
+
+private fun onPermissionResult(result: Map<String, Boolean>, lambda: (allGranted: Boolean, deniedPermanently: Boolean) -> Unit) {
+    if (result.keys.all { result[it] == true }) {
+        lambda(true, /* not used */ false)
+    } else {
+        if (permissionDialogDisplayed) {
+            // A permission dialog has been displayed, so even if the user has checked the do not ask again button, we do
+            // not tell the user to open the app settings
+            lambda(false, false)
+        } else {
+            // No dialog has been displayed, so tell the user to go to the system setting
+            lambda(false, true)
+        }
+    }
+    // Reset
+    permissionDialogDisplayed = false
 }
 
 /**

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorView.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorView.kt
@@ -206,7 +206,7 @@ class AttachmentTypeSelectorView(context: Context,
     /**
      * The all possible types to pick with their required permissions.
      */
-    enum class Type(val permissionsBit: Int) {
+    enum class Type(val permissions: List<String>) {
         CAMERA(PERMISSIONS_FOR_TAKING_PHOTO),
         GALLERY(PERMISSIONS_EMPTY),
         FILE(PERMISSIONS_EMPTY),

--- a/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
@@ -40,8 +40,8 @@ import im.vector.app.core.di.ScreenComponent
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.core.utils.PERMISSIONS_FOR_AUDIO_IP_CALL
 import im.vector.app.core.utils.PERMISSIONS_FOR_VIDEO_IP_CALL
-import im.vector.app.core.utils.allGranted
 import im.vector.app.core.utils.checkPermissions
+import im.vector.app.core.utils.registerForPermissionsResult
 import im.vector.app.databinding.ActivityCallBinding
 import im.vector.app.features.call.dialpad.CallDialPadBottomSheet
 import im.vector.app.features.call.dialpad.DialPadFragment
@@ -139,11 +139,11 @@ class VectorCallActivity : VectorBaseActivity<ActivityCallBinding>(), CallContro
                 .disposeOnDestroy()
 
         if (callArgs.isVideoCall) {
-            if (checkPermissions(PERMISSIONS_FOR_VIDEO_IP_CALL, this, CAPTURE_PERMISSION_REQUEST_CODE, R.string.permissions_rationale_msg_camera_and_audio)) {
+            if (checkPermissions(PERMISSIONS_FOR_VIDEO_IP_CALL, this, permissionCameraLauncher, R.string.permissions_rationale_msg_camera_and_audio)) {
                 start()
             }
         } else {
-            if (checkPermissions(PERMISSIONS_FOR_AUDIO_IP_CALL, this, CAPTURE_PERMISSION_REQUEST_CODE, R.string.permissions_rationale_msg_record_audio)) {
+            if (checkPermissions(PERMISSIONS_FOR_AUDIO_IP_CALL, this, permissionCameraLauncher, R.string.permissions_rationale_msg_record_audio)) {
                 start()
             }
         }
@@ -298,9 +298,8 @@ class VectorCallActivity : VectorBaseActivity<ActivityCallBinding>(), CallContro
         }
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == CAPTURE_PERMISSION_REQUEST_CODE && allGranted(grantResults)) {
+    private val permissionCameraLauncher = registerForPermissionsResult { allGranted ->
+        if (allGranted) {
             start()
         } else {
             // TODO display something
@@ -370,8 +369,6 @@ class VectorCallActivity : VectorBaseActivity<ActivityCallBinding>(), CallContro
     }
 
     companion object {
-
-        private const val CAPTURE_PERMISSION_REQUEST_CODE = 1
         private const val EXTRA_MODE = "EXTRA_MODE"
         private const val FRAGMENT_DIAL_PAD_TAG = "FRAGMENT_DIAL_PAD_TAG"
 

--- a/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
@@ -298,7 +298,7 @@ class VectorCallActivity : VectorBaseActivity<ActivityCallBinding>(), CallContro
         }
     }
 
-    private val permissionCameraLauncher = registerForPermissionsResult { allGranted ->
+    private val permissionCameraLauncher = registerForPermissionsResult { allGranted, _ ->
         if (allGranted) {
             start()
         } else {

--- a/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomActivity.kt
@@ -108,14 +108,14 @@ class CreateDirectRoomActivity : SimpleFragmentActivity(), UserListViewModel.Fac
     }
 
     private fun openAddByQrCode() {
-        if (checkPermissions(PERMISSIONS_FOR_TAKING_PHOTO, this, permissionCameraLauncher, 0)) {
+        if (checkPermissions(PERMISSIONS_FOR_TAKING_PHOTO, this, permissionCameraLauncher)) {
             addFragment(R.id.container, CreateDirectRoomByQrCodeFragment::class.java)
         }
     }
 
     private fun openPhoneBook() {
         // Check permission first
-        if (checkPermissions(PERMISSIONS_FOR_MEMBERS_SEARCH, this, permissionReadContactLauncher, 0)) {
+        if (checkPermissions(PERMISSIONS_FOR_MEMBERS_SEARCH, this, permissionReadContactLauncher)) {
             addFragmentToBackstack(R.id.container, ContactsBookFragment::class.java)
         }
     }

--- a/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomActivity.kt
@@ -120,18 +120,18 @@ class CreateDirectRoomActivity : SimpleFragmentActivity(), UserListViewModel.Fac
         }
     }
 
-    private val permissionReadContactLauncher = registerForPermissionsResult { allGranted ->
+    private val permissionReadContactLauncher = registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
             doOnPostResume { addFragmentToBackstack(R.id.container, ContactsBookFragment::class.java) }
-        } else {
+        } else if (deniedPermanently) {
             onPermissionDeniedSnackbar(R.string.permissions_denied_add_contact)
         }
     }
 
-    private val permissionCameraLauncher = registerForPermissionsResult { allGranted ->
+    private val permissionCameraLauncher = registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
             addFragment(R.id.container, CreateDirectRoomByQrCodeFragment::class.java)
-        } else {
+        } else if (deniedPermanently) {
             onPermissionDeniedSnackbar(R.string.permissions_denied_qr_code)
         }
     }

--- a/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomActivity.kt
@@ -38,11 +38,9 @@ import im.vector.app.core.platform.SimpleFragmentActivity
 import im.vector.app.core.platform.WaitingViewData
 import im.vector.app.core.utils.PERMISSIONS_FOR_MEMBERS_SEARCH
 import im.vector.app.core.utils.PERMISSIONS_FOR_TAKING_PHOTO
-import im.vector.app.core.utils.PERMISSION_REQUEST_CODE_LAUNCH_CAMERA
-import im.vector.app.core.utils.PERMISSION_REQUEST_CODE_READ_CONTACTS
-import im.vector.app.core.utils.allGranted
 import im.vector.app.core.utils.checkPermissions
 import im.vector.app.core.utils.onPermissionDeniedSnackbar
+import im.vector.app.core.utils.registerForPermissionsResult
 import im.vector.app.features.contactsbook.ContactsBookFragment
 import im.vector.app.features.contactsbook.ContactsBookViewModel
 import im.vector.app.features.contactsbook.ContactsBookViewState
@@ -52,7 +50,6 @@ import im.vector.app.features.userdirectory.UserListSharedAction
 import im.vector.app.features.userdirectory.UserListSharedActionViewModel
 import im.vector.app.features.userdirectory.UserListViewModel
 import im.vector.app.features.userdirectory.UserListViewState
-
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.session.room.failure.CreateRoomFailure
 import java.net.HttpURLConnection
@@ -111,35 +108,31 @@ class CreateDirectRoomActivity : SimpleFragmentActivity(), UserListViewModel.Fac
     }
 
     private fun openAddByQrCode() {
-        if (checkPermissions(PERMISSIONS_FOR_TAKING_PHOTO, this, PERMISSION_REQUEST_CODE_LAUNCH_CAMERA, 0)) {
+        if (checkPermissions(PERMISSIONS_FOR_TAKING_PHOTO, this, permissionCameraLauncher, 0)) {
             addFragment(R.id.container, CreateDirectRoomByQrCodeFragment::class.java)
         }
     }
 
     private fun openPhoneBook() {
         // Check permission first
-        if (checkPermissions(PERMISSIONS_FOR_MEMBERS_SEARCH,
-                        this,
-                        PERMISSION_REQUEST_CODE_READ_CONTACTS,
-                        0)) {
+        if (checkPermissions(PERMISSIONS_FOR_MEMBERS_SEARCH, this, permissionReadContactLauncher, 0)) {
             addFragmentToBackstack(R.id.container, ContactsBookFragment::class.java)
         }
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (allGranted(grantResults)) {
-            if (requestCode == PERMISSION_REQUEST_CODE_READ_CONTACTS) {
-                doOnPostResume { addFragmentToBackstack(R.id.container, ContactsBookFragment::class.java) }
-            } else if (requestCode == PERMISSION_REQUEST_CODE_LAUNCH_CAMERA) {
-                addFragment(R.id.container, CreateDirectRoomByQrCodeFragment::class.java)
-            }
+    private val permissionReadContactLauncher = registerForPermissionsResult { allGranted ->
+        if (allGranted) {
+            doOnPostResume { addFragmentToBackstack(R.id.container, ContactsBookFragment::class.java) }
         } else {
-            if (requestCode == PERMISSION_REQUEST_CODE_LAUNCH_CAMERA) {
-                onPermissionDeniedSnackbar(R.string.permissions_denied_qr_code)
-            } else if (requestCode == PERMISSION_REQUEST_CODE_READ_CONTACTS) {
-                onPermissionDeniedSnackbar(R.string.permissions_denied_add_contact)
-            }
+            onPermissionDeniedSnackbar(R.string.permissions_denied_add_contact)
+        }
+    }
+
+    private val permissionCameraLauncher = registerForPermissionsResult { allGranted ->
+        if (allGranted) {
+            addFragment(R.id.container, CreateDirectRoomByQrCodeFragment::class.java)
+        } else {
+            onPermissionDeniedSnackbar(R.string.permissions_denied_qr_code)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomByQrCodeFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomByQrCodeFragment.kt
@@ -27,6 +27,7 @@ import im.vector.app.core.extensions.hideKeyboard
 import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.core.utils.PERMISSIONS_FOR_TAKING_PHOTO
 import im.vector.app.core.utils.checkPermissions
+import im.vector.app.core.utils.onPermissionDeniedDialog
 import im.vector.app.core.utils.registerForPermissionsResult
 import im.vector.app.databinding.FragmentQrCodeScannerBinding
 import im.vector.app.features.userdirectory.PendingSelection
@@ -44,9 +45,11 @@ class CreateDirectRoomByQrCodeFragment @Inject constructor() : VectorBaseFragmen
         return FragmentQrCodeScannerBinding.inflate(inflater, container, false)
     }
 
-    private val openCameraActivityResultLauncher = registerForPermissionsResult { allGranted ->
+    private val openCameraActivityResultLauncher = registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
             startCamera()
+        } else if (deniedPermanently) {
+            activity?.onPermissionDeniedDialog(R.string.denied_permission_camera)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodFragment.kt
@@ -23,12 +23,14 @@ import android.view.ViewGroup
 import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.parentFragmentViewModel
 import com.airbnb.mvrx.withState
+import im.vector.app.R
 import im.vector.app.core.extensions.cleanup
 import im.vector.app.core.extensions.configureWith
 import im.vector.app.core.extensions.registerStartForActivityResult
 import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.core.utils.PERMISSIONS_FOR_TAKING_PHOTO
 import im.vector.app.core.utils.checkPermissions
+import im.vector.app.core.utils.onPermissionDeniedDialog
 import im.vector.app.core.utils.registerForPermissionsResult
 import im.vector.app.databinding.BottomSheetVerificationChildFragmentBinding
 import im.vector.app.features.crypto.verification.VerificationAction
@@ -79,9 +81,11 @@ class VerificationChooseMethodFragment @Inject constructor(
                 state.pendingRequest.invoke()?.transactionId ?: ""))
     }
 
-    private val openCameraActivityResultLauncher = registerForPermissionsResult { allGranted ->
+    private val openCameraActivityResultLauncher = registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
             doOpenQRCodeScanner()
+        } else if (deniedPermanently) {
+            activity?.onPermissionDeniedDialog(R.string.denied_permission_camera)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -1990,7 +1990,7 @@ class RoomDetailFragment @Inject constructor(
     }
 
     override fun onTypeSelected(type: AttachmentTypeSelectorView.Type) {
-        if (checkPermissions(type.permissionsBit, requireActivity(), typeSelectedActivityResultLauncher)) {
+        if (checkPermissions(type.permissions, requireActivity(), typeSelectedActivityResultLauncher)) {
             launchAttachmentProcess(type)
         } else {
             attachmentsHelper.pendingType = type

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -101,6 +101,7 @@ import im.vector.app.core.utils.copyToClipboard
 import im.vector.app.core.utils.createJSonViewerStyleProvider
 import im.vector.app.core.utils.createUIHandler
 import im.vector.app.core.utils.isValidUrl
+import im.vector.app.core.utils.onPermissionDeniedDialog
 import im.vector.app.core.utils.openUrlInExternalBrowser
 import im.vector.app.core.utils.registerForPermissionsResult
 import im.vector.app.core.utils.saveMedia
@@ -1062,14 +1063,16 @@ class RoomDetailFragment @Inject constructor(
         }
     }
 
-    private val startCallActivityResultLauncher = registerForPermissionsResult { allGranted ->
+    private val startCallActivityResultLauncher = registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
             (roomDetailViewModel.pendingAction as? RoomDetailAction.StartCall)?.let {
                 roomDetailViewModel.pendingAction = null
                 roomDetailViewModel.handle(it)
             }
         } else {
-            context?.toast(R.string.permissions_action_not_performed_missing_permissions)
+            if (deniedPermanently) {
+                activity?.onPermissionDeniedDialog(R.string.denied_permission_generic)
+            }
             cleanUpAfterPermissionNotGranted()
         }
     }
@@ -1738,13 +1741,16 @@ class RoomDetailFragment @Inject constructor(
         }
     }
 
-    private val saveActionActivityResultLauncher = registerForPermissionsResult { allGranted ->
+    private val saveActionActivityResultLauncher = registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
             sharedActionViewModel.pendingAction?.let {
                 handleActions(it)
                 sharedActionViewModel.pendingAction = null
             }
         } else {
+            if (deniedPermanently) {
+                activity?.onPermissionDeniedDialog(R.string.denied_permission_generic)
+            }
             cleanUpAfterPermissionNotGranted()
         }
     }
@@ -1977,7 +1983,7 @@ class RoomDetailFragment @Inject constructor(
 
 // AttachmentTypeSelectorView.Callback
 
-    private val typeSelectedActivityResultLauncher = registerForPermissionsResult { allGranted ->
+    private val typeSelectedActivityResultLauncher = registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
             val pendingType = attachmentsHelper.pendingType
             if (pendingType != null) {
@@ -1985,6 +1991,9 @@ class RoomDetailFragment @Inject constructor(
                 launchAttachmentProcess(pendingType)
             }
         } else {
+            if (deniedPermanently) {
+                activity?.onPermissionDeniedDialog(R.string.denied_permission_generic)
+            }
             cleanUpAfterPermissionNotGranted()
         }
     }

--- a/vector/src/main/java/im/vector/app/features/invite/InviteUsersToRoomActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/invite/InviteUsersToRoomActivity.kt
@@ -34,6 +34,7 @@ import im.vector.app.core.platform.SimpleFragmentActivity
 import im.vector.app.core.platform.WaitingViewData
 import im.vector.app.core.utils.PERMISSIONS_FOR_MEMBERS_SEARCH
 import im.vector.app.core.utils.checkPermissions
+import im.vector.app.core.utils.onPermissionDeniedSnackbar
 import im.vector.app.core.utils.registerForPermissionsResult
 import im.vector.app.core.utils.toast
 import im.vector.app.features.contactsbook.ContactsBookFragment
@@ -122,11 +123,11 @@ class InviteUsersToRoomActivity : SimpleFragmentActivity(), UserListViewModel.Fa
         }
     }
 
-    private val permissionContactLauncher = registerForPermissionsResult { allGranted ->
+    private val permissionContactLauncher = registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
             doOnPostResume { addFragmentToBackstack(R.id.container, ContactsBookFragment::class.java) }
-        } else {
-            Toast.makeText(baseContext, R.string.missing_permissions_error, Toast.LENGTH_SHORT).show()
+        } else if (deniedPermanently) {
+            onPermissionDeniedSnackbar(R.string.permissions_denied_add_contact)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/invite/InviteUsersToRoomActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/invite/InviteUsersToRoomActivity.kt
@@ -21,7 +21,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
-import android.widget.Toast
 import com.airbnb.mvrx.MvRx
 import com.airbnb.mvrx.viewModel
 import com.google.android.material.dialog.MaterialAlertDialogBuilder

--- a/vector/src/main/java/im/vector/app/features/invite/InviteUsersToRoomActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/invite/InviteUsersToRoomActivity.kt
@@ -33,9 +33,8 @@ import im.vector.app.core.extensions.addFragmentToBackstack
 import im.vector.app.core.platform.SimpleFragmentActivity
 import im.vector.app.core.platform.WaitingViewData
 import im.vector.app.core.utils.PERMISSIONS_FOR_MEMBERS_SEARCH
-import im.vector.app.core.utils.PERMISSION_REQUEST_CODE_READ_CONTACTS
-import im.vector.app.core.utils.allGranted
 import im.vector.app.core.utils.checkPermissions
+import im.vector.app.core.utils.registerForPermissionsResult
 import im.vector.app.core.utils.toast
 import im.vector.app.features.contactsbook.ContactsBookFragment
 import im.vector.app.features.contactsbook.ContactsBookViewModel
@@ -118,20 +117,14 @@ class InviteUsersToRoomActivity : SimpleFragmentActivity(), UserListViewModel.Fa
 
     private fun openPhoneBook() {
         // Check permission first
-        if (checkPermissions(PERMISSIONS_FOR_MEMBERS_SEARCH,
-                        this,
-                        PERMISSION_REQUEST_CODE_READ_CONTACTS,
-                        0)) {
+        if (checkPermissions(PERMISSIONS_FOR_MEMBERS_SEARCH, this, permissionContactLauncher)) {
             addFragmentToBackstack(R.id.container, ContactsBookFragment::class.java)
         }
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (allGranted(grantResults)) {
-            if (requestCode == PERMISSION_REQUEST_CODE_READ_CONTACTS) {
-                doOnPostResume { addFragmentToBackstack(R.id.container, ContactsBookFragment::class.java) }
-            }
+    private val permissionContactLauncher = registerForPermissionsResult { allGranted ->
+        if (allGranted) {
+            doOnPostResume { addFragmentToBackstack(R.id.container, ContactsBookFragment::class.java) }
         } else {
             Toast.makeText(baseContext, R.string.missing_permissions_error, Toast.LENGTH_SHORT).show()
         }

--- a/vector/src/main/java/im/vector/app/features/usercode/ScanUserCodeFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/usercode/ScanUserCodeFragment.kt
@@ -65,7 +65,7 @@ class ScanUserCodeFragment @Inject constructor()
         }
     }
 
-    private val openCameraActivityResultLauncher = registerForPermissionsResult { allGranted ->
+    private val openCameraActivityResultLauncher = registerForPermissionsResult { allGranted, _ ->
         if (allGranted) {
             startCamera()
         } else {

--- a/vector/src/main/java/im/vector/app/features/usercode/ScanUserCodeFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/usercode/ScanUserCodeFragment.kt
@@ -112,7 +112,7 @@ class ScanUserCodeFragment @Inject constructor()
         super.onResume()
         // Register ourselves as a handler for scan results.
         views.userCodeScannerView.setResultHandler(this)
-        if (PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA)) {
+        if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
             startCamera()
         }
     }

--- a/vector/src/main/java/im/vector/app/features/usercode/ShowUserCodeFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/usercode/ShowUserCodeFragment.kt
@@ -43,11 +43,11 @@ class ShowUserCodeFragment @Inject constructor(
 
     val sharedViewModel: UserCodeSharedViewModel by activityViewModel()
 
-    private val openCameraActivityResultLauncher = registerForPermissionsResult { allGranted ->
+    private val openCameraActivityResultLauncher = registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
             doOpenQRCodeScanner()
         } else {
-            sharedViewModel.handle(UserCodeActions.CameraPermissionNotGranted)
+            sharedViewModel.handle(UserCodeActions.CameraPermissionNotGranted(deniedPermanently))
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/usercode/UserCodeActions.kt
+++ b/vector/src/main/java/im/vector/app/features/usercode/UserCodeActions.kt
@@ -24,6 +24,6 @@ sealed class UserCodeActions : VectorViewModelAction {
     data class SwitchMode(val mode: UserCodeState.Mode) : UserCodeActions()
     data class DecodedQRCode(val code: String) : UserCodeActions()
     data class StartChattingWithUser(val matrixItem: MatrixItem) : UserCodeActions()
-    object CameraPermissionNotGranted : UserCodeActions()
+    data class CameraPermissionNotGranted(val deniedPermanently: Boolean) : UserCodeActions()
     object ShareByText : UserCodeActions()
 }

--- a/vector/src/main/java/im/vector/app/features/usercode/UserCodeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/usercode/UserCodeActivity.kt
@@ -81,13 +81,17 @@ class UserCodeActivity : VectorBaseActivity<ActivitySimpleBinding>(),
 
         sharedViewModel.observeViewEvents {
             when (it) {
-                UserCodeShareViewEvents.Dismiss                    -> ActivityCompat.finishAfterTransition(this)
-                UserCodeShareViewEvents.ShowWaitingScreen          -> views.simpleActivityWaitingView.isVisible = true
-                UserCodeShareViewEvents.HideWaitingScreen          -> views.simpleActivityWaitingView.isVisible = false
-                is UserCodeShareViewEvents.ToastMessage            -> Toast.makeText(this, it.message, Toast.LENGTH_LONG).show()
-                is UserCodeShareViewEvents.NavigateToRoom          -> navigator.openRoom(this, it.roomId)
-                UserCodeShareViewEvents.CameraPermissionNotGranted -> onPermissionDeniedSnackbar(R.string.permissions_denied_qr_code)
-                else                                               -> {
+                UserCodeShareViewEvents.Dismiss                       -> ActivityCompat.finishAfterTransition(this)
+                UserCodeShareViewEvents.ShowWaitingScreen             -> views.simpleActivityWaitingView.isVisible = true
+                UserCodeShareViewEvents.HideWaitingScreen             -> views.simpleActivityWaitingView.isVisible = false
+                is UserCodeShareViewEvents.ToastMessage               -> Toast.makeText(this, it.message, Toast.LENGTH_LONG).show()
+                is UserCodeShareViewEvents.NavigateToRoom             -> navigator.openRoom(this, it.roomId)
+                is UserCodeShareViewEvents.CameraPermissionNotGranted -> {
+                    if (it.deniedPermanently) {
+                        onPermissionDeniedSnackbar(R.string.permissions_denied_qr_code)
+                    }
+                }
+                else                                                  -> {
                 }
             }
         }

--- a/vector/src/main/java/im/vector/app/features/usercode/UserCodeShareViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/usercode/UserCodeShareViewEvents.kt
@@ -24,6 +24,6 @@ sealed class UserCodeShareViewEvents : VectorViewEvents {
     object HideWaitingScreen : UserCodeShareViewEvents()
     data class ToastMessage(val message: String) : UserCodeShareViewEvents()
     data class NavigateToRoom(val roomId: String) : UserCodeShareViewEvents()
-    object CameraPermissionNotGranted : UserCodeShareViewEvents()
+    data class CameraPermissionNotGranted(val deniedPermanently: Boolean) : UserCodeShareViewEvents()
     data class SharePlainText(val text: String, val title: String, val richPlainText: String) : UserCodeShareViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/usercode/UserCodeSharedViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/usercode/UserCodeSharedViewModel.kt
@@ -76,7 +76,7 @@ class UserCodeSharedViewModel @AssistedInject constructor(
             is UserCodeActions.SwitchMode -> setState { copy(mode = action.mode) }
             is UserCodeActions.DecodedQRCode -> handleQrCodeDecoded(action)
             is UserCodeActions.StartChattingWithUser -> handleStartChatting(action)
-            UserCodeActions.CameraPermissionNotGranted -> _viewEvents.post(UserCodeShareViewEvents.CameraPermissionNotGranted)
+            is UserCodeActions.CameraPermissionNotGranted -> _viewEvents.post(UserCodeShareViewEvents.CameraPermissionNotGranted(action.deniedPermanently))
             UserCodeActions.ShareByText -> handleShareByText()
         }
     }

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -386,12 +386,16 @@
     <string name="reset">Reset</string>
     <string name="start_chatting">Start Chatting</string>
 
+    <!-- Permissions denied forever -->
+    <string name="denied_permission_generic">Some permissions are missing to perform this action, please grant the permissions from the system settings.</string>
+    <string name="denied_permission_camera">To perform this action, please grant the Camera permission from the system settings.</string>
 
     <!-- First param will be replace by the value of ongoing_conference_call_voice, and second one by the value of ongoing_conference_call_video -->
     <string name="ongoing_conference_call">Ongoing conference call.\nJoin as %1$s or %2$s</string>
     <string name="ongoing_conference_call_voice">Voice</string>
     <string name="ongoing_conference_call_video">Video</string>
     <string name="cannot_start_call">Cannot start the call, please try later</string>
+    <string name="missing_permissions_title">Missing permissions</string>
     <string name="missing_permissions_warning">"Due to missing permissions, some features may be missing…</string>
     <string name="missing_permissions_error">"Due to missing permissions, this action is not possible.</string>
     <string name="missing_permissions_to_start_conf_call">You need permission to invite to start a conference in this room</string>


### PR DESCRIPTION
Especially better handling of the "denied forever" permission user story.

Add a new debug screen to play with permission request from the application.

so now when requesting permissions:
- already granted: sync call (no change on this part)
- not yet granted:
  - user give permission: async success
  - user denies: no more thing to do, the action is not performed
  - user denies and check `do not ask again`: no more thing to do, the action is not performed
- not yet granted, user has previously checked `do not ask again`:
  - a dialog or a snackbar is displayed to ask the user to open the system settings to grant the permission


https://user-images.githubusercontent.com/3940906/125365236-2caa4580-e374-11eb-9cf6-3d84c2f54885.mp4

