### PR TITLE
Adding benchmarking script to start monitoring build times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .idea/*.xml
 .DS_Store
 /build
+/benchmark-out
 /captures
 .externalNativeBuild
 

--- a/tools/benchmark/benchmark.profile
+++ b/tools/benchmark/benchmark.profile
@@ -1,0 +1,39 @@
+#
+# Copyright 2021 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+clean_assemble {
+  tasks = ["clean", ":vector:assembleGPlayDebug"]
+}
+
+clean_assemble_build_cache {
+  tasks = ["clean", ":vector:assembleGPlayDebug"]
+  gradle-args = ["--build-cache"]
+}
+
+clean_assemble_without_cache {
+  tasks = ["clean", ":vector:assembleGPlayDebug"]
+  gradle-args = ["--no-build-cache"]
+}
+
+incremental_assemble_sdk_abi {
+  tasks = [":vector:assembleGPlayDebug"]
+  apply-abi-change-to = "matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/Matrix.kt"
+}
+
+incremental_assemble_sdk_no_abi {
+  tasks = [":vector:assembleGPlayDebug"]
+  apply-non-abi-change-to = "matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/Matrix.kt"
+}

--- a/tools/benchmark/run_benchmark.sh
+++ b/tools/benchmark/run_benchmark.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2021 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if ! command -v gradle-profiler &> /dev/null
+then
+    echo "gradle-profiler could not be found https://github.com/gradle/gradle-profiler"
+    exit
+fi
+
+gradle-profiler \
+  --benchmark \
+  --project-dir . \
+  --scenario-file tools/benchmark/benchmark.profile \
+  --output-dir benchmark-out/output \
+  --gradle-user-home benchmark-out/gradle-home \
+  --warmups 3 \
+  --iterations 3 \
+  $1


### PR DESCRIPTION
Adds a script to run the [gradle-profiler](https://github.com/gradle/gradle-profiler) so that we can start monitoring and quantifying build time improvements  

### Usage 

- Requires the gradle-profile to be installed
- running from the root of the repository `./tools/benchmark/run-benchmark "comma separated scenario names or blank to run all"`


The warm up and run iterations have been reduced from the defaults, makes the overall suite take less time but at the cost some reliability

Here's some early results...

#### Recompiling

```
assemble {
  tasks = [":vector:assembleGPlayDebug"]
}
```

![2021-09-23T16:08:22,201186771+01:00](https://user-images.githubusercontent.com/1848238/134535277-f52189f7-f89e-423a-803b-926e00fe2bc0.png)

recompiling without any changes takes 1 second~ it's almost entirely gradle configuration, it shows our gradle setup isn't invaliding the configuration and causing extra processing


#### Clean builds 
assemble clean builds with and without the build cache, build cache is disabled by default
```
assemble {
  tasks = ["clean", ":vector:assembleGPlayDebug"]
}

assemble_build_cache {
  tasks = ["clean", ":vector:assembleGPlayDebug"]
  gradle-args = ["--build-cache"]
}
```

![2021-09-23T15:49:46,263256186+01:00](https://user-images.githubusercontent.com/1848238/134530110-21a198b7-4e2a-44f9-9a9b-4a70ca499961.png)

From these results we can see that the build cache saves a massive amount of build time, 2m 30s~ down to 14~ seconds, not too unexpected as the build cache doesn't get cleared with a `clean` and since we're only doing a clean we should get lots of cache hits.

#### Incremental

Making a non ABI and ABI change in the matrix sdk module

![2021-09-23T16:07:57,679358923+01:00](https://user-images.githubusercontent.com/1848238/134533634-d9122453-88c3-4337-93dd-0b9c5fb735d1.png)

a 15 second~ incremental time shows us at a high level that the SDK module in correctly compiling incrementally, a clean assembly of the sdk module takes 1 minute~. Bencharking ABI changes will be more useful as we introduce more modules as gradle will force clients of modules with ABI to also recompile.  


More information can be found at https://developer.android.com/studio/build/profile-your-build
