### PR TITLE
Room details: check power level before displaying actions in the timeline

### DIFF
--- a/changelog.d/3959.feature
+++ b/changelog.d/3959.feature
@@ -1,0 +1,1 @@
+Check power level before displaying actions in the room details' timeline

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MergedHeaderItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MergedHeaderItemFactory.kt
@@ -206,6 +206,7 @@ class MergedHeaderItemFactory @Inject constructor(private val activeSessionHolde
                     callback = callback,
                     currentUserId = currentUserId,
                     roomSummary = partialState.roomSummary,
+                    canInvite = powerLevelsHelper?.isUserAbleToInvite(currentUserId) ?: false,
                     canChangeAvatar = powerLevelsHelper?.isUserAllowedToSend(currentUserId, true, EventType.STATE_ROOM_AVATAR) ?: false,
                     canChangeTopic = powerLevelsHelper?.isUserAllowedToSend(currentUserId, true, EventType.STATE_ROOM_TOPIC) ?: false,
                     canChangeName = powerLevelsHelper?.isUserAllowedToSend(currentUserId, true, EventType.STATE_ROOM_NAME) ?: false

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MergedRoomCreationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MergedRoomCreationItem.kt
@@ -143,7 +143,8 @@ abstract class MergedRoomCreationItem : BasedMergedItem<MergedRoomCreationItem.H
         val topic = roomSummary?.topic
         if (topic.isNullOrBlank()) {
             // do not show hint for DMs or group DMs
-            if (!isDirect) {
+            val canSetTopic = attributes.canChangeTopic && !isDirect
+            if (canSetTopic) {
                 val addTopicLink = holder.view.resources.getString(R.string.add_a_topic_link_text)
                 val styledText = SpannableString(holder.view.resources.getString(R.string.room_created_summary_no_topic_creation_text, addTopicLink))
                 holder.roomTopicText.setTextOrHide(styledText.tappableMatchingText(addTopicLink, object : ClickableSpan() {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MergedRoomCreationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MergedRoomCreationItem.kt
@@ -190,8 +190,9 @@ abstract class MergedRoomCreationItem : BasedMergedItem<MergedRoomCreationItem.H
             }
         }
 
-        holder.addPeopleButton.isVisible = !isDirect
-        if (!isDirect) {
+        val canInvite = attributes.canInvite && !isDirect
+        holder.addPeopleButton.isVisible = canInvite
+        if (canInvite) {
             holder.addPeopleButton.onClick {
                 attributes.callback?.onTimelineItemAction(RoomDetailAction.QuickActionInvitePeople)
             }
@@ -228,6 +229,7 @@ abstract class MergedRoomCreationItem : BasedMergedItem<MergedRoomCreationItem.H
             val hasEncryptionEvent: Boolean,
             val isEncryptionAlgorithmSecure: Boolean,
             val roomSummary: RoomSummary?,
+            val canInvite: Boolean = false,
             val canChangeAvatar: Boolean = false,
             val canChangeName: Boolean = false,
             val canChangeTopic: Boolean = false


### PR DESCRIPTION
This PR fixes #3959 

User power-level is now checked before showing action as set a topic or invite people to a room.
Previously, an error dialog was shown **after** the forbidden action, making a bad user experience.