### PR TITLE
Ensure OTKs are uploaded when the session is created

### DIFF
--- a/changelog.d/3724.bugfix
+++ b/changelog.d/3724.bugfix
@@ -1,0 +1,1 @@
+Ensure OTKs are uploaded when the session is created

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -314,6 +314,12 @@ internal class DefaultCryptoService @Inject constructor(
         cryptoCoroutineScope.launchToCallback(coroutineDispatchers.crypto, NoOpMatrixCallback()) {
             // Open the store
             cryptoStore.open()
+
+            if (!cryptoStore.getDeviceKeysUploaded()) {
+                // Schedule upload of OTK
+                oneTimeKeysUploader.updateOneTimeKeyCount(0)
+            }
+
             // this can throw if no network
             tryOrNull {
                 uploadDeviceKeys()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -315,7 +315,7 @@ internal class DefaultCryptoService @Inject constructor(
             // Open the store
             cryptoStore.open()
 
-            if (!cryptoStore.getDeviceKeysUploaded()) {
+            if (!cryptoStore.areDeviceKeysUploaded()) {
                 // Schedule upload of OTK
                 oneTimeKeysUploader.updateOneTimeKeyCount(0)
             }
@@ -911,7 +911,7 @@ internal class DefaultCryptoService @Inject constructor(
      * Upload my user's device keys.
      */
     private suspend fun uploadDeviceKeys() {
-        if (cryptoStore.getDeviceKeysUploaded()) {
+        if (cryptoStore.areDeviceKeysUploaded()) {
             Timber.d("Keys already uploaded, nothing to do")
             return
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OneTimeKeysUploader.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OneTimeKeysUploader.kt
@@ -95,17 +95,15 @@ internal class OneTimeKeysUploader @Inject constructor(
             // private keys clogging up our local storage.
             // So we need some kind of engineering compromise to balance all of
             // these factors.
-            try {
+            tryOrNull {
                 val uploadedKeys = uploadOTK(oneTimeKeyCountFromSync, keyLimit)
                 Timber.v("## uploadKeys() : success, $uploadedKeys key(s) sent")
-            } finally {
-                oneTimeKeyCheckInProgress = false
             }
         } else {
             Timber.w("maybeUploadOneTimeKeys: waiting to know the number of OTK from the sync")
-            oneTimeKeyCheckInProgress = false
             lastOneTimeKeyCheck = 0
         }
+        oneTimeKeyCheckInProgress = false
     }
 
     private suspend fun fetchOtkNumber(): Int? {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OneTimeKeysUploader.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OneTimeKeysUploader.kt
@@ -80,7 +80,7 @@ internal class OneTimeKeysUploader @Inject constructor(
         val keyLimit = floor(maxOneTimeKeys / 2.0).toInt()
         if (oneTimeKeyCount == null) {
             // Ask the server how many otk he has
-            oneTimeKeyCount = fetchOtkNumber()
+            oneTimeKeyCount = fetchOtkCount()
         }
         val oneTimeKeyCountFromSync = oneTimeKeyCount
         if (oneTimeKeyCountFromSync != null) {
@@ -95,7 +95,7 @@ internal class OneTimeKeysUploader @Inject constructor(
             // private keys clogging up our local storage.
             // So we need some kind of engineering compromise to balance all of
             // these factors.
-            tryOrNull {
+            tryOrNull("Unable to upload OTK") {
                 val uploadedKeys = uploadOTK(oneTimeKeyCountFromSync, keyLimit)
                 Timber.v("## uploadKeys() : success, $uploadedKeys key(s) sent")
             }
@@ -106,8 +106,8 @@ internal class OneTimeKeysUploader @Inject constructor(
         oneTimeKeyCheckInProgress = false
     }
 
-    private suspend fun fetchOtkNumber(): Int? {
-        return tryOrNull {
+    private suspend fun fetchOtkCount(): Int? {
+        return tryOrNull("Unable to get OTK count") {
             val result = uploadKeysTask.execute(UploadKeysTask.Params(null, null))
             result.oneTimeKeyCountsForAlgorithm(MXKey.KEY_SIGNED_CURVE_25519_TYPE)
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
@@ -475,7 +475,7 @@ internal interface IMXCryptoStore {
     fun getGossipingEvents(): List<Event>
 
     fun setDeviceKeysUploaded(uploaded: Boolean)
-    fun getDeviceKeysUploaded(): Boolean
+    fun areDeviceKeysUploaded(): Boolean
     fun tidyUpDataBase()
     fun logDbUsageInfo()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -937,7 +937,7 @@ internal class RealmCryptoStore @Inject constructor(
         }
     }
 
-    override fun getDeviceKeysUploaded(): Boolean {
+    override fun areDeviceKeysUploaded(): Boolean {
         return doWithRealm(realmConfiguration) {
             it.where<CryptoMetadataEntity>().findFirst()?.deviceKeysSentToServer
         } ?: false


### PR DESCRIPTION
The sync response can omit the field `device_one_time_keys_count.signed_curve25519` and the SDK was waiting to know this value to eventually upload some OTKs, even after a session creation.

Now the SDK uploads the OTK when it uploads the device keys.

This is due to recent change on Synapse sync response: https://github.com/matrix-org/synapse/pull/10214/files/7978990f5139067e1868d100d223e28e4447d2fb#diff-70f29654c1c37fb886340dc6f22a99571503f4a54dc46942ca6028b8896b00b7L254