### PR TITLE
Use ShareCompat.IntentBuilder for sharing images

### DIFF
--- a/changelog.d/3965.bugfix
+++ b/changelog.d/3965.bugfix
@@ -1,0 +1,1 @@
+Enable image preview in Android's share sheet (Android 11+)

--- a/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
@@ -36,6 +36,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsSession
+import androidx.core.app.ShareCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.getSystemService
 import im.vector.app.BuildConfig
@@ -297,23 +298,19 @@ fun openMedia(activity: Activity, savedMediaPath: String, mimeType: String) {
 }
 
 fun shareMedia(context: Context, file: File, mediaMimeType: String?) {
-    var mediaUri: Uri? = null
-    try {
-        mediaUri = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".fileProvider", file)
+    val mediaUri = try {
+        FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".fileProvider", file)
     } catch (e: Exception) {
         Timber.e(e, "onMediaAction Selected File cannot be shared")
+        return
     }
 
-    if (null != mediaUri) {
-        val sendIntent = Intent()
-        sendIntent.action = Intent.ACTION_SEND
-        // Grant temporary read permission to the content URI
-        sendIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        sendIntent.type = mediaMimeType
-        sendIntent.putExtra(Intent.EXTRA_STREAM, mediaUri)
+    val sendIntent = ShareCompat.IntentBuilder(context)
+            .setType(mediaMimeType)
+            .setStream(mediaUri)
+            .getIntent()
 
-        sendShareIntent(context, sendIntent)
-    }
+    sendShareIntent(context, sendIntent)
 }
 
 fun shareText(context: Context, text: String) {


### PR DESCRIPTION
Use `ShareCompat.IntentBuilder` for sharing images. `ShareCompat` does the right thing with URI permissions so image previews show up in the Share sheet of Android 11.

Before and after:

<img src="https://user-images.githubusercontent.com/218061/132071686-7ce8ed1a-1ad1-45fc-bc4a-f79444b46f47.png" alt="element__share_image__before" width=300> <img src="https://user-images.githubusercontent.com/218061/132071691-a6abf2a6-8fda-45fd-9eda-3a68761700ba.png" alt="element__share_image__after" width=300>


### Pull Request Checklist

- [x] Changes have been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)

Signed-off-by: cketti <ck@cketti.de>