### PR TITLE
Fixing notifications not being dismissed when read from other devices

### DIFF
--- a/changelog.d/3347.bugfix
+++ b/changelog.d/3347.bugfix
@@ -1,0 +1,1 @@
+Fixes notifications not dismissing when reading messages on other devices

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/query/ReadQueries.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/query/ReadQueries.kt
@@ -78,7 +78,6 @@ private fun Realm.hasReadReceiptInLatestChunk(latestChunkEntity: ChunkEntity, ro
     } != null
 }
 
-
 internal fun isReadMarkerMoreRecent(realmConfiguration: RealmConfiguration,
                                     roomId: String?,
                                     eventId: String?): Boolean {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/query/ReadQueries.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/query/ReadQueries.kt
@@ -23,6 +23,9 @@ import org.matrix.android.sdk.internal.database.model.TimelineEventEntity
 import io.realm.Realm
 import io.realm.RealmConfiguration
 
+private const val MARK_OLD_EVENT_AS_READ = true
+private const val MARK_UNREAD_DUE_TO_FASTLANE = false
+
 internal fun isEventRead(realmConfiguration: RealmConfiguration,
                          userId: String?,
                          roomId: String?,
@@ -39,10 +42,7 @@ internal fun isEventRead(realmConfiguration: RealmConfiguration,
         val liveChunk = ChunkEntity.findLastForwardChunkOfRoom(realm, roomId) ?: return@use
         val eventToCheck = liveChunk.timelineEvents.find(eventId)
         isEventRead = when {
-            eventToCheck == null                -> {
-                // This can happen in case of fast lane Event
-                false
-            }
+            eventToCheck == null                -> handleMissingEvent(realm, liveChunk, roomId, userId, eventId)
             eventToCheck.root?.sender == userId -> true
             else                                -> {
                 val readReceipt = ReadReceiptEntity.where(realm, roomId, userId).findFirst()
@@ -58,6 +58,26 @@ internal fun isEventRead(realmConfiguration: RealmConfiguration,
 
     return isEventRead
 }
+
+private fun handleMissingEvent(realm: Realm, latestChunkEntity: ChunkEntity, roomId: String, userId: String, eventId: String): Boolean {
+    return if (realm.doesEventExistInChunkHistory(eventId) && realm.hasReadReceiptInLatestChunk(latestChunkEntity, roomId, userId)) {
+        MARK_OLD_EVENT_AS_READ
+    } else {
+        // This can happen when fast lane events are displayed before the database finishes updating
+        MARK_UNREAD_DUE_TO_FASTLANE
+    }
+}
+
+private fun Realm.doesEventExistInChunkHistory(eventId: String): Boolean {
+    return ChunkEntity.findIncludingEvent(this, eventId) != null
+}
+
+private fun Realm.hasReadReceiptInLatestChunk(latestChunkEntity: ChunkEntity, roomId: String, userId: String) : Boolean {
+    return ReadReceiptEntity.where(this, roomId, userId).findFirst()?.let {
+        latestChunkEntity.timelineEvents.find(it.eventId)
+    } != null
+}
+
 
 internal fun isReadMarkerMoreRecent(realmConfiguration: RealmConfiguration,
                                     roomId: String?,


### PR DESCRIPTION
Fixes #3347 and #523 

Our notification dismissing works by matching the currently held notification events to the latest timeline chunk for the room, this presents a problem when the next chunk is created which doesn't reference those original notification events, which then presents itself as notifications not being dismissed when read from other sessions.

The fix is to check the existence of missing events against the entire chunk history if there's also a read receipt event in the latest chunk.

- I was able to to reproduce the issue by spamming messages to force the timeline to create a new chunk

Here's the worlds least exciting gif... notice the element icon in the top
| |
| --- |
|![after-new-chunk](https://user-images.githubusercontent.com/1848238/135493519-80b872e1-06cd-4b15-a364-00bd7d1299d1.gif)


