### PR TITLE
Update Account Data with user matrix id for invited user by email

### DIFF
--- a/changelog.d/3743.bugfix
+++ b/changelog.d/3743.bugfix
@@ -1,0 +1,1 @@
+Update the AccountData with the users' matrix Id instead of their email for those invited by email in a direct chat

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomTask.kt
@@ -123,7 +123,7 @@ internal class DefaultCreateRoomTask @Inject constructor(
                 this.isDirect = true
             }
         }
-        val directChats = directChatsHelper.getLocalUserAccount()
+        val directChats = directChatsHelper.getLocalDirectMessages()
         updateUserAccountDataTask.execute(UpdateUserAccountDataTask.DirectChatParams(directMessages = directChats))
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregator.kt
@@ -19,4 +19,6 @@ package org.matrix.android.sdk.internal.session.sync
 internal class SyncResponsePostTreatmentAggregator {
     // List of RoomId
     val ephemeralFilesToDelete = mutableListOf<String>()
+    // Map of roomId to directUserId
+    val directChatsToCheck = mutableMapOf<String, String>()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregatorHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregatorHandler.kt
@@ -17,6 +17,7 @@
 package org.matrix.android.sdk.internal.session.sync
 
 import org.matrix.android.sdk.api.MatrixPatterns
+import org.matrix.android.sdk.internal.session.sync.model.accountdata.toMutable
 import org.matrix.android.sdk.internal.session.user.accountdata.DirectChatsHelper
 import org.matrix.android.sdk.internal.session.user.accountdata.UpdateUserAccountDataTask
 import javax.inject.Inject
@@ -38,7 +39,7 @@ internal class SyncResponsePostTreatmentAggregatorHandler @Inject constructor(
     }
 
     private suspend fun updateDirectUserIds(directUserIdsToUpdate: Map<String, String>) {
-        val directChats = directChatsHelper.getLocalDirectMessages()
+        val directChats = directChatsHelper.getLocalDirectMessages().toMutable()
         var hasUpdate = false
         directUserIdsToUpdate.forEach { (roomId, candidateUserId) ->
             // consider room is a DM if referenced in the DM dictionary

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregatorHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregatorHandler.kt
@@ -16,18 +16,53 @@
 
 package org.matrix.android.sdk.internal.session.sync
 
+import org.matrix.android.sdk.api.MatrixPatterns
+import org.matrix.android.sdk.internal.session.user.accountdata.DirectChatsHelper
+import org.matrix.android.sdk.internal.session.user.accountdata.UpdateUserAccountDataTask
 import javax.inject.Inject
 
 internal class SyncResponsePostTreatmentAggregatorHandler @Inject constructor(
-        private val ephemeralTemporaryStore: RoomSyncEphemeralTemporaryStore
+        private val directChatsHelper: DirectChatsHelper,
+        private val ephemeralTemporaryStore: RoomSyncEphemeralTemporaryStore,
+        private val updateUserAccountDataTask: UpdateUserAccountDataTask
 ) {
-    fun handle(synResHaResponsePostTreatmentAggregator: SyncResponsePostTreatmentAggregator) {
+    suspend fun handle(synResHaResponsePostTreatmentAggregator: SyncResponsePostTreatmentAggregator) {
         cleanupEphemeralFiles(synResHaResponsePostTreatmentAggregator.ephemeralFilesToDelete)
+        updateDirectUserIds(synResHaResponsePostTreatmentAggregator.directChatsToCheck)
     }
 
     private fun cleanupEphemeralFiles(ephemeralFilesToDelete: List<String>) {
         ephemeralFilesToDelete.forEach {
             ephemeralTemporaryStore.delete(it)
+        }
+    }
+
+    private suspend fun updateDirectUserIds(directUserIdsToUpdate: Map<String, String>) {
+        val directChats = directChatsHelper.getLocalDirectMessages()
+        var hasUpdate = false
+        directUserIdsToUpdate.forEach { (roomId, candidateUserId) ->
+            // consider room is a DM if referenced in the DM dictionary
+            val currentDirectUserId = directChats.firstNotNullOfOrNull { (userId, roomIds) -> userId.takeIf { roomId in roomIds } }
+            // update directUserId with the given candidateUserId if it mismatches the current one
+            if (currentDirectUserId != null && !MatrixPatterns.isUserId(currentDirectUserId)) {
+                // link roomId with the matrix id
+                directChats
+                        .getOrPut(candidateUserId) { arrayListOf() }
+                        .apply {
+                            if (!contains(roomId)) {
+                                hasUpdate = true
+                                add(roomId)
+                            }
+                        }
+
+                // remove roomId from currentDirectUserId entry
+                hasUpdate = hasUpdate or(directChats[currentDirectUserId]?.remove(roomId) == true)
+                // remove currentDirectUserId entry if there is no attached room anymore
+                hasUpdate = hasUpdate or(directChats.takeIf { it[currentDirectUserId].isNullOrEmpty() }?.remove(currentDirectUserId) != null)
+            }
+        }
+        if (hasUpdate) {
+            updateUserAccountDataTask.execute(UpdateUserAccountDataTask.DirectChatParams(directMessages = directChats))
         }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/UserAccountDataSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/UserAccountDataSyncHandler.kt
@@ -83,7 +83,7 @@ internal class UserAccountDataSyncHandler @Inject constructor(
     // If we get some direct chat invites, we synchronize the user account data including those.
     suspend fun synchronizeWithServerIfNeeded(invites: Map<String, InvitedRoomSync>) {
         if (invites.isNullOrEmpty()) return
-        val directChats = directChatsHelper.getLocalUserAccount()
+        val directChats = directChatsHelper.getLocalDirectMessages()
         var hasUpdate = false
         monarchy.doWithRealm { realm ->
             invites.forEach { (roomId, _) ->

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/UserAccountDataSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/UserAccountDataSyncHandler.kt
@@ -53,6 +53,7 @@ import org.matrix.android.sdk.internal.session.sync.model.accountdata.Breadcrumb
 import org.matrix.android.sdk.internal.session.sync.model.accountdata.DirectMessagesContent
 import org.matrix.android.sdk.internal.session.sync.model.accountdata.IgnoredUsersContent
 import org.matrix.android.sdk.internal.session.sync.model.accountdata.UserAccountDataSync
+import org.matrix.android.sdk.internal.session.sync.model.accountdata.toMutable
 import org.matrix.android.sdk.internal.session.user.accountdata.DirectChatsHelper
 import org.matrix.android.sdk.internal.session.user.accountdata.UpdateUserAccountDataTask
 import timber.log.Timber
@@ -83,7 +84,7 @@ internal class UserAccountDataSyncHandler @Inject constructor(
     // If we get some direct chat invites, we synchronize the user account data including those.
     suspend fun synchronizeWithServerIfNeeded(invites: Map<String, InvitedRoomSync>) {
         if (invites.isNullOrEmpty()) return
-        val directChats = directChatsHelper.getLocalDirectMessages()
+        val directChats = directChatsHelper.getLocalDirectMessages().toMutable()
         var hasUpdate = false
         monarchy.doWithRealm { realm ->
             invites.forEach { (roomId, _) ->

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/model/accountdata/DirectMessagesContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/model/accountdata/DirectMessagesContent.kt
@@ -19,4 +19,13 @@ package org.matrix.android.sdk.internal.session.sync.model.accountdata
 /**
  * Keys are userIds, values are list of roomIds
  */
-internal typealias DirectMessagesContent = MutableMap<String, MutableList<String>>
+internal typealias DirectMessagesContent = Map<String, List<String>>
+
+/**
+ * Returns a new [MutableMap] with all elements of this collection.
+ */
+internal fun DirectMessagesContent.toMutable(): MutableMap<String, MutableList<String>> {
+    return map { it.key to it.value.toMutableList() }
+            .toMap()
+            .toMutableMap()
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/model/accountdata/DirectMessagesContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/model/accountdata/DirectMessagesContent.kt
@@ -19,4 +19,4 @@ package org.matrix.android.sdk.internal.session.sync.model.accountdata
 /**
  * Keys are userIds, values are list of roomIds
  */
-internal typealias DirectMessagesContent = Map<String, List<String>>
+internal typealias DirectMessagesContent = MutableMap<String, MutableList<String>>

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/accountdata/DirectChatsHelper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/accountdata/DirectChatsHelper.kt
@@ -21,6 +21,7 @@ import org.matrix.android.sdk.internal.database.query.getDirectRooms
 import org.matrix.android.sdk.internal.di.SessionDatabase
 import io.realm.Realm
 import io.realm.RealmConfiguration
+import org.matrix.android.sdk.internal.session.sync.model.accountdata.DirectMessagesContent
 import javax.inject.Inject
 
 internal class DirectChatsHelper @Inject constructor(@SessionDatabase
@@ -29,7 +30,7 @@ internal class DirectChatsHelper @Inject constructor(@SessionDatabase
     /**
      * @return a map of userId <-> list of roomId
      */
-    fun getLocalUserAccount(filterRoomId: String? = null): MutableMap<String, MutableList<String>> {
+    fun getLocalDirectMessages(filterRoomId: String? = null): DirectMessagesContent {
         return Realm.getInstance(realmConfiguration).use { realm ->
             // Makes sure we have the latest realm updates, this is important as we sent this information to the server.
             realm.refresh()


### PR DESCRIPTION
Fixes #3643 

Update the Account Data when an user has been invited to a DM by email (which is not bound to an existing account).

The DM is initially populated with the invited user email and stuck with this email when the user has joined Element by creating an account. Therefore, the `RoomSummary.directUserId` is also stuck on the email and does not match the otherUserId which has been updated with the user matrix id.

To handle the user registration, we catch the `m.room.member` event which contains the matrix id as part of the third_party_invite content. Then, we check the account data dictionary and update the entries matching the roomId attached to the event, and where the user id does not match the matrix id pattern.
Update the account data will then cause the update of the directUserId in the RoomSummary.