### PR TITLE
Remove redundant heading from bug report issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -21,14 +21,17 @@ body:
     validations:
       required: true
   - type: textarea
-    id: result
+    id: expected-result
     attributes:
-      label: What happened?
-      placeholder: Tell us what went wrong
-      value: |
-        ### What did you expect?
-
-        ### What happened?
+      label: What did you expect?
+      placeholder: Write here what you think should have happened.
+    validations:
+      required: true
+  - type: textarea
+    id: actual-result
+    attributes:
+      label: What actually happened?
+      placeholder: Write here what happened which was different from your expectations.
     validations:
       required: true
   - type: input

--- a/changelog.d/4048.misc
+++ b/changelog.d/4048.misc
@@ -1,0 +1,1 @@
+Remove redundant heading from bug report issue form


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog

The issue form currently generates a bug report that contains the "What happened?" heading twice. See https://github.com/vector-im/element-android/issues/4047#issue-1001300890. This splits the two questions off into their own (compulsory) text boxes.