### PR TITLE
Fix default encrypted for restricted

### DIFF
--- a/changelog.d/4045.bugfix
+++ b/changelog.d/4045.bugfix
@@ -1,0 +1,1 @@
+Align new room encryption default to Web

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomController.kt
@@ -165,7 +165,11 @@ class CreateRoomController @Inject constructor(
                             host.stringProvider.getString(R.string.create_room_encryption_description)
                         }
                 )
-                switchChecked(viewState.isEncrypted)
+                if (viewState.isEncrypted != null) {
+                    switchChecked(viewState.isEncrypted)
+                } else {
+                    switchChecked(viewState.defaultEncrypted[viewState.roomJoinRules] ?: false)
+                }
 
                 listener { value ->
                     host.listener?.setIsEncrypted(value)

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomController.kt
@@ -29,6 +29,7 @@ import im.vector.app.features.form.formEditTextItem
 import im.vector.app.features.form.formEditableAvatarItem
 import im.vector.app.features.form.formSubmitButtonItem
 import im.vector.app.features.form.formSwitchItem
+import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.room.failure.CreateRoomFailure
 import org.matrix.android.sdk.api.session.room.model.RoomJoinRules
 import javax.inject.Inject
@@ -165,11 +166,8 @@ class CreateRoomController @Inject constructor(
                             host.stringProvider.getString(R.string.create_room_encryption_description)
                         }
                 )
-                if (viewState.isEncrypted != null) {
-                    switchChecked(viewState.isEncrypted)
-                } else {
-                    switchChecked(viewState.defaultEncrypted[viewState.roomJoinRules] ?: false)
-                }
+
+                switchChecked(viewState.isEncrypted ?: viewState.defaultEncrypted[viewState.roomJoinRules].orFalse())
 
                 listener { value ->
                     host.listener?.setIsEncrypted(value)

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomFragment.kt
@@ -163,8 +163,9 @@ class CreateRoomFragment @Inject constructor(
     }
 
     override fun selectVisibility() = withState(viewModel) { state ->
-
-        val allowed = if (state.supportsRestricted) {
+        // If restricted is supported and the user is in the context of a parent space
+        // then show restricted option.
+        val allowed = if (state.supportsRestricted && state.parentSpaceId != null) {
             listOf(RoomJoinRules.INVITE, RoomJoinRules.PUBLIC, RoomJoinRules.RESTRICTED)
         } else {
             listOf(RoomJoinRules.INVITE, RoomJoinRules.PUBLIC)

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
@@ -36,6 +36,7 @@ import im.vector.app.features.settings.VectorPreferences
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.MatrixPatterns.getDomain
+import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.raw.RawService
 import org.matrix.android.sdk.api.session.Session
@@ -291,17 +292,13 @@ class CreateRoomViewModel @AssistedInject constructor(@Assisted private val init
                     disableFederation = state.disableFederation
 
                     // Encryption
-                    // we ignore the isEncrypted for public room as the switch is hidden in this case
-                    if (state.roomJoinRules != RoomJoinRules.PUBLIC && state.isEncrypted != null) {
-                        // the user explicitly switch the toggle
-                        if (state.isEncrypted) {
-                            enableEncryption()
-                        }
-                    } else {
-                        // based on default
-                        if (state.defaultEncrypted[state.roomJoinRules] == true) {
-                            enableEncryption()
-                        }
+                    val shouldEncrypt = when (state.roomJoinRules) {
+                        // we ignore the isEncrypted for public room as the switch is hidden in this case
+                        RoomJoinRules.PUBLIC -> false
+                        else                 -> state.isEncrypted ?: state.defaultEncrypted[state.roomJoinRules].orFalse()
+                    }
+                    if (shouldEncrypt) {
+                        enableEncryption()
                     }
                 }
 

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewModel.kt
@@ -109,8 +109,13 @@ class CreateRoomViewModel @AssistedInject constructor(@Assisted private val init
 
             setState {
                 copy(
-                        isEncrypted = RoomJoinRules.INVITE == roomJoinRules && adminE2EByDefault,
-                        hsAdminHasDisabledE2E = !adminE2EByDefault
+                        hsAdminHasDisabledE2E = !adminE2EByDefault,
+                        defaultEncrypted = mapOf(
+                                RoomJoinRules.INVITE to adminE2EByDefault,
+                                RoomJoinRules.PUBLIC to false,
+                                RoomJoinRules.RESTRICTED to adminE2EByDefault
+                        )
+
                 )
             }
         }
@@ -286,8 +291,17 @@ class CreateRoomViewModel @AssistedInject constructor(@Assisted private val init
                     disableFederation = state.disableFederation
 
                     // Encryption
-                    if (state.isEncrypted) {
-                        enableEncryption()
+                    // we ignore the isEncrypted for public room as the switch is hidden in this case
+                    if (state.roomJoinRules != RoomJoinRules.PUBLIC && state.isEncrypted != null) {
+                        // the user explicitly switch the toggle
+                        if (state.isEncrypted) {
+                            enableEncryption()
+                        }
+                    } else {
+                        // based on default
+                        if (state.defaultEncrypted[state.roomJoinRules] == true) {
+                            enableEncryption()
+                        }
                     }
                 }
 

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewState.kt
@@ -29,6 +29,7 @@ data class CreateRoomViewState(
         val roomTopic: String = "",
         val roomJoinRules: RoomJoinRules = RoomJoinRules.INVITE,
         val isEncrypted: Boolean? = null,
+        val defaultEncrypted: Map<RoomJoinRules, Boolean> = emptyMap(),
         val showAdvanced: Boolean = false,
         val disableFederation: Boolean = false,
         val homeServerName: String = "",
@@ -38,8 +39,7 @@ data class CreateRoomViewState(
         val parentSpaceSummary: RoomSummary? = null,
         val supportsRestricted: Boolean = false,
         val aliasLocalPart: String? = null,
-        val isSubSpace: Boolean = false,
-        val defaultEncrypted: Map<RoomJoinRules, Boolean> = emptyMap()
+        val isSubSpace: Boolean = false
 ) : MvRxState {
 
     constructor(args: CreateRoomArgs) : this(

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomViewState.kt
@@ -28,7 +28,7 @@ data class CreateRoomViewState(
         val roomName: String = "",
         val roomTopic: String = "",
         val roomJoinRules: RoomJoinRules = RoomJoinRules.INVITE,
-        val isEncrypted: Boolean = false,
+        val isEncrypted: Boolean? = null,
         val showAdvanced: Boolean = false,
         val disableFederation: Boolean = false,
         val homeServerName: String = "",
@@ -38,7 +38,8 @@ data class CreateRoomViewState(
         val parentSpaceSummary: RoomSummary? = null,
         val supportsRestricted: Boolean = false,
         val aliasLocalPart: String? = null,
-        val isSubSpace: Boolean = false
+        val isSubSpace: Boolean = false,
+        val defaultEncrypted: Map<RoomJoinRules, Boolean> = emptyMap()
 ) : MvRxState {
 
     constructor(args: CreateRoomArgs) : this(


### PR DESCRIPTION
Fixes #4045 

Align default encrypted for restricted room as web is doing it, i.e use what is in well-known (default e2e).
Private and restricted encrypted switch is on if well-known e2e is by default.
=> Also if the user did manually change the encrypted toggled then always take that value and not the default.

Additional Fix:
When no space was selected, the option to set the room to restricted was visible, that would create a room restricted to nothing. So now if no space selected you'll only have a choice between Private or Public
