### PR TITLE
Fix sending encrypted messages after someone logged out a device

### DIFF
--- a/changelog.d/3781.bugfix
+++ b/changelog.d/3781.bugfix
@@ -1,0 +1,1 @@
+Fix sending encrypted messages after someone logged out a device

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -286,11 +286,16 @@ internal class RealmCryptoStore @Inject constructor(
                 val userEntity = UserEntity.getOrCreate(realm, userId)
                 // First delete the removed devices
                 val deviceIds = devices.keys
+                val devicesToDelete = ArrayList<DeviceInfoEntity>()
                 userEntity.devices.iterator().forEach { deviceInfoEntity ->
                     if (deviceInfoEntity.deviceId !in deviceIds) {
                         Timber.d("Remove device ${deviceInfoEntity.deviceId} of user $userId")
-                        deviceInfoEntity.deleteOnCascade()
+                        devicesToDelete.add(deviceInfoEntity)
                     }
+                }
+                while (devicesToDelete.isNotEmpty()) {
+                    val device = devicesToDelete.removeAt(0)
+                    device.deleteOnCascade()
                 }
                 // Then update existing devices or add new one
                 devices.values.forEach { cryptoDeviceInfo ->


### PR DESCRIPTION
Removing devices in foreach resulted in an exception, thus the device
did not get properly removed, which resulted in following issues:

- Sending encrypted messages to contacts who logged out a device
  fails with a "Message failed to send" with Retry button showing
- In the room settings, members would show with unverified devices,
  where devices were actually logged out

```
E/ /Tag: ## CRYPTO | refreshOutdatedDeviceLists() : ERROR updating device keys for users [@redacted:somematrixserver.com]
java.util.NoSuchElementException: Cannot access index 10 when size is 9. Remember to check hasNext() before using next().
	at io.realm.RealmList$RealmItr.next(RealmList.java:9)
	at org.matrix.android.sdk.internal.crypto.store.db.RealmCryptoStore$storeUserDevices$1.invoke(RealmCryptoStore.kt:41)
	at org.matrix.android.sdk.internal.crypto.store.db.RealmCryptoStore$storeUserDevices$1.invoke(RealmCryptoStore.kt:1)
	at org.matrix.android.sdk.internal.crypto.store.db.-$$Lambda$HelperKt$XtYpPdQTMtzbOWZdtlMV_aWM9XY.execute(lambda:2)
	at io.realm.Realm.executeTransaction(Realm.java:9)
	at org.matrix.android.sdk.api.MatrixCallback$DefaultImpls.doRealmTransaction(MatrixCallback.kt:2)
	at org.matrix.android.sdk.internal.crypto.store.db.RealmCryptoStore.storeUserDevices(RealmCryptoStore.kt:1)
	at org.matrix.android.sdk.internal.crypto.DeviceListManager.doKeyDownloadForUsers(DeviceListManager.kt:120)
	at org.matrix.android.sdk.internal.crypto.DeviceListManager$doKeyDownloadForUsers$1.invokeSuspend(DeviceListManager.kt:1)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:3)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:18)
	at android.os.Handler.handleCallback(Handler.java:883)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loop(Looper.java:237)
	at android.os.HandlerThread.run(HandlerThread.java:67)
```

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>

### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
