### PR TITLE
Incr sync investigation

### DIFF
--- a/changelog.d/4046.feature
+++ b/changelog.d/4046.feature
@@ -1,0 +1,1 @@
+Push and syncs: add debug info on room list and on room detail screen and improves the log format.

--- a/changelog.d/4046.misc
+++ b/changelog.d/4046.misc
@@ -1,0 +1,1 @@
+InitialSyncProgressService has been renamed to SyncStatusService and its function getInitialSyncProgressStatus() has been renamed to getSyncStatusLive()

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -55,6 +55,8 @@ ext.libs = [
                 'lifecycleExtensions'     : "androidx.lifecycle:lifecycle-extensions:$lifecycle",
                 'lifecycleJava8'          : "androidx.lifecycle:lifecycle-common-java8:$lifecycle",
                 'lifecycleLivedata'       : "androidx.lifecycle:lifecycle-livedata-ktx:2.3.1",
+                'datastore'               : "androidx.datastore:datastore:1.0.0",
+                'datastorepreferences'    : "androidx.datastore:datastore-preferences:1.0.0",
                 'pagingRuntimeKtx'        : "androidx.paging:paging-runtime-ktx:2.1.2",
                 'coreTesting'             : "androidx.arch.core:core-testing:2.1.0",
                 'testCore'                : "androidx.test:core:$androidxTest",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,8 +7,8 @@ ext.versions = [
         'targetCompat'      : JavaVersion.VERSION_11,
 ]
 
-// Ref: https://kotlinlang.org/releases.html
 def gradle = "7.0.2"
+// Ref: https://kotlinlang.org/releases.html
 def kotlin = "1.5.30"
 def kotlinCoroutines = "1.5.1"
 def dagger = "2.38.1"

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/logger/LoggerTag.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/logger/LoggerTag.kt
@@ -24,6 +24,7 @@ package org.matrix.android.sdk.api.logger
  */
 open class LoggerTag(_value: String, parentTag: LoggerTag? = null) {
 
+    object SYNC : LoggerTag("SYNC")
     object VOIP : LoggerTag("VOIP")
 
     val value: String = if (parentTag == null) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/Session.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/Session.kt
@@ -36,7 +36,7 @@ import org.matrix.android.sdk.api.session.file.FileService
 import org.matrix.android.sdk.api.session.group.GroupService
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilitiesService
 import org.matrix.android.sdk.api.session.identity.IdentityService
-import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
+import org.matrix.android.sdk.api.session.initsync.SyncStatusService
 import org.matrix.android.sdk.api.session.integrationmanager.IntegrationManagerService
 import org.matrix.android.sdk.api.session.media.MediaService
 import org.matrix.android.sdk.api.session.openid.OpenIdService
@@ -75,7 +75,7 @@ interface Session :
         ProfileService,
         PushRuleService,
         PushersService,
-        InitialSyncProgressService,
+        SyncStatusService,
         HomeServerCapabilitiesService,
         SecureStorageService,
         AccountService {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/initsync/InitialSyncProgressService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/initsync/InitialSyncProgressService.kt
@@ -36,6 +36,7 @@ interface InitialSyncProgressService {
                 val rooms: Int,
                 val toDevice: Int
         ) : IncrementalSyncStatus()
+        object IncrementalSyncError : IncrementalSyncStatus()
         object IncrementalSyncDone : IncrementalSyncStatus()
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/initsync/InitialSyncProgressService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/initsync/InitialSyncProgressService.kt
@@ -17,6 +17,7 @@ package org.matrix.android.sdk.api.session.initsync
 
 import androidx.lifecycle.LiveData
 
+// TODO Rename or since we also observe classical sync here
 interface InitialSyncProgressService {
 
     fun getInitialSyncProgressStatus(): LiveData<Status>
@@ -27,5 +28,11 @@ interface InitialSyncProgressService {
                 val initSyncStep: InitSyncStep,
                 val percentProgress: Int = 0
         ) : Status()
+
+        abstract class IncrementalSyncStatus: Status()
+
+        object IncrementalSyncIdle : IncrementalSyncStatus()
+        object IncrementalSyncParsing : IncrementalSyncStatus()
+        object IncrementalSyncDone : IncrementalSyncStatus()
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/initsync/InitialSyncProgressService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/initsync/InitialSyncProgressService.kt
@@ -32,7 +32,10 @@ interface InitialSyncProgressService {
         abstract class IncrementalSyncStatus: Status()
 
         object IncrementalSyncIdle : IncrementalSyncStatus()
-        object IncrementalSyncParsing : IncrementalSyncStatus()
+        data class IncrementalSyncParsing(
+                val rooms: Int,
+                val toDevice: Int
+        ) : IncrementalSyncStatus()
         object IncrementalSyncDone : IncrementalSyncStatus()
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/initsync/SyncStatusService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/initsync/SyncStatusService.kt
@@ -17,18 +17,25 @@ package org.matrix.android.sdk.api.session.initsync
 
 import androidx.lifecycle.LiveData
 
-// TODO Rename or since we also observe classical sync here
-interface InitialSyncProgressService {
+interface SyncStatusService {
 
-    fun getInitialSyncProgressStatus(): LiveData<Status>
+    fun getSyncStatusLive(): LiveData<Status>
 
     sealed class Status {
-        object Idle : Status()
+        /**
+         * For initial sync
+         */
+        abstract class InitialSyncStatus: Status()
+
+        object Idle : InitialSyncStatus()
         data class Progressing(
                 val initSyncStep: InitSyncStep,
                 val percentProgress: Int = 0
-        ) : Status()
+        ) : InitialSyncStatus()
 
+        /**
+         * For incremental sync
+         */
         abstract class IncrementalSyncStatus: Status()
 
         object IncrementalSyncIdle : IncrementalSyncStatus()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
@@ -40,7 +40,7 @@ import org.matrix.android.sdk.api.session.file.ContentDownloadStateTracker
 import org.matrix.android.sdk.api.session.file.FileService
 import org.matrix.android.sdk.api.session.group.GroupService
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilitiesService
-import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
+import org.matrix.android.sdk.api.session.initsync.SyncStatusService
 import org.matrix.android.sdk.api.session.integrationmanager.IntegrationManagerService
 import org.matrix.android.sdk.api.session.media.MediaService
 import org.matrix.android.sdk.api.session.openid.OpenIdService
@@ -115,7 +115,7 @@ internal class DefaultSession @Inject constructor(
         private val contentUploadProgressTracker: ContentUploadStateTracker,
         private val typingUsersTracker: TypingUsersTracker,
         private val contentDownloadStateTracker: ContentDownloadStateTracker,
-        private val initialSyncProgressService: Lazy<InitialSyncProgressService>,
+        private val syncStatusService: Lazy<SyncStatusService>,
         private val homeServerCapabilitiesService: Lazy<HomeServerCapabilitiesService>,
         private val accountDataService: Lazy<SessionAccountDataService>,
         private val _sharedSecretStorageService: Lazy<SharedSecretStorageService>,
@@ -141,7 +141,7 @@ internal class DefaultSession @Inject constructor(
         PushersService by pushersService.get(),
         EventService by eventService.get(),
         TermsService by termsService.get(),
-        InitialSyncProgressService by initialSyncProgressService.get(),
+        SyncStatusService by syncStatusService.get(),
         SecureStorageService by secureStorageService.get(),
         HomeServerCapabilitiesService by homeServerCapabilitiesService.get(),
         ProfileService by profileService.get(),

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionModule.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionModule.kt
@@ -37,7 +37,7 @@ import org.matrix.android.sdk.api.session.SessionLifecycleObserver
 import org.matrix.android.sdk.api.session.accountdata.SessionAccountDataService
 import org.matrix.android.sdk.api.session.events.EventService
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilitiesService
-import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
+import org.matrix.android.sdk.api.session.initsync.SyncStatusService
 import org.matrix.android.sdk.api.session.openid.OpenIdService
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService
 import org.matrix.android.sdk.api.session.securestorage.SecureStorageService
@@ -81,7 +81,7 @@ import org.matrix.android.sdk.internal.session.download.DownloadProgressIntercep
 import org.matrix.android.sdk.internal.session.events.DefaultEventService
 import org.matrix.android.sdk.internal.session.homeserver.DefaultHomeServerCapabilitiesService
 import org.matrix.android.sdk.internal.session.identity.DefaultIdentityService
-import org.matrix.android.sdk.internal.session.initsync.DefaultInitialSyncProgressService
+import org.matrix.android.sdk.internal.session.initsync.DefaultSyncStatusService
 import org.matrix.android.sdk.internal.session.integrationmanager.IntegrationManager
 import org.matrix.android.sdk.internal.session.openid.DefaultOpenIdService
 import org.matrix.android.sdk.internal.session.permalinks.DefaultPermalinkService
@@ -355,7 +355,7 @@ internal abstract class SessionModule {
     abstract fun bindEventSenderProcessorAsSessionLifecycleObserver(processor: EventSenderProcessorCoroutine): SessionLifecycleObserver
 
     @Binds
-    abstract fun bindInitialSyncProgressService(service: DefaultInitialSyncProgressService): InitialSyncProgressService
+    abstract fun bindSyncStatusService(service: DefaultSyncStatusService): SyncStatusService
 
     @Binds
     abstract fun bindSecureStorageService(service: DefaultSecureStorageService): SecureStorageService

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/initsync/DefaultInitialSyncProgressService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/initsync/DefaultInitialSyncProgressService.kt
@@ -35,6 +35,11 @@ internal class DefaultInitialSyncProgressService @Inject constructor()
         return status
     }
 
+    // Only to be used for incremental sync
+    fun setStatus(newStatus: InitialSyncProgressService.Status) {
+        status.postValue(newStatus)
+    }
+
     /**
      * Create a rootTask
      */

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/initsync/DefaultSyncStatusService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/initsync/DefaultSyncStatusService.kt
@@ -18,25 +18,25 @@ package org.matrix.android.sdk.internal.session.initsync
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import org.matrix.android.sdk.api.session.initsync.InitSyncStep
-import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
+import org.matrix.android.sdk.api.session.initsync.SyncStatusService
 import org.matrix.android.sdk.internal.session.SessionScope
 import javax.inject.Inject
 
 @SessionScope
-internal class DefaultInitialSyncProgressService @Inject constructor()
-    : InitialSyncProgressService,
+internal class DefaultSyncStatusService @Inject constructor()
+    : SyncStatusService,
         ProgressReporter {
 
-    private val status = MutableLiveData<InitialSyncProgressService.Status>()
+    private val status = MutableLiveData<SyncStatusService.Status>()
 
     private var rootTask: TaskInfo? = null
 
-    override fun getInitialSyncProgressStatus(): LiveData<InitialSyncProgressService.Status> {
+    override fun getSyncStatusLive(): LiveData<SyncStatusService.Status> {
         return status
     }
 
     // Only to be used for incremental sync
-    fun setStatus(newStatus: InitialSyncProgressService.Status) {
+    fun setStatus(newStatus: SyncStatusService.Status.IncrementalSyncStatus) {
         status.postValue(newStatus)
     }
 
@@ -72,7 +72,7 @@ internal class DefaultInitialSyncProgressService @Inject constructor()
                 // Update the progress of the leaf and all its parents
                 leaf.setProgress(progress)
                 // Then update the live data using leaf wording and root progress
-                status.postValue(InitialSyncProgressService.Status.Progressing(leaf.initSyncStep, root.currentProgress.toInt()))
+                status.postValue(SyncStatusService.Status.Progressing(leaf.initSyncStep, root.currentProgress.toInt()))
             }
         }
     }
@@ -87,13 +87,13 @@ internal class DefaultInitialSyncProgressService @Inject constructor()
                 // And close it
                 endedTask.parent.child = null
             } else {
-                status.postValue(InitialSyncProgressService.Status.Idle)
+                status.postValue(SyncStatusService.Status.Idle)
             }
         }
     }
 
     fun endAll() {
         rootTask = null
-        status.postValue(InitialSyncProgressService.Status.Idle)
+        status.postValue(SyncStatusService.Status.Idle)
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncTask.kt
@@ -137,7 +137,10 @@ internal class DefaultSyncTask @Inject constructor(
                         readTimeOut = readTimeOut
                 )
             }
-            initialSyncProgressService.setStatus(InitialSyncProgressService.Status.IncrementalSyncParsing)
+            initialSyncProgressService.setStatus(InitialSyncProgressService.Status.IncrementalSyncParsing(
+                    rooms = syncResponse.rooms?.invite.orEmpty().size + syncResponse.rooms?.join.orEmpty().size + syncResponse.rooms?.leave.orEmpty().size,
+                    toDevice = syncResponse.toDevice?.events.orEmpty().size
+            ))
             syncResponseHandler.handleResponse(syncResponse, token, null)
             initialSyncProgressService.setStatus(InitialSyncProgressService.Status.IncrementalSyncDone)
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncTask.kt
@@ -18,6 +18,7 @@ package org.matrix.android.sdk.internal.session.sync
 
 import okhttp3.ResponseBody
 import org.matrix.android.sdk.api.session.initsync.InitSyncStep
+import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
 import org.matrix.android.sdk.internal.di.SessionFilesDirectory
 import org.matrix.android.sdk.internal.di.UserId
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
@@ -129,13 +130,16 @@ internal class DefaultSyncTask @Inject constructor(
             }
             initialSyncProgressService.endAll()
         } else {
+            initialSyncProgressService.setStatus(InitialSyncProgressService.Status.IncrementalSyncIdle)
             val syncResponse = executeRequest(globalErrorReceiver) {
                 syncAPI.sync(
                         params = requestParams,
                         readTimeOut = readTimeOut
                 )
             }
+            initialSyncProgressService.setStatus(InitialSyncProgressService.Status.IncrementalSyncParsing)
             syncResponseHandler.handleResponse(syncResponse, token, null)
+            initialSyncProgressService.setStatus(InitialSyncProgressService.Status.IncrementalSyncDone)
         }
         Timber.v("Sync task finished on Thread: ${Thread.currentThread().name}")
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncTask.kt
@@ -131,11 +131,16 @@ internal class DefaultSyncTask @Inject constructor(
             initialSyncProgressService.endAll()
         } else {
             initialSyncProgressService.setStatus(InitialSyncProgressService.Status.IncrementalSyncIdle)
-            val syncResponse = executeRequest(globalErrorReceiver) {
-                syncAPI.sync(
-                        params = requestParams,
-                        readTimeOut = readTimeOut
-                )
+            val syncResponse = try {
+                executeRequest(globalErrorReceiver) {
+                    syncAPI.sync(
+                            params = requestParams,
+                            readTimeOut = readTimeOut
+                    )
+                }
+            } catch (throwable: Throwable) {
+                initialSyncProgressService.setStatus(InitialSyncProgressService.Status.IncrementalSyncError)
+                throw throwable
             }
             initialSyncProgressService.setStatus(InitialSyncProgressService.Status.IncrementalSyncParsing(
                     rooms = syncResponse.rooms?.invite.orEmpty().size + syncResponse.rooms?.join.orEmpty().size + syncResponse.rooms?.leave.orEmpty().size,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncThread.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncThread.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.matrix.android.sdk.api.logger.LoggerTag
 import org.matrix.android.sdk.api.session.call.MxCall
 import org.matrix.android.sdk.internal.session.call.ActiveCallHandler
 import org.matrix.android.sdk.internal.session.sync.SyncPresence
@@ -48,6 +49,8 @@ import kotlin.concurrent.schedule
 
 private const val RETRY_WAIT_TIME_MS = 10_000L
 private const val DEFAULT_LONG_POOL_TIMEOUT = 30_000L
+
+private val loggerTag = LoggerTag("SyncThread", LoggerTag.SYNC)
 
 internal class SyncThread @Inject constructor(private val syncTask: SyncTask,
                                               private val networkConnectivityChecker: NetworkConnectivityChecker,
@@ -83,7 +86,7 @@ internal class SyncThread @Inject constructor(private val syncTask: SyncTask,
 
     fun restart() = synchronized(lock) {
         if (!isStarted) {
-            Timber.v("Resume sync...")
+            Timber.tag(loggerTag.value).d("Resume sync...")
             isStarted = true
             // Check again server availability and the token validity
             canReachServer = true
@@ -94,7 +97,7 @@ internal class SyncThread @Inject constructor(private val syncTask: SyncTask,
 
     fun pause() = synchronized(lock) {
         if (isStarted) {
-            Timber.v("Pause sync...")
+            Timber.tag(loggerTag.value).d("Pause sync...")
             isStarted = false
             retryNoNetworkTask?.cancel()
             syncScope.coroutineContext.cancelChildren()
@@ -102,7 +105,7 @@ internal class SyncThread @Inject constructor(private val syncTask: SyncTask,
     }
 
     fun kill() = synchronized(lock) {
-        Timber.v("Kill sync...")
+        Timber.tag(loggerTag.value).d("Kill sync...")
         updateStateTo(SyncState.Killing)
         retryNoNetworkTask?.cancel()
         syncScope.coroutineContext.cancelChildren()
@@ -124,21 +127,21 @@ internal class SyncThread @Inject constructor(private val syncTask: SyncTask,
     }
 
     override fun run() {
-        Timber.v("Start syncing...")
+        Timber.tag(loggerTag.value).d("Start syncing...")
 
         isStarted = true
         networkConnectivityChecker.register(this)
         backgroundDetectionObserver.register(this)
         registerActiveCallsObserver()
         while (state != SyncState.Killing) {
-            Timber.v("Entering loop, state: $state")
+            Timber.tag(loggerTag.value).d("Entering loop, state: $state")
             if (!isStarted) {
-                Timber.v("Sync is Paused. Waiting...")
+                Timber.tag(loggerTag.value).d("Sync is Paused. Waiting...")
                 updateStateTo(SyncState.Paused)
                 synchronized(lock) { lock.wait() }
-                Timber.v("...unlocked")
+                Timber.tag(loggerTag.value).d("...unlocked")
             } else if (!canReachServer) {
-                Timber.v("No network. Waiting...")
+                Timber.tag(loggerTag.value).d("No network. Waiting...")
                 updateStateTo(SyncState.NoNetwork)
                 // We force retrying in RETRY_WAIT_TIME_MS maximum. Otherwise it will be unlocked by onConnectivityChanged() or restart()
                 retryNoNetworkTask = Timer(SyncState.NoNetwork.toString(), false).schedule(RETRY_WAIT_TIME_MS) {
@@ -148,19 +151,19 @@ internal class SyncThread @Inject constructor(private val syncTask: SyncTask,
                     }
                 }
                 synchronized(lock) { lock.wait() }
-                Timber.v("...retry")
+                Timber.tag(loggerTag.value).d("...retry")
             } else if (!isTokenValid) {
-                Timber.v("Token is invalid. Waiting...")
+                Timber.tag(loggerTag.value).d("Token is invalid. Waiting...")
                 updateStateTo(SyncState.InvalidToken)
                 synchronized(lock) { lock.wait() }
-                Timber.v("...unlocked")
+                Timber.tag(loggerTag.value).d("...unlocked")
             } else {
                 if (state !is SyncState.Running) {
                     updateStateTo(SyncState.Running(afterPause = true))
                 }
                 // No timeout after a pause
                 val timeout = state.let { if (it is SyncState.Running && it.afterPause) 0 else DEFAULT_LONG_POOL_TIMEOUT }
-                Timber.v("Execute sync request with timeout $timeout")
+                Timber.tag(loggerTag.value).d("Execute sync request with timeout $timeout")
                 val params = SyncTask.Params(timeout, SyncPresence.Online)
                 val sync = syncScope.launch {
                     doSync(params)
@@ -168,10 +171,10 @@ internal class SyncThread @Inject constructor(private val syncTask: SyncTask,
                 runBlocking {
                     sync.join()
                 }
-                Timber.v("...Continue")
+                Timber.tag(loggerTag.value).d("...Continue")
             }
         }
-        Timber.v("Sync killed")
+        Timber.tag(loggerTag.value).d("Sync killed")
         updateStateTo(SyncState.Killed)
         backgroundDetectionObserver.unregister(this)
         networkConnectivityChecker.unregister(this)
@@ -199,19 +202,19 @@ internal class SyncThread @Inject constructor(private val syncTask: SyncTask,
             }
             if (failure is Failure.NetworkConnection && failure.cause is SocketTimeoutException) {
                 // Timeout are not critical
-                Timber.v("Timeout")
+                Timber.tag(loggerTag.value).d("Timeout")
             } else if (failure is CancellationException) {
-                Timber.v("Cancelled")
+                Timber.tag(loggerTag.value).d("Cancelled")
             } else if (failure.isTokenError()) {
                 // No token or invalid token, stop the thread
-                Timber.w(failure, "Token error")
+                Timber.tag(loggerTag.value).w(failure, "Token error")
                 isStarted = false
                 isTokenValid = false
             } else {
-                Timber.e(failure)
+                Timber.tag(loggerTag.value).e(failure)
                 if (failure !is Failure.NetworkConnection || failure.cause is JsonEncodingException) {
                     // Wait 10s before retrying
-                    Timber.v("Wait 10s")
+                    Timber.tag(loggerTag.value).d("Wait 10s")
                     delay(RETRY_WAIT_TIME_MS)
                 }
             }
@@ -225,7 +228,7 @@ internal class SyncThread @Inject constructor(private val syncTask: SyncTask,
     }
 
     private fun updateStateTo(newState: SyncState) {
-        Timber.v("Update state from $state to $newState")
+        Timber.tag(loggerTag.value).d("Update state from $state to $newState")
         if (newState == state) {
             return
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/LogUtil.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/LogUtil.kt
@@ -17,6 +17,7 @@
 package org.matrix.android.sdk.internal.util
 
 import org.matrix.android.sdk.BuildConfig
+import org.matrix.android.sdk.api.logger.LoggerTag
 import timber.log.Timber
 
 internal fun <T> Collection<T>.logLimit(maxQuantity: Int = 5): String {
@@ -32,14 +33,15 @@ internal fun <T> Collection<T>.logLimit(maxQuantity: Int = 5): String {
 }
 
 internal suspend fun <T> logDuration(message: String,
+                                     loggerTag: LoggerTag,
                                      block: suspend () -> T): T {
-    Timber.d("$message -- BEGIN")
+    Timber.tag(loggerTag.value).d("$message -- BEGIN")
     val start = System.currentTimeMillis()
     val result = logRamUsage(message) {
         block()
     }
     val duration = System.currentTimeMillis() - start
-    Timber.d("$message -- END duration: $duration ms")
+    Timber.tag(loggerTag.value).d("$message -- END duration: $duration ms")
 
     return result
 }

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -345,6 +345,9 @@ dependencies {
     implementation libs.androidx.lifecycleExtensions
     implementation libs.androidx.lifecycleLivedata
 
+    implementation libs.androidx.datastore
+    implementation libs.androidx.datastorepreferences
+
 
     // Log
     implementation libs.jakewharton.timber
@@ -406,7 +409,7 @@ dependencies {
     // To convert voice message on old platforms
     implementation 'com.arthenica:ffmpeg-kit-audio:4.4.LTS'
 
-    //Alerter
+    // Alerter
     implementation 'com.tapadoo.android:alerter:7.0.1'
 
     implementation 'com.otaliastudios:autocomplete:1.1.0'

--- a/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
@@ -39,11 +39,13 @@ import im.vector.app.features.notifications.NotifiableMessageEvent
 import im.vector.app.features.notifications.NotificationDrawerManager
 import im.vector.app.features.notifications.NotificationUtils
 import im.vector.app.features.notifications.SimpleNotifiableEvent
+import im.vector.app.features.settings.VectorDataStore
 import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.push.fcm.FcmHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.pushrules.Action
 import org.matrix.android.sdk.api.session.Session
@@ -60,6 +62,7 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
     private lateinit var pusherManager: PushersManager
     private lateinit var activeSessionHolder: ActiveSessionHolder
     private lateinit var vectorPreferences: VectorPreferences
+    private lateinit var vectorDataStore: VectorDataStore
     private lateinit var wifiDetector: WifiDetector
 
     private val coroutineScope = CoroutineScope(SupervisorJob())
@@ -77,6 +80,7 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
             pusherManager = pusherManager()
             activeSessionHolder = activeSessionHolder()
             vectorPreferences = vectorPreferences()
+            vectorDataStore = vectorDataStore()
             wifiDetector = wifiDetector()
         }
     }
@@ -91,6 +95,10 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
             Timber.d("## onMessageReceived() %s", message.data.toString())
         }
         Timber.d("## onMessageReceived() from FCM with priority %s", message.priority)
+
+        runBlocking {
+            vectorDataStore.incrementPushCounter()
+        }
 
         // Diagnostic Push
         if (message.data["event_id"] == PushersManager.TEST_EVENT_ID) {

--- a/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
@@ -152,7 +152,7 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
             if (BuildConfig.LOW_PRIVACY_LOG_ENABLE) {
                 Timber.d("## onMessageReceivedInternal() : $data")
             } else {
-                Timber.d("## onMessageReceivedInternal() : $data")
+                Timber.d("## onMessageReceivedInternal()")
             }
 
             // update the badge counter

--- a/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
@@ -47,10 +47,13 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.matrix.android.sdk.api.extensions.tryOrNull
+import org.matrix.android.sdk.api.logger.LoggerTag
 import org.matrix.android.sdk.api.pushrules.Action
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.events.model.Event
 import timber.log.Timber
+
+private val loggerTag = LoggerTag("Push", LoggerTag.SYNC)
 
 /**
  * Class extending FirebaseMessagingService.
@@ -92,9 +95,9 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
      */
     override fun onMessageReceived(message: RemoteMessage) {
         if (BuildConfig.LOW_PRIVACY_LOG_ENABLE) {
-            Timber.d("## onMessageReceived() %s", message.data.toString())
+            Timber.tag(loggerTag.value).d("## onMessageReceived() %s", message.data.toString())
         }
-        Timber.d("## onMessageReceived() from FCM with priority %s", message.priority)
+        Timber.tag(loggerTag.value).d("## onMessageReceived() from FCM with priority %s", message.priority)
 
         runBlocking {
             vectorDataStore.incrementPushCounter()
@@ -108,14 +111,14 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
         }
 
         if (!vectorPreferences.areNotificationEnabledForDevice()) {
-            Timber.i("Notification are disabled for this device")
+            Timber.tag(loggerTag.value).i("Notification are disabled for this device")
             return
         }
 
         mUIHandler.post {
             if (ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
                 // we are in foreground, let the sync do the things?
-                Timber.d("PUSH received in a foreground state, ignore")
+                Timber.tag(loggerTag.value).d("PUSH received in a foreground state, ignore")
             } else {
                 onMessageReceivedInternal(message.data)
             }
@@ -129,7 +132,7 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
      * you retrieve the token.
      */
     override fun onNewToken(refreshedToken: String) {
-        Timber.i("onNewToken: FCM Token has been updated")
+        Timber.tag(loggerTag.value).i("onNewToken: FCM Token has been updated")
         FcmHelper.storeFcmToken(this, refreshedToken)
         if (vectorPreferences.areNotificationEnabledForDevice() && activeSessionHolder.hasActiveSession()) {
             pusherManager.registerPusherWithFcmKey(refreshedToken)
@@ -146,7 +149,7 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
      *  It is recommended that the app do a full sync with the app server after receiving this call.
      */
     override fun onDeletedMessages() {
-        Timber.v("## onDeletedMessages()")
+        Timber.tag(loggerTag.value).v("## onDeletedMessages()")
     }
 
     /**
@@ -158,9 +161,9 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
     private fun onMessageReceivedInternal(data: Map<String, String>) {
         try {
             if (BuildConfig.LOW_PRIVACY_LOG_ENABLE) {
-                Timber.d("## onMessageReceivedInternal() : $data")
+                Timber.tag(loggerTag.value).d("## onMessageReceivedInternal() : $data")
             } else {
-                Timber.d("## onMessageReceivedInternal()")
+                Timber.tag(loggerTag.value).d("## onMessageReceivedInternal()")
             }
 
             // update the badge counter
@@ -170,24 +173,24 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
             val session = activeSessionHolder.getSafeActiveSession()
 
             if (session == null) {
-                Timber.w("## Can't sync from push, no current session")
+                Timber.tag(loggerTag.value).w("## Can't sync from push, no current session")
             } else {
                 val eventId = data["event_id"]
                 val roomId = data["room_id"]
 
                 if (isEventAlreadyKnown(eventId, roomId)) {
-                    Timber.d("Ignoring push, event already known")
+                    Timber.tag(loggerTag.value).d("Ignoring push, event already known")
                 } else {
                     // Try to get the Event content faster
-                    Timber.d("Requesting event in fast lane")
+                    Timber.tag(loggerTag.value).d("Requesting event in fast lane")
                     getEventFastLane(session, roomId, eventId)
 
-                    Timber.d("Requesting background sync")
+                    Timber.tag(loggerTag.value).d("Requesting background sync")
                     session.requireBackgroundSync()
                 }
             }
         } catch (e: Exception) {
-            Timber.e(e, "## onMessageReceivedInternal() failed")
+            Timber.tag(loggerTag.value).e(e, "## onMessageReceivedInternal() failed")
         }
     }
 
@@ -201,18 +204,18 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
         }
 
         if (wifiDetector.isConnectedToWifi().not()) {
-            Timber.d("No WiFi network, do not get Event")
+            Timber.tag(loggerTag.value).d("No WiFi network, do not get Event")
             return
         }
 
         coroutineScope.launch {
-            Timber.d("Fast lane: start request")
+            Timber.tag(loggerTag.value).d("Fast lane: start request")
             val event = tryOrNull { session.getEvent(roomId, eventId) } ?: return@launch
 
             val resolvedEvent = notifiableEventResolver.resolveInMemoryEvent(session, event)
 
             resolvedEvent
-                    ?.also { Timber.d("Fast lane: notify drawer") }
+                    ?.also { Timber.tag(loggerTag.value).d("Fast lane: notify drawer") }
                     ?.let {
                         it.isPushGatewayEvent = true
                         notificationDrawerManager.onNotifiableEventReceived(it)
@@ -230,7 +233,7 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
                 val room = session.getRoom(roomId) ?: return false
                 return room.getTimeLineEvent(eventId) != null
             } catch (e: Exception) {
-                Timber.e(e, "## isEventAlreadyKnown() : failed to check if the event was already defined")
+                Timber.tag(loggerTag.value).e(e, "## isEventAlreadyKnown() : failed to check if the event was already defined")
             }
         }
         return false
@@ -238,7 +241,7 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
 
     private fun handleNotificationWithoutSyncingMode(data: Map<String, String>, session: Session?) {
         if (session == null) {
-            Timber.e("## handleNotificationWithoutSyncingMode cannot find session")
+            Timber.tag(loggerTag.value).e("## handleNotificationWithoutSyncingMode cannot find session")
             return
         }
 
@@ -271,9 +274,9 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
             val notifiableEvent = notifiableEventResolver.resolveEvent(event, session)
 
             if (notifiableEvent == null) {
-                Timber.e("Unsupported notifiable event $eventId")
+                Timber.tag(loggerTag.value).e("Unsupported notifiable event $eventId")
                 if (BuildConfig.LOW_PRIVACY_LOG_ENABLE) {
-                    Timber.e("--> $event")
+                    Timber.tag(loggerTag.value).e("--> $event")
                 }
             } else {
                 if (notifiableEvent is NotifiableMessageEvent) {

--- a/vector/src/main/java/im/vector/app/core/di/VectorComponent.kt
+++ b/vector/src/main/java/im/vector/app/core/di/VectorComponent.kt
@@ -58,6 +58,7 @@ import im.vector.app.features.rageshake.VectorFileLogger
 import im.vector.app.features.rageshake.VectorUncaughtExceptionHandler
 import im.vector.app.features.reactions.data.EmojiDataSource
 import im.vector.app.features.session.SessionListener
+import im.vector.app.features.settings.VectorDataStore
 import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.ui.UiStateRepository
 import org.matrix.android.sdk.api.Matrix
@@ -144,6 +145,8 @@ interface VectorComponent {
     fun notifiableEventResolver(): NotifiableEventResolver
 
     fun vectorPreferences(): VectorPreferences
+
+    fun vectorDataStore(): VectorDataStore
 
     fun wifiDetector(): WifiDetector
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -309,10 +309,10 @@ class HomeActivity :
 
     private fun renderState(state: HomeActivityViewState) {
         when (val status = state.initialSyncProgressServiceStatus) {
-            is InitialSyncProgressService.Status.Idle        -> {
+            is InitialSyncProgressService.Status.Idle                  -> {
                 views.waitingView.root.isVisible = false
             }
-            is InitialSyncProgressService.Status.Progressing -> {
+            is InitialSyncProgressService.Status.Progressing           -> {
                 val initSyncStepStr = initSyncStepFormatter.format(status.initSyncStep)
                 Timber.v("$initSyncStepStr ${status.percentProgress}")
                 views.waitingView.root.setOnClickListener {
@@ -330,6 +330,7 @@ class HomeActivity :
                 }
                 views.waitingView.root.isVisible = true
             }
+            is InitialSyncProgressService.Status.IncrementalSyncStatus -> Unit
         }.exhaustive
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -330,7 +330,7 @@ class HomeActivity :
                 }
                 views.waitingView.root.isVisible = true
             }
-            is SyncStatusService.Status.IncrementalSyncStatus -> Unit
+            else                                              -> Unit
         }.exhaustive
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -475,8 +475,8 @@ class HomeActivity :
     override fun getMenuRes() = R.menu.home
 
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
-        menu.findItem(R.id.menu_home_init_sync_legacy)?.isVisible = vectorPreferences.developerMode()
-        menu.findItem(R.id.menu_home_init_sync_optimized)?.isVisible = vectorPreferences.developerMode()
+        menu.findItem(R.id.menu_home_init_sync_legacy).isVisible = vectorPreferences.developerMode()
+        menu.findItem(R.id.menu_home_init_sync_optimized).isVisible = vectorPreferences.developerMode()
         return super.onPrepareOptionsMenu(menu)
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -70,7 +70,7 @@ import im.vector.app.features.workers.signout.ServerBackupStatusViewState
 import im.vector.app.push.fcm.FcmHelper
 import io.reactivex.android.schedulers.AndroidSchedulers
 import kotlinx.parcelize.Parcelize
-import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
+import org.matrix.android.sdk.api.session.initsync.SyncStatusService
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService
 import org.matrix.android.sdk.api.util.MatrixItem
 import org.matrix.android.sdk.internal.session.sync.InitialSyncStrategy
@@ -308,11 +308,11 @@ class HomeActivity :
     }
 
     private fun renderState(state: HomeActivityViewState) {
-        when (val status = state.initialSyncProgressServiceStatus) {
-            is InitialSyncProgressService.Status.Idle                  -> {
+        when (val status = state.syncStatusServiceStatus) {
+            is SyncStatusService.Status.Idle                  -> {
                 views.waitingView.root.isVisible = false
             }
-            is InitialSyncProgressService.Status.Progressing           -> {
+            is SyncStatusService.Status.Progressing           -> {
                 val initSyncStepStr = initSyncStepFormatter.format(status.initSyncStep)
                 Timber.v("$initSyncStepStr ${status.percentProgress}")
                 views.waitingView.root.setOnClickListener {
@@ -330,7 +330,7 @@ class HomeActivity :
                 }
                 views.waitingView.root.isVisible = true
             }
-            is InitialSyncProgressService.Status.IncrementalSyncStatus -> Unit
+            is SyncStatusService.Status.IncrementalSyncStatus -> Unit
         }.exhaustive
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -40,7 +40,7 @@ import org.matrix.android.sdk.api.auth.registration.RegistrationFlowResponse
 import org.matrix.android.sdk.api.auth.registration.nextUncompletedStage
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.pushrules.RuleIds
-import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
+import org.matrix.android.sdk.api.session.initsync.SyncStatusService
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.roomSummaryQueryParams
 import org.matrix.android.sdk.api.util.toMatrixItem
@@ -122,26 +122,26 @@ class HomeActivityViewModel @AssistedInject constructor(
     private fun observeInitialSync() {
         val session = activeSessionHolder.getSafeActiveSession() ?: return
 
-        session.getInitialSyncProgressStatus()
+        session.getSyncStatusLive()
                 .asObservable()
                 .subscribe { status ->
                     when (status) {
-                        is InitialSyncProgressService.Status.Progressing -> {
+                        is SyncStatusService.Status.Progressing -> {
                             // Schedule a check of the bootstrap when the init sync will be finished
                             checkBootstrap = true
                         }
-                        is InitialSyncProgressService.Status.Idle        -> {
+                        is SyncStatusService.Status.Idle        -> {
                             if (checkBootstrap) {
                                 checkBootstrap = false
                                 maybeBootstrapCrossSigningAfterInitialSync()
                             }
                         }
-                        else                                             -> Unit
+                        else                                    -> Unit
                     }
 
                     setState {
                         copy(
-                                initialSyncProgressServiceStatus = status
+                                syncStatusServiceStatus = status
                         )
                     }
                 }

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -136,6 +136,7 @@ class HomeActivityViewModel @AssistedInject constructor(
                                 maybeBootstrapCrossSigningAfterInitialSync()
                             }
                         }
+                        else                                             -> Unit
                     }
 
                     setState {

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewState.kt
@@ -17,8 +17,8 @@
 package im.vector.app.features.home
 
 import com.airbnb.mvrx.MvRxState
-import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
+import org.matrix.android.sdk.api.session.initsync.SyncStatusService
 
 data class HomeActivityViewState(
-        val initialSyncProgressServiceStatus: InitialSyncProgressService.Status = InitialSyncProgressService.Status.Idle
+        val syncStatusServiceStatus: SyncStatusService.Status = SyncStatusService.Status.Idle
 ) : MvRxState

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
@@ -440,7 +440,11 @@ class HomeDetailFragment @Inject constructor(
         views.bottomNavigationView.getOrCreateBadge(R.id.bottom_action_people).render(it.notificationCountPeople, it.notificationHighlightPeople)
         views.bottomNavigationView.getOrCreateBadge(R.id.bottom_action_rooms).render(it.notificationCountRooms, it.notificationHighlightRooms)
         views.bottomNavigationView.getOrCreateBadge(R.id.bottom_action_notification).render(it.notificationCountCatchup, it.notificationHighlightCatchup)
-        views.syncStateView.render(it.syncState, it.incrementalSyncStatus, vectorPreferences.developerShowDebugInfo())
+        views.syncStateView.render(
+                it.syncState,
+                it.incrementalSyncStatus,
+                it.pushCounter,
+                vectorPreferences.developerShowDebugInfo())
 
         hasUnreadRooms = it.hasUnreadMessages
     }

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
@@ -440,7 +440,7 @@ class HomeDetailFragment @Inject constructor(
         views.bottomNavigationView.getOrCreateBadge(R.id.bottom_action_people).render(it.notificationCountPeople, it.notificationHighlightPeople)
         views.bottomNavigationView.getOrCreateBadge(R.id.bottom_action_rooms).render(it.notificationCountRooms, it.notificationHighlightRooms)
         views.bottomNavigationView.getOrCreateBadge(R.id.bottom_action_notification).render(it.notificationCountCatchup, it.notificationHighlightCatchup)
-        views.syncStateView.render(it.syncState, it.incrementalSyncStatus, vectorPreferences.developerMode())
+        views.syncStateView.render(it.syncState, it.incrementalSyncStatus, vectorPreferences.developerShowDebugInfo())
 
         hasUnreadRooms = it.hasUnreadMessages
     }

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
@@ -440,7 +440,7 @@ class HomeDetailFragment @Inject constructor(
         views.bottomNavigationView.getOrCreateBadge(R.id.bottom_action_people).render(it.notificationCountPeople, it.notificationHighlightPeople)
         views.bottomNavigationView.getOrCreateBadge(R.id.bottom_action_rooms).render(it.notificationCountRooms, it.notificationHighlightRooms)
         views.bottomNavigationView.getOrCreateBadge(R.id.bottom_action_notification).render(it.notificationCountCatchup, it.notificationHighlightCatchup)
-        views.syncStateView.render(it.syncState)
+        views.syncStateView.render(it.syncState, it.incrementalSyncStatus, vectorPreferences.developerMode())
 
         hasUnreadRooms = it.hasUnreadMessages
     }

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.query.ActiveSpaceFilter
 import org.matrix.android.sdk.api.query.RoomCategoryFilter
 import org.matrix.android.sdk.api.session.Session
-import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
+import org.matrix.android.sdk.api.session.initsync.SyncStatusService
 import org.matrix.android.sdk.api.session.room.RoomSortOrder
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.roomSummaryQueryParams
@@ -191,10 +191,10 @@ class HomeDetailViewModel @AssistedInject constructor(@Assisted initialState: Ho
                 }
                 .disposeOnClear()
 
-        session.getInitialSyncProgressStatus()
+        session.getSyncStatusLive()
                 .asObservable()
                 .subscribe {
-                    if (it is InitialSyncProgressService.Status.IncrementalSyncStatus) {
+                    if (it is SyncStatusService.Status.IncrementalSyncStatus) {
                         setState {
                             copy(incrementalSyncStatus = it)
                         }

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.query.ActiveSpaceFilter
 import org.matrix.android.sdk.api.query.RoomCategoryFilter
 import org.matrix.android.sdk.api.session.Session
+import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
 import org.matrix.android.sdk.api.session.room.RoomSortOrder
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.roomSummaryQueryParams
@@ -59,7 +60,7 @@ class HomeDetailViewModel @AssistedInject constructor(@Assisted initialState: Ho
                                                       private val callManager: WebRtcCallManager,
                                                       private val directRoomHelper: DirectRoomHelper,
                                                       private val appStateHandler: AppStateHandler,
-private val autoAcceptInvites: AutoAcceptInvites)
+                                                      private val autoAcceptInvites: AutoAcceptInvites)
     : VectorViewModel<HomeDetailViewState, HomeDetailAction, HomeDetailViewEvents>(initialState),
         CallProtocolsChecker.Listener {
 
@@ -170,6 +171,17 @@ private val autoAcceptInvites: AutoAcceptInvites)
                 .subscribe { syncState ->
                     setState {
                         copy(syncState = syncState)
+                    }
+                }
+                .disposeOnClear()
+
+        session.getInitialSyncProgressStatus()
+                .asObservable()
+                .subscribe {
+                    if (it is InitialSyncProgressService.Status.IncrementalSyncStatus) {
+                        setState {
+                            copy(incrementalSyncStatus = it)
+                        }
                     }
                 }
                 .disposeOnClear()

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewState.kt
@@ -41,6 +41,7 @@ data class HomeDetailViewState(
         val hasUnreadMessages: Boolean = false,
         val syncState: SyncState = SyncState.Idle,
         val incrementalSyncStatus: InitialSyncProgressService.Status.IncrementalSyncStatus = InitialSyncProgressService.Status.IncrementalSyncIdle,
+        val pushCounter: Int = 0,
         val showDialPadTab: Boolean = false
 ) : MvRxState
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewState.kt
@@ -22,6 +22,7 @@ import com.airbnb.mvrx.MvRxState
 import com.airbnb.mvrx.Uninitialized
 import im.vector.app.R
 import im.vector.app.RoomGroupingMethod
+import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 import org.matrix.android.sdk.api.session.sync.SyncState
 import org.matrix.android.sdk.api.util.MatrixItem
@@ -39,6 +40,7 @@ data class HomeDetailViewState(
         val notificationHighlightRooms: Boolean = false,
         val hasUnreadMessages: Boolean = false,
         val syncState: SyncState = SyncState.Idle,
+        val incrementalSyncStatus: InitialSyncProgressService.Status.IncrementalSyncStatus = InitialSyncProgressService.Status.IncrementalSyncIdle,
         val showDialPadTab: Boolean = false
 ) : MvRxState
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewState.kt
@@ -22,7 +22,7 @@ import com.airbnb.mvrx.MvRxState
 import com.airbnb.mvrx.Uninitialized
 import im.vector.app.R
 import im.vector.app.RoomGroupingMethod
-import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
+import org.matrix.android.sdk.api.session.initsync.SyncStatusService
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 import org.matrix.android.sdk.api.session.sync.SyncState
 import org.matrix.android.sdk.api.util.MatrixItem
@@ -40,7 +40,7 @@ data class HomeDetailViewState(
         val notificationHighlightRooms: Boolean = false,
         val hasUnreadMessages: Boolean = false,
         val syncState: SyncState = SyncState.Idle,
-        val incrementalSyncStatus: InitialSyncProgressService.Status.IncrementalSyncStatus = InitialSyncProgressService.Status.IncrementalSyncIdle,
+        val incrementalSyncStatus: SyncStatusService.Status.IncrementalSyncStatus = SyncStatusService.Status.IncrementalSyncIdle,
         val pushCounter: Int = 0,
         val showDialPadTab: Boolean = false
 ) : MvRxState

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -391,7 +391,7 @@ class RoomDetailFragment @Inject constructor(
                 RoomDetailViewState::syncState,
                 RoomDetailViewState::incrementalSyncStatus
         ) { syncState, incrementalSyncStatus ->
-            views.syncStateView.render(syncState, incrementalSyncStatus, vectorPreferences.developerMode())
+            views.syncStateView.render(syncState, incrementalSyncStatus, vectorPreferences.developerShowDebugInfo())
         }
 
         roomDetailViewModel.observeViewEvents {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -389,9 +389,15 @@ class RoomDetailFragment @Inject constructor(
 
         roomDetailViewModel.selectSubscribe(
                 RoomDetailViewState::syncState,
-                RoomDetailViewState::incrementalSyncStatus
-        ) { syncState, incrementalSyncStatus ->
-            views.syncStateView.render(syncState, incrementalSyncStatus, vectorPreferences.developerShowDebugInfo())
+                RoomDetailViewState::incrementalSyncStatus,
+                RoomDetailViewState::pushCounter
+        ) { syncState, incrementalSyncStatus, pushCounter ->
+            views.syncStateView.render(
+                    syncState,
+                    incrementalSyncStatus,
+                    pushCounter,
+                    vectorPreferences.developerShowDebugInfo()
+            )
         }
 
         roomDetailViewModel.observeViewEvents {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -387,8 +387,11 @@ class RoomDetailFragment @Inject constructor(
             }
         }
 
-        roomDetailViewModel.selectSubscribe(RoomDetailViewState::syncState) { syncState ->
-            views.syncStateView.render(syncState)
+        roomDetailViewModel.selectSubscribe(
+                RoomDetailViewState::syncState,
+                RoomDetailViewState::incrementalSyncStatus
+        ) { syncState, incrementalSyncStatus ->
+            views.syncStateView.render(syncState, incrementalSyncStatus, vectorPreferences.developerMode())
         }
 
         roomDetailViewModel.observeViewEvents {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
@@ -38,9 +38,9 @@ import im.vector.app.core.extensions.exhaustive
 import im.vector.app.core.mvrx.runCatchingToAsync
 import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.core.resources.StringProvider
-import im.vector.app.features.call.conference.JitsiActiveConferenceHolder
 import im.vector.app.features.attachments.toContentAttachmentData
 import im.vector.app.features.call.conference.ConferenceEvent
+import im.vector.app.features.call.conference.JitsiActiveConferenceHolder
 import im.vector.app.features.call.conference.JitsiService
 import im.vector.app.features.call.lookup.CallProtocolsChecker
 import im.vector.app.features.call.webrtc.WebRtcCallManager
@@ -1515,7 +1515,7 @@ class RoomDetailViewModel @AssistedInject constructor(
         session.getSyncStatusLive()
                 .asObservable()
                 .subscribe { it ->
-                    if(it is SyncStatusService.Status.IncrementalSyncStatus) {
+                    if (it is SyncStatusService.Status.IncrementalSyncStatus) {
                         setState {
                             copy(incrementalSyncStatus = it)
                         }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
@@ -82,7 +82,7 @@ import org.matrix.android.sdk.api.session.events.model.isTextMessage
 import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.file.FileService
-import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
+import org.matrix.android.sdk.api.session.initsync.SyncStatusService
 import org.matrix.android.sdk.api.session.room.members.ChangeMembershipState
 import org.matrix.android.sdk.api.session.room.members.roomMemberQueryParams
 import org.matrix.android.sdk.api.session.room.model.Membership
@@ -1512,10 +1512,10 @@ class RoomDetailViewModel @AssistedInject constructor(
                 }
                 .disposeOnClear()
 
-        session.getInitialSyncProgressStatus()
+        session.getSyncStatusLive()
                 .asObservable()
                 .subscribe { it ->
-                    if(it is InitialSyncProgressService.Status.IncrementalSyncStatus) {
+                    if(it is SyncStatusService.Status.IncrementalSyncStatus) {
                         setState {
                             copy(incrementalSyncStatus = it)
                         }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
@@ -80,6 +80,7 @@ import org.matrix.android.sdk.api.session.events.model.isTextMessage
 import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.file.FileService
+import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
 import org.matrix.android.sdk.api.session.room.members.ChangeMembershipState
 import org.matrix.android.sdk.api.session.room.members.roomMemberQueryParams
 import org.matrix.android.sdk.api.session.room.model.Membership
@@ -102,6 +103,7 @@ import org.matrix.android.sdk.api.session.space.CreateSpaceParams
 import org.matrix.android.sdk.api.session.widgets.model.WidgetType
 import org.matrix.android.sdk.api.util.toOptional
 import org.matrix.android.sdk.internal.crypto.model.event.WithHeldCode
+import org.matrix.android.sdk.rx.asObservable
 import org.matrix.android.sdk.rx.rx
 import org.matrix.android.sdk.rx.unwrap
 import timber.log.Timber
@@ -1490,6 +1492,17 @@ class RoomDetailViewModel @AssistedInject constructor(
                 .subscribe { syncState ->
                     setState {
                         copy(syncState = syncState)
+                    }
+                }
+                .disposeOnClear()
+
+        session.getInitialSyncProgressStatus()
+                .asObservable()
+                .subscribe { it ->
+                    if(it is InitialSyncProgressService.Status.IncrementalSyncStatus) {
+                        setState {
+                            copy(incrementalSyncStatus = it)
+                        }
                     }
                 }
                 .disposeOnClear()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -21,6 +21,7 @@ import com.airbnb.mvrx.MvRxState
 import com.airbnb.mvrx.Uninitialized
 import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
 import org.matrix.android.sdk.api.session.room.members.ChangeMembershipState
 import org.matrix.android.sdk.api.session.room.model.RoomMemberSummary
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
@@ -77,6 +78,7 @@ data class RoomDetailViewState(
         val tombstoneEvent: Event? = null,
         val joinUpgradedRoomAsync: Async<String> = Uninitialized,
         val syncState: SyncState = SyncState.Idle,
+        val incrementalSyncStatus: InitialSyncProgressService.Status.IncrementalSyncStatus = InitialSyncProgressService.Status.IncrementalSyncIdle,
         val highlightedEventId: String? = null,
         val unreadState: UnreadState = UnreadState.Unknown,
         val canShowJumpToReadMarker: Boolean = true,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -79,6 +79,7 @@ data class RoomDetailViewState(
         val joinUpgradedRoomAsync: Async<String> = Uninitialized,
         val syncState: SyncState = SyncState.Idle,
         val incrementalSyncStatus: InitialSyncProgressService.Status.IncrementalSyncStatus = InitialSyncProgressService.Status.IncrementalSyncIdle,
+        val pushCounter: Int = 0,
         val highlightedEventId: String? = null,
         val unreadState: UnreadState = UnreadState.Unknown,
         val canShowJumpToReadMarker: Boolean = true,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -21,7 +21,7 @@ import com.airbnb.mvrx.MvRxState
 import com.airbnb.mvrx.Uninitialized
 import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.events.model.Event
-import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
+import org.matrix.android.sdk.api.session.initsync.SyncStatusService
 import org.matrix.android.sdk.api.session.room.members.ChangeMembershipState
 import org.matrix.android.sdk.api.session.room.model.RoomMemberSummary
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
@@ -78,7 +78,7 @@ data class RoomDetailViewState(
         val tombstoneEvent: Event? = null,
         val joinUpgradedRoomAsync: Async<String> = Uninitialized,
         val syncState: SyncState = SyncState.Idle,
-        val incrementalSyncStatus: InitialSyncProgressService.Status.IncrementalSyncStatus = InitialSyncProgressService.Status.IncrementalSyncIdle,
+        val incrementalSyncStatus: SyncStatusService.Status.IncrementalSyncStatus = SyncStatusService.Status.IncrementalSyncIdle,
         val pushCounter: Int = 0,
         val highlightedEventId: String? = null,
         val unreadState: UnreadState = UnreadState.Unknown,

--- a/vector/src/main/java/im/vector/app/features/settings/VectorDataStore.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorDataStore.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "vector_settings")
+
+class VectorDataStore @Inject constructor(
+        private val context: Context
+) {
+
+    private val pushCounter = intPreferencesKey("push_counter")
+
+    val pushCounterFlow: Flow<Int> = context.dataStore.data.map { preferences ->
+        preferences[pushCounter] ?: 0
+    }
+
+    suspend fun incrementPushCounter() {
+        context.dataStore.edit { settings ->
+            val currentCounterValue = settings[pushCounter] ?: 0
+            settings[pushCounter] = currentCounterValue + 1
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -159,6 +159,7 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         private const val SETTINGS_LABS_SHOW_HIDDEN_EVENTS_PREFERENCE_KEY = "SETTINGS_LABS_SHOW_HIDDEN_EVENTS_PREFERENCE_KEY"
         private const val SETTINGS_LABS_ENABLE_SWIPE_TO_REPLY = "SETTINGS_LABS_ENABLE_SWIPE_TO_REPLY"
         private const val SETTINGS_DEVELOPER_MODE_FAIL_FAST_PREFERENCE_KEY = "SETTINGS_DEVELOPER_MODE_FAIL_FAST_PREFERENCE_KEY"
+        private const val SETTINGS_DEVELOPER_MODE_SHOW_INFO_ON_SCREEN_KEY = "SETTINGS_DEVELOPER_MODE_SHOW_INFO_ON_SCREEN_KEY"
 
         // SETTINGS_LABS_HIDE_TECHNICAL_E2E_ERRORS
         private const val SETTINGS_LABS_SHOW_COMPLETE_HISTORY_IN_ENCRYPTED_ROOM = "SETTINGS_LABS_SHOW_COMPLETE_HISTORY_IN_ENCRYPTED_ROOM"
@@ -310,6 +311,10 @@ class VectorPreferences @Inject constructor(private val context: Context) {
 
     fun developerMode(): Boolean {
         return defaultPrefs.getBoolean(SETTINGS_DEVELOPER_MODE_PREFERENCE_KEY, false)
+    }
+
+    fun developerShowDebugInfo(): Boolean {
+        return developerMode() && defaultPrefs.getBoolean(SETTINGS_DEVELOPER_MODE_SHOW_INFO_ON_SCREEN_KEY, false)
     }
 
     fun shouldShowHiddenEvents(): Boolean {

--- a/vector/src/main/java/im/vector/app/features/sync/widget/SyncStateView.kt
+++ b/vector/src/main/java/im/vector/app/features/sync/widget/SyncStateView.kt
@@ -41,11 +41,15 @@ class SyncStateView @JvmOverloads constructor(context: Context, attrs: Attribute
     @SuppressLint("SetTextI18n")
     fun render(newState: SyncState,
                incrementalSyncStatus: InitialSyncProgressService.Status.IncrementalSyncStatus,
-               showDebugInfo: Boolean) {
+               pushCounter: Int,
+               showDebugInfo: Boolean
+    ) {
         views.syncStateDebugInfo.isVisible = showDebugInfo
         if (showDebugInfo) {
-            views.syncStateDebugInfo.text =
+            views.syncStateDebugInfoText.text =
                     "Sync thread : ${newState.toHumanReadable()}\nSync request: ${incrementalSyncStatus.toHumanReadable()}"
+            views.syncStateDebugInfoPushCounter.text =
+                    "Push: $pushCounter"
         }
         views.syncStateProgressBar.isVisible = newState is SyncState.Running && newState.afterPause
 

--- a/vector/src/main/java/im/vector/app/features/sync/widget/SyncStateView.kt
+++ b/vector/src/main/java/im/vector/app/features/sync/widget/SyncStateView.kt
@@ -73,9 +73,9 @@ class SyncStateView @JvmOverloads constructor(context: Context, attrs: Attribute
 
     private fun InitialSyncProgressService.Status.IncrementalSyncStatus.toHumanReadable(): String {
         return when (this) {
-            is InitialSyncProgressService.Status.IncrementalSyncIdle    -> "Idle"
-            is InitialSyncProgressService.Status.IncrementalSyncParsing -> "Parsing"
-            is InitialSyncProgressService.Status.IncrementalSyncDone    -> "Done"
+            InitialSyncProgressService.Status.IncrementalSyncIdle       -> "Idle"
+            is InitialSyncProgressService.Status.IncrementalSyncParsing -> "Parsing ${this.rooms} room(s) ${this.toDevice} toDevice(s)"
+            InitialSyncProgressService.Status.IncrementalSyncDone       -> "Done"
             else                                                        -> "?"
         }
     }

--- a/vector/src/main/java/im/vector/app/features/sync/widget/SyncStateView.kt
+++ b/vector/src/main/java/im/vector/app/features/sync/widget/SyncStateView.kt
@@ -75,6 +75,7 @@ class SyncStateView @JvmOverloads constructor(context: Context, attrs: Attribute
         return when (this) {
             InitialSyncProgressService.Status.IncrementalSyncIdle       -> "Idle"
             is InitialSyncProgressService.Status.IncrementalSyncParsing -> "Parsing ${this.rooms} room(s) ${this.toDevice} toDevice(s)"
+            InitialSyncProgressService.Status.IncrementalSyncError      -> "Error"
             InitialSyncProgressService.Status.IncrementalSyncDone       -> "Done"
             else                                                        -> "?"
         }

--- a/vector/src/main/java/im/vector/app/features/sync/widget/SyncStateView.kt
+++ b/vector/src/main/java/im/vector/app/features/sync/widget/SyncStateView.kt
@@ -24,7 +24,7 @@ import androidx.core.view.isVisible
 import im.vector.app.R
 import im.vector.app.core.utils.isAirplaneModeOn
 import im.vector.app.databinding.ViewSyncStateBinding
-import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
+import org.matrix.android.sdk.api.session.initsync.SyncStatusService
 import org.matrix.android.sdk.api.session.sync.SyncState
 
 class SyncStateView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyle: Int = 0)
@@ -40,7 +40,7 @@ class SyncStateView @JvmOverloads constructor(context: Context, attrs: Attribute
 
     @SuppressLint("SetTextI18n")
     fun render(newState: SyncState,
-               incrementalSyncStatus: InitialSyncProgressService.Status.IncrementalSyncStatus,
+               incrementalSyncStatus: SyncStatusService.Status.IncrementalSyncStatus,
                pushCounter: Int,
                showDebugInfo: Boolean
     ) {
@@ -75,13 +75,13 @@ class SyncStateView @JvmOverloads constructor(context: Context, attrs: Attribute
         }
     }
 
-    private fun InitialSyncProgressService.Status.IncrementalSyncStatus.toHumanReadable(): String {
+    private fun SyncStatusService.Status.IncrementalSyncStatus.toHumanReadable(): String {
         return when (this) {
-            InitialSyncProgressService.Status.IncrementalSyncIdle       -> "Idle"
-            is InitialSyncProgressService.Status.IncrementalSyncParsing -> "Parsing ${this.rooms} room(s) ${this.toDevice} toDevice(s)"
-            InitialSyncProgressService.Status.IncrementalSyncError      -> "Error"
-            InitialSyncProgressService.Status.IncrementalSyncDone       -> "Done"
-            else                                                        -> "?"
+            SyncStatusService.Status.IncrementalSyncIdle       -> "Idle"
+            is SyncStatusService.Status.IncrementalSyncParsing -> "Parsing ${this.rooms} room(s) ${this.toDevice} toDevice(s)"
+            SyncStatusService.Status.IncrementalSyncError      -> "Error"
+            SyncStatusService.Status.IncrementalSyncDone       -> "Done"
+            else                                               -> "?"
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/sync/widget/SyncStateView.kt
+++ b/vector/src/main/java/im/vector/app/features/sync/widget/SyncStateView.kt
@@ -16,27 +16,37 @@
 
 package im.vector.app.features.sync.widget
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
-import android.widget.FrameLayout
+import android.widget.LinearLayout
 import androidx.core.view.isVisible
 import im.vector.app.R
 import im.vector.app.core.utils.isAirplaneModeOn
 import im.vector.app.databinding.ViewSyncStateBinding
-
+import org.matrix.android.sdk.api.session.initsync.InitialSyncProgressService
 import org.matrix.android.sdk.api.session.sync.SyncState
 
 class SyncStateView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyle: Int = 0)
-    : FrameLayout(context, attrs, defStyle) {
+    : LinearLayout(context, attrs, defStyle) {
 
     private val views: ViewSyncStateBinding
 
     init {
         inflate(context, R.layout.view_sync_state, this)
         views = ViewSyncStateBinding.bind(this)
+        orientation = VERTICAL
     }
 
-    fun render(newState: SyncState) {
+    @SuppressLint("SetTextI18n")
+    fun render(newState: SyncState,
+               incrementalSyncStatus: InitialSyncProgressService.Status.IncrementalSyncStatus,
+               showDebugInfo: Boolean) {
+        views.syncStateDebugInfo.isVisible = showDebugInfo
+        if (showDebugInfo) {
+            views.syncStateDebugInfo.text =
+                    "Sync thread : ${newState.toHumanReadable()}\nSync request: ${incrementalSyncStatus.toHumanReadable()}"
+        }
         views.syncStateProgressBar.isVisible = newState is SyncState.Running && newState.afterPause
 
         if (newState == SyncState.NoNetwork) {
@@ -46,6 +56,27 @@ class SyncStateView @JvmOverloads constructor(context: Context, attrs: Attribute
         } else {
             views.syncStateNoNetwork.isVisible = false
             views.syncStateNoNetworkAirplane.isVisible = false
+        }
+    }
+
+    private fun SyncState.toHumanReadable(): String {
+        return when (this) {
+            SyncState.Idle         -> "Idle"
+            SyncState.InvalidToken -> "InvalidToken"
+            SyncState.Killed       -> "Killed"
+            SyncState.Killing      -> "Killing"
+            SyncState.NoNetwork    -> "NoNetwork"
+            SyncState.Paused       -> "Paused"
+            is SyncState.Running   -> "$this"
+        }
+    }
+
+    private fun InitialSyncProgressService.Status.IncrementalSyncStatus.toHumanReadable(): String {
+        return when (this) {
+            is InitialSyncProgressService.Status.IncrementalSyncIdle    -> "Idle"
+            is InitialSyncProgressService.Status.IncrementalSyncParsing -> "Parsing"
+            is InitialSyncProgressService.Status.IncrementalSyncDone    -> "Done"
+            else                                                        -> "?"
         }
     }
 }

--- a/vector/src/main/res/layout/view_sync_state.xml
+++ b/vector/src/main/res/layout/view_sync_state.xml
@@ -9,9 +9,11 @@
 
     <TextView
         android:id="@+id/syncStateDebugInfo"
+        style="@style/Widget.Vector.TextView.Caption"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fontFamily="monospace"
+        android:padding="2dp"
         android:visibility="gone"
         tools:text="debug info"
         tools:visibility="visible" />

--- a/vector/src/main/res/layout/view_sync_state.xml
+++ b/vector/src/main/res/layout/view_sync_state.xml
@@ -7,6 +7,15 @@
     tools:orientation="vertical"
     tools:parentTag="android.widget.LinearLayout">
 
+    <TextView
+        android:id="@+id/syncStateDebugInfo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="monospace"
+        android:visibility="gone"
+        tools:text="debug info"
+        tools:visibility="visible" />
+
     <!-- Trick to remove surrounding padding (clip from wrapping frame) -->
     <FrameLayout
         android:id="@+id/syncStateProgressBar"

--- a/vector/src/main/res/layout/view_sync_state.xml
+++ b/vector/src/main/res/layout/view_sync_state.xml
@@ -7,16 +7,33 @@
     tools:orientation="vertical"
     tools:parentTag="android.widget.LinearLayout">
 
-    <TextView
+    <FrameLayout
         android:id="@+id/syncStateDebugInfo"
-        style="@style/Widget.Vector.TextView.Caption"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fontFamily="monospace"
         android:padding="2dp"
         android:visibility="gone"
-        tools:text="debug info"
-        tools:visibility="visible" />
+        tools:visibility="visible">
+
+        <TextView
+            android:id="@+id/syncStateDebugInfoText"
+            style="@style/Widget.Vector.TextView.Caption"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="monospace"
+            tools:text="debug info" />
+
+        <TextView
+            android:id="@+id/syncStateDebugInfoPushCounter"
+            style="@style/Widget.Vector.TextView.Caption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|center_vertical"
+            android:fontFamily="monospace"
+            android:textStyle="bold"
+            tools:text="123" />
+
+    </FrameLayout>
 
     <!-- Trick to remove surrounding padding (clip from wrapping frame) -->
     <FrameLayout

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2659,6 +2659,9 @@
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
     <string name="template_settings_developer_mode_fail_fast_summary">${app_name} may crash more often when an unexpected error occurs</string>
 
+    <string name="settings_developer_mode_show_info_on_screen_title">Show debug info on screen</string>
+    <string name="settings_developer_mode_show_info_on_screen_summary">Show some useful info to help debugging the application</string>
+
     <string name="command_description_shrug">Prepends ¯\\_(ツ)_/¯ to a plain-text message</string>
 
     <string name="create_room_encryption_title">"Enable encryption"</string>

--- a/vector/src/main/res/xml/vector_settings_advanced_settings.xml
+++ b/vector/src/main/res/xml/vector_settings_advanced_settings.xml
@@ -6,8 +6,8 @@
 
         <im.vector.app.core.preference.VectorSwitchPreference
             android:defaultValue="false"
-            android:key="SETTINGS_DEVELOPER_MODE_PREFERENCE_KEY"
             android:icon="@drawable/ic_verification_glasses"
+            android:key="SETTINGS_DEVELOPER_MODE_PREFERENCE_KEY"
             android:summary="@string/settings_developer_mode_summary"
             android:title="@string/settings_developer_mode" />
 
@@ -16,6 +16,13 @@
             android:dependency="SETTINGS_DEVELOPER_MODE_PREFERENCE_KEY"
             android:key="SETTINGS_LABS_SHOW_HIDDEN_EVENTS_PREFERENCE_KEY"
             android:title="@string/settings_labs_show_hidden_events_in_timeline" />
+
+        <im.vector.app.core.preference.VectorSwitchPreference
+            android:defaultValue="false"
+            android:dependency="SETTINGS_DEVELOPER_MODE_PREFERENCE_KEY"
+            android:key="SETTINGS_DEVELOPER_MODE_SHOW_INFO_ON_SCREEN_KEY"
+            android:summary="@string/settings_developer_mode_show_info_on_screen_summary"
+            android:title="@string/settings_developer_mode_show_info_on_screen_title" />
 
         <im.vector.app.core.preference.VectorSwitchPreference
             android:defaultValue="false"


### PR DESCRIPTION
This PR add debug info on room list and on room detail screen, if and only if developer mode and new option "show de bug info on screen" is on:

<img width="329" alt="image" src="https://user-images.githubusercontent.com/3940906/134027639-b6285b8a-4b9a-4bb9-8882-f4474b7a4c1d.png">

Displayed info are: 
- state of the sync thread
- state of the sync request
- number of PUSH received

Also this PR improves the log related to those parts of the code, so rageshakes will be more valuable

I used JetPack DataStore to store the number of received Push.