### PR TITLE
Force call ringtones to loop

### DIFF
--- a/changelog.d/4047.bugfix
+++ b/changelog.d/4047.bugfix
@@ -1,0 +1,1 @@
+Fixing call ringtones only playing once when the ringtone doesn't contain looping metadata (android 9.0 and above)

--- a/vector/src/main/java/im/vector/app/core/services/CallRingPlayer.kt
+++ b/vector/src/main/java/im/vector/app/core/services/CallRingPlayer.kt
@@ -62,6 +62,10 @@ class CallRingPlayerIncoming(
         val ringtoneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
         ringtone = RingtoneManager.getRingtone(applicationContext, ringtoneUri)
         Timber.v("Play ringtone for incoming call")
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            ringtone?.isLooping = true
+        }
         ringtone?.play()
     }
 


### PR DESCRIPTION
Fixes #4047 

Out of the box android is relying on audio file metadata to determine if the ringtone should loop

- Android 9.0 introduced an api to programmatically enable looping https://developer.android.com/reference/android/media/Ringtone#setLooping(boolean)
- Users below Android 9.0 will need to select other ringtones or edit them to include a `ANDROID_LOOP true` tag