### PR TITLE
Load existing DM instead of creating a new one

### DIFF
--- a/changelog.d/4157.feature
+++ b/changelog.d/4157.feature
@@ -1,0 +1,1 @@
+Check if DM exists before creating a new one

--- a/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomAction.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomAction.kt
@@ -21,7 +21,6 @@ import im.vector.app.features.userdirectory.PendingSelection
 
 sealed class CreateDirectRoomAction : VectorViewModelAction {
     data class CreateRoomAndInviteSelectedUsers(
-            val selections: Set<PendingSelection>,
-            val existingDmRoomId: String?
+            val selections: Set<PendingSelection>
     ) : CreateDirectRoomAction()
 }

--- a/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomActivity.kt
@@ -138,10 +138,7 @@ class CreateDirectRoomActivity : SimpleFragmentActivity(), UserListViewModel.Fac
 
     private fun onMenuItemSelected(action: UserListSharedAction.OnMenuItemSelected) {
         if (action.itemId == R.id.action_create_direct_room) {
-            viewModel.handle(CreateDirectRoomAction.CreateRoomAndInviteSelectedUsers(
-                    action.selections,
-                    null
-            ))
+            viewModel.handle(CreateDirectRoomAction.CreateRoomAndInviteSelectedUsers(action.selections))
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomByQrCodeFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomByQrCodeFragment.kt
@@ -99,7 +99,6 @@ class CreateDirectRoomByQrCodeFragment @Inject constructor() : VectorBaseFragmen
             Toast.makeText(requireContext(), R.string.invalid_qr_code_uri, Toast.LENGTH_SHORT).show()
             requireActivity().finish()
         } else {
-            val existingDm = viewModel.session.getExistingDirectRoomWithUser(mxid)
             // The following assumes MXIDs are case insensitive
             if (mxid.equals(other = viewModel.session.myUserId, ignoreCase = true)) {
                 Toast.makeText(requireContext(), R.string.cannot_dm_self, Toast.LENGTH_SHORT).show()
@@ -109,7 +108,7 @@ class CreateDirectRoomByQrCodeFragment @Inject constructor() : VectorBaseFragmen
                 val qrInvitee = if (viewModel.session.getUser(mxid) != null) viewModel.session.getUser(mxid)!! else User(mxid, null, null)
 
                 viewModel.handle(
-                        CreateDirectRoomAction.CreateRoomAndInviteSelectedUsers(setOf(PendingSelection.UserPendingSelection(qrInvitee)), existingDm)
+                        CreateDirectRoomAction.CreateRoomAndInviteSelectedUsers(setOf(PendingSelection.UserPendingSelection(qrInvitee)))
                 )
             }
         }

--- a/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomViewModel.kt
@@ -71,10 +71,13 @@ class CreateDirectRoomViewModel @AssistedInject constructor(@Assisted
      * If users already have a DM room then navigate to it instead of creating a new room.
      */
     private fun onSubmitInvitees(action: CreateDirectRoomAction.CreateRoomAndInviteSelectedUsers) {
-        if (action.existingDmRoomId != null) {
+        val existingRoomId = action.selections.singleOrNull()?.getMxId()?.let { userId ->
+            session.getExistingDirectRoomWithUser(userId)
+        }
+        if (existingRoomId != null) {
             // Do not create a new DM, just tell that the creation is successful by passing the existing roomId
             setState {
-                copy(createAndInviteState = Success(action.existingDmRoomId))
+                copy(createAndInviteState = Success(existingRoomId))
             }
         } else {
             // Create the DM

--- a/vector/src/main/java/im/vector/app/features/userdirectory/PendingSelection.kt
+++ b/vector/src/main/java/im/vector/app/features/userdirectory/PendingSelection.kt
@@ -29,4 +29,11 @@ sealed class PendingSelection {
             is ThreePidPendingSelection -> threePid.value
         }
     }
+
+    fun getMxId(): String {
+        return when (this) {
+            is UserPendingSelection     -> user.userId
+            is ThreePidPendingSelection -> threePid.value
+        }
+    }
 }


### PR DESCRIPTION
In previous implementation, existing DM was checked only for QR code invites.
This PR moves this check in the ViewModel side (which makes more sense) and applies it for 1:1 in both cases (QR and user invites).