### PR TITLE
Missing ability to invite users by email

### DIFF
--- a/vector/src/main/java/im/vector/app/core/utils/Dialogs.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/Dialogs.kt
@@ -42,8 +42,8 @@ fun Context.displayInWebView(url: String) {
 
 fun Context.showIdentityServerConsentDialog(configuredIdentityServer: String?, policyLinkCallback: () -> Unit, consentCallBack: (() -> Unit)) {
     MaterialAlertDialogBuilder(this)
-            .setTitle(R.string.identity_server_consent_dialog_title)
-            .setMessage(getString(R.string.identity_server_consent_dialog_content_2, configuredIdentityServer ?: ""))
+            .setTitle(getString(R.string.identity_server_consent_dialog_title_2, configuredIdentityServer ?: ""))
+            .setMessage(R.string.identity_server_consent_dialog_content_2)
             .setPositiveButton(R.string.yes) { _, _ ->
                 consentCallBack.invoke()
             }

--- a/vector/src/main/java/im/vector/app/core/utils/Dialogs.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/Dialogs.kt
@@ -43,7 +43,7 @@ fun Context.displayInWebView(url: String) {
 fun Context.showIdentityServerConsentDialog(configuredIdentityServer: String?, policyLinkCallback: () -> Unit, consentCallBack: (() -> Unit)) {
     MaterialAlertDialogBuilder(this)
             .setTitle(R.string.identity_server_consent_dialog_title)
-            .setMessage(getString(R.string.identity_server_consent_dialog_content, configuredIdentityServer ?: ""))
+            .setMessage(getString(R.string.identity_server_consent_dialog_content_2, configuredIdentityServer ?: ""))
             .setPositiveButton(R.string.yes) { _, _ ->
                 consentCallBack.invoke()
             }

--- a/vector/src/main/java/im/vector/app/features/discovery/DiscoverySettingsController.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/DiscoverySettingsController.kt
@@ -95,7 +95,7 @@ class DiscoverySettingsController @Inject constructor(
         } else {
             settingsInfoItem {
                 id("idConsentInfo")
-                helperTextResId(R.string.settings_discovery_consent_notice_off)
+                helperTextResId(R.string.settings_discovery_consent_notice_off_2)
             }
             settingsButtonItem {
                 id("idConsentButton")

--- a/vector/src/main/java/im/vector/app/features/userdirectory/UserListAction.kt
+++ b/vector/src/main/java/im/vector/app/features/userdirectory/UserListAction.kt
@@ -25,4 +25,5 @@ sealed class UserListAction : VectorViewModelAction {
     data class RemovePendingSelection(val pendingSelection: PendingSelection) : UserListAction()
     object ComputeMatrixToLinkForSharing : UserListAction()
     data class UpdateUserConsent(val consent: Boolean) : UserListAction()
+    object Resumed : UserListAction()
 }

--- a/vector/src/main/java/im/vector/app/features/userdirectory/UserListController.kt
+++ b/vector/src/main/java/im/vector/app/features/userdirectory/UserListController.kt
@@ -146,7 +146,7 @@ class UserListController @Inject constructor(private val session: Session,
                             text(
                                     span {
                                         span {
-                                            text = host.stringProvider.getString(R.string.settings_discovery_consent_notice_off)
+                                            text = host.stringProvider.getString(R.string.settings_discovery_consent_notice_off_2)
                                         }
                                         +"\n"
                                         span {

--- a/vector/src/main/java/im/vector/app/features/userdirectory/UserListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/userdirectory/UserListFragment.kt
@@ -222,6 +222,11 @@ class UserListFragment @Inject constructor(
         )
     }
 
+    override fun onResume() {
+        super.onResume()
+        viewModel.handle(UserListAction.Resumed)
+    }
+
     override fun giveIdentityServerConsent() {
         withState(viewModel) { state ->
             requireContext().showIdentityServerConsentDialog(

--- a/vector/src/main/java/im/vector/app/features/userdirectory/UserListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/userdirectory/UserListViewModel.kt
@@ -177,11 +177,9 @@ class UserListViewModel @AssistedInject constructor(@Assisted initialState: User
     private suspend fun executeSearchEmail(search: String) {
         suspend {
             val params = listOf(ThreePid.Email(search))
-            val foundThreePid = tryOrNull {
-                session.identityService().lookUp(params).firstOrNull()
-            }
+            val foundThreePid = session.identityService().lookUp(params).firstOrNull()
             if (foundThreePid == null) {
-                null
+                ThreePidUser(email = search, user = null)
             } else {
                 try {
                     val json = session.getProfile(foundThreePid.matrixId)

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2363,11 +2363,13 @@
     <string name="settings_discovery_consent_title">Send emails and phone numbers</string>
     <string name="settings_discovery_consent_notice_on">You have given your consent to send emails and phone numbers to this identity server to discover other users from your contacts.</string>
     <string name="settings_discovery_consent_notice_off">You have not given your consent to send emails and phone numbers to this identity server to discover other users from your contacts.</string>
+    <string name="settings_discovery_consent_notice_off_2">Your contacts are private. You\'ll need to share your contact info to find people you know.</string>
     <string name="settings_discovery_consent_action_revoke">Revoke my consent</string>
     <string name="settings_discovery_consent_action_give_consent">Give consent</string>
 
     <string name="identity_server_consent_dialog_title">Send emails and phone numbers</string>
     <string name="identity_server_consent_dialog_content">In order to discover existing contacts you know, do you accept to send your contact data (phone numbers and/or emails) to the configured identity server (%1$s)?\n\nFor more privacy, the sent data will be hashed before being sent.</string>
+    <string name="identity_server_consent_dialog_content_2">Your contacts can\'t find you, and you can\'t find them. In order to see each other you must share your contact info with your identity server (%s).\n\nYour data will be sent securely.</string>
     <string name="identity_server_consent_dialog_neutral_policy">Policy</string>
 
     <string name="settings_discovery_enter_identity_server">Enter an identity server URL</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2363,13 +2363,14 @@
     <string name="settings_discovery_consent_title">Send emails and phone numbers</string>
     <string name="settings_discovery_consent_notice_on">You have given your consent to send emails and phone numbers to this identity server to discover other users from your contacts.</string>
     <string name="settings_discovery_consent_notice_off">You have not given your consent to send emails and phone numbers to this identity server to discover other users from your contacts.</string>
-    <string name="settings_discovery_consent_notice_off_2">Your contacts are private. You\'ll need to share your contact info to find people you know.</string>
+    <string name="settings_discovery_consent_notice_off_2">Your contacts are private. To discover users from your contacts, we need your permission to send contact info to your identity server.</string>
     <string name="settings_discovery_consent_action_revoke">Revoke my consent</string>
     <string name="settings_discovery_consent_action_give_consent">Give consent</string>
 
     <string name="identity_server_consent_dialog_title">Send emails and phone numbers</string>
+    <string name="identity_server_consent_dialog_title_2">Send emails and phone numbers to %s</string>
     <string name="identity_server_consent_dialog_content">In order to discover existing contacts you know, do you accept to send your contact data (phone numbers and/or emails) to the configured identity server (%1$s)?\n\nFor more privacy, the sent data will be hashed before being sent.</string>
-    <string name="identity_server_consent_dialog_content_2">Your contacts can\'t find you, and you can\'t find them. In order to see each other you must share your contact info with your identity server (%s).\n\nYour data will be sent securely.</string>
+    <string name="identity_server_consent_dialog_content_2">To discover existing contacts, you need to send contact info to your identity server.\n\nWe hash your data before sending for privacy. Do you consent to send this info?</string>
     <string name="identity_server_consent_dialog_neutral_policy">Policy</string>
 
     <string name="settings_discovery_enter_identity_server">Enter an identity server URL</string>


### PR DESCRIPTION
Fixes the email invites not being available when searching for users #4297

- `onIdentityServerChange` is using exceptions to control the flow so we can't use `tryEmit` in this case. This caused the identity server steps to be missed
- `MutableStateFlow` automatically deduplicates emissions so we have to provide some more data in order to re-emit identical search terms (which the identity server steps rely on in order to refresh the page and move to the next step) 

| BEFORE | AFTER | GIF |
| --- | --- | --- | 
![Screenshot_20211026_132047](https://user-images.githubusercontent.com/1848238/138877612-68c8d6d8-f01a-431b-b8ae-681241104e5f.png)|![Screenshot_20211026_131814](https://user-images.githubusercontent.com/1848238/138877316-ab7c937e-e51e-40b8-8a81-0b9155b0bb96.png)|![after-invite-email](https://user-images.githubusercontent.com/1848238/138877318-e8f63d69-f304-48e0-b839-1f40fde6b1be.gif)


Copy updates 

| BEFORE | AFTER |
| --- | --- |
![before-you-have-not](https://user-images.githubusercontent.com/1848238/139283098-e179ddef-b348-40e8-9dee-420413b2abc2.png)|![Screenshot_20211104_115135](https://user-images.githubusercontent.com/1848238/140309086-99899407-821f-4d4e-bfbd-ab1517cdb383.png)
![before-give-consent](https://user-images.githubusercontent.com/1848238/139283097-20dc65dd-6fc2-4a26-9e12-6cbb11bbc524.png)|![Screenshot_20211104_115438](https://user-images.githubusercontent.com/1848238/140309237-4177c662-41f8-417b-9316-e27375247d11.png)



