### PR TITLE
Add initialState support to CreateRoomParams

### DIFF
--- a/changelog.d/3713.removal
+++ b/changelog.d/3713.removal
@@ -1,0 +1,1 @@
+Add initialState support to CreateRoomParams (#3713)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/create/CreateRoomParams.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/create/CreateRoomParams.kt
@@ -25,7 +25,6 @@ import org.matrix.android.sdk.api.session.room.model.RoomHistoryVisibility
 import org.matrix.android.sdk.api.session.room.model.RoomJoinRulesAllowEntry
 import org.matrix.android.sdk.internal.crypto.MXCRYPTO_ALGORITHM_MEGOLM
 
-// TODO Give a way to include other initial states
 open class CreateRoomParams {
     /**
      * A public visibility indicates that the room will be shown in the published room list.
@@ -102,6 +101,13 @@ open class CreateRoomParams {
      * Future versions of the specification may allow the server to clobber other keys.
      */
     val creationContent = mutableMapOf<String, Any>()
+
+    /**
+     * A list of state events to set in the new room. This allows the user to override the default state events
+     * set in the new room. The expected format of the state events are an object with type, state_key and content keys set.
+     * Takes precedence over events set by preset, but gets overridden by name and topic keys.
+     */
+    val initialStates = mutableListOf<CreateRoomStateEvent>()
 
     /**
      * Set to true to disable federation of this room.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/create/CreateRoomStateEvent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/create/CreateRoomStateEvent.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.api.session.room.model.create
+
+import org.matrix.android.sdk.api.session.events.model.Content
+
+data class CreateRoomStateEvent(
+        /**
+         * Required. The type of event to send.
+         */
+        val type: String,
+
+        /**
+         * Required. The content of the event.
+         */
+        val content: Content,
+
+        /**
+         * The state_key of the state event. Defaults to an empty string.
+         */
+        val stateKey: String = ""
+)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomBodyBuilder.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomBodyBuilder.kt
@@ -81,13 +81,14 @@ internal class CreateRoomBodyBuilder @Inject constructor(
             params.historyVisibility = params.historyVisibility ?: RoomHistoryVisibility.SHARED
             params.guestAccess = params.guestAccess ?: GuestAccess.Forbidden
         }
-        val initialStates = listOfNotNull(
+        val initialStates = (listOfNotNull(
                 buildEncryptionWithAlgorithmEvent(params),
                 buildHistoryVisibilityEvent(params),
                 buildAvatarEvent(params),
                 buildGuestAccess(params),
                 buildJoinRulesRestricted(params)
         )
+                + buildCustomInitialStates(params))
                 .takeIf { it.isNotEmpty() }
 
         return CreateRoomBody(
@@ -105,6 +106,16 @@ internal class CreateRoomBodyBuilder @Inject constructor(
                 roomVersion = params.roomVersion
 
         )
+    }
+
+    private fun buildCustomInitialStates(params: CreateRoomParams): List<Event> {
+        return params.initialStates.map {
+            Event(
+                    type = it.type,
+                    stateKey = it.stateKey,
+                    content = it.content
+            )
+        }
     }
 
     private suspend fun buildAvatarEvent(params: CreateRoomParams): Event? {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomBodyBuilder.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomBodyBuilder.kt
@@ -96,7 +96,7 @@ internal class CreateRoomBodyBuilder @Inject constructor(
                 roomAliasName = params.roomAliasName,
                 name = params.name,
                 topic = params.topic,
-                invitedUserIds = params.invitedUserIds.filter { it != userId },
+                invitedUserIds = params.invitedUserIds.filter { it != userId }.takeIf { it.isNotEmpty() },
                 invite3pids = invite3pids,
                 creationContent = params.creationContent.takeIf { it.isNotEmpty() },
                 initialStates = initialStates,
@@ -104,7 +104,6 @@ internal class CreateRoomBodyBuilder @Inject constructor(
                 isDirect = params.isDirect,
                 powerLevelContentOverride = params.powerLevelContentOverride,
                 roomVersion = params.roomVersion
-
         )
     }
 


### PR DESCRIPTION
Fixes #3713

Usage, for instance to set the room name (which can be done normally more simplier):

```kotlin
CreateRoomParams().apply {
    initialStates.add(CreateRoomStateEvent(
            EventType.STATE_ROOM_NAME,
            content = RoomNameContent(
                    name = state.roomName
            ).toContent()
    ))
}
```

Tested OK on my side, with temporary code. There is no dedicated test for room creation yet...