### PR TITLE
support email invite

### DIFF
--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/PermalinkParserTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/PermalinkParserTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk
+
+import org.junit.Assert
+import org.junit.FixMethodOrder
+import org.junit.Test
+import org.junit.runners.MethodSorters
+import org.matrix.android.sdk.api.session.permalinks.PermalinkData
+import org.matrix.android.sdk.api.session.permalinks.PermalinkParser
+
+@FixMethodOrder(MethodSorters.JVM)
+class PermalinkParserTest {
+
+    @Test
+    fun testParseEmailInvite() {
+        val rawInvite = """
+            https://app.element.io/#/room/%21MRBNLPtFnMAazZVPMO%3Amatrix.org?email=bob%2Bspace%40example.com&signurl=https%3A%2F%2Fvector.im%2F_matrix%2Fidentity%2Fapi%2Fv1%2Fsign-ed25519%3Ftoken%3DXmOwRZnSFabCRhTywFbJWKXWVNPysOpXIbroMGaUymqkJSvHeVKRsjHajwjCYdBsvGSvHauxbKfJmOxtXldtyLnyBMLKpBQCMzyYggrdapbVIceWZBtmslOQrXLABRoe%26private_key%3DT2gq0c3kJB_8OroXVxl1pBnzHsN7V6Xn4bEBSeW1ep4&room_name=Team2&room_avatar_url=&inviter_name=hiphop5&guest_access_token=&guest_user_id=
+        """.trimIndent()
+                .replace("https://app.element.io/#/room/", "https://matrix.to/#/")
+
+        val parsedLink = PermalinkParser.parse(rawInvite)
+        Assert.assertTrue("Should be parsed as email invite but was ${parsedLink::class.java}", parsedLink is PermalinkData.RoomEmailInviteLink)
+        parsedLink as PermalinkData.RoomEmailInviteLink
+        Assert.assertEquals("!MRBNLPtFnMAazZVPMO:matrix.org", parsedLink.roomId)
+        Assert.assertEquals("XmOwRZnSFabCRhTywFbJWKXWVNPysOpXIbroMGaUymqkJSvHeVKRsjHajwjCYdBsvGSvHauxbKfJmOxtXldtyLnyBMLKpBQCMzyYggrdapbVIceWZBtmslOQrXLABRoe", parsedLink.token)
+        Assert.assertEquals("vector.im", parsedLink.identityServer)
+        Assert.assertEquals("Team2", parsedLink.roomName)
+        Assert.assertEquals("hiphop5", parsedLink.inviterName)
+    }
+
+    @Test
+    fun testParseLinkWIthEvent() {
+        val rawInvite = "https://matrix.to/#/!OGEhHVWSdvArJzumhm:matrix.org/\$xuvJUVDJnwEeVjPx029rAOZ50difpmU_5gZk_T0jGfc?via=matrix.org&via=libera.chat&via=matrix.example.io"
+
+        val parsedLink = PermalinkParser.parse(rawInvite)
+        Assert.assertTrue("Should be parsed as room link", parsedLink is PermalinkData.RoomLink)
+        parsedLink as PermalinkData.RoomLink
+        Assert.assertEquals("!OGEhHVWSdvArJzumhm:matrix.org", parsedLink.roomIdOrAlias)
+        Assert.assertEquals("\$xuvJUVDJnwEeVjPx029rAOZ50difpmU_5gZk_T0jGfc", parsedLink.eventId)
+        Assert.assertEquals(3, parsedLink.viaParameters.size)
+        Assert.assertTrue(parsedLink.viaParameters.contains("matrix.example.io"))
+        Assert.assertTrue(parsedLink.viaParameters.contains("matrix.org"))
+        Assert.assertTrue(parsedLink.viaParameters.contains("matrix.example.io"))
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/identity/IdentityService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/identity/IdentityService.kt
@@ -16,6 +16,8 @@
 
 package org.matrix.android.sdk.api.session.identity
 
+import org.matrix.android.sdk.internal.session.identity.model.SignInvitationResult
+
 /**
  * Provides access to the identity server configuration and services identity server can provide
  */
@@ -121,6 +123,9 @@ interface IdentityService {
      */
     suspend fun getShareStatus(threePids: List<ThreePid>): Map<ThreePid, SharedState>
 
+    suspend fun sign3pidInvitation(identiyServer: String, token: String, secret: String) : SignInvitationResult
+
     fun addListener(listener: IdentityServiceListener)
+
     fun removeListener(listener: IdentityServiceListener)
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/permalinks/PermalinkData.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/permalinks/PermalinkData.kt
@@ -17,6 +17,8 @@
 package org.matrix.android.sdk.api.session.permalinks
 
 import android.net.Uri
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
 /**
  * This sealed class represents all the permalink cases.
@@ -30,6 +32,25 @@ sealed class PermalinkData {
             val eventId: String?,
             val viaParameters: List<String>
     ) : PermalinkData()
+
+    /**
+     * &room_name=Team2
+        &room_avatar_url=mxc:
+         &inviter_name=bob
+     */
+    @Parcelize
+    data class RoomEmailInviteLink(
+        val roomId: String,
+        val email: String,
+        val signUrl: String,
+        val roomName: String?,
+        val roomAvatarUrl: String?,
+        val inviterName: String?,
+        val identityServer: String,
+        val token: String,
+        val privateKey: String,
+        val roomType: String?
+    ) : PermalinkData(), Parcelable
 
     data class UserLink(val userId: String) : PermalinkData()
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomService.kt
@@ -27,6 +27,7 @@ import org.matrix.android.sdk.api.session.room.model.create.CreateRoomParams
 import org.matrix.android.sdk.api.session.room.peeking.PeekResult
 import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
 import org.matrix.android.sdk.api.util.Optional
+import org.matrix.android.sdk.internal.session.identity.model.SignInvitationResult
 import org.matrix.android.sdk.internal.session.room.alias.RoomAliasDescription
 
 /**
@@ -62,6 +63,18 @@ interface RoomService {
     suspend fun joinRoom(roomIdOrAlias: String,
                          reason: String? = null,
                          viaServers: List<String> = emptyList())
+
+    /**
+     * @param roomId the roomId of the room to join
+     * @param reason optional reason for joining the room
+     * @param thirdPartySigned A signature of an m.third_party_invite token to prove that this user owns a third party identity
+     * which has been invited to the room.
+     */
+    suspend fun joinRoom(
+            roomId: String,
+            reason: String? = null,
+            thirdPartySigned: SignInvitationResult
+    )
 
     /**
      * Get a room from a roomId

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkConstants.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkConstants.kt
@@ -30,6 +30,7 @@ internal object NetworkConstants {
     // Identity server
     const val URI_IDENTITY_PREFIX_PATH = "_matrix/identity/v2"
     const val URI_IDENTITY_PATH_V2 = "$URI_IDENTITY_PREFIX_PATH/"
+    const val URI_IDENTITY_PATH_V1 = "_matrix/identity/api/v1/"
 
     // Push Gateway
     const val URI_PUSH_GATEWAY_PREFIX_PATH = "_matrix/push/v1/"

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/DefaultIdentityService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/DefaultIdentityService.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.Session
+import org.matrix.android.sdk.internal.session.identity.model.SignInvitationResult
 import timber.log.Timber
 import javax.inject.Inject
 import javax.net.ssl.HttpsURLConnection
@@ -79,6 +80,7 @@ internal class DefaultIdentityService @Inject constructor(
         private val identityApiProvider: IdentityApiProvider,
         private val accountDataDataSource: UserAccountDataDataSource,
         private val homeServerCapabilitiesService: HomeServerCapabilitiesService,
+        private val sign3pidInvitationTask: DefaultSign3pidInvitationTask,
         private val sessionParams: SessionParams
 ) : IdentityService, SessionLifecycleObserver {
 
@@ -288,6 +290,14 @@ internal class DefaultIdentityService @Inject constructor(
         val token = identityRegisterTask.execute(IdentityRegisterTask.Params(api, openIdToken))
 
         return token.token
+    }
+
+    override suspend fun sign3pidInvitation(identiyServer: String, token: String, secret: String): SignInvitationResult {
+        return sign3pidInvitationTask.execute(Sign3pidInvitationTask.Params(
+                url = identiyServer,
+                token = token,
+                privateKey = secret
+        ))
     }
 
     override fun addListener(listener: IdentityServiceListener) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/IdentityAPI.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/IdentityAPI.kt
@@ -26,10 +26,12 @@ import org.matrix.android.sdk.internal.session.identity.model.IdentityRequestOwn
 import org.matrix.android.sdk.internal.session.identity.model.IdentityRequestTokenForEmailBody
 import org.matrix.android.sdk.internal.session.identity.model.IdentityRequestTokenForMsisdnBody
 import org.matrix.android.sdk.internal.session.identity.model.IdentityRequestTokenResponse
+import org.matrix.android.sdk.internal.session.identity.model.SignInvitationResult
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 /**
  * Ref: https://matrix.org/docs/spec/identity_service/latest
@@ -95,4 +97,16 @@ internal interface IdentityAPI {
     @POST(NetworkConstants.URI_IDENTITY_PATH_V2 + "validate/{medium}/submitToken")
     suspend fun submitToken(@Path("medium") medium: String,
                             @Body body: IdentityRequestOwnershipParams): SuccessResult
+
+    /**
+     * https://matrix.org/docs/spec/identity_service/r0.3.0#post-matrix-identity-v2-sign-ed25519
+     *
+     * Have to rely on V1 for now
+     */
+    @POST(NetworkConstants.URI_IDENTITY_PATH_V1 + "sign-ed25519")
+    suspend fun signInvitationDetails(
+            @Query("token") token: String,
+            @Query("private_key") privateKey: String,
+            @Query("mxid") mxid: String
+    ): SignInvitationResult
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/Sign3pidInvitationTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/Sign3pidInvitationTask.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.identity
+
+import dagger.Lazy
+import okhttp3.OkHttpClient
+import org.matrix.android.sdk.internal.di.AuthenticatedIdentity
+import org.matrix.android.sdk.internal.di.UserId
+import org.matrix.android.sdk.internal.network.RetrofitFactory
+import org.matrix.android.sdk.internal.session.identity.model.SignInvitationResult
+import org.matrix.android.sdk.internal.task.Task
+import javax.inject.Inject
+
+internal interface Sign3pidInvitationTask : Task<Sign3pidInvitationTask.Params, SignInvitationResult> {
+    data class Params(
+            val token: String,
+            val url: String,
+            val privateKey: String
+    )
+}
+
+internal class DefaultSign3pidInvitationTask @Inject constructor(
+        @AuthenticatedIdentity
+        private val okHttpClient: Lazy<OkHttpClient>,
+        private val retrofitFactory: RetrofitFactory,
+        @UserId private val userId: String
+) : Sign3pidInvitationTask {
+
+    override suspend fun execute(params: Sign3pidInvitationTask.Params): SignInvitationResult {
+        val identityAPI = params.url
+                .let { retrofitFactory.create(okHttpClient, "https://$it") }
+                .create(IdentityAPI::class.java)
+        return identityAPI.signInvitationDetails(params.token, params.privateKey, userId)
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/model/SignInvitationBody.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/model/SignInvitationBody.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.identity.model
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal data class SignInvitationBody(
+        /**The Matrix user ID of the user accepting the invitation.*/
+        val mxid: String,
+        /**The token from the call to store- invite..*/
+        val token: String,
+        /** The private key, encoded as Unpadded base64. */
+        val private_key: String
+)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/model/SignInvitationResult.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/identity/model/SignInvitationResult.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.identity.model
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class SignInvitationResult(
+        /** The Matrix user ID of the user accepting the invitation.*/
+        val mxid: String,
+        /** The Matrix user ID of the user who sent the invitation.*/
+        val sender: String,
+        /**The token from the call to store- invite..*/
+        val signatures: Map<String, *>,
+        /** The token for the invitation */
+        val token: String
+)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoomService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoomService.kt
@@ -38,6 +38,7 @@ import org.matrix.android.sdk.api.util.toOptional
 import org.matrix.android.sdk.internal.database.mapper.asDomain
 import org.matrix.android.sdk.internal.database.model.RoomMemberSummaryEntityFields
 import org.matrix.android.sdk.internal.di.SessionDatabase
+import org.matrix.android.sdk.internal.session.identity.model.SignInvitationResult
 import org.matrix.android.sdk.internal.session.room.alias.DeleteRoomAliasTask
 import org.matrix.android.sdk.internal.session.room.alias.GetRoomIdByAliasTask
 import org.matrix.android.sdk.internal.session.room.alias.RoomAliasDescription
@@ -120,6 +121,12 @@ internal class DefaultRoomService @Inject constructor(
 
     override suspend fun joinRoom(roomIdOrAlias: String, reason: String?, viaServers: List<String>) {
         joinRoomTask.execute(JoinRoomTask.Params(roomIdOrAlias, reason, viaServers))
+    }
+
+    override suspend fun joinRoom(roomIdOrAlias: String,
+                                  reason: String?,
+                                  thirdPartySigned: SignInvitationResult) {
+        joinRoomTask.execute(JoinRoomTask.Params(roomIdOrAlias, reason, thirdPartySigned = thirdPartySigned))
     }
 
     override suspend fun markAllAsRead(roomIds: List<String>) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
@@ -253,7 +253,7 @@ internal interface RoomAPI {
     @POST(NetworkConstants.URI_API_PREFIX_PATH_R0 + "join/{roomIdOrAlias}")
     suspend fun join(@Path("roomIdOrAlias") roomIdOrAlias: String,
                      @Query("server_name") viaServers: List<String>,
-                     @Body params: Map<String, String?>): JoinRoomResponse
+                     @Body params:  @JvmSuppressWildcards Map<String, Any>): JoinRoomResponse
 
     /**
      * Leave the given room.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomModule.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomModule.kt
@@ -28,6 +28,8 @@ import org.matrix.android.sdk.api.session.space.SpaceService
 import org.matrix.android.sdk.internal.session.DefaultFileService
 import org.matrix.android.sdk.internal.session.SessionScope
 import org.matrix.android.sdk.internal.session.directory.DirectoryAPI
+import org.matrix.android.sdk.internal.session.identity.DefaultSign3pidInvitationTask
+import org.matrix.android.sdk.internal.session.identity.Sign3pidInvitationTask
 import org.matrix.android.sdk.internal.session.room.accountdata.DefaultUpdateRoomAccountDataTask
 import org.matrix.android.sdk.internal.session.room.accountdata.UpdateRoomAccountDataTask
 import org.matrix.android.sdk.internal.session.room.alias.AddRoomAliasTask
@@ -248,4 +250,7 @@ internal abstract class RoomModule {
 
     @Binds
     abstract fun bindRoomVersionUpgradeTask(task: DefaultRoomVersionUpgradeTask): RoomVersionUpgradeTask
+
+    @Binds
+    abstract fun bindSign3pidInvitationTask(task: DefaultSign3pidInvitationTask): Sign3pidInvitationTask
 }

--- a/vector/src/main/java/im/vector/app/features/matrixto/MatrixToBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/matrixto/MatrixToBottomSheetViewModel.kt
@@ -183,6 +183,7 @@ class MatrixToBottomSheetViewModel @AssistedInject constructor(
                 // not yet supported
                 _viewEvents.post(MatrixToViewEvents.Dismiss)
             }
+            is PermalinkData.RoomEmailInviteLink,
             is PermalinkData.FallbackLink -> {
                 _viewEvents.post(MatrixToViewEvents.Dismiss)
             }

--- a/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
@@ -86,6 +86,7 @@ import im.vector.app.features.widgets.WidgetActivity
 import im.vector.app.features.widgets.WidgetArgsBuilder
 import im.vector.app.space
 import org.matrix.android.sdk.api.session.crypto.verification.IncomingSasVerificationTransaction
+import org.matrix.android.sdk.api.session.permalinks.PermalinkData
 import org.matrix.android.sdk.api.session.room.model.roomdirectory.PublicRoom
 import org.matrix.android.sdk.api.session.terms.TermsService
 import org.matrix.android.sdk.api.session.widgets.model.Widget
@@ -249,7 +250,7 @@ class DefaultNavigator @Inject constructor(
         context.startActivity(intent)
     }
 
-    override fun openRoomPreview(context: Context, roomPreviewData: RoomPreviewData) {
+    override fun openRoomPreview(context: Context, roomPreviewData: RoomPreviewData, fromEmailInviteLink: PermalinkData.RoomEmailInviteLink?) {
         val intent = RoomPreviewActivity.newIntent(context, roomPreviewData)
         context.startActivity(intent)
     }

--- a/vector/src/main/java/im/vector/app/features/navigation/Navigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/Navigator.kt
@@ -30,6 +30,7 @@ import im.vector.app.features.roomdirectory.RoomDirectoryData
 import im.vector.app.features.roomdirectory.roompreview.RoomPreviewData
 import im.vector.app.features.settings.VectorSettingsActivity
 import im.vector.app.features.share.SharedData
+import org.matrix.android.sdk.api.session.permalinks.PermalinkData
 import org.matrix.android.sdk.api.session.room.model.roomdirectory.PublicRoom
 import org.matrix.android.sdk.api.session.terms.TermsService
 import org.matrix.android.sdk.api.session.widgets.model.Widget
@@ -65,7 +66,7 @@ interface Navigator {
 
     fun openRoomPreview(context: Context, publicRoom: PublicRoom, roomDirectoryData: RoomDirectoryData)
 
-    fun openRoomPreview(context: Context, roomPreviewData: RoomPreviewData)
+    fun openRoomPreview(context: Context, roomPreviewData: RoomPreviewData, fromEmailInviteLink: PermalinkData.RoomEmailInviteLink? = null)
 
     fun openMatrixToBottomSheet(context: Context, link: String)
 

--- a/vector/src/main/java/im/vector/app/features/permalink/PermalinkHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/permalink/PermalinkHandler.kt
@@ -22,6 +22,7 @@ import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.utils.toast
 import im.vector.app.features.navigation.Navigator
+import im.vector.app.features.roomdirectory.roompreview.RoomPreviewData
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
@@ -77,7 +78,7 @@ class PermalinkHandler @Inject constructor(private val activeSessionHolder: Acti
             buildTask: Boolean
     ): Single<Boolean> {
         return when (permalinkData) {
-            is PermalinkData.RoomLink -> {
+            is PermalinkData.RoomLink            -> {
                 permalinkData.getRoomId()
                         .observeOn(AndroidSchedulers.mainThread())
                         .map {
@@ -94,18 +95,29 @@ class PermalinkHandler @Inject constructor(private val activeSessionHolder: Acti
                             true
                         }
             }
-            is PermalinkData.GroupLink -> {
+            is PermalinkData.GroupLink           -> {
                 navigator.openGroupDetail(permalinkData.groupId, context, buildTask)
                 Single.just(true)
             }
-            is PermalinkData.UserLink -> {
+            is PermalinkData.UserLink            -> {
                 if (navigationInterceptor?.navToMemberProfile(permalinkData.userId, rawLink) != true) {
                     navigator.openRoomMemberProfile(userId = permalinkData.userId, roomId = null, context = context, buildTask = buildTask)
                 }
                 Single.just(true)
             }
-            is PermalinkData.FallbackLink -> {
+            is PermalinkData.FallbackLink        -> {
                 Single.just(false)
+            }
+            is PermalinkData.RoomEmailInviteLink -> {
+                val data = RoomPreviewData(
+                        roomId = permalinkData.roomId,
+                        roomName = permalinkData.roomName,
+                        avatarUrl = permalinkData.roomAvatarUrl,
+                        fromEmailInvite = permalinkData,
+                        roomType = permalinkData.roomType
+                )
+                navigator.openRoomPreview(context, data)
+                Single.just(true)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/roompreview/RoomPreviewAction.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/roompreview/RoomPreviewAction.kt
@@ -20,4 +20,5 @@ import im.vector.app.core.platform.VectorViewModelAction
 
 sealed class RoomPreviewAction : VectorViewModelAction {
     object Join : RoomPreviewAction()
+    object JoinThirdParty : RoomPreviewAction()
 }

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/roompreview/RoomPreviewActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/roompreview/RoomPreviewActivity.kt
@@ -27,6 +27,7 @@ import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.databinding.ActivitySimpleBinding
 import im.vector.app.features.roomdirectory.RoomDirectoryData
 import kotlinx.parcelize.Parcelize
+import org.matrix.android.sdk.api.session.permalinks.PermalinkData
 import org.matrix.android.sdk.api.session.room.model.roomdirectory.PublicRoom
 import org.matrix.android.sdk.api.util.MatrixItem
 import timber.log.Timber
@@ -37,12 +38,14 @@ data class RoomPreviewData(
         val eventId: String? = null,
         val roomName: String? = null,
         val roomAlias: String? = null,
+        val roomType: String? = null,
         val topic: String? = null,
         val worldReadable: Boolean = false,
         val avatarUrl: String? = null,
         val homeServers: List<String> = emptyList(),
         val peekFromServer: Boolean = false,
-        val buildTask: Boolean = false
+        val buildTask: Boolean = false,
+        val fromEmailInvite: PermalinkData.RoomEmailInviteLink? = null
 ) : Parcelable {
     val matrixItem: MatrixItem
         get() = MatrixItem.RoomItem(roomId, roomName ?: roomAlias, avatarUrl)

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/roompreview/RoomPreviewViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/roompreview/RoomPreviewViewState.kt
@@ -20,6 +20,8 @@ import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.MvRxState
 import com.airbnb.mvrx.Uninitialized
 import im.vector.app.features.roomdirectory.JoinState
+import org.matrix.android.sdk.api.session.permalinks.PermalinkData
+import org.matrix.android.sdk.api.session.room.model.RoomType
 import org.matrix.android.sdk.api.util.MatrixItem
 
 data class RoomPreviewViewState(
@@ -27,6 +29,7 @@ data class RoomPreviewViewState(
         // The room id
         val roomId: String = "",
         val roomAlias: String? = null,
+        val roomType: String? = null,
 
         val roomName: String? = null,
         val roomTopic: String? = null,
@@ -40,7 +43,11 @@ data class RoomPreviewViewState(
         // Current state of the room in preview
         val roomJoinState: JoinState = JoinState.NOT_JOINED,
         // Last error of join room request
-        val lastError: Throwable? = null
+        val lastError: Throwable? = null,
+
+        val fromEmailInvite: PermalinkData.RoomEmailInviteLink? = null,
+        // used only if it's an email invite
+        val isEmailBoundToAccount: Boolean = false
 ) : MvRxState {
 
     constructor(args: RoomPreviewData) : this(
@@ -50,10 +57,13 @@ data class RoomPreviewViewState(
             roomName = args.roomName,
             roomTopic = args.topic,
             avatarUrl = args.avatarUrl,
-            shouldPeekFromServer = args.peekFromServer
+            shouldPeekFromServer = args.peekFromServer,
+            fromEmailInvite = args.fromEmailInvite,
+            roomType = args.roomType
     )
 
     fun matrixItem() : MatrixItem {
-        return MatrixItem.RoomItem(roomId, roomName ?: roomAlias, avatarUrl)
+        return if (roomType == RoomType.SPACE) MatrixItem.SpaceItem(roomId, roomName ?: roomAlias, avatarUrl)
+            else MatrixItem.RoomItem(roomId, roomName ?: roomAlias, avatarUrl)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsActivity.kt
@@ -26,6 +26,7 @@ import im.vector.app.core.di.ScreenComponent
 import im.vector.app.core.extensions.replaceFragment
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.databinding.ActivityVectorSettingsBinding
+import im.vector.app.features.discovery.DiscoverySettingsFragment
 import im.vector.app.features.settings.devices.VectorSettingsDevicesFragment
 
 import org.matrix.android.sdk.api.failure.GlobalError
@@ -77,6 +78,9 @@ class VectorSettingsActivity : VectorBaseActivity<ActivityVectorSettingsBinding>
                 EXTRA_DIRECT_ACCESS_NOTIFICATIONS                    -> {
                     requestHighlightPreferenceKeyOnResume(VectorPreferences.SETTINGS_ENABLE_THIS_DEVICE_PREFERENCE_KEY)
                     replaceFragment(R.id.vector_settings_page, VectorSettingsNotificationPreferenceFragment::class.java, null, FRAGMENT_TAG)
+                }
+                EXTRA_DIRECT_ACCESS_DISCOVERY_SETTINGS                    -> {
+                    replaceFragment(R.id.vector_settings_page, DiscoverySettingsFragment::class.java, null, FRAGMENT_TAG)
                 }
 
                 else                                                 ->
@@ -159,6 +163,7 @@ class VectorSettingsActivity : VectorBaseActivity<ActivityVectorSettingsBinding>
         const val EXTRA_DIRECT_ACCESS_SECURITY_PRIVACY_MANAGE_SESSIONS = 3
         const val EXTRA_DIRECT_ACCESS_GENERAL = 4
         const val EXTRA_DIRECT_ACCESS_NOTIFICATIONS = 5
+        const val EXTRA_DIRECT_ACCESS_DISCOVERY_SETTINGS = 6
 
         private const val FRAGMENT_TAG = "VectorSettingsPreferencesFragment"
     }

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3445,4 +3445,10 @@
     <string name="room_upgrade_to_recommended_version">Upgrade to the recommended room version</string>
 
     <string name="error_failed_to_join_room">Sorry, an error occurred while trying to join: %s</string>
+
+    <string name="this_invite_to_this_room_was_sent">This invite to this room was sent to %s which is not associated with your account</string>
+    <string name="this_invite_to_this_space_was_sent">This invite to this space was sent to %s which is not associated with your account</string>
+    <!-- this is the part of link_this_email_with_your_account that should be a link-->
+    <string name="link_this_email_settings_link">Link this email with your account</string>
+    <string name="link_this_email_with_your_account">Link this email with your account in Settings to receive invites directly in Element.</string>
 </resources>


### PR DESCRIPTION
Supports accepting email invite when the email is not bound to the account.

When your email is bound to an identity server and you are invited by email to a room, the invite will come down as part of the sync and the invite will appear in the UI. If not (no identity server or no mail bound), the invite will not show in the UX.

This PR will allow to accept invites on Element Android when your email is not bound to an IS by using [Ephemeral Invitation Signing](https://matrix.org/docs/spec/identity_service/r0.3.0#ephemeral-invitation-signing)
When clicking on the link of the email invite, EA will open and will allow you to validate the invitation.

NB: The link generated in the API is a v1 link that is deprecated, so EA will use v1 API. v2 API cannot be used now because it requires auth and accept terms, and it degrades the invite flow too much.

Ideally EA should perform the signing locally as it as all info and is crypto capabale, but the documentation is not saying what the signing should be :/

<img width="326" alt="image" src="https://user-images.githubusercontent.com/9841565/127114489-69b38793-d6dc-4ef7-bc00-7e6a387f665c.png">


The email invite looks like that
````
https://app.element.io/#/room/!MOIPZPtFnMAazZzotO:eample.org?
email=john+doe@mail.com
&signurl=https://vector.im/_matrix/identity/api/v1/sign-ed25519?token=XmOwRZnSFabCRhTywFbIURTTysOpXIbroMGaUymqkJSvHeVKRsjHajwjCYdBsvGSvHauxbKfJmOxtXldtyLnyBMLKpBQCMzyYggrdapbVIceWZBtmslOQrXLABRoe&private_key=T2gq0c3kJB_8OroXVxl1pBnzHsN7V6Xn4bEBSeW1ep4
&room_name=Team2
&room_avatar_url=
&inviter_name=hiphop5
&guest_access_token=&guest_user_id=
````

In prevision of [MSC3288](https://github.com/matrix-org/matrix-doc/pull/3288) this PR also support a room_type event in the link in order to adapt the invite text.


 