### PR TITLE
Show mxto bottom sheet when tapping invite notification

### DIFF
--- a/changelog.d/4043.bugfix
+++ b/changelog.d/4043.bugfix
@@ -1,0 +1,1 @@
+Spaces invitation system notifications don't take me to the join space toast

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -81,7 +81,8 @@ import javax.inject.Inject
 @Parcelize
 data class HomeActivityArgs(
         val clearNotification: Boolean,
-        val accountCreation: Boolean
+        val accountCreation: Boolean,
+        val inviteNotificationRoomId: String? = null
 ) : Parcelable
 
 class HomeActivity :
@@ -228,6 +229,11 @@ class HomeActivity :
 
         if (args?.clearNotification == true) {
             notificationDrawerManager.clearAllEvents()
+        }
+        if (args?.inviteNotificationRoomId != null) {
+            activeSessionHolder.getSafeActiveSession()?.permalinkService()?.createPermalink(args.inviteNotificationRoomId)?.let {
+                navigator.openMatrixToBottomSheet(this, it)
+            }
         }
 
         homeActivityViewModel.observeViewEvents {
@@ -422,8 +428,16 @@ class HomeActivity :
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-        if (intent?.getParcelableExtra<HomeActivityArgs>(MvRx.KEY_ARG)?.clearNotification == true) {
+        val parcelableExtra = intent?.getParcelableExtra<HomeActivityArgs>(MvRx.KEY_ARG)
+        if (parcelableExtra?.clearNotification == true) {
             notificationDrawerManager.clearAllEvents()
+        }
+        if (parcelableExtra?.inviteNotificationRoomId != null) {
+            activeSessionHolder.getSafeActiveSession()
+                    ?.permalinkService()
+                    ?.createPermalink(parcelableExtra.inviteNotificationRoomId)?.let {
+                        navigator.openMatrixToBottomSheet(this, it)
+                    }
         }
         handleIntent(intent)
     }
@@ -548,10 +562,15 @@ class HomeActivity :
     }
 
     companion object {
-        fun newIntent(context: Context, clearNotification: Boolean = false, accountCreation: Boolean = false): Intent {
+        fun newIntent(context: Context,
+                      clearNotification: Boolean = false,
+                      accountCreation: Boolean = false,
+                      inviteNotificationRoomId: String? = null
+        ): Intent {
             val args = HomeActivityArgs(
                     clearNotification = clearNotification,
-                    accountCreation = accountCreation
+                    accountCreation = accountCreation,
+                    inviteNotificationRoomId = inviteNotificationRoomId
             )
 
             return Intent(context, HomeActivity::class.java)

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
@@ -679,7 +679,7 @@ class NotificationUtils @Inject constructor(private val context: Context,
                             stringProvider.getString(R.string.join),
                             joinIntentPendingIntent)
 
-                    val contentIntent = HomeActivity.newIntent(context)
+                    val contentIntent = HomeActivity.newIntent(context, inviteNotificationRoomId = inviteNotifiableEvent.roomId)
                     contentIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
                     // pending intent get reused by system, this will mess up the extra params, so put unique info to avoid that
                     contentIntent.data = Uri.parse("foobar://" + inviteNotifiableEvent.eventId)


### PR DESCRIPTION
Fixes #4043 

Tapping on a space invite notification, was only opening the app in the home screen.
Was acceptable for rooms as the invite would show up on top of the roomlist.

But now with spaces we need to do more (the space invite will only appear in the left drawer).
So with this PR, on notification tap a bottomsheet will appear with preview and join button:
<img width="392" alt="image" src="https://user-images.githubusercontent.com/9841565/133986482-c8717039-d1b3-402b-b403-ca7bb7df723d.png">


Will work also for rooms