### PR TITLE
feature/aris/issue_dinsic_618

### DIFF
--- a/changelog.d/4018.misc
+++ b/changelog.d/4018.misc
@@ -1,0 +1,1 @@
+Minimize the use of exported="true" in android Manifest (link: https://github.com/matrix-org/matrix-dinsic/issues/618)

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -92,8 +92,10 @@
             android:theme="@style/Theme.Vector.Launcher" />
 
         <!-- Activity alias for the launcher Activity (must be declared after the Activity it targets) -->
+        <!-- exported="true" is required to launch application -->
         <activity-alias
             android:name=".features.Alias"
+            android:exported="true"
             android:targetActivity=".features.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -107,9 +109,12 @@
         </activity-alias>
 
         <activity android:name=".features.home.HomeActivity" />
+
+        <!-- exported="true" is required to handle android.intent.action.VIEW for URL redirection-->
         <activity
             android:name=".features.login.LoginActivity"
             android:enabled="@bool/useLoginV1"
+            android:exported="true"
             android:launchMode="singleTask"
             android:windowSoftInputMode="adjustResize">
             <!-- Add intent filter to handle redirection URL after SSO login in external browser -->
@@ -124,9 +129,12 @@
                     android:scheme="element" />
             </intent-filter>
         </activity>
+
+        <!-- exported="true" is required to handle android.intent.action.VIEW for URL redirection-->
         <activity
             android:name=".features.login2.LoginActivity2"
             android:enabled="@bool/useLoginV2"
+            android:exported="true"
             android:launchMode="singleTask"
             android:windowSoftInputMode="adjustResize">
             <!-- Add intent filter to handle redirection URL after SSO login in external browser -->
@@ -147,7 +155,6 @@
             android:name=".features.media.VectorAttachmentViewerActivity"
             android:theme="@style/Theme.Vector.Black.Transparent"
             tools:ignore="Instantiatable" />
-
         <activity android:name=".features.media.BigImageViewerActivity" />
         <activity
             android:name=".features.rageshake.BugReportActivity"
@@ -165,7 +172,6 @@
         <activity
             android:name=".features.crypto.keysbackup.settings.KeysBackupManageActivity"
             android:label="@string/encryption_message_recovery" />
-
         <activity
             android:name=".features.reactions.EmojiReactionPickerActivity"
             android:label="@string/title_activity_emoji_reaction_picker" />
@@ -186,6 +192,7 @@
         <activity android:name=".features.webview.VectorWebViewActivity" />
 
         <!-- Activity to intercept links coming from a web instance -->
+        <!-- exported="true" is required to handle android.intent.action.VIEW for URL redirection-->
         <activity
             android:name=".features.link.LinkHandlerActivity"
             android:enabled="true"
@@ -206,6 +213,7 @@
         </activity>
 
         <!-- Activity alias for matrix.to or element permalinks -->
+        <!-- exported="true" is required to handle android.intent.action.VIEW for URL redirection-->
         <activity-alias
             android:name=".features.permalink.PermalinkHandlerActivity"
             android:enabled="true"
@@ -231,8 +239,10 @@
             </intent-filter>
         </activity-alias>
 
+        <!-- exported="true" is required for the share functionality-->
         <activity
             android:name=".features.share.IncomingShareActivity"
+            android:exported="true"
             android:parentActivityName=".features.home.HomeActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
@@ -257,10 +267,8 @@
                 android:name="android.service.chooser.chooser_target_service"
                 android:value="androidx.sharetarget.ChooserTargetServiceCompat" />
         </activity>
-
         <activity android:name=".features.roomprofile.RoomProfileActivity" />
         <activity android:name=".features.roomprofile.settings.joinrule.RoomJoinRuleActivity" />
-
         <activity android:name=".features.signout.hard.SignedOutActivity" />
         <activity
             android:name=".features.signout.soft.SoftLogoutActivity"
@@ -275,12 +283,10 @@
         </activity>
 
         <activity android:name=".features.qrcode.QrCodeScannerActivity" />
-
         <activity android:name=".features.crypto.quads.SharedSecureStorageActivity" />
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
             android:screenOrientation="portrait" />
-
         <activity
             android:name=".features.attachments.preview.AttachmentsPreviewActivity"
             android:theme="@style/Theme.Vector.Black.AttachmentsPreview" />
@@ -308,7 +314,6 @@
         <!-- Single instance is very important for the custom scheme callback-->
         <activity
             android:name=".features.auth.ReAuthActivity"
-            android:exported="false"
             android:launchMode="singleInstance">
 
             <!-- XXX: UIA SSO has only web fallback, i.e no url redirect, so for now we comment this out
@@ -334,6 +339,7 @@
         <activity android:name=".features.spaces.manage.SpaceManageActivity" />
         <activity android:name=".features.spaces.people.SpacePeopleActivity" />
         <activity android:name=".features.spaces.leave.SpaceLeaveAdvancedActivity" />
+
         <!-- Services -->
 
         <service
@@ -353,6 +359,7 @@
 
         <service
             android:name=".features.call.telecom.VectorConnectionService"
+            android:exported="false"
             android:permission="android.permission.BIND_TELECOM_CONNECTION_SERVICE">
             <intent-filter>
                 <action android:name="android.telecom.ConnectionService" />
@@ -379,7 +386,9 @@
         A media button receiver receives and helps translate hardware media playback buttons,
         such as those found on wired and wireless headsets, into the appropriate callbacks in your app.
            -->
-        <receiver android:name="androidx.media.session.MediaButtonReceiver">
+        <receiver
+            android:name="androidx.media.session.MediaButtonReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>


### PR DESCRIPTION
_Apps targeting Android 12 and higher are required to specify an explicit value for android:exported when the corresponding
component has an intent filter defined._

### android:exported=“true”

**Activities**

```
.features.MainActivity 
[intent-filter] —> Required to launch the app

.features.login.LoginActivity
[intent-filter] -> Redirection URL after SSO login in external browser

.features.login2.LoginActivity2
[intent-filter] -> Redirection URL after SSO login in external browser

.features.link.LinkHandlerActivity
[intent-filter] -> Deep Link Converter/Transformer

.features.permalink.PermalinkHandlerActivity
[intent-filter] -> Deep Links Handling

.features.share.IncomingShareActivity
[intent-filter] -> Share functionality

```
**Services**
```
.features.call.telecom.VectorConnectionService
[intent-filter] -> Call connection service.  [maybe false?]
```

**Receivers**
```
androidx.media.session.MediaButtonReceiver
[intent-filter] -> Translate hardware media playback buttons  [maybe false?]
```

### android:exported=“false”
```
All the other activities, services, receivers, providers
```