### PR TITLE
Client side validation of alias max length

### DIFF
--- a/changelog.d/3934.bugfix
+++ b/changelog.d/3934.bugfix
@@ -1,0 +1,1 @@
+Validate public space address length when user clicks away from

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/MatrixPatterns.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/MatrixPatterns.kt
@@ -165,6 +165,8 @@ object MatrixPatterns {
     fun candidateAliasFromRoomName(name: String): String {
         return Regex("\\s").replace(name.lowercase(), "_").let {
             "[^a-z0-9._%#@=+-]".toRegex().replace(it, "")
+        }.let { alias ->
+            if (alias.length > 255) alias.substring(0, 255) else alias
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/form/FormEditTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/form/FormEditTextItem.kt
@@ -17,6 +17,7 @@
 package im.vector.app.features.form
 
 import android.text.Editable
+import android.text.InputFilter
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.TextView
@@ -77,6 +78,9 @@ abstract class FormEditTextItem : VectorEpoxyModel<FormEditTextItem.Holder>() {
     @EpoxyAttribute
     var suffixText: String? = null
 
+    @EpoxyAttribute
+    var maxLength: Int? = null
+
     private val onTextChangeListener = object : SimpleTextWatcher() {
         override fun afterTextChanged(s: Editable) {
             onTextChange?.invoke(s.toString())
@@ -109,6 +113,15 @@ abstract class FormEditTextItem : VectorEpoxyModel<FormEditTextItem.Holder>() {
         holder.textInputEditText.addTextChangedListenerOnce(onTextChangeListener)
         holder.textInputEditText.setOnEditorActionListener(editorActionListener)
         holder.textInputEditText.onFocusChangeListener = onFocusChangedListener
+
+        if (maxLength != null) {
+            holder.textInputEditText.filters = arrayOf(InputFilter.LengthFilter(maxLength!!))
+            holder.textInputLayout.isCounterEnabled = true
+            holder.textInputLayout.counterMaxLength = maxLength!!
+        } else {
+            holder.textInputEditText.filters = arrayOf()
+            holder.textInputLayout.isCounterEnabled = false
+        }
     }
 
     override fun shouldSaveViewState(): Boolean {

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomController.kt
@@ -140,6 +140,7 @@ class CreateRoomController @Inject constructor(
                 value(viewState.aliasLocalPart)
                 suffixText(":" + viewState.homeServerName)
                 prefixText("#")
+                maxLength(255)
                 hint(host.stringProvider.getString(R.string.room_alias_address_hint))
                 errorMessage(
                         host.roomAliasErrorFormatter.format(

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
@@ -55,7 +55,7 @@ import timber.log.Timber
 class CreateRoomViewModel @AssistedInject constructor(@Assisted private val initialState: CreateRoomViewState,
                                                       private val session: Session,
                                                       private val rawService: RawService,
-                                                      private val vectorPreferences: VectorPreferences
+                                                      vectorPreferences: VectorPreferences
 ) : VectorViewModel<CreateRoomViewState, CreateRoomAction, CreateRoomViewEvents>(initialState) {
 
     @AssistedFactory

--- a/vector/src/main/java/im/vector/app/features/spaces/create/SpaceDetailEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/create/SpaceDetailEpoxyController.kt
@@ -94,6 +94,8 @@ class SpaceDetailEpoxyController @Inject constructor(
                 hint(host.stringProvider.getString(R.string.create_space_alias_hint))
                 suffixText(":" + data.homeServerName)
                 prefixText("#")
+                // spaces alias are limited to 255
+                maxLength(255)
                 onFocusChange { hasFocus ->
                     host.aliasTextIsFocused = hasFocus
                 }


### PR DESCRIPTION
Fixes #3934

Adding client side limitation on room alias length

<img width="357" alt="image" src="https://user-images.githubusercontent.com/9841565/134369000-9b1c9d93-c417-4a40-8892-38a2ca0ec327.png">


Just a maxlength on input with a counter