### PR TITLE
Standardise spelling and casing of homeserver, identity server, and integration manager

### DIFF
--- a/changelog.d/491.bugfix
+++ b/changelog.d/491.bugfix
@@ -1,0 +1,1 @@
+Standardise spelling and casing of homeserver, identity server, and integration manager.

--- a/docs/identity_server.md
+++ b/docs/identity_server.md
@@ -4,7 +4,7 @@ Issue: #607
 PR: #1354
 
 ## Introduction
-Identity Servers support contact discovery on Matrix by letting people look up Third Party Identifiers to see if the owner has publicly linked them with their Matrix ID.
+Identity servers support contact discovery on Matrix by letting people look up Third Party Identifiers to see if the owner has publicly linked them with their Matrix ID.
 
 ## Implementation
 
@@ -87,6 +87,6 @@ This screen displays the identity server configuration and the binding of the us
 This screen is a form to set a new identity server URL
 
 ## Ref:
-- https://matrix.org/blog/2019/09/27/privacy-improvements-in-synapse-1-4-and-riot-1-4 is a good summary of the role of an Identity server and the proper way to configure and use it in respect to the privacy and the consent of the user.
+- https://matrix.org/blog/2019/09/27/privacy-improvements-in-synapse-1-4-and-riot-1-4 is a good summary of the role of an identity server and the proper way to configure and use it in respect to the privacy and the consent of the user.
 - API documentation: https://matrix.org/docs/spec/identity_service/latest
 - vector.im TOS: https://vector.im/identity-server-privacy-notice

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -2,11 +2,11 @@ This document aims to describe how Element android displays notifications to the
 
 # Table of Contents
 1. [Prerequisites Knowledge](#prerequisites-knowledge)
-    * [How does a matrix client get a message from a Home Server?](#how-does-a-matrix-client-get-a-message-from-a-home-server)
+    * [How does a matrix client get a message from a homeserver?](#how-does-a-matrix-client-get-a-message-from-a-homeserver)
     * [How does a mobile app receives push notification?](#how-does-a-mobile-app-receives-push-notification)
     * [Push VS Notification](#push-vs-notification)
     * [Push in the matrix federated world](#push-in-the-matrix-federated-world)
-    * [How does the Home Server knows when to notify a client?](#how-does-the-home-server-knows-when-to-notify-a-client)
+    * [How does the homeserver know when to notify a client?](#how-does-the-homeserver-know-when-to-notify-a-client)
     * [Push vs privacy, and mitigation](#push-vs-privacy-and-mitigation)
     * [Background processing limitations](#background-processing-limitations)
 2. [Element Notification implementations](#element-notification-implementations)
@@ -22,9 +22,9 @@ First let's start with some prerequisite knowledge
 
 # Prerequisites Knowledge
 
-## How does a matrix client get a message from a Home Server?
+## How does a matrix client get a message from a homeserver?
 
-In order to get messages from a home server, a matrix client need to perform a ``sync`` operation.
+In order to get messages from a homeserver, a matrix client need to perform a ``sync`` operation.
 
 `To read events, the intended flow of operation is for clients to first call the /sync API without a since parameter. This returns the most recent message events for each room, as well as the state of the room at the start of the returned timeline. `
 
@@ -90,7 +90,7 @@ That means that Element Android, a matrix client created by New Vector, is using
 
 If you create your own matrix client, you will also need to deploy an instance of a **Push Gateway** with the credentials needed to use FCM for your app.
 
-On registration, a matrix client must tell to it's Home Server what Push Gateway to use.
+On registration, a matrix client must tell its homeserver what Push Gateway to use.
 
 See [Sygnal](https://github.com/matrix-org/sygnal/) for a reference implementation.
 ```
@@ -122,13 +122,13 @@ Recommended reading:
 * https://matrix.org/docs/spec/client_server/r0.4.0.html#id128
 
 
-## How does the Home Server knows when to notify a client?
+## How does the homeserver know when to notify a client?
 
 This is defined by [**push rules**](https://matrix.org/docs/spec/client_server/r0.4.0.html#push-rules-).
 
 `A push rule is a single rule that states under what conditions an event should be passed onto a push gateway and how the notification should be presented (sound / importance).`
 
-A Home Server can be configured with default rules (for Direct messages, group messages, mentions, etc.. ). 
+A homeserver can be configured with default rules (for Direct messages, group messages, mentions, etc.. ).
 
 There are different kind of push rules, it can be per room (each new message on this room should be notified), it can also define a pattern that a message should match (when you are mentioned, or key word based).
 
@@ -217,7 +217,7 @@ Homeserver ----> Sygnal ----> FCM ----> Element
 
 **Possible outcomes**
 
-Upon reception of the FCM push, Element will perform a sync call to the Home Server, during this process it is possible that:
+Upon reception of the FCM push, Element will perform a sync call to the homeserver, during this process it is possible that:
   * Happy path, the sync is performed, the message resolved and displayed in the notification drawer
   * The notified message is not in the sync. Can happen if a lot of things did happen since the push (`gappy sync`)
   * The sync generates additional notifications (e.g an encrypted message where the user is mentioned detected locally)

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -187,7 +187,7 @@ In background, and depending on wether push is available or not, Element will us
 
 ## Push (FCM) received in background 
 
-In order to enable Push, Element must first get a push token from the firebase SDK, then register a pusher with this token on the HomeServer.
+In order to enable Push, Element must first get a push token from the firebase SDK, then register a pusher with this token on the homeserver.
 
 When a message should be notified to a user,  the user's homeserver notifies the registered `push gateway` for Element, that is [sygnal](https://github.com/matrix-org/sygnal) _- The reference implementation for push gateways -_ hosted by matrix.org. 
 
@@ -199,7 +199,7 @@ Homeserver ----> Sygnal (configured for Element) ----> FCM ----> Element
 
 The push gateway is configured to only send  `(eventId,roomId)` in the push payload (for better [privacy](#push-vs-privacy-and-mitigation)).
 
-Element needs then to synchronise with the user's HomeServer, in order to resolve the event and create a notification.
+Element needs then to synchronise with the user's homeserver, in order to resolve the event and create a notification.
 
 As per [Google recommendation](https://android-developers.googleblog.com/2018/09/notifying-your-users-with-fcm.html), Element will then use the WorkManager API in order to trigger a background sync. 
 

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/CommonTestHelper.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/CommonTestHelper.kt
@@ -78,7 +78,7 @@ class CommonTestHelper(context: Context) {
     }
 
     /**
-     * Create a Home server configuration, with Http connection allowed for test
+     * Create a homeserver configuration, with Http connection allowed for test
      */
     fun createHomeServerConfig(): HomeServerConnectionConfig {
         return HomeServerConnectionConfig.Builder()

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/keysbackup/KeysBackupTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/keysbackup/KeysBackupTest.kt
@@ -816,7 +816,7 @@ class KeysBackupTest : InstrumentedTest {
         // - Do an e2e backup to the homeserver
         mKeysBackupTestHelper.prepareAndCreateKeysBackupData(keysBackup)
 
-        // Get key backup version from the home server
+        // Get key backup version from the homeserver
         val keysVersionResult = mTestHelper.doSync<KeysVersionResult?> {
             keysBackup.getCurrentVersion(it)
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/data/HomeServerConnectionConfig.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/data/HomeServerConnectionConfig.kt
@@ -73,14 +73,14 @@ data class HomeServerConnectionConfig(
          */
         fun withHomeServerUri(hsUri: Uri): Builder {
             if (hsUri.scheme != "http" && hsUri.scheme != "https") {
-                throw RuntimeException("Invalid home server URI: $hsUri")
+                throw RuntimeException("Invalid homeserver URI: $hsUri")
             }
             // ensure trailing /
             val hsString = hsUri.toString().ensureTrailingSlash()
             homeServerUri = try {
                 Uri.parse(hsString)
             } catch (e: Exception) {
-                throw RuntimeException("Invalid home server URI: $hsUri")
+                throw RuntimeException("Invalid homeserver URI: $hsUri")
             }
             return this
         }
@@ -138,7 +138,7 @@ data class HomeServerConnectionConfig(
         }
 
         /**
-         * Add an accepted TLS version for TLS connections with the home server.
+         * Add an accepted TLS version for TLS connections with the homeserver.
          *
          * @param tlsVersion the tls version to add to the set of TLS versions accepted.
          * @return this builder
@@ -160,7 +160,7 @@ data class HomeServerConnectionConfig(
         }
 
         /**
-         * Add a TLS cipher suite to the list of accepted TLS connections with the home server.
+         * Add a TLS cipher suite to the list of accepted TLS connections with the homeserver.
          *
          * @param tlsCipherSuite the tls cipher suite to add.
          * @return this builder

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/registration/RegistrationFlowResponse.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/registration/RegistrationFlowResponse.kt
@@ -38,7 +38,7 @@ data class RegistrationFlowResponse(
         val completedStages: List<String>? = null,
 
         /**
-         * The session identifier that the client must pass back to the home server, if one is provided,
+         * The session identifier that the client must pass back to the homeserver, if one is provided,
          * in subsequent attempts to authenticate in the same API call.
          */
         @Json(name = "session")

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/KeysBackupService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/KeysBackupService.kt
@@ -28,7 +28,7 @@ import org.matrix.android.sdk.internal.crypto.store.SavedKeyBackupKeyInfo
 
 interface KeysBackupService {
     /**
-     * Retrieve the current version of the backup from the home server
+     * Retrieve the current version of the backup from the homeserver
      *
      * It can be different than keysBackupVersion.
      * @param callback onSuccess(null) will be called if there is no backup on the server

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/KeysBackupState.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/KeysBackupState.kt
@@ -54,7 +54,7 @@ enum class KeysBackupState {
     // Need to check the current backup version on the homeserver
     Unknown,
 
-    // Checking if backup is enabled on home server
+    // Checking if backup is enabled on homeserver
     CheckingBackUpOnHomeserver,
 
     // Backup has been stopped because a new backup version has been detected on the homeserver

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
@@ -104,7 +104,7 @@ data class Event(
 
     /**
      * The `age` value transcoded in a timestamp based on the device clock when the SDK received
-     * the event from the home server.
+     * the event from the homeserver.
      * Unlike `age`, this value is static.
      */
     @Transient

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/SessionCreator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/SessionCreator.kt
@@ -38,7 +38,7 @@ internal class DefaultSessionCreator @Inject constructor(
 ) : SessionCreator {
 
     /**
-     * Credentials can affect the homeServerConnectionConfig, override home server url and/or
+     * Credentials can affect the homeServerConnectionConfig, override homeserver url and/or
      * identity server url if provided in the credentials
      */
     override suspend fun createSession(credentials: Credentials, homeServerConnectionConfig: HomeServerConnectionConfig): Session {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/MXDeviceInfo.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/MXDeviceInfo.kt
@@ -56,7 +56,7 @@ data class MXDeviceInfo(
         val signatures: Map<String, Map<String, String>>? = null,
 
         /*
-         * Additional data from the home server.
+         * Additional data from the homeserver.
          */
         @Json(name = "unsigned")
         val unsigned: JsonDict? = null,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/UserAccountDataEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/UserAccountDataEntity.kt
@@ -20,7 +20,7 @@ import io.realm.RealmObject
 import io.realm.annotations.Index
 
 /**
- * Clients can store custom config data for their account on their HomeServer.
+ * Clients can store custom config data for their account on their homeserver.
  * This account data will be synced between different devices and can persist across installations on a particular device.
  * Users may only view the account data for their own account.
  * The account_data may be either global or scoped to a particular rooms.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/legacy/riot/Credentials.java
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/legacy/riot/Credentials.java
@@ -41,7 +41,7 @@ public class Credentials {
 
     public String deviceId;
 
-    // Optional data that may contain info to override home server and/or identity server
+    // Optional data that may contain info to override homeserver and/or identity server
     public WellKnown wellKnown;
 
     public JSONObject toJson() throws JSONException {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/legacy/riot/HomeServerConnectionConfig.java
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/legacy/riot/HomeServerConnectionConfig.java
@@ -44,7 +44,7 @@ import timber.log.Timber;
  */
 public class HomeServerConnectionConfig {
 
-    // the home server URI
+    // the homeserver URI
     private Uri mHomeServerUri;
     // the jitsi server URI. Can be null
     @Nullable
@@ -82,7 +82,7 @@ public class HomeServerConnectionConfig {
     }
 
     /**
-     * Update the home server URI.
+     * Update the homeserver URI.
      *
      * @param uri the new HS uri
      */
@@ -91,7 +91,7 @@ public class HomeServerConnectionConfig {
     }
 
     /**
-     * @return the home server uri
+     * @return the homeserver uri
      */
     public Uri getHomeserverUri() {
         return mHomeServerUri;
@@ -145,7 +145,7 @@ public class HomeServerConnectionConfig {
     public void setCredentials(Credentials credentials) {
         mCredentials = credentials;
 
-        // Override home server url and/or identity server url if provided
+        // Override homeserver url and/or identity server url if provided
         if (credentials.wellKnown != null) {
             if (credentials.wellKnown.homeServer != null) {
                 String homeServerUrl = credentials.wellKnown.homeServer.baseURL;
@@ -200,7 +200,7 @@ public class HomeServerConnectionConfig {
     }
 
     /**
-     * TLS versions accepted for TLS connections with the home server.
+     * TLS versions accepted for TLS connections with the homeserver.
      */
     @Nullable
     public List<TlsVersion> getAcceptedTlsVersions() {
@@ -208,7 +208,7 @@ public class HomeServerConnectionConfig {
     }
 
     /**
-     * TLS cipher suites accepted for TLS connections with the home server.
+     * TLS cipher suites accepted for TLS connections with the homeserver.
      */
     @Nullable
     public List<CipherSuite> getAcceptedTlsCipherSuites() {
@@ -426,7 +426,7 @@ public class HomeServerConnectionConfig {
          */
         public Builder withHomeServerUri(final Uri homeServerUri) {
             if (homeServerUri == null || (!"http".equals(homeServerUri.getScheme()) && !"https".equals(homeServerUri.getScheme()))) {
-                throw new RuntimeException("Invalid home server URI: " + homeServerUri);
+                throw new RuntimeException("Invalid homeserver URI: " + homeServerUri);
             }
 
             // remove trailing /
@@ -435,7 +435,7 @@ public class HomeServerConnectionConfig {
                     String url = homeServerUri.toString();
                     mHomeServerConnectionConfig.mHomeServerUri = Uri.parse(url.substring(0, url.length() - 1));
                 } catch (Exception e) {
-                    throw new RuntimeException("Invalid home server URI: " + homeServerUri);
+                    throw new RuntimeException("Invalid homeserver URI: " + homeServerUri);
                 }
             } else {
                 mHomeServerConnectionConfig.mHomeServerUri = homeServerUri;
@@ -549,7 +549,7 @@ public class HomeServerConnectionConfig {
         }
 
         /**
-         * Add an accepted TLS version for TLS connections with the home server.
+         * Add an accepted TLS version for TLS connections with the homeserver.
          *
          * @param tlsVersion the tls version to add to the set of TLS versions accepted.
          * @return this builder
@@ -577,7 +577,7 @@ public class HomeServerConnectionConfig {
         }
 
         /**
-         * Add a TLS cipher suite to the list of accepted TLS connections with the home server.
+         * Add a TLS cipher suite to the list of accepted TLS connections with the homeserver.
          *
          * @param tlsCipherSuite the tls cipher suite to add.
          * @return this builder
@@ -666,7 +666,7 @@ public class HomeServerConnectionConfig {
         public HomeServerConnectionConfig build() {
             // Check mandatory parameters
             if (mHomeServerConnectionConfig.mHomeServerUri == null) {
-                throw new RuntimeException("Home server URI not set");
+                throw new RuntimeException("Homeserver URI not set");
             }
 
             return mHomeServerConnectionConfig;

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/legacy/riot/LoginStorage.java
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/legacy/riot/LoginStorage.java
@@ -38,7 +38,7 @@ import timber.log.Timber;
 public class LoginStorage {
     private static final String PREFS_LOGIN = "Vector.LoginStorage";
 
-    // multi accounts + home server config
+    // multi accounts + homeserver config
     private static final String PREFS_KEY_CONNECTION_CONFIGS = "PREFS_KEY_CONNECTION_CONFIGS";
 
     private final Context mContext;
@@ -49,7 +49,7 @@ public class LoginStorage {
     }
 
     /**
-     * @return the list of home server configurations.
+     * @return the list of homeserver configurations.
      */
     public List<HomeServerConnectionConfig> getCredentialsList() {
         SharedPreferences prefs = mContext.getSharedPreferences(PREFS_LOGIN, Context.MODE_PRIVATE);
@@ -85,7 +85,7 @@ public class LoginStorage {
     /**
      * Add a credentials to the credentials list
      *
-     * @param config the home server config to add.
+     * @param config the homeserver config to add.
      */
     public void addCredentials(HomeServerConnectionConfig config) {
         if (null != config && config.getCredentials() != null) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/DefaultIdentityService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/DefaultIdentityService.kt
@@ -241,7 +241,7 @@ internal class DefaultIdentityService @Inject constructor(
 
     override suspend fun getShareStatus(threePids: List<ThreePid>): Map<ThreePid, SharedState> {
         // Note: we do not require user consent here, because it is used for emails and phone numbers that the user has already sent
-        // to the home server, and not emails and phone numbers from the contact book of the user
+        // to the homeserver, and not emails and phone numbers from the contact book of the user
 
         if (threePids.isEmpty()) {
             return emptyMap()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/DefaultIdentityService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/DefaultIdentityService.kt
@@ -191,7 +191,7 @@ internal class DefaultIdentityService @Inject constructor(
         } else {
             // Disconnect previous one if any, first, because the token will change.
             // In case of error when configuring the new identity server, this is not a big deal,
-            // we will ask for a new token on the previous Identity server
+            // we will ask for a new token on the previous identity server
             runCatching { identityDisconnectTask.execute(Unit) }
                     .onFailure { Timber.w(it, "Unable to disconnect identity server") }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/IdentityAuthAPI.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/IdentityAuthAPI.kt
@@ -42,7 +42,7 @@ internal interface IdentityAuthAPI {
     suspend fun ping()
 
     /**
-     * Ping v1 will be used to check outdated Identity server
+     * Ping v1 will be used to check outdated identity server
      */
     @GET("_matrix/identity/api/v1")
     suspend fun pingV1()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/integrationmanager/IntegrationManager.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/integrationmanager/IntegrationManager.kt
@@ -44,7 +44,7 @@ import javax.inject.Inject
 /**
  * The integration manager allows to
  *  - Get the Integration Manager that a user has explicitly set for its account (via account data)
- *  - Get the recommended/preferred Integration Manager list as defined by the HomeServer (via wellknown)
+ *  - Get the recommended/preferred Integration Manager list as defined by the homeserver (via wellknown)
  *  - Check if the user has disabled the integration manager feature
  *  - Allow / Disallow Integration manager (propagated to other riot clients)
  *

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/integrationmanager/IntegrationManager.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/integrationmanager/IntegrationManager.kt
@@ -43,8 +43,8 @@ import javax.inject.Inject
 
 /**
  * The integration manager allows to
- *  - Get the Integration Manager that a user has explicitly set for its account (via account data)
- *  - Get the recommended/preferred Integration Manager list as defined by the homeserver (via wellknown)
+ *  - Get the integration manager that a user has explicitly set for its account (via account data)
+ *  - Get the recommended/preferred integration manager list as defined by the homeserver (via wellknown)
  *  - Check if the user has disabled the integration manager feature
  *  - Allow / Disallow Integration manager (propagated to other riot clients)
  *

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/profile/ProfileAPI.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/profile/ProfileAPI.kt
@@ -86,7 +86,7 @@ internal interface ProfileAPI {
     suspend fun addMsisdn(@Body body: AddMsisdnBody): AddMsisdnResponse
 
     /**
-     * Validate Msisdn code (same model than for Identity server API)
+     * Validate Msisdn code (same model than for identity server API)
      */
     @POST
     suspend fun validateMsisdn(@Url url: String,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomBodyBuilder.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomBodyBuilder.kt
@@ -59,7 +59,7 @@ internal class CreateRoomBodyBuilder @Inject constructor(
         val invite3pids = params.invite3pids
                 .takeIf { it.isNotEmpty() }
                 ?.let { invites ->
-                    // This can throw Exception if Identity server is not configured
+                    // This can throw an exception if identity server is not configured
                     ensureIdentityTokenTask.execute(Unit)
 
                     val identityServerUrlWithoutProtocol = identityStore.getIdentityServerUrlWithoutProtocol()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/queue/EventSenderProcessorCoroutine.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/queue/EventSenderProcessorCoroutine.kt
@@ -46,7 +46,7 @@ private const val MAX_RETRY_COUNT = 3
 
 /**
  * This class is responsible for sending events in order in each room. It uses the QueuedTask.queueIdentifier to execute tasks sequentially.
- * Each send is retried 3 times, if there is no network (e.g if cannot ping home server) it will wait and
+ * Each send is retried 3 times, if there is no network (e.g if cannot ping homeserver) it will wait and
  * periodically test reachability before resume (does not count as a retry)
  *
  * If the app is killed before all event were sent, on next wakeup the scheduled events will be re posted

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/queue/EventSenderProcessorThread.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/queue/EventSenderProcessorThread.kt
@@ -42,7 +42,7 @@ import kotlin.concurrent.schedule
 
 /**
  * A simple ever running thread unique for that session responsible of sending events in order.
- * Each send is retried 3 times, if there is no network (e.g if cannot ping home server) it will wait and
+ * Each send is retried 3 times, if there is no network (e.g if cannot ping homeserver) it will wait and
  * periodically test reachability before resume (does not count as a retry)
  *
  * If the app is killed before all event were sent, on next wakeup the scheduled events will be re posted

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncTask.kt
@@ -94,7 +94,7 @@ internal class DefaultSyncTask @Inject constructor(
             userStore.createOrUpdate(userId)
             initialSyncProgressService.startRoot(InitSyncStep.ImportingAccount, 100)
         }
-        // Maybe refresh the home server capabilities data we know
+        // Maybe refresh the homeserver capabilities data we know
         getHomeServerCapabilitiesTask.execute(GetHomeServerCapabilitiesTask.Params(forceRefresh = false))
 
         val readTimeOut = (params.timeout + TIMEOUT_MARGIN).coerceAtLeast(TimeOutInterceptor.DEFAULT_LONG_TIMEOUT)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/wellknown/GetWellknownTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/wellknown/GetWellknownTask.kt
@@ -130,7 +130,7 @@ internal class DefaultGetWellknownTask @Inject constructor(
     }
 
     /**
-     * Return true if home server is valid, and (if applicable) if identity server is pingable
+     * Return true if homeserver is valid, and (if applicable) if identity server is pingable
      */
     private suspend fun validateHomeServer(homeServerBaseUrl: String, wellKnown: WellKnown, client: OkHttpClient): WellknownResult {
         val capabilitiesAPI = retrofitFactory.create(client, homeServerBaseUrl)
@@ -186,7 +186,7 @@ internal class DefaultGetWellknownTask @Inject constructor(
     }
 
     /**
-     * Try to get an identity server URL from a home server URL, using a .wellknown request
+     * Try to get an identity server URL from a homeserver URL, using a .wellknown request
      */
     /*
     fun getIdentityServer(homeServerUrl: String, callback: ApiCallback<String?>) {

--- a/matrix-sdk-android/src/main/java/org/matrix/androidsdk/crypto/data/MXDeviceInfo.java
+++ b/matrix-sdk-android/src/main/java/org/matrix/androidsdk/crypto/data/MXDeviceInfo.java
@@ -66,7 +66,7 @@ public class MXDeviceInfo implements Serializable {
     public Map<String, Map<String, String>> signatures;
 
     /*
-     * Additional data from the home server.
+     * Additional data from the homeserver.
      */
     public Map<String, Object> unsigned;
 

--- a/vector/src/androidTest/java/im/vector/app/RegistrationTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/RegistrationTest.kt
@@ -57,7 +57,7 @@ class RegistrationTest {
         onView(withId(R.id.loginSplashSubmit))
                 .perform(click())
 
-        // Check that home server options are shown
+        // Check that homeserver options are shown
         onView(withId(R.id.loginServerTitle))
                 .check(matches(isDisplayed()))
                 .check(matches(withText(R.string.login_server_title)))

--- a/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -486,7 +486,7 @@ class UiAllScreensSanityTest {
         clickOn(R.string.add_identity_server)
         pressBack()
         pressBack()
-        // Home server
+        // Homeserver
         clickOnPreference(R.string.settings_home_server)
         pressBack()
         // Identity server

--- a/vector/src/main/java/im/vector/app/features/homeserver/ServerUrlsRepository.kt
+++ b/vector/src/main/java/im/vector/app/features/homeserver/ServerUrlsRepository.kt
@@ -30,7 +30,7 @@ object ServerUrlsRepository {
     private const val DEFAULT_REFERRER_HOME_SERVER_URL_PREF = "default_referrer_home_server_url"
     private const val DEFAULT_REFERRER_IDENTITY_SERVER_URL_PREF = "default_referrer_identity_server_url"
 
-    // Keys used to store current home server url and identity url
+    // Keys used to store current homeserver url and identity url
     const val HOME_SERVER_URL_PREF = "home_server_url"
     const val IDENTITY_SERVER_URL_PREF = "identity_server_url"
 
@@ -62,7 +62,7 @@ object ServerUrlsRepository {
     }
 
     /**
-     * Return last used home server url, or the default one from referrer or the default one from resources
+     * Return last used homeserver url, or the default one from referrer or the default one from resources
      */
     fun getLastHomeServerUrl(context: Context): String {
         val prefs = DefaultSharedPreferences.getInstance(context)
@@ -73,12 +73,12 @@ object ServerUrlsRepository {
     }
 
     /**
-     * Return true if url is the default home server url form resources
+     * Return true if url is the default homeserver url form resources
      */
     fun isDefaultHomeServerUrl(context: Context, url: String) = url == getDefaultHomeServerUrl(context)
 
     /**
-     * Return default home server url from resources
+     * Return default homeserver url from resources
      */
     fun getDefaultHomeServerUrl(context: Context): String = context.getString(R.string.matrix_org_server_url)
 }

--- a/vector/src/main/java/im/vector/app/features/link/LinkHandlerActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/link/LinkHandlerActivity.kt
@@ -122,7 +122,7 @@ class LinkHandlerActivity : VectorBaseActivity<ActivityProgressBinding>() {
     }
 
     /**
-     * Start the login screen with identity server and home server pre-filled
+     * Start the login screen with identity server and homeserver pre-filled
      */
     private fun startLoginActivity(uri: Uri) {
         navigator.openLogin(

--- a/vector/src/main/java/im/vector/app/features/login/LoginServerUrlFormFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginServerUrlFormFragment.kt
@@ -159,7 +159,7 @@ class LoginServerUrlFormFragment @Inject constructor() : AbstractLoginFragment<F
         views.loginServerUrlFormClearHistory.isInvisible = state.knownCustomHomeServersUrls.isEmpty()
 
         if (state.loginMode != LoginMode.Unknown) {
-            // The home server url is valid
+            // The homeserver url is valid
             loginViewModel.handle(LoginAction.PostViewEvent(LoginViewEvents.OnLoginFlowRetrieved))
         }
     }

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
@@ -567,7 +567,7 @@ class LoginViewModel @AssistedInject constructor(
                 is WellknownResult.Prompt     ->
                     onWellknownSuccess(action, data, homeServerConnectionConfig)
                 is WellknownResult.FailPrompt ->
-                    // Relax on IS discovery if home server is valid
+                    // Relax on IS discovery if homeserver is valid
                     if (data.homeServerUrl != null && data.wellKnown != null) {
                         onWellknownSuccess(action, WellknownResult.Prompt(data.homeServerUrl!!, null, data.wellKnown!!), homeServerConnectionConfig)
                     } else {

--- a/vector/src/main/java/im/vector/app/features/login2/LoginViewModel2.kt
+++ b/vector/src/main/java/im/vector/app/features/login2/LoginViewModel2.kt
@@ -590,7 +590,7 @@ class LoginViewModel2 @AssistedInject constructor(
                 is WellknownResult.Prompt          ->
                     onWellknownSuccess(action, data, homeServerConnectionConfig)
                 is WellknownResult.FailPrompt      ->
-                    // Relax on IS discovery if home server is valid
+                    // Relax on IS discovery if homeserver is valid
                     if (data.homeServerUrl != null && data.wellKnown != null) {
                         onWellknownSuccess(action, WellknownResult.Prompt(data.homeServerUrl!!, null, data.wellKnown!!), homeServerConnectionConfig)
                     } else {

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/RoomDirectoryData.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/RoomDirectoryData.kt
@@ -22,7 +22,7 @@ package im.vector.app.features.roomdirectory
 data class RoomDirectoryData(
         /**
          * The server name (might be null)
-         * Set null when the server is the current user's home server.
+         * Set null when the server is the current user's homeserver.
          */
         val homeServer: String? = null,
 

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/roompreview/RoomPreviewViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/roompreview/RoomPreviewViewState.kt
@@ -34,7 +34,7 @@ data class RoomPreviewViewState(
 
         val shouldPeekFromServer: Boolean = false,
         /**
-         * Can be empty when the server is the current user's home server.
+         * Can be empty when the server is the current user's homeserver.
          */
         val homeServers: List<String> = emptyList(),
         // Current state of the room in preview

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -273,7 +273,7 @@ class VectorPreferences @Inject constructor(private val context: Context) {
     fun clearPreferences() {
         val keysToKeep = HashSet(mKeysToKeepAfterLogout)
 
-        // home server urls
+        // homeserver urls
         keysToKeep.add(ServerUrlsRepository.HOME_SERVER_URL_PREF)
         keysToKeep.add(ServerUrlsRepository.IDENTITY_SERVER_URL_PREF)
 

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsGeneralFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsGeneralFragment.kt
@@ -179,7 +179,7 @@ class VectorSettingsGeneralFragment @Inject constructor(
         findPreference<VectorPreference>(VectorPreferences.SETTINGS_LOGGED_IN_PREFERENCE_KEY)!!
                 .summary = session.myUserId
 
-        // home server
+        // homeserver
         findPreference<VectorPreference>(VectorPreferences.SETTINGS_HOME_SERVER_PREFERENCE_KEY)!!
                 .summary = session.sessionParams.homeServerUrl
 

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsNotificationPreferenceFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsNotificationPreferenceFragment.kt
@@ -64,7 +64,7 @@ class VectorSettingsNotificationPreferenceFragment @Inject constructor(
                     .find { it.ruleId == RuleIds.RULE_ID_DISABLE_ALL }
 
             if (mRuleMaster == null) {
-                // The home server does not support RULE_ID_DISABLE_ALL, so hide the preference
+                // The homeserver does not support RULE_ID_DISABLE_ALL, so hide the preference
                 pref.isVisible = false
                 return
             }

--- a/vector/src/main/java/im/vector/app/features/webview/ConsentWebViewEventListener.kt
+++ b/vector/src/main/java/im/vector/app/features/webview/ConsentWebViewEventListener.kt
@@ -58,7 +58,7 @@ class ConsentWebViewEventListener(activity: VectorBaseActivity<*>,
                 session.profileApiClient
                         .displayname(RIOT_BOT_ID, object : MatrixCallback<String>(createRiotBotRoomCallback) {
                             override fun onSuccess(info: String?) {
-                                // Ok, the Home Server knows riot-Bot, so create a Room with him
+                                // Ok, the homeserver knows riot-Bot, so create a Room with him
                                 session.createDirectMessageRoom(RIOT_BOT_ID, createRiotBotRoomCallback)
                             }
                         })

--- a/vector/src/main/res/layout/dialog_ssl_fingerprint.xml
+++ b/vector/src/main/res/layout/dialog_ssl_fingerprint.xml
@@ -33,7 +33,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="6dp"
-            tools:text="Home Server URL: http://matrix.org" />
+            tools:text="Homeserver URL: http://matrix.org" />
 
         <TextView
             android:id="@+id/ssl_fingerprint_title"

--- a/vector/src/main/res/layout/item_tos.xml
+++ b/vector/src/main/res/layout/item_tos.xml
@@ -26,7 +26,7 @@
         app:layout_constraintEnd_toStartOf="@id/term_policy_arrow"
         app:layout_constraintStart_toEndOf="@id/term_accept_checkbox"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="Integration Manager" />
+        tools:text="Integration manager" />
 
     <TextView
         android:id="@+id/term_description"


### PR DESCRIPTION
This PR standardises the spelling and casing of the following terms, across the codebase, as per vector-im/element-android#491:

- homeserver
- identity server
- integration manager

While the issue mentions only user-visible text, this PR changes all instances of the terms, regardless of whether they're user-visible or not. I think there's value in standardising these terms even in non-user-visible text, so I went ahead and applied the changes to all text.

For reference, here's the script I used to find candidates for replacement: https://gist.github.com/psrpinto/b3787bae212d5d99649b517e2efd4dce

The same work has been done on element-web, in vector-im/element-web#17980