### PR TITLE
Better room preview, use room Summary API if available

### DIFF
--- a/changelog.d/3946.bugfix
+++ b/changelog.d/3946.bugfix
@@ -1,0 +1,1 @@
+ Restricted Room previews aren't working

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomStrippedState.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomStrippedState.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.matrix.android.sdk.api.session.room.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * These are the same fields as those returned by /publicRooms, with a few additions: room_type, membership and is_encrypted.
+ */
+@JsonClass(generateAdapter = true)
+data class RoomStrippedState(
+        /**
+         * Aliases of the room. May be empty.
+         */
+        @Json(name = "aliases")
+        val aliases: List<String>? = null,
+
+        /**
+         * The canonical alias of the room, if any.
+         */
+        @Json(name = "canonical_alias")
+        val canonicalAlias: String? = null,
+
+        /**
+         * The name of the room, if any.
+         */
+        @Json(name = "name")
+        val name: String? = null,
+
+        /**
+         * Required. The number of members joined to the room.
+         */
+        @Json(name = "num_joined_members")
+        val numJoinedMembers: Int = 0,
+
+        /**
+         * Required. The ID of the room.
+         */
+        @Json(name = "room_id")
+        val roomId: String,
+
+        /**
+         * The topic of the room, if any.
+         */
+        @Json(name = "topic")
+        val topic: String? = null,
+
+        /**
+         * Required. Whether the room may be viewed by guest users without joining.
+         */
+        @Json(name = "world_readable")
+        val worldReadable: Boolean = false,
+
+        /**
+         * Required. Whether guest users may join the room and participate in it. If they can,
+         * they will be subject to ordinary power level rules like any other user.
+         */
+        @Json(name = "guest_can_join")
+        val guestCanJoin: Boolean = false,
+
+        /**
+         * The URL for the room's avatar, if one is set.
+         */
+        @Json(name = "avatar_url")
+        val avatarUrl: String? = null,
+
+        /**
+         * Undocumented item
+         */
+        @Json(name = "m.federate")
+        val isFederated: Boolean = false,
+
+        /**
+         * Optional. If the room is encrypted. This is already accessible as stripped state.
+         */
+        @Json(name = "is_encrypted")
+        val isEncrypted: Boolean?,
+
+        /**
+         * Optional. Type of the room, if any, i.e. m.space
+         */
+        @Json(name = "room_type")
+        val roomType: String?,
+
+        /**
+         * The current membership of this user in the room. Usually leave if the room is fetched over federation.
+         */
+        @Json(name = "membership")
+        val membership: String?
+) {
+    /**
+     * Return the canonical alias, or the first alias from the list of aliases, or null
+     */
+    fun getPrimaryAlias(): String? {
+        return canonicalAlias ?: aliases?.firstOrNull()
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/GetRoomSummaryTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/GetRoomSummaryTask.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.room
+
+import org.matrix.android.sdk.api.session.room.model.RoomStrippedState
+import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
+import org.matrix.android.sdk.internal.network.executeRequest
+import org.matrix.android.sdk.internal.task.Task
+import javax.inject.Inject
+
+internal interface GetRoomSummaryTask : Task<GetRoomSummaryTask.Params, RoomStrippedState> {
+    data class Params(
+            val roomId: String,
+            val viaServers: List<String>?
+    )
+}
+
+internal class DefaultGetRoomSummaryTask @Inject constructor(
+        private val roomAPI: RoomAPI,
+        private val globalErrorReceiver: GlobalErrorReceiver
+) : GetRoomSummaryTask {
+
+    override suspend fun execute(params: GetRoomSummaryTask.Params): RoomStrippedState {
+        return executeRequest(globalErrorReceiver) {
+            roomAPI.getRoomSummary(params.roomId, params.viaServers)
+        }
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
@@ -389,7 +389,7 @@ internal interface RoomAPI {
      * as well as if the user is already a member of that room.
      * https://github.com/deepbluev7/matrix-doc/blob/room-summaries/proposals/3266-room-summary.md
      */
-    @GET(NetworkConstants.URI_API_PREFIX_PATH_UNSTABLE + "im.nheko.summary/rooms/{roomidOrAlias}/summary")
-    suspend fun getRoomSummary(@Path("roomidOrAlias") roomidOrAlias: String,
+    @GET(NetworkConstants.URI_API_PREFIX_PATH_UNSTABLE + "im.nheko.summary/rooms/{roomIdOrAlias}/summary")
+    suspend fun getRoomSummary(@Path("roomIdOrAlias") roomidOrAlias: String,
                                @Query("via") viaServers: List<String>?): RoomStrippedState
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
@@ -19,6 +19,7 @@ package org.matrix.android.sdk.internal.session.room
 import org.matrix.android.sdk.api.session.events.model.Content
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.room.model.Membership
+import org.matrix.android.sdk.api.session.room.model.RoomStrippedState
 import org.matrix.android.sdk.api.session.room.model.roomdirectory.PublicRoomsParams
 import org.matrix.android.sdk.api.session.room.model.roomdirectory.PublicRoomsResponse
 import org.matrix.android.sdk.api.util.JsonDict
@@ -254,7 +255,7 @@ internal interface RoomAPI {
     @POST(NetworkConstants.URI_API_PREFIX_PATH_R0 + "join/{roomIdOrAlias}")
     suspend fun join(@Path("roomIdOrAlias") roomIdOrAlias: String,
                      @Query("server_name") viaServers: List<String>,
-                     @Body params:  JsonDict): JoinRoomResponse
+                     @Body params: JsonDict): JoinRoomResponse
 
     /**
      * Leave the given room.
@@ -381,4 +382,14 @@ internal interface RoomAPI {
     @POST(NetworkConstants.URI_API_PREFIX_PATH_R0 + "rooms/{roomId}/upgrade")
     suspend fun upgradeRoom(@Path("roomId") roomId: String,
                             @Body body: RoomUpgradeBody): RoomUpgradeResponse
+
+    /**
+     * The API returns the summary of the specified room, if the room could be found and the client should be able to view
+     * its contents according to the join_rules, history visibility, space membership and similar rules outlined in MSC3173
+     * as well as if the user is already a member of that room.
+     * https://github.com/deepbluev7/matrix-doc/blob/room-summaries/proposals/3266-room-summary.md
+     */
+    @GET(NetworkConstants.URI_API_PREFIX_PATH_UNSTABLE + "im.nheko.summary/rooms/{roomidOrAlias}/summary")
+    suspend fun getRoomSummary(@Path("roomidOrAlias") roomidOrAlias: String,
+                               @Query("via") viaServers: List<String>?): RoomStrippedState
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomModule.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomModule.kt
@@ -255,5 +255,5 @@ internal abstract class RoomModule {
     abstract fun bindSign3pidInvitationTask(task: DefaultSign3pidInvitationTask): Sign3pidInvitationTask
 
     @Binds
-    abstract fun bindSGetRoomSummaryTask(task: DefaultGetRoomSummaryTask): GetRoomSummaryTask
+    abstract fun bindGetRoomSummaryTask(task: DefaultGetRoomSummaryTask): GetRoomSummaryTask
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomModule.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomModule.kt
@@ -253,4 +253,7 @@ internal abstract class RoomModule {
 
     @Binds
     abstract fun bindSign3pidInvitationTask(task: DefaultSign3pidInvitationTask): Sign3pidInvitationTask
+
+    @Binds
+    abstract fun bindSGetRoomSummaryTask(task: DefaultGetRoomSummaryTask): GetRoomSummaryTask
 }


### PR DESCRIPTION
Fixes #3946 

Implements [MSC 3266](https://github.com/matrix-org/matrix-doc/pull/3266)

Improve Room preview by using the new Room Summary API (stripped state). This allows you to get minimum information on a room (name/topic/avatar/type/member count...) even if you cannot peek state or if it's not in public directory.
Basically if you can join the room you will get a summary.
