### PR TITLE
crypto: Don't use the transaction ID of the verification for the request

### DIFF
--- a/changelog.d/3589.bugfix
+++ b/changelog.d/3589.bugfix
@@ -1,0 +1,1 @@
+Don't use the transaction ID of the verification for the request

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/verification/VerificationTransportToDevice.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/verification/VerificationTransportToDevice.kt
@@ -68,7 +68,7 @@ internal class VerificationTransportToDevice(
             contentMap.setObject(otherUserId, it, keyReq)
         }
         sendToDeviceTask
-                .configureWith(SendToDeviceTask.Params(MessageType.MSGTYPE_VERIFICATION_REQUEST, contentMap, localId)) {
+                .configureWith(SendToDeviceTask.Params(MessageType.MSGTYPE_VERIFICATION_REQUEST, contentMap)) {
                     this.callback = object : MatrixCallback<Unit> {
                         override fun onSuccess(data: Unit) {
                             Timber.v("## verification [$tx.transactionId] send toDevice request success")
@@ -124,7 +124,7 @@ internal class VerificationTransportToDevice(
         contentMap.setObject(tx.otherUserId, tx.otherDeviceId, toSendToDeviceObject)
 
         sendToDeviceTask
-                .configureWith(SendToDeviceTask.Params(type, contentMap, tx.transactionId)) {
+                .configureWith(SendToDeviceTask.Params(type, contentMap)) {
                     this.callback = object : MatrixCallback<Unit> {
                         override fun onSuccess(data: Unit) {
                             Timber.v("## SAS verification [$tx.transactionId] toDevice type '$type' success.")
@@ -155,7 +155,7 @@ internal class VerificationTransportToDevice(
         val contentMap = MXUsersDevicesMap<Any>()
         contentMap.setObject(otherUserId, otherUserDeviceId, cancelMessage)
         sendToDeviceTask
-                .configureWith(SendToDeviceTask.Params(EventType.KEY_VERIFICATION_DONE, contentMap, transactionId)) {
+                .configureWith(SendToDeviceTask.Params(EventType.KEY_VERIFICATION_DONE, contentMap)) {
                     this.callback = object : MatrixCallback<Unit> {
                         override fun onSuccess(data: Unit) {
                             onDone?.invoke()
@@ -176,7 +176,7 @@ internal class VerificationTransportToDevice(
         val contentMap = MXUsersDevicesMap<Any>()
         contentMap.setObject(otherUserId, otherUserDeviceId, cancelMessage)
         sendToDeviceTask
-                .configureWith(SendToDeviceTask.Params(EventType.KEY_VERIFICATION_CANCEL, contentMap, transactionId)) {
+                .configureWith(SendToDeviceTask.Params(EventType.KEY_VERIFICATION_CANCEL, contentMap)) {
                     this.callback = object : MatrixCallback<Unit> {
                         override fun onSuccess(data: Unit) {
                             Timber.v("## SAS verification [$transactionId] canceled for reason ${code.value}")


### PR DESCRIPTION
Verification flows have something called a transaction id. This is a client-set custom ID that identifies the flow and is established by the first message that gets sent out. This transaction ID needs to be kept the
same and be part of all events that are sent during the verification flow.

To-device requests have something called a transaction id. This is a client-set custom ID that identifies a given request. It is used to ensure idempotency of requests, i.e. retrying to send a request won't result in two events being sent as long as the transaction id is kept the same.

This patch removes usage of the first type of transaction ID for the second use-case.

Before:
![before](https://user-images.githubusercontent.com/552026/126349466-6d35b6cf-eaa1-48cb-b299-5919e229cc45.png)
![before2](https://user-images.githubusercontent.com/552026/126349502-072f15b8-8624-4d5a-b878-93cea6b0c610.png)

After:
![after](https://user-images.githubusercontent.com/552026/126349532-e5d59886-6b3f-4e06-a65a-f2878f4fafde.png)

To be honest, I have no idea how that ever worked.

This closes: #3589.

Signed-off-by: Damir Jelić poljar@termina.org.uk

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
