### PR TITLE
Remove redundancy in heading in bug report issue form 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -23,10 +23,10 @@ body:
   - type: textarea
     id: result
     attributes:
-      label: Intended vs. Actual Result
+      label: Intended result and actual result
       placeholder: Tell us what went wrong
       value: |
-        #### What did you expect to happen?
+        #### What did you expect?
 
         #### What happened instead?
     validations:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -23,12 +23,12 @@ body:
   - type: textarea
     id: result
     attributes:
-      label: What happened?
+      label: Intended vs. Actual Result
       placeholder: Tell us what went wrong
       value: |
-        ### What did you expect?
+        #### What did you expect to happen?
 
-        ### What happened?
+        #### What happened instead?
     validations:
       required: true
   - type: input

--- a/changelog.d/4076.misc
+++ b/changelog.d/4076.misc
@@ -1,1 +1,1 @@
-Remove redundant heading from bug report issue form
+Fix redundancy in heading in the bug report issue form

--- a/changelog.d/4076.misc
+++ b/changelog.d/4076.misc
@@ -1,0 +1,1 @@
+Remove redundant heading from bug report issue form


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog

The issue form currently generates a bug report that contains the "What happened?" heading twice. See https://github.com/vector-im/element-android/issues/4047#issue-1001300890.

This PR edits the culprit heading and its subheadings to remove the redundancy and clarify what is meant.