### PR TITLE
Fix permalink handling

### DIFF
--- a/changelog.d/4369.bugfix
+++ b/changelog.d/4369.bugfix
@@ -1,0 +1,1 @@
+Fix handling of links coming from web instance reported as malformed by mistake

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -273,14 +273,13 @@ class HomeActivity :
             val resolvedLink = when {
                 // Element custom scheme is not handled by the sdk, convert it to matrix.to link for compatibility
                 deepLink.startsWith(MATRIX_TO_CUSTOM_SCHEME_URL_BASE) -> {
-                    val let = when {
+                    when {
                         deepLink.startsWith(USER_LINK_PREFIX) -> deepLink.substring(USER_LINK_PREFIX.length)
                         deepLink.startsWith(ROOM_LINK_PREFIX) -> deepLink.substring(ROOM_LINK_PREFIX.length)
                         else                                  -> null
                     }?.let { permalinkId ->
                         activeSessionHolder.getSafeActiveSession()?.permalinkService()?.createPermalink(permalinkId)
                     }
-                    let
                 }
                 else                                                  -> deepLink
             }

--- a/vector/src/main/java/im/vector/app/features/permalink/PermalinkHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/permalink/PermalinkHandler.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.permalink
 
 import android.content.Context
 import android.net.Uri
+import androidx.core.net.toUri
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.extensions.isIgnored
@@ -118,9 +119,8 @@ class PermalinkHandler @Inject constructor(private val activeSessionHolder: Acti
 
     private fun isPermalinkSupported(context: Context, url: String): Boolean {
         return url.startsWith(PermalinkService.MATRIX_TO_URL_BASE) ||
-                context.resources.getStringArray(R.array.permalink_supported_hosts).any {
-                    url.startsWith(it)
-                }
+                context.resources.getStringArray(R.array.permalink_supported_hosts)
+                        .any { url.toUri().host == it }
     }
 
     private suspend fun PermalinkData.RoomLink.getRoomId(): String? {


### PR DESCRIPTION
The whole link base url (eg. `https://develop.element.io`) was compared to the supported hosts list instead of the host part only (`develop.element.io`), causing the link not handled anymore (displaying a malformed link dialog, which was not true...)