### PR TITLE
Open URL on external browser task

### DIFF
--- a/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
@@ -76,6 +76,8 @@ fun openUrlInExternalBrowser(context: Context, url: String?) {
 fun openUrlInExternalBrowser(context: Context, uri: Uri?) {
     uri?.let {
         val browserIntent = Intent(Intent.ACTION_VIEW, it).apply {
+            // Open activity on browser task and not on element task
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
             putExtra(Browser.EXTRA_APPLICATION_ID, context.packageName)
             putExtra(Browser.EXTRA_CREATE_NEW_TAB, true)
         }


### PR DESCRIPTION
When you click on URL the browser activity is stacked on Element task. it's better to open the URL on existing browser task or open the browser in new task if it's not already opened.