### PR TITLE
Fallback keys implementation

### DIFF
--- a/changelog.d/3473.bugfix
+++ b/changelog.d/3473.bugfix
@@ -1,0 +1,1 @@
+MSC2732: Olm fallback keys

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/sync/model/SyncResponse.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/sync/model/SyncResponse.kt
@@ -59,6 +59,14 @@ data class SyncResponse(
         val deviceOneTimeKeysCount: DeviceOneTimeKeysCountSyncResponse? = null,
 
         /**
+         * The key algorithms for which the server has an unused fallback key for the device.
+         * If the client wants the server to have a fallback key for a given key algorithm,
+         * but that algorithm is not listed in device_unused_fallback_key_types, the client will upload a new key.
+         */
+        @Json(name = "org.matrix.msc2732.device_unused_fallback_key_types")
+        val deviceUnusedFallbackKeyTypes: List<String>? = null,
+
+        /**
          * List of groups.
          */
         @Json(name = "groups") val groups: GroupsSyncResponse? = null

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -67,6 +67,7 @@ import org.matrix.android.sdk.internal.crypto.model.CryptoDeviceInfo
 import org.matrix.android.sdk.internal.crypto.model.ImportRoomKeysResult
 import org.matrix.android.sdk.internal.crypto.model.MXDeviceInfo
 import org.matrix.android.sdk.internal.crypto.model.MXEncryptEventContentResult
+import org.matrix.android.sdk.internal.crypto.model.MXKey.Companion.KEY_SIGNED_CURVE_25519_TYPE
 import org.matrix.android.sdk.internal.crypto.model.MXUsersDevicesMap
 import org.matrix.android.sdk.internal.crypto.model.event.EncryptedEventContent
 import org.matrix.android.sdk.internal.crypto.model.event.RoomKeyContent
@@ -329,7 +330,7 @@ internal class DefaultCryptoService @Inject constructor(
                 uploadDeviceKeys()
             }
 
-            oneTimeKeysUploader.maybeUploadOneTimeKeys()
+            oneTimeKeysUploader.maybeUploadOneTimeKeys(shouldGenerateFallbackKey = false)
             // this can throw if no backup
             tryOrNull {
                 keysBackupService.checkAndStartKeysBackup()
@@ -431,7 +432,17 @@ internal class DefaultCryptoService @Inject constructor(
                 if (isStarted()) {
                     // Make sure we process to-device messages before generating new one-time-keys #2782
                     deviceListManager.refreshOutdatedDeviceLists()
-                    oneTimeKeysUploader.maybeUploadOneTimeKeys()
+                    // The presence of device_unused_fallback_key_types indicates that the server supports fallback keys.
+                    // If there's no unused signed_curve25519 fallback key we need a new one.
+                    val shouldGenerateFallbackKey = if (syncResponse.deviceUnusedFallbackKeyTypes != null) {
+                        // Generate a fallback key only if the server does not already have an unused fallback key.
+                        !syncResponse.deviceUnusedFallbackKeyTypes.contains(KEY_SIGNED_CURVE_25519_TYPE)
+                    } else {
+                        // Server does not support fallbackKey
+                        false
+                    }
+
+                    oneTimeKeysUploader.maybeUploadOneTimeKeys(shouldGenerateFallbackKey)
                     incomingGossipingRequestManager.processReceivedGossipingRequests()
                 }
             }
@@ -928,7 +939,7 @@ internal class DefaultCryptoService @Inject constructor(
                 signatures = objectSigner.signObject(canonicalJson)
         )
 
-        val uploadDeviceKeysParams = UploadKeysTask.Params(rest, null)
+        val uploadDeviceKeysParams = UploadKeysTask.Params(rest, null, null)
         uploadKeysTask.execute(uploadDeviceKeysParams)
 
         cryptoStore.setDeviceKeysUploaded(true)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -330,7 +330,7 @@ internal class DefaultCryptoService @Inject constructor(
                 uploadDeviceKeys()
             }
 
-            oneTimeKeysUploader.maybeUploadOneTimeKeys(shouldGenerateFallbackKey = false)
+            oneTimeKeysUploader.maybeUploadOneTimeKeys()
             // this can throw if no backup
             tryOrNull {
                 keysBackupService.checkAndStartKeysBackup()
@@ -434,15 +434,13 @@ internal class DefaultCryptoService @Inject constructor(
                     deviceListManager.refreshOutdatedDeviceLists()
                     // The presence of device_unused_fallback_key_types indicates that the server supports fallback keys.
                     // If there's no unused signed_curve25519 fallback key we need a new one.
-                    val shouldGenerateFallbackKey = if (syncResponse.deviceUnusedFallbackKeyTypes != null) {
-                        // Generate a fallback key only if the server does not already have an unused fallback key.
-                        !syncResponse.deviceUnusedFallbackKeyTypes.contains(KEY_SIGNED_CURVE_25519_TYPE)
-                    } else {
-                        // Server does not support fallbackKey
-                        false
+                    if (syncResponse.deviceUnusedFallbackKeyTypes != null
+                            // Generate a fallback key only if the server does not already have an unused fallback key.
+                            && !syncResponse.deviceUnusedFallbackKeyTypes.contains(KEY_SIGNED_CURVE_25519_TYPE)) {
+                        oneTimeKeysUploader.setNeedsNewFallback()
                     }
 
-                    oneTimeKeysUploader.maybeUploadOneTimeKeys(shouldGenerateFallbackKey)
+                    oneTimeKeysUploader.maybeUploadOneTimeKeys()
                     incomingGossipingRequestManager.processReceivedGossipingRequests()
                 }
             }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -434,9 +434,9 @@ internal class DefaultCryptoService @Inject constructor(
                     deviceListManager.refreshOutdatedDeviceLists()
                     // The presence of device_unused_fallback_key_types indicates that the server supports fallback keys.
                     // If there's no unused signed_curve25519 fallback key we need a new one.
-                    if (syncResponse.deviceUnusedFallbackKeyTypes != null
+                    if (syncResponse.deviceUnusedFallbackKeyTypes != null &&
                             // Generate a fallback key only if the server does not already have an unused fallback key.
-                            && !syncResponse.deviceUnusedFallbackKeyTypes.contains(KEY_SIGNED_CURVE_25519_TYPE)) {
+                            !syncResponse.deviceUnusedFallbackKeyTypes.contains(KEY_SIGNED_CURVE_25519_TYPE)) {
                         oneTimeKeysUploader.setNeedsNewFallback()
                     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -437,7 +437,7 @@ internal class DefaultCryptoService @Inject constructor(
                     if (syncResponse.deviceUnusedFallbackKeyTypes != null &&
                             // Generate a fallback key only if the server does not already have an unused fallback key.
                             !syncResponse.deviceUnusedFallbackKeyTypes.contains(KEY_SIGNED_CURVE_25519_TYPE)) {
-                        oneTimeKeysUploader.setNeedsNewFallback()
+                        oneTimeKeysUploader.needsNewFallback()
                     }
 
                     oneTimeKeysUploader.maybeUploadOneTimeKeys()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/MXOlmDevice.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/MXOlmDevice.kt
@@ -136,6 +136,24 @@ internal class MXOlmDevice @Inject constructor(
         return store.getOlmAccount().maxOneTimeKeys()
     }
 
+    fun getFallbackKey(): MutableMap<String, MutableMap<String, String>>? {
+        try {
+            return store.getOlmAccount().fallbackKey()
+        } catch (e: Exception) {
+            Timber.e("## getFallbackKey() : failed")
+        }
+        return null
+    }
+
+    fun generateFallbackKey() {
+        try {
+            store.getOlmAccount().generateFallbackKey()
+            store.saveOlmAccount()
+        } catch (e: Exception) {
+            Timber.e("## generateFallbackKey() : failed")
+        }
+    }
+
     /**
      * Release the instance
      */

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/MXOlmDevice.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/MXOlmDevice.kt
@@ -150,13 +150,26 @@ internal class MXOlmDevice @Inject constructor(
         return null
     }
 
-    fun generateFallbackKey() {
+    /**
+     * Generates a new fallback key if there is not already
+     * an unpublished one.
+     * @return true if a new key was generated
+     */
+    fun generateFallbackKeyIfNeeded(): Boolean {
         try {
-            store.getOlmAccount().generateFallbackKey()
-            store.saveOlmAccount()
+            if (!hasUnpublishedFallbackKey()) {
+                store.getOlmAccount().generateFallbackKey()
+                store.saveOlmAccount()
+                return true
+            }
         } catch (e: Exception) {
             Timber.e("## generateFallbackKey() : failed")
         }
+        return false
+    }
+
+    internal fun hasUnpublishedFallbackKey(): Boolean {
+        return getFallbackKey()?.get(OlmAccount.JSON_KEY_ONE_TIME_KEY).orEmpty().isNotEmpty()
     }
 
     fun forgetFallbackKey() {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/MXOlmDevice.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/MXOlmDevice.kt
@@ -136,6 +136,11 @@ internal class MXOlmDevice @Inject constructor(
         return store.getOlmAccount().maxOneTimeKeys()
     }
 
+    /**
+     * Returns an unpublished fallback key
+     * A call to markKeysAsPublished will mark it as published and this
+     * call will return null (until a call to generateFallbackKey is made)
+     */
     fun getFallbackKey(): MutableMap<String, MutableMap<String, String>>? {
         try {
             return store.getOlmAccount().fallbackKey()
@@ -151,6 +156,15 @@ internal class MXOlmDevice @Inject constructor(
             store.saveOlmAccount()
         } catch (e: Exception) {
             Timber.e("## generateFallbackKey() : failed")
+        }
+    }
+
+    fun forgetFallbackKey() {
+        try {
+            store.getOlmAccount().forgetFallbackKey()
+            store.saveOlmAccount()
+        } catch (e: Exception) {
+            Timber.e("## forgetFallbackKey() : failed")
         }
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OneTimeKeysUploader.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OneTimeKeysUploader.kt
@@ -147,7 +147,6 @@ internal class OneTimeKeysUploader @Inject constructor(
         olmDevice.markKeysAsPublished()
         needNewFallbackKey = false
 
-
         if (response.hasOneTimeKeyCountsForAlgorithm(MXKey.KEY_SIGNED_CURVE_25519_TYPE)) {
             // Maybe upload other keys
             return keysThisLoop + uploadOTK(response.oneTimeKeyCountsForAlgorithm(MXKey.KEY_SIGNED_CURVE_25519_TYPE), keyLimit)
@@ -176,7 +175,6 @@ internal class OneTimeKeysUploader @Inject constructor(
 
             oneTimeJson["signed_curve25519:$key_id"] = k
         }
-
 
         val fallbackJson = mutableMapOf<String, Any>()
         if (needNewFallbackKey) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OneTimeKeysUploader.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OneTimeKeysUploader.kt
@@ -124,15 +124,15 @@ internal class OneTimeKeysUploader @Inject constructor(
      * @param keyLimit the limit
      * @return the number of uploaded keys
      */
-    private suspend fun uploadOTK(keyCount: Int, keyLimit: Int, shouldGenerateFallbackKey: Boolean): Int {
-        if (keyLimit <= keyCount && !shouldGenerateFallbackKey) {
+    private suspend fun uploadOTK(keyCount: Int, keyLimit: Int, shouldUploadFallbackKey: Boolean): Int {
+        if (keyLimit <= keyCount && !shouldUploadFallbackKey) {
             // If we don't need to generate any more keys then we are done.
             return 0
         }
         val keysThisLoop = min(keyLimit - keyCount, ONE_TIME_KEY_GENERATION_MAX_NUMBER)
         olmDevice.generateOneTimeKeys(keysThisLoop)
 
-        val fallbackKey = if (shouldGenerateFallbackKey) olmDevice.getFallbackKey() else null
+        val fallbackKey = if (shouldUploadFallbackKey) olmDevice.getFallbackKey() else null
 
         val response = uploadOneTimeKeys(olmDevice.getOneTimeKeys(), fallbackKey)
         olmDevice.markKeysAsPublished()
@@ -183,7 +183,7 @@ internal class OneTimeKeysUploader @Inject constructor(
         val uploadParams = UploadKeysTask.Params(
                 deviceKeys = null,
                 oneTimeKeys = oneTimeJson,
-                fallbackKeys = if (fallbackJson.isNotEmpty()) fallbackJson else null
+                fallbackKeys = fallbackJson.takeIf { fallbackJson.isNotEmpty() }
         )
         return uploadKeysTask.execute(uploadParams)
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OneTimeKeysUploader.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OneTimeKeysUploader.kt
@@ -30,7 +30,7 @@ import kotlin.math.floor
 import kotlin.math.min
 
 // THe spec recommend a 5mn delay, but due to federation
-// or server down we give it a bit more time (1 hour)
+// or server downtime we give it a bit more time (1 hour)
 const val FALLBACK_KEY_FORGET_DELAY = 60 * 60_000L
 
 @SessionScope

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OneTimeKeysUploader.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OneTimeKeysUploader.kt
@@ -29,7 +29,7 @@ import javax.inject.Inject
 import kotlin.math.floor
 import kotlin.math.min
 
-// THe spec recommend a 5mn delay, but due to federation
+// The spec recommend a 5mn delay, but due to federation
 // or server downtime we give it a bit more time (1 hour)
 const val FALLBACK_KEY_FORGET_DELAY = 60 * 60_000L
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/rest/KeysUploadBody.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/rest/KeysUploadBody.kt
@@ -40,5 +40,12 @@ internal data class KeysUploadBody(
          * May be absent if no new one-time keys are required.
          */
         @Json(name = "one_time_keys")
-        val oneTimeKeys: JsonDict? = null
+        val oneTimeKeys: JsonDict? = null,
+
+        /**
+         * If the user had previously uploaded a fallback key for a given algorithm, it is replaced.
+         * The server will only keep one fallback key per algorithm for each user.
+         */
+        @Json(name = "org.matrix.msc2732.fallback_keys")
+        val fallbackKeys: JsonDict? = null
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/UploadKeysTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/UploadKeysTask.kt
@@ -32,7 +32,8 @@ internal interface UploadKeysTask : Task<UploadKeysTask.Params, KeysUploadRespon
             // the device keys to send.
             val deviceKeys: DeviceKeys?,
             // the one-time keys to send.
-            val oneTimeKeys: JsonDict?
+            val oneTimeKeys: JsonDict?,
+            val fallbackKeys: JsonDict?
     )
 }
 
@@ -44,7 +45,8 @@ internal class DefaultUploadKeysTask @Inject constructor(
     override suspend fun execute(params: UploadKeysTask.Params): KeysUploadResponse {
         val body = KeysUploadBody(
                 deviceKeys = params.deviceKeys,
-                oneTimeKeys = params.oneTimeKeys
+                oneTimeKeys = params.oneTimeKeys,
+                fallbackKeys = params.fallbackKeys
         )
 
         Timber.i("## Uploading device keys -> $body")


### PR DESCRIPTION
### Problem
Olm uses a set of one-time keys when initializing a session between two devices: Alice uploads one-time keys to her homeserver, and Bob claims one of them to perform a Diffie-Hellman to generate a shared key. As implied by the name, a one-time key is only to be used once. However, if all of Alice's one-time keys are claimed, Bob will not be able to create a session with Alice.

### Proposal
A new response parameter, `device_unused_fallback_key_types` is added to /sync. If the client wants the server to have a fallback key for a given key algorithm, but that algorithm is not listed in `device_unused_fallback_key_types`, the client will upload a new key.

Here is the proposed logic to decide whether we need to generate a new fallback keys or not:
```
// The presence of device_unused_fallback_key_types indicates that the server supports fallback keys.
// If there's no unused signed_curve25519 fallback key we need a new one.
val shouldGenerateFallbackKey = if (syncResponse.deviceUnusedFallbackKeyTypes != null) {
    // Generate a fallback key only if the server does not already have an unused fallback key.
    !syncResponse.deviceUnusedFallbackKeyTypes.contains(KEY_SIGNED_CURVE_25519_TYPE)
} else {
    // Server does not support fallbackKey
    false
}
```

We need to use the existing `UploadKeysTask` by adding `fallbackKeys` parameter to the request.
