### PR TITLE
Sorting social providers by priority

### DIFF
--- a/changelog.d/4277.feature
+++ b/changelog.d/4277.feature
@@ -1,0 +1,1 @@
+Updating single sign on providers ordering to match priority/popularity

--- a/vector/src/main/java/im/vector/app/features/login/LoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginFragment.kt
@@ -193,7 +193,7 @@ class LoginFragment @Inject constructor() : AbstractSSOLoginFragment<FragmentLog
 
             if (state.loginMode is LoginMode.SsoAndPassword) {
                 views.loginSocialLoginContainer.isVisible = true
-                views.loginSocialLoginButtons.ssoIdentityProviders = state.loginMode.ssoIdentityProviders
+                views.loginSocialLoginButtons.ssoIdentityProviders = state.loginMode.ssoIdentityProviders?.sorted()
                 views.loginSocialLoginButtons.listener = object : SocialLoginButtonsView.InteractionListener {
                     override fun onProviderSelected(id: String?) {
                         loginViewModel.getSsoUrl(

--- a/vector/src/main/java/im/vector/app/features/login/LoginSignUpSignInSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginSignUpSignInSelectionFragment.kt
@@ -72,7 +72,7 @@ class LoginSignUpSignInSelectionFragment @Inject constructor() : AbstractSSOLogi
         when (state.loginMode) {
             is LoginMode.SsoAndPassword -> {
                 views.loginSignupSigninSignInSocialLoginContainer.isVisible = true
-                views.loginSignupSigninSocialLoginButtons.ssoIdentityProviders = state.loginMode.ssoIdentityProviders()
+                views.loginSignupSigninSocialLoginButtons.ssoIdentityProviders = state.loginMode.ssoIdentityProviders()?.sorted()
                 views.loginSignupSigninSocialLoginButtons.listener = object : SocialLoginButtonsView.InteractionListener {
                     override fun onProviderSelected(id: String?) {
                         loginViewModel.getSsoUrl(


### PR DESCRIPTION
Fixes #4277 

Orders the SSO providers by the priority in [SsoIdentityProvider](https://github.com/vector-im/element-android/blob/main/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/data/SsoIdentityProvider.kt#L66)


| BEFORE | AFTER |
| --- | --- |
|![before-sso](https://user-images.githubusercontent.com/1848238/139669788-1fb45561-9f55-4bf5-910d-8395a64342c8.png)|![after-sso](https://user-images.githubusercontent.com/1848238/139669785-1a4432dd-a8e6-4c7b-9deb-91ee73f440f3.png)
![before-sso-sign-up](https://user-images.githubusercontent.com/1848238/139669786-9c2d497e-4df0-4d18-a852-328a99f41330.png)|![after-sso-sign-up](https://user-images.githubusercontent.com/1848238/139669783-e7377494-b646-40dd-b331-05824f021ab6.png)
![before-sso-sign-in](https://user-images.githubusercontent.com/1848238/139669787-7dbeb1fb-1cdf-4180-aa63-58e115fc152d.png)|![after-sso-sign-in](https://user-images.githubusercontent.com/1848238/139669784-9e2e8924-fe72-4666-84f6-9d5899280158.png)




