### PR TITLE
Fix /  Kick user dialog for spaces talks about rooms

### DIFF
--- a/changelog.d/3956.bugfix
+++ b/changelog.d/3956.bugfix
@@ -1,0 +1,1 @@
+ Kick user dialog for spaces talks about rooms

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileController.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileController.kt
@@ -45,8 +45,8 @@ class RoomMemberProfileController @Inject constructor(
         fun onJumpToReadReceiptClicked()
         fun onMentionClicked()
         fun onEditPowerLevel(currentRole: Role)
-        fun onKickClicked()
-        fun onBanClicked(isUserBanned: Boolean)
+        fun onKickClicked(isSpace: Boolean)
+        fun onBanClicked(isSpace: Boolean, isUserBanned: Boolean)
         fun onCancelInviteClicked()
         fun onInviteClicked()
     }
@@ -85,7 +85,9 @@ class RoomMemberProfileController @Inject constructor(
     }
 
     private fun buildRoomMemberActions(state: RoomMemberProfileViewState) {
-        buildSecuritySection(state)
+        if (!state.isSpace) {
+            buildSecuritySection(state)
+        }
         buildMoreSection(state)
         buildAdminSection(state)
     }
@@ -181,7 +183,7 @@ class RoomMemberProfileController @Inject constructor(
                     action = { callback?.onOpenDmClicked() }
             )
 
-            if (state.hasReadReceipt) {
+            if (!state.isSpace && state.hasReadReceipt) {
                 buildProfileAction(
                         id = "read_receipt",
                         editable = false,
@@ -191,16 +193,18 @@ class RoomMemberProfileController @Inject constructor(
             }
 
             val ignoreActionTitle = state.buildIgnoreActionTitle()
-
-            buildProfileAction(
-                    id = "mention",
-                    title = stringProvider.getString(R.string.room_participants_action_mention),
-                    editable = false,
-                    divider = ignoreActionTitle != null,
-                    action = { callback?.onMentionClicked() }
-            )
+            if (!state.isSpace) {
+                buildProfileAction(
+                        id = "mention",
+                        title = stringProvider.getString(R.string.room_participants_action_mention),
+                        editable = false,
+                        divider = ignoreActionTitle != null,
+                        action = { callback?.onMentionClicked() }
+                )
+            }
 
             val canInvite = state.actionPermissions.canInvite
+
             if (canInvite && (membership == Membership.LEAVE || membership == Membership.KNOCK)) {
                 buildProfileAction(
                         id = "invite",
@@ -261,7 +265,7 @@ class RoomMemberProfileController @Inject constructor(
                             divider = canBan,
                             destructive = true,
                             title = stringProvider.getString(R.string.room_participants_action_kick),
-                            action = { callback?.onKickClicked() }
+                            action = { callback?.onKickClicked(state.isSpace) }
                     )
                 }
                 Membership.INVITE -> {
@@ -288,7 +292,7 @@ class RoomMemberProfileController @Inject constructor(
                     editable = false,
                     destructive = true,
                     title = banActionTitle,
-                    action = { callback?.onBanClicked(membership == Membership.BAN) }
+                    action = { callback?.onBanClicked(state.isSpace, membership == Membership.BAN) }
             )
         }
     }

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
@@ -305,16 +305,16 @@ class RoomMemberProfileFragment @Inject constructor(
         val views = DialogShareQrCodeBinding.bind(view)
         views.itemShareQrCodeImage.setData(permalink)
         MaterialAlertDialogBuilder(requireContext())
-            .setView(view)
-            .setNeutralButton(R.string.ok, null)
-            .setPositiveButton(R.string.share_by_text) { _, _ ->
-                startSharePlainTextIntent(
-                        fragment = this,
-                        activityResultLauncher = null,
-                        chooserTitle = null,
-                        text = permalink
-                )
-            }.show()
+                .setView(view)
+                .setNeutralButton(R.string.ok, null)
+                .setPositiveButton(R.string.share_by_text) { _, _ ->
+                    startSharePlainTextIntent(
+                            fragment = this,
+                            activityResultLauncher = null,
+                            chooserTitle = null,
+                            text = permalink
+                    )
+                }.show()
     }
 
     private fun onAvatarClicked(view: View, userMatrixItem: MatrixItem) {
@@ -327,12 +327,13 @@ class RoomMemberProfileFragment @Inject constructor(
         }
     }
 
-    override fun onKickClicked() {
+    override fun onKickClicked(isSpace: Boolean) {
         ConfirmationDialogBuilder
                 .show(
                         activity = requireActivity(),
                         askForReason = true,
-                        confirmationRes = R.string.room_participants_kick_prompt_msg,
+                        confirmationRes = if (isSpace) R.string.space_participants_kick_prompt_msg
+                        else R.string.room_participants_kick_prompt_msg,
                         positiveRes = R.string.room_participants_action_kick,
                         reasonHintRes = R.string.room_participants_kick_reason,
                         titleRes = R.string.room_participants_kick_title
@@ -341,16 +342,18 @@ class RoomMemberProfileFragment @Inject constructor(
                 }
     }
 
-    override fun onBanClicked(isUserBanned: Boolean) {
+    override fun onBanClicked(isSpace: Boolean, isUserBanned: Boolean) {
         val titleRes: Int
         val positiveButtonRes: Int
         val confirmationRes: Int
         if (isUserBanned) {
-            confirmationRes = R.string.room_participants_unban_prompt_msg
+            confirmationRes = if (isSpace) R.string.space_participants_unban_prompt_msg
+            else R.string.room_participants_unban_prompt_msg
             titleRes = R.string.room_participants_unban_title
             positiveButtonRes = R.string.room_participants_action_unban
         } else {
-            confirmationRes = R.string.room_participants_ban_prompt_msg
+            confirmationRes = if (isSpace) R.string.space_participants_ban_prompt_msg
+            else R.string.room_participants_ban_prompt_msg
             titleRes = R.string.room_participants_ban_title
             positiveButtonRes = R.string.room_participants_action_ban
         }

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewModel.kt
@@ -48,6 +48,7 @@ import org.matrix.android.sdk.api.session.room.members.roomMemberQueryParams
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.model.PowerLevelsContent
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import org.matrix.android.sdk.api.session.room.model.RoomType
 import org.matrix.android.sdk.api.session.room.powerlevels.PowerLevelsHelper
 import org.matrix.android.sdk.api.session.room.powerlevels.Role
 import org.matrix.android.sdk.api.util.MatrixItem
@@ -86,7 +87,8 @@ class RoomMemberProfileViewModel @AssistedInject constructor(@Assisted private v
             copy(
                     isMine = session.myUserId == this.userId,
                     userMatrixItem = room?.getRoomMember(initialState.userId)?.toMatrixItem()?.let { Success(it) } ?: Uninitialized,
-                    hasReadReceipt = room?.getUserReadReceipt(initialState.userId) != null
+                    hasReadReceipt = room?.getUserReadReceipt(initialState.userId) != null,
+                    isSpace = room?.roomSummary()?.roomType == RoomType.SPACE
             )
         }
         observeIgnoredState()

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewState.kt
@@ -28,6 +28,7 @@ import org.matrix.android.sdk.api.util.MatrixItem
 data class RoomMemberProfileViewState(
         val userId: String,
         val roomId: String?,
+        val isSpace: Boolean = false,
         val showAsMember: Boolean = false,
         val isMine: Boolean = false,
         val isIgnored: Async<Boolean> = Uninitialized,

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -903,11 +903,14 @@
     <string name="room_participants_kick_title">Kick user</string>
     <string name="room_participants_kick_reason">Reason to kick</string>
     <string name="room_participants_kick_prompt_msg">kicking user will remove them from this room.\n\nTo prevent them from joining again, you should ban them instead.</string>
+    <string name="space_participants_kick_prompt_msg">kicking user will remove them from this space.\n\nTo prevent them from joining again, you should ban them instead.</string>
     <string name="room_participants_ban_title">Ban user</string>
     <string name="room_participants_ban_reason">Reason to ban</string>
     <string name="room_participants_unban_title">Unban user</string>
     <string name="room_participants_ban_prompt_msg">Banning user will kick them from this room and prevent them from joining again.</string>
+    <string name="space_participants_ban_prompt_msg">Banning user will kick them from this space and prevent them from joining again.</string>
     <string name="room_participants_unban_prompt_msg">Unbanning user will allow them to join the room again.</string>
+    <string name="space_participants_unban_prompt_msg">Unbanning user will allow them to join the space again.</string>
 
     <string name="reason_hint">Reason</string>
 


### PR DESCRIPTION
Fixes #3956 

Change copy to room when it's a room and space when it's a space, and remove un-needed action (jump to read receipt, mention,  secruity section..)
<img width="895" alt="image" src="https://user-images.githubusercontent.com/9841565/132531566-c7467fb5-9f60-431a-9edb-ea0fa0ca0195.png">
