### PR TITLE
Improve invite bottom sheet

### DIFF
--- a/changelog.d/4057.feature
+++ b/changelog.d/4057.feature
@@ -1,0 +1,1 @@
+Improve space invite bottom sheet

--- a/vector/src/main/java/im/vector/app/features/spaces/invite/SpaceInviteBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/invite/SpaceInviteBottomSheetViewModel.kt
@@ -89,7 +89,6 @@ class SpaceInviteBottomSheetViewModel @AssistedInject constructor(
                         )
                 )
             }
-
         }
     }
 


### PR DESCRIPTION
Quick improvement of invite bottomsheet:
Whe showing an invite we try in background to query the room Summary API to get a bit more information (like the number of members). Also it could get a more up to date strippedState than the one in the room invite sync.

<img width="809" alt="image" src="https://user-images.githubusercontent.com/9841565/134347291-91f3c715-5a3f-4a0f-9a8c-6793aff0329d.png">
