### PR TITLE
[ignore] Temporarily running the sanity tests on mac-osx VM

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -69,7 +69,7 @@ jobs:
           python3 -m venv .synapse
           source .synapse/bin/activate
           pip install synapse matrix-synapse
-          curl -sL https://raw.githubusercontent.com/matrix-org/synapse/develop/demo/start.sh --no-rate-limit \
+          curl -sL https://raw.githubusercontent.com/matrix-org/synapse/develop/demo/start.sh \
             | sed s/127.0.0.1/0.0.0.0/g | bash
       - name: Run integration tests on API ${{ matrix.api-level }}
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -46,7 +46,7 @@ jobs:
           python3 -m venv .synapse
           source .synapse/bin/activate
           pip install synapse matrix-synapse
-          curl -sL https://raw.githubusercontent.com/matrix-org/synapse/develop/demo/start.sh --no-rate-limit \
+          curl -sL https://raw.githubusercontent.com/matrix-org/synapse/develop/demo/start.sh \
             | sed s/127.0.0.1/0.0.0.0/g | sed 's/http:\/\/localhost/http:\/\/10.0.2.2/g' | bash
       - uses: actions/setup-java@v2
         with:

--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -56,5 +56,10 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          arch: x86
+          profile: Nexus 5X
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-build: 7425822
           script: ./gradlew $CI_GRADLE_ARG_PROPERTIES -PallWarningsAsErrors=false connectedGplayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=im.vector.app.ui.UiAllScreensSanityTest
 

--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -47,7 +47,7 @@ jobs:
           source .synapse/bin/activate
           pip install synapse matrix-synapse
           curl -sL https://raw.githubusercontent.com/matrix-org/synapse/develop/demo/start.sh --no-rate-limit \
-            | sed s/127.0.0.1/0.0.0.0/g | bash
+            | sed s/127.0.0.1/0.0.0.0/g | sed 's/http:\/\/localhost/http:\/\/10.0.2.2/g' | bash
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'

--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   integration-tests:
     name: Sanity Tests (Synapse)
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +48,10 @@ jobs:
           pip install synapse matrix-synapse
           curl -sL https://raw.githubusercontent.com/matrix-org/synapse/develop/demo/start.sh --no-rate-limit \
             | sed s/127.0.0.1/0.0.0.0/g | bash
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
       - name: Run sanity tests on API ${{ matrix.api-level }}
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -290,8 +290,9 @@ class UiAllScreensSanityTest {
 
         // Leave
         clickListItem(R.id.matrixProfileRecyclerView, 13)
+        sleep(1000)
         clickDialogNegativeButton()
-
+        sleep(1000)
         // Advanced
         // Room addresses
         clickListItem(R.id.matrixProfileRecyclerView, 15)
@@ -352,6 +353,7 @@ class UiAllScreensSanityTest {
 
     private fun createDm() {
         clickOn(R.id.createChatRoomButton)
+        sleep(1000)
 
         withIdlingResource(activityIdlingResource(CreateDirectRoomActivity::class.java)) {
             onView(withId(R.id.userListRecyclerView))
@@ -362,6 +364,7 @@ class UiAllScreensSanityTest {
 
         closeSoftKeyboard()
         pressBack()
+        sleep(500)
         pressBack()
     }
 

--- a/vector/src/androidTest/java/im/vector/app/ui/UiTestBase.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiTestBase.kt
@@ -29,6 +29,7 @@ import im.vector.app.R
 import im.vector.app.espresso.tools.waitUntilActivityVisible
 import im.vector.app.features.home.HomeActivity
 import im.vector.app.waitForView
+import java.lang.Thread.sleep
 
 class UiTestBase {
     fun createAccount(userId: String, password: String = "password", homeServerUrl: String = "http://10.0.2.2:8080") {
@@ -52,6 +53,7 @@ class UiTestBase {
         writeTo(R.id.loginServerUrlFormHomeServerUrl, homeServerUrl)
         assertEnabled(R.id.loginServerUrlFormSubmit)
         closeSoftKeyboard()
+        sleep(500)
         clickOn(R.id.loginServerUrlFormSubmit)
         onView(isRoot()).perform(waitForView(withId(R.id.loginSignupSigninSubmit)))
 
@@ -75,6 +77,7 @@ class UiTestBase {
         assertEnabled(R.id.loginSubmit)
 
         closeSoftKeyboard()
+        sleep(500)
         clickOn(R.id.loginSubmit)
 
         // Wait


### PR DESCRIPTION
Attempting to get the sanity tests to run to completion, the current theory is we need a hardware accelerated emulator in order to correctly render the UI