### PR TITLE
Ensure initial sync progress dialog is hidden when the initial sync is over

### DIFF
--- a/changelog.d/983.bugfix
+++ b/changelog.d/983.bugfix
@@ -1,0 +1,1 @@
+Ensure initial sync progress dialog is hidden when the initial sync is over

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -313,10 +313,7 @@ class HomeActivity :
 
     private fun renderState(state: HomeActivityViewState) {
         when (val status = state.syncStatusServiceStatus) {
-            is SyncStatusService.Status.Idle                  -> {
-                views.waitingView.root.isVisible = false
-            }
-            is SyncStatusService.Status.Progressing           -> {
+            is SyncStatusService.Status.Progressing -> {
                 val initSyncStepStr = initSyncStepFormatter.format(status.initSyncStep)
                 Timber.v("$initSyncStepStr ${status.percentProgress}")
                 views.waitingView.root.setOnClickListener {
@@ -334,7 +331,10 @@ class HomeActivity :
                 }
                 views.waitingView.root.isVisible = true
             }
-            else                                              -> Unit
+            else                                    -> {
+                // Idle or Incremental sync status
+                views.waitingView.root.isVisible = false
+            }
         }.exhaustive
     }
 


### PR DESCRIPTION
Add robustness, if Idle state is lost for any reason, the dialog will be hidden also on incr sync Events.

It does not fix the pb with foreground service notification not displayed. 