### PR TITLE
Update Bluetooth permissions to work with Android 12 and other small fixes

### DIFF
--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     package="im.vector.app">
 
     <!-- Needed for VOIP call to detect and switch to headset-->
-    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/vector/src/main/java/im/vector/app/core/intent/Filename.kt
+++ b/vector/src/main/java/im/vector/app/core/intent/Filename.kt
@@ -25,7 +25,8 @@ fun getFilenameFromUri(context: Context?, uri: Uri): String? {
         val cursor = context.contentResolver.query(uri, null, null, null, null)
         cursor?.use {
             if (it.moveToFirst()) {
-                return it.getString(it.getColumnIndex(OpenableColumns.DISPLAY_NAME))
+                val index = it.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (index >= 0) return it.getString(index)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/core/platform/VectorBaseActivity.kt
+++ b/vector/src/main/java/im/vector/app/core/platform/VectorBaseActivity.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.core.platform
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.res.Configuration
@@ -425,6 +426,7 @@ abstract class VectorBaseActivity<VB : ViewBinding> : AppCompatActivity(), HasSc
      * Force to render the activity in fullscreen
      */
     @Suppress("DEPRECATION")
+    @SuppressLint("WrongConstant")
     private fun setFullScreen() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             // New API instead of SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN and SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION

--- a/vector/src/main/java/im/vector/app/features/rageshake/BugReporterMultipartBody.java
+++ b/vector/src/main/java/im/vector/app/features/rageshake/BugReporterMultipartBody.java
@@ -224,7 +224,7 @@ public class BugReporterMultipartBody extends RequestBody {
         }
 
         public static Part createFormData(String name, String value) {
-            return createFormData(name, null, RequestBody.create(null, value));
+            return createFormData(name, null, RequestBody.create(value, null));
         }
 
         public static Part createFormData(String name, String filename, RequestBody body) {

--- a/vector/src/main/res/values-cs/strings.xml
+++ b/vector/src/main/res/values-cs/strings.xml
@@ -2873,7 +2873,7 @@
     <string name="upgrade_room_no_power_to_manage">K aktualizaci místnosti potřebujete oprávnění</string>
     <string name="upgrade_room_update_parent_space">Automaticky aktualizovat mateřský prostor</string>
     <string name="upgrade_room_auto_invite">Automaticky pozvat uživatele</string>
-    <string name="upgrade_public_room_from_to">Budete aktualizovat tuto místnost z %s na %s.</string>
+    <string name="upgrade_public_room_from_to">Budete aktualizovat tuto místnost z %1$s na %2$s.</string>
     <string name="upgrade_room_warning">Aktualizace místnosti je pokročilá akce a obvykle se doporučuje tehdy, je-li místnost nestabilní kvůli chybám, chybějícím funkcím nebo slabým místům v zabezpečení.
 \nObvykle má vliv pouze na to, jak server místnost zpracovává.</string>
     <string name="upgrade_private_room">Aktualizovat soukromou místnost</string>

--- a/vector/src/main/res/values-et/strings.xml
+++ b/vector/src/main/res/values-et/strings.xml
@@ -2822,7 +2822,7 @@
     <string name="upgrade_room_no_power_to_manage">Jututoa versiooni uuendamiseks on sul vaja õigusi</string>
     <string name="upgrade_room_update_parent_space">Uuenda automaatselt ka kogukonnakeskust, kus jututuba osaleb</string>
     <string name="upgrade_room_auto_invite">Kutsu automaatselt kasutajaid</string>
-    <string name="upgrade_public_room_from_to">Sa oled uuendamas jututoa versiooni: %s -&gt; %s.</string>
+    <string name="upgrade_public_room_from_to">Sa oled uuendamas jututoa versiooni: %1$s -&gt; %2$s.</string>
     <string name="upgrade_room_warning">Jututoa versiooni uuendamine on erandlik tegevus ning soovitame seda vaid siis kui ta on vigade tõttu raskestikasutatav, tal puuduvad uued funktsionaalsused või temas leidub turvavigu.
 \nTavaliselt versiooniuuendus mõjutab vaid seda viisi kuidas andmeid töödeldakse serveris.</string>
     <string name="upgrade_private_room">Uuenda omavaheline jututuba</string>

--- a/vector/src/main/res/values-fa/strings.xml
+++ b/vector/src/main/res/values-fa/strings.xml
@@ -2809,7 +2809,7 @@
     <string name="upgrade_room_no_power_to_manage">برای ارتقای اتاق نیاز به اجازه دارید</string>
     <string name="upgrade_room_update_parent_space">به‌روز رسانی خودکار والد فضا</string>
     <string name="upgrade_room_auto_invite">دعوت خودکار کاربران</string>
-    <string name="upgrade_public_room_from_to">این اتاق را از %s به %s ارتقا خواهید داد.</string>
+    <string name="upgrade_public_room_from_to">این اتاق را از %1$s به %2$s ارتقا خواهید داد.</string>
     <string name="upgrade_room_warning">ارتقای اتاق، عملی پیش‌رفته است و معمولاً هنگامی که اتاقی به خاطر اشکال‌ها، کمبود ویژگی‌ها یا آسیب‌پذیری‌های امنیتی ناپایدار است، پیشنهاد می‌شود.
 \nاین عمل معمولاً فقط روی چگونگی فراوری اتاق روی کارساز اثر می‌گذارد.</string>
     <string name="upgrade_private_room">ارتقای اتاق خصوصی</string>

--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -2827,7 +2827,7 @@
     <string name="upgrade_room_no_power_to_manage">Vous devez avoir le droit de mettre à jour ce salon</string>
     <string name="upgrade_room_update_parent_space">Mettre à jour automatiquement l’espace parent</string>
     <string name="upgrade_room_auto_invite">Inviter automatiquement des utilisateurs</string>
-    <string name="upgrade_public_room_from_to">Vous allez mettre à jour ce salon de %s à %s.</string>
+    <string name="upgrade_public_room_from_to">Vous allez mettre à jour ce salon de %1$s à %2$s.</string>
     <string name="upgrade_room_warning">La mise-à-jour d’un salon est une action avancée et n’est normalement recommandé que si un salon est instable à cause de bogues, fonctionnalités manquantes, ou failles de sécurité.
 \nCela n’affecte normalement que la manière dont le salon est géré par le serveur.</string>
     <string name="upgrade_private_room">Mettre à jour un salon privé</string>

--- a/vector/src/main/res/values-hu/strings.xml
+++ b/vector/src/main/res/values-hu/strings.xml
@@ -2825,7 +2825,7 @@ Ha nem te állítottad be a visszaállítási metódust, akkor egy támadó pró
     <string name="upgrade_room_no_power_to_manage">A szoba fejlesztéséhez engedélyre van szükséged</string>
     <string name="upgrade_room_update_parent_space">Szülő tér automatikus frissítése</string>
     <string name="upgrade_room_auto_invite">Felhasználók automatikus meghívása</string>
-    <string name="upgrade_public_room_from_to">A szobát fejleszted %s verzióról %s verzióra.</string>
+    <string name="upgrade_public_room_from_to">A szobát fejleszted %1$s verzióról %2$s verzióra.</string>
     <string name="upgrade_room_warning">A szoba fejlesztése haladó művelet és általában akkor ajánlott, ha a szoba valami hiba miatt instabil, hiányzik belőle valamilyen funkció vagy biztonsági hiányosság van benne.
 \nEz általában a szoba szerveren való feldolgozásának módját érinti.</string>
     <string name="upgrade_private_room">Privát szoba fejlesztése</string>

--- a/vector/src/main/res/values-it/strings.xml
+++ b/vector/src/main/res/values-it/strings.xml
@@ -2873,7 +2873,7 @@
     <string name="upgrade_room_no_power_to_manage">Ti serve il permesso per aggiornare una stanza</string>
     <string name="upgrade_room_update_parent_space">Aggiorna il padre dello spazio automaticamente</string>
     <string name="upgrade_room_auto_invite">Invita utenti automaticamente</string>
-    <string name="upgrade_public_room_from_to">Aggiornerai questa stanza dalla %s alla %s.</string>
+    <string name="upgrade_public_room_from_to">Aggiornerai questa stanza dalla %1$s alla %2$s.</string>
     <string name="upgrade_room_warning">L\'aggiornamento di una stanza è un\'azione avanzata e solitamente è consigliata quando una stanza è instabile a causa di errori, funzionalità mancanti o vulnerabilità di sicurezza.
 \nDi solito influisce solo su come la stanza viene elaborata sul server.</string>
     <string name="upgrade_private_room">Aggiorna stanza privata</string>

--- a/vector/src/main/res/values-pt-rBR/strings.xml
+++ b/vector/src/main/res/values-pt-rBR/strings.xml
@@ -2890,7 +2890,7 @@
     <string name="upgrade_room_no_power_to_manage">Você precisa de permissão para fazer upgrade de uma sala</string>
     <string name="upgrade_room_update_parent_space">Fazer update de pai de espaço automaticamente</string>
     <string name="upgrade_room_auto_invite">Convidar usuárias(os) automaticamente</string>
-    <string name="upgrade_public_room_from_to">Você vai fazer upgrade desta sala de %s para %s.</string>
+    <string name="upgrade_public_room_from_to">Você vai fazer upgrade desta sala de %1$s para %2$s.</string>
     <string name="upgrade_room_warning">Fazer upgrade de uma sala é uma ação avançada e é geralmente recomendado quando uma sala está instável devido a bugs, funcionalidades faltando ou vulnerabilidades de segurança.
 \nIsto geralmente só afeta como a sala é processada no servidor.</string>
     <string name="upgrade_private_room">Fazer upgrade de sala privada</string>

--- a/vector/src/main/res/values-ru/strings.xml
+++ b/vector/src/main/res/values-ru/strings.xml
@@ -2829,7 +2829,7 @@
     <string name="upgrade_room_no_power_to_manage">Для обновления комнаты необходимо разрешение</string>
     <string name="upgrade_room_update_parent_space">Автоматическое обновление родительского пространства</string>
     <string name="upgrade_room_auto_invite">Автоматическое приглашение пользователей</string>
-    <string name="upgrade_public_room_from_to">Вы обновили эту комнату с %s до %s.</string>
+    <string name="upgrade_public_room_from_to">Вы обновили эту комнату с %1$s до %2$s.</string>
     <string name="upgrade_room_warning">Обновление комнаты - это расширенное действие, которое обычно рекомендуется, когда комната работает нестабильно из-за ошибок, отсутствующих функций или уязвимостей безопасности.
 \nОбычно это влияет только на то, как комната обрабатывается на сервере.</string>
     <string name="upgrade_private_room">Модернизировать приватную комнату</string>

--- a/vector/src/main/res/values-sq/strings.xml
+++ b/vector/src/main/res/values-sq/strings.xml
@@ -2810,7 +2810,7 @@
     <string name="upgrade_room_no_power_to_manage">Ju duhen leje për të përmirësua një dhomë</string>
     <string name="upgrade_room_update_parent_space">Përditëso automatikisht mëmë hapësire</string>
     <string name="upgrade_room_auto_invite">Fto përdorues automatikisht</string>
-    <string name="upgrade_public_room_from_to">Do ta përmirësoni këtë dhomë nga %s në %s.</string>
+    <string name="upgrade_public_room_from_to">Do ta përmirësoni këtë dhomë nga %1$s në %2$s.</string>
     <string name="upgrade_room_warning">Përmirësimi i një dhome është një veprim i thelluar dhe zakonisht i rekomanduar kur një dhomë është e paqëndrueshme për shkak të metash, veçorish që mungojnë ose cenueshmëri sigurie.
 \nZakonisht kjo prek vetëm mënyrën se si trajtohet dhoma te shërbyesi.</string>
     <string name="upgrade_private_room">Përmirësoni dhomë private</string>

--- a/vector/src/main/res/values-zh-rCN/strings.xml
+++ b/vector/src/main/res/values-zh-rCN/strings.xml
@@ -2777,7 +2777,7 @@
     <string name="upgrade_room_no_power_to_manage">您需要权限才能升级聊天室</string>
     <string name="upgrade_room_update_parent_space">自动更新空间父级</string>
     <string name="upgrade_room_auto_invite">自动邀请用户</string>
-    <string name="upgrade_public_room_from_to">你将把此聊天室从 %s 升级到 %s。</string>
+    <string name="upgrade_public_room_from_to">你将把此聊天室从 %1$s 升级到 %2$s。</string>
     <string name="upgrade_room_warning">升级聊天室是一项高级操作，通常建议在由于错误、缺少功能或安全漏洞造成聊天室不稳定时进行此操作。
 \n这通常只会影响此服务器如何处理该聊天室。</string>
     <string name="upgrade_private_room">升级私人聊天室</string>

--- a/vector/src/main/res/values-zh-rTW/strings.xml
+++ b/vector/src/main/res/values-zh-rTW/strings.xml
@@ -2767,7 +2767,7 @@
     <string name="upgrade_room_no_power_to_manage">您需要升級聊天室的權限</string>
     <string name="upgrade_room_update_parent_space">自動更新空間上層</string>
     <string name="upgrade_room_auto_invite">自動邀請使用者</string>
-    <string name="upgrade_public_room_from_to">您將要把此聊天室從 %s 升級到 %s。</string>
+    <string name="upgrade_public_room_from_to">您將要把此聊天室從 %1$s 升級到 %2$s。</string>
     <string name="upgrade_room_warning">升級聊天是是一項進階動作，通常建議在聊天室因臭蟲、缺少功能或安全漏洞而不穩定時使用。
 \n這通常只會影響聊天是在伺服器上的處理方式。</string>
     <string name="upgrade_private_room">升級私人聊天室</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3470,7 +3470,7 @@
     <string name="upgrade_public_room">Upgrade public room</string>
     <string name="upgrade_private_room">Upgrade private room</string>
     <string name="upgrade_room_warning">Upgrading a room is an advanced action and is usually recommended when a room is unstable due to bugs, missing features or security vulnerabilities.\nThis usually only affects how the room is processed on the server.</string>
-    <string name="upgrade_public_room_from_to">You\'ll upgrade this room from %s to %s.</string>
+    <string name="upgrade_public_room_from_to">You\'ll upgrade this room from %1$s to %2$s.</string>
     <string name="upgrade_room_auto_invite">Automatically invite users</string>
     <string name="upgrade_room_update_parent_space">Automatically update space parent</string>
     <string name="upgrade_room_no_power_to_manage">You need permission to upgrade a room</string>


### PR DESCRIPTION
This PR fixes some issues and warnings which prevent the CI tests from passing and bluetooth from working on Android 12+
### Fixes:
- bluetooth permissions for Android 12 (https://developer.android.com/about/versions/12/features/bluetooth-permissions)
- string formatting for `upgrade_public_room_from_to` values
- replaces depracated Okhttp call
- asserts that columnIndex is not -1 in Filename.kt (fixes linter warning)
- suppress linter for [WrongConstant] when setting system bar behavior (triggers on API 31+, which the CI uses)

Signed-off-by: Tigermouthbear tigermouthbear@tigr.dev