### PR TITLE
Fix a crash which can happen when user signs out.

### DIFF
--- a/changelog.d/3720.bugfix
+++ b/changelog.d/3720.bugfix
@@ -1,0 +1,1 @@
+Fix a crash which can happen when user signs out


### PR DESCRIPTION
The crypto DB has been deleted, and the key download request is cancelled, but in the catch block we tried to write to the deleted DB.

Tested OK on my device.