### PR TITLE
Fixing no tests found when running vector:connectedAndroidTest

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -58,6 +58,7 @@ ext.libs = [
                 'pagingRuntimeKtx'        : "androidx.paging:paging-runtime-ktx:2.1.2",
                 'coreTesting'             : "androidx.arch.core:core-testing:2.1.0",
                 'testCore'                : "androidx.test:core:$androidxTest",
+                'orchestrator'            : "androidx.test:orchestrator:$androidxTest",
                 'testRunner'              : "androidx.test:runner:$androidxTest",
                 'testRules'               : "androidx.test:rules:$androidxTest",
                 'espressoCore'            : "androidx.test.espresso:espresso-core:$espresso",

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -179,5 +179,5 @@ dependencies {
     // Plant Timber tree for test
     androidTestImplementation libs.tests.timberJunitRule
 
-    androidTestUtil 'androidx.test:orchestrator:1.4.0'
+    androidTestUtil libs.androidx.orchestrator
 }

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -508,4 +508,5 @@ dependencies {
     androidTestImplementation('com.adevinta.android:barista:4.1.0') {
         exclude group: 'org.jetbrains.kotlin'
     }
+    androidTestUtil 'androidx.test:orchestrator:1.4.0'
 }

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -508,5 +508,5 @@ dependencies {
     androidTestImplementation('com.adevinta.android:barista:4.1.0') {
         exclude group: 'org.jetbrains.kotlin'
     }
-    androidTestUtil 'androidx.test:orchestrator:1.4.0'
+    androidTestUtil libs.androidx.orchestrator
 }

--- a/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -283,6 +283,7 @@ class UiAllScreensSanityTest {
         clickListItem(R.id.matrixProfileRecyclerView, 9)
         // File tab
         clickOn(R.string.uploads_files_title)
+        sleep(1000)
         pressBack()
 
         assertDisplayed(R.id.roomProfileAvatarView)
@@ -334,6 +335,7 @@ class UiAllScreensSanityTest {
     private fun navigateToRoomPeople() {
         // Open first user
         clickListItem(R.id.roomSettingsRecyclerView, 1)
+        sleep(1000)
         assertDisplayed(R.id.memberProfilePowerLevelView)
 
         // Verification
@@ -342,8 +344,9 @@ class UiAllScreensSanityTest {
 
         // Role
         clickListItem(R.id.matrixProfileRecyclerView, 3)
+        sleep(1000)
         clickDialogNegativeButton()
-
+        sleep(1000)
         clickBack()
     }
 


### PR DESCRIPTION
Adds missing orchestrator test util, this was being set in the `matrix-android-sdk` module but not in `vector`.

This should hopefully get the CI sanity test step completing again

caught by @onurays  :pray: 