### PR TITLE
FIx / bad format of restricted join rule

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomJoinRulesAllowEntry.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomJoinRulesAllowEntry.kt
@@ -23,11 +23,15 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class RoomJoinRulesAllowEntry(
         /**
-         * space: The room ID of the space to check the membership of.
+         * The room ID to check the membership of.
          */
-        @Json(name = "space") val spaceID: String,
+        @Json(name = "room_id") val roomId: String?,
         /**
-         * via: A list of servers which may be used to peek for membership of the space.
+         * "m.room_membership" to describe that we are allowing access via room membership. Future MSCs may define other types.
          */
-        @Json(name = "via") val via: List<String>
-)
+        @Json(name = "type") val type: String?
+) {
+    companion object {
+        fun restrictedToRoom(roomId: String) = RoomJoinRulesAllowEntry(roomId, "m.room_membership")
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomJoinRulesContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomJoinRulesContent.kt
@@ -29,7 +29,9 @@ import timber.log.Timber
 data class RoomJoinRulesContent(
         @Json(name = "join_rule") val _joinRules: String? = null,
         /**
-         * If the allow key is an empty list (or not a list at all), then the room reverts to standard public join rules
+         * If the allow key is an empty list (or not a list at all),
+         * then no users are allowed to join without an invite.
+         * Each entry is expected to be an object with the following keys:
          */
         @Json(name = "allow") val allowList: List<RoomJoinRulesAllowEntry>? = null
 ) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/ViaParameterFinder.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/ViaParameterFinder.kt
@@ -78,6 +78,10 @@ internal class ViaParameterFinder @Inject constructor(
                 .toSet()
     }
 
+    // not used much for now but as per MSC1772
+    // the via parameter of m.space.child must contain a via key which gives a list of candidate servers that can be used to join the room.
+    // It is possible for the list of candidate servers and the list of authorised servers to diverge.
+    // It may not be possible for a user to join a room if there's no overlap between these
     fun computeViaParamsForRestricted(roomId: String, max: Int): List<String> {
         val userThatCanInvite = roomGetterProvider.get().getRoom(roomId)
                 ?.getRoomMembers(roomMemberQueryParams { memberships = listOf(Membership.JOIN) })

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/state/DefaultStateService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/state/DefaultStateService.kt
@@ -182,7 +182,7 @@ internal class DefaultStateService @AssistedInject constructor(@Assisted private
     override suspend fun setJoinRuleRestricted(allowList: List<String>) {
         // we need to compute correct via parameters and check if PL are correct
         val allowEntries = allowList.map { spaceId ->
-            RoomJoinRulesAllowEntry(spaceId, viaParameterFinder.computeViaParamsForRestricted(spaceId, 3))
+            RoomJoinRulesAllowEntry.restrictedToRoom(spaceId)
         }
         updateJoinRule(RoomJoinRules.RESTRICTED, null, allowEntries)
     }

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
@@ -253,10 +253,7 @@ class CreateRoomViewModel @AssistedInject constructor(@Assisted private val init
                             state.parentSpaceId?.let {
                                 featurePreset = RestrictedRoomPreset(
                                         session.getHomeServerCapabilities(),
-                                        listOf(RoomJoinRulesAllowEntry(
-                                                state.parentSpaceId,
-                                                listOf(state.homeServerName)
-                                        ))
+                                        listOf(RoomJoinRulesAllowEntry.restrictedToRoom(state.parentSpaceId))
                                 )
                             }
                         }

--- a/vector/src/main/java/im/vector/app/features/spaces/create/CreateSpaceViewModelTask.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/create/CreateSpaceViewModelTask.kt
@@ -111,10 +111,7 @@ class CreateSpaceViewModelTask @Inject constructor(
                                         this.featurePreset = RestrictedRoomPreset(
                                                 homeServerCapabilities,
                                                 listOf(
-                                                        RoomJoinRulesAllowEntry(
-                                                                spaceID = spaceID,
-                                                                via = session.sessionParams.homeServerHost?.let { listOf(it) } ?: emptyList()
-                                                        )
+                                                        RoomJoinRulesAllowEntry.restrictedToRoom(spaceID)
                                                 )
                                         )
                                         if (e2eByDefault) {


### PR DESCRIPTION
EA was using an old format of restriced join rule
````
"join_rule": restricted
"allow" : [
    {
      "space" : "!mods:example.org",
      "via": ["m.org","ex.org"]
    }
]
````
instead of

````
"join_rule": "restricted",
"allow": [
    {
        "type": "m.room_membership",
        "room_id": "!mods:example.org"
    }
]
````