### PR TITLE
Fix attachment menu animation order

### DIFF
--- a/changelog.d/3793.bugfix
+++ b/changelog.d/3793.bugfix
@@ -1,0 +1,1 @@
+Fix order in which the items of the attachement menu appear

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorView.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorView.kt
@@ -102,8 +102,8 @@ class AttachmentTypeSelectorView(context: Context,
         contentView.doOnNextLayout {
             animateWindowInCircular(anchor, contentView)
         }
-        animateButtonIn(views.attachmentGalleryButton, ANIMATION_DURATION / 4)
-        animateButtonIn(views.attachmentCameraButton, ANIMATION_DURATION / 2)
+        animateButtonIn(views.attachmentGalleryButton, ANIMATION_DURATION / 2)
+        animateButtonIn(views.attachmentCameraButton, ANIMATION_DURATION / 4)
         animateButtonIn(views.attachmentFileButton, ANIMATION_DURATION / 2)
         animateButtonIn(views.attachmentAudioButton, 0)
         animateButtonIn(views.attachmentContactButton, ANIMATION_DURATION / 4)

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorView.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorView.kt
@@ -102,12 +102,12 @@ class AttachmentTypeSelectorView(context: Context,
         contentView.doOnNextLayout {
             animateWindowInCircular(anchor, contentView)
         }
-        animateButtonIn(views.attachmentGalleryButton, ANIMATION_DURATION / 2)
+        animateButtonIn(views.attachmentGalleryButton, ANIMATION_DURATION / 4)
         animateButtonIn(views.attachmentCameraButton, ANIMATION_DURATION / 2)
-        animateButtonIn(views.attachmentFileButton, ANIMATION_DURATION / 4)
-        animateButtonIn(views.attachmentAudioButton, ANIMATION_DURATION / 2)
+        animateButtonIn(views.attachmentFileButton, ANIMATION_DURATION / 2)
+        animateButtonIn(views.attachmentAudioButton, 0)
         animateButtonIn(views.attachmentContactButton, ANIMATION_DURATION / 4)
-        animateButtonIn(views.attachmentStickersButton, 0)
+        animateButtonIn(views.attachmentStickersButton, ANIMATION_DURATION / 2)
     }
 
     override fun dismiss() {


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21

Tested on device with Android 11, shouldn't matter (assuming it worked before 😉)
- [x] UI change has been tested on both light and dark themes
- [X] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

# What it does
This PR changes the order in which the items in the attachement menu appear. Currently, the ones on the right are faster than the ones on the left. Because the '+'-Button to trigger the menu is on the left, this doesn't make sense.

This behavior is more noticable if animations are disabled, because the menu doesn't have the circular mask animation. That's why the videos are recorded with animations disabled.

# Current animation
https://user-images.githubusercontent.com/37022952/128323836-4de37c81-6fd0-44d8-bd67-09713c635942.mp4

# New animation
https://user-images.githubusercontent.com/37022952/129963137-51ae4628-c16f-44e9-9ff9-2be4550c058a.mp4