### PR TITLE
Verify exported keys output

### DIFF
--- a/changelog.d/4082.bugfix
+++ b/changelog.d/4082.bugfix
@@ -1,0 +1,1 @@
+Verifying exported E2E keys to provide user feedback when the output is malformed

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -314,6 +314,11 @@ android {
     }
 }
 
+configurations {
+    // videocache includes a sl4j logger which causes mockk to attempt to call the static android Log
+    testImplementation.exclude group: 'org.slf4j', module: 'slf4j-android'
+}
+
 dependencies {
 
     implementation project(":matrix-sdk-android")
@@ -490,6 +495,7 @@ dependencies {
     // TESTS
     testImplementation libs.tests.junit
     testImplementation libs.tests.kluent
+    testImplementation libs.mockk.mockk
     // Plant Timber tree for test
     testImplementation libs.tests.timberJunitRule
 

--- a/vector/src/main/java/im/vector/app/core/di/VectorComponent.kt
+++ b/vector/src/main/java/im/vector/app/core/di/VectorComponent.kt
@@ -26,6 +26,7 @@ import im.vector.app.EmojiCompatFontProvider
 import im.vector.app.EmojiCompatWrapper
 import im.vector.app.VectorApplication
 import im.vector.app.core.dialogs.UnrecognizedCertificateDialog
+import im.vector.app.core.dispatchers.CoroutineDispatchers
 import im.vector.app.core.error.ErrorFormatter
 import im.vector.app.core.network.WifiDetector
 import im.vector.app.core.pushers.PushersManager
@@ -170,6 +171,8 @@ interface VectorComponent {
     fun webRtcCallManager(): WebRtcCallManager
 
     fun appCoroutineScope(): CoroutineScope
+
+    fun coroutineDispatchers(): CoroutineDispatchers
 
     fun jitsiActiveConferenceHolder(): JitsiActiveConferenceHolder
 

--- a/vector/src/main/java/im/vector/app/core/di/VectorModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/VectorModule.kt
@@ -34,7 +34,6 @@ import im.vector.app.features.pin.PinCodeStore
 import im.vector.app.features.pin.SharedPrefPinCodeStore
 import im.vector.app.features.ui.SharedPreferencesUiStateRepository
 import im.vector.app.features.ui.UiStateRepository
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob

--- a/vector/src/main/java/im/vector/app/core/di/VectorModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/VectorModule.kt
@@ -23,6 +23,7 @@ import android.content.res.Resources
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
+import im.vector.app.core.dispatchers.CoroutineDispatchers
 import im.vector.app.core.error.DefaultErrorFormatter
 import im.vector.app.core.error.ErrorFormatter
 import im.vector.app.features.invite.AutoAcceptInvites
@@ -33,6 +34,7 @@ import im.vector.app.features.pin.PinCodeStore
 import im.vector.app.features.pin.SharedPrefPinCodeStore
 import im.vector.app.features.ui.SharedPreferencesUiStateRepository
 import im.vector.app.features.ui.UiStateRepository
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -104,6 +106,12 @@ abstract class VectorModule {
         @Singleton
         fun providesApplicationCoroutineScope(): CoroutineScope {
             return CoroutineScope(SupervisorJob() + Dispatchers.Main)
+        }
+
+        @Provides
+        @JvmStatic
+        fun providesCoroutineDispatchers(): CoroutineDispatchers {
+            return CoroutineDispatchers(io = Dispatchers.IO)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/core/dispatchers/CoroutineDispatchers.kt
+++ b/vector/src/main/java/im/vector/app/core/dispatchers/CoroutineDispatchers.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.dispatchers
+
+import kotlinx.coroutines.CoroutineDispatcher
+import javax.inject.Inject
+
+data class CoroutineDispatchers @Inject constructor(val io: CoroutineDispatcher)

--- a/vector/src/main/java/im/vector/app/features/crypto/keys/KeysExporter.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keys/KeysExporter.kt
@@ -19,7 +19,6 @@ package im.vector.app.features.crypto.keys
 import android.content.Context
 import android.net.Uri
 import im.vector.app.core.dispatchers.CoroutineDispatchers
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.matrix.android.sdk.api.session.Session
 import javax.inject.Inject
@@ -49,7 +48,7 @@ class KeysExporter @Inject constructor(
             output.statSize != expectedSize -> {
                 throw UnexpectedExportKeysFileSizeException(
                         expectedFileSize = output.statSize,
-                        actualFileSize = expectedSize,
+                        actualFileSize = expectedSize
                 )
             }
         }

--- a/vector/src/main/java/im/vector/app/features/crypto/keys/KeysExporter.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keys/KeysExporter.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.crypto.keys
 
 import android.content.Context
 import android.net.Uri
+import im.vector.app.core.dispatchers.CoroutineDispatchers
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.matrix.android.sdk.api.session.Session
@@ -25,17 +26,36 @@ import javax.inject.Inject
 
 class KeysExporter @Inject constructor(
         private val session: Session,
-        private val context: Context
+        private val context: Context,
+        private val dispatchers: CoroutineDispatchers
 ) {
     /**
      * Export keys and write them to the provided uri
      */
     suspend fun export(password: String, uri: Uri) {
-        return withContext(Dispatchers.IO) {
+        withContext(dispatchers.io) {
             val data = session.cryptoService().exportRoomKeys(password)
             context.contentResolver.openOutputStream(uri)
                     ?.use { it.write(data) }
-                    ?: throw IllegalStateException("Unable to open file for writting")
+                    ?: throw IllegalStateException("Unable to open file for writing")
+            verifyExportedKeysOutputFileSize(uri, expectedSize = data.size.toLong())
+        }
+    }
+
+    private fun verifyExportedKeysOutputFileSize(uri: Uri, expectedSize: Long) {
+        val output = context.contentResolver.openFileDescriptor(uri, "r", null)
+        when {
+            output == null                  -> throw IllegalStateException("Exported file not found")
+            output.statSize != expectedSize -> {
+                throw UnexpectedExportKeysFileSizeException(
+                        expectedFileSize = output.statSize,
+                        actualFileSize = expectedSize,
+                )
+            }
         }
     }
 }
+
+class UnexpectedExportKeysFileSizeException(expectedFileSize: Long, actualFileSize: Long) : IllegalStateException(
+        "Exported Keys file has unexpected file size, got: $actualFileSize but expected: $expectedFileSize"
+)

--- a/vector/src/main/java/im/vector/app/features/crypto/keys/KeysExporter.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keys/KeysExporter.kt
@@ -47,8 +47,8 @@ class KeysExporter @Inject constructor(
             output == null                  -> throw IllegalStateException("Exported file not found")
             output.statSize != expectedSize -> {
                 throw UnexpectedExportKeysFileSizeException(
-                        expectedFileSize = output.statSize,
-                        actualFileSize = expectedSize
+                        expectedFileSize = expectedSize,
+                        actualFileSize = output.statSize
                 )
             }
         }

--- a/vector/src/test/java/im/vector/app/features/crypto/keys/KeysExporterTest.kt
+++ b/vector/src/test/java/im/vector/app/features/crypto/keys/KeysExporterTest.kt
@@ -42,7 +42,7 @@ class KeysExporterTest {
     private val keysExporter = KeysExporter(
             session = FakeSession(cryptoService = cryptoService),
             context = context.instance,
-            dispatchers = CoroutineDispatchers(Dispatchers.Unconfined),
+            dispatchers = CoroutineDispatchers(Dispatchers.Unconfined)
     )
 
     @Before

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeContext.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeContext.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import io.mockk.every
+import io.mockk.mockk
+import java.io.OutputStream
+
+class FakeContext {
+
+    private val contentResolver = mockk<ContentResolver>()
+    val instance = mockk<Context>()
+
+    init {
+        every { instance.contentResolver } returns contentResolver
+    }
+
+    fun givenFileDescriptor(uri: Uri, mode: String, factory: () -> ParcelFileDescriptor?) {
+        val fileDescriptor = factory()
+        every { contentResolver.openFileDescriptor(uri, mode, null) } returns fileDescriptor
+    }
+
+    fun givenOutputStreamFor(uri: Uri): OutputStream {
+        val outputStream = mockk<OutputStream>(relaxed = true)
+        every { contentResolver.openOutputStream(uri) } returns outputStream
+        return outputStream
+    }
+
+    fun givenMissingOutputStreamFor(uri: Uri) {
+        every { contentResolver.openOutputStream(uri) } returns null
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeCryptoService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeCryptoService.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import io.mockk.mockk
+import org.matrix.android.sdk.api.session.crypto.CryptoService
+
+class FakeCryptoService : CryptoService by mockk() {
+
+    var roomKeysExport = ByteArray(size = 1)
+
+    override suspend fun exportRoomKeys(password: String) = roomKeysExport
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeSession.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeSession.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import io.mockk.mockk
+import org.matrix.android.sdk.api.session.Session
+import org.matrix.android.sdk.api.session.crypto.CryptoService
+
+class FakeSession(
+        private val cryptoService: CryptoService = FakeCryptoService()
+) : Session by mockk(relaxed = true) {
+    override fun cryptoService() = cryptoService
+}


### PR DESCRIPTION
Whilst looking into #4082 (missing content in the exported room keys) there were no obvious issues with the packing algorithm that would cause appending the trailer line to fail without the entire packing failing. 

```kotlin
outStream.write("\n".toByteArray())
outStream.write(TRAILER_LINE.toByteArray())
outStream.write("\n".toByteArray())
```

There are some stylistic differences in the packing but their logic is the same. 

```
// android
val nLines = (data.size + LINE_LENGTH - 1) / LINE_LENGTH

// web
const nLines = Math.ceil(data.length / LINE_LENGTH)
```

I suspect an error occurred on the filesystem which meant the output wasn't correctly written to disk.

This PR adds a naive file size verification after writing the exported E2E keys, this attempts to catch any file system abnormalities that could lead to the file missing sections (eg running out of disk space and not propagating any errors)

- Makes the coroutine dispatchers injectable
- Adds unit tests around the KeysExporter flows
