### PR TITLE
Fix missing sounds on room notifications (messages, invitations, etc).

### DIFF
--- a/changelog.d/3243.bugfix
+++ b/changelog.d/3243.bugfix
@@ -1,0 +1,1 @@
+Notifications - Fix missing sound on notifications.

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
@@ -100,13 +100,14 @@ class NotificationDrawerManager @Inject constructor(private val context: Context
             if (existing != null) {
                 if (existing.isPushGatewayEvent) {
                     // Use the event coming from the event stream as it may contains more info than
-                    // the fcm one (like type/content/clear text)
+                    // the fcm one (like type/content/clear text) (e.g when an encrypted message from
+                    // FCM should be update with clear text after a sync)
                     // In this case the message has already been notified, and might have done some noise
                     // So we want the notification to be updated even if it has already been displayed
-                    // But it should make no noise (e.g when an encrypted message from FCM should be
-                    // update with clear text after a sync)
+                    // Use setOnlyAlertOnce to ensure update notification does not interfere with sound
+                    // from first notify invocation as outlined in:
+                    // https://developer.android.com/training/notify-user/build-notification#Updating
                     notifiableEvent.hasBeenDisplayed = false
-                    notifiableEvent.noisy = false
                     eventList.remove(existing)
                     eventList.add(notifiableEvent)
                 } else {

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
@@ -540,6 +540,7 @@ class NotificationUtils @Inject constructor(private val context: Context,
 
         val channelID = if (roomInfo.shouldBing) NOISY_NOTIFICATION_CHANNEL_ID else SILENT_NOTIFICATION_CHANNEL_ID
         return NotificationCompat.Builder(context, channelID)
+                .setOnlyAlertOnce(true)
                 .setWhen(lastMessageTimestamp)
                 // MESSAGING_STYLE sets title and content for API 16 and above devices.
                 .setStyle(messageStyle)
@@ -641,6 +642,7 @@ class NotificationUtils @Inject constructor(private val context: Context,
         val channelID = if (inviteNotifiableEvent.noisy) NOISY_NOTIFICATION_CHANNEL_ID else SILENT_NOTIFICATION_CHANNEL_ID
 
         return NotificationCompat.Builder(context, channelID)
+                .setOnlyAlertOnce(true)
                 .setContentTitle(stringProvider.getString(R.string.app_name))
                 .setContentText(inviteNotifiableEvent.description)
                 .setGroup(stringProvider.getString(R.string.app_name))
@@ -704,6 +706,7 @@ class NotificationUtils @Inject constructor(private val context: Context,
         val channelID = if (simpleNotifiableEvent.noisy) NOISY_NOTIFICATION_CHANNEL_ID else SILENT_NOTIFICATION_CHANNEL_ID
 
         return NotificationCompat.Builder(context, channelID)
+                .setOnlyAlertOnce(true)
                 .setContentTitle(stringProvider.getString(R.string.app_name))
                 .setContentText(simpleNotifiableEvent.description)
                 .setGroup(stringProvider.getString(R.string.app_name))


### PR DESCRIPTION
### Old behaviour
On receiving of push notifications we do a background sync to fill in missing information in the push content.
Previously we would update the notification with a call to notify but with the sound disabled in an attempt to update the notification and avoid a second notify sound.
Depending on on the time it would take to do the background sync you would sometimes see different behaviours:
- The first sound would play, the sync would complete after it had finished and the the push would be updated silently.
- The first sound would start to play,  the sync would complete during it playing and the, second call to notify would cut off the sound playing.
- The sync would complete before the sound played, the second call to notify would in effect silence the sound.

### New behaviour
I am removing the modification of the notification `noisy` property and as per [this guide](https://developer.android.com/training/notify-user/build-notification#Updating) using the `setOnlyAlertOnce` property on all group notifications other than the summary notification. So that any sounds on notifications are not silenced(or double fired) by updates. Child notifications continue to be rolled up into a single summary notification [here](https://github.com/vector-im/element-android/blob/1d9baaf0e34f1efd6f05d3feed72f8cbd0bc6e10/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt#L567).

The behaviour also appears different across android versions. As reported in the issue it appears to affect versions 8+ but in those below it does not seem to cut off the notification on update.

I tested this on 7.0 and 8+ and is working across both. 
I'll look for somebody else to test this on API < 24 as I don't have an old device and it's difficult to test push on the emulator for versions that old.
I'll also wait for this to be reviewed by @bmarty when he is available as I think he has most context on this code. 

Fixes https://github.com/vector-im/element-android/issues/3243
