### PR TITLE
Send an empty body for POST rooms/{roomId}/receipt/{receiptType}/{eve…

### DIFF
--- a/changelog.d/3789.bugfix
+++ b/changelog.d/3789.bugfix
@@ -1,0 +1,1 @@
+Send an empty body for POST rooms/{roomId}/receipt/{receiptType}/{eventId}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
@@ -159,7 +159,8 @@ internal interface RoomAPI {
     @POST(NetworkConstants.URI_API_PREFIX_PATH_R0 + "rooms/{roomId}/receipt/{receiptType}/{eventId}")
     suspend fun sendReceipt(@Path("roomId") roomId: String,
                             @Path("receiptType") receiptType: String,
-                            @Path("eventId") eventId: String)
+                            @Path("eventId") eventId: String,
+                            @Body body: JsonDict = emptyMap())
 
     /**
      * Invite a user to the given room.


### PR DESCRIPTION
…ntId}

Fixes #3789 