### PR TITLE
Fix do not hide toolbar on scroll

### DIFF
--- a/changelog.d/3935.bugfix
+++ b/changelog.d/3935.bugfix
@@ -1,0 +1,1 @@
+Save button for adding rooms to a space is hidden when scrolling through list of rooms

--- a/vector/src/main/res/layout/fragment_space_add_rooms.xml
+++ b/vector/src/main/res/layout/fragment_space_add_rooms.xml
@@ -24,8 +24,7 @@
             android:id="@+id/addRoomToSpaceToolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:minHeight="0dp"
-            app:layout_scrollFlags="scroll|exitUntilCollapsed|snap|enterAlways">
+            android:minHeight="0dp">
 
             <LinearLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #3935 

We should not hide the toolbar on scroll as it can have the save button