### PR TITLE
Single `PushTriggerListener` dispatch

### DIFF
--- a/changelog.d/4401.removal
+++ b/changelog.d/4401.removal
@@ -1,0 +1,1 @@
+Breaking SDK API change to PushRuleListener, the separated callbacks have been merged into one with a data class which includes all the previously separated push information

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/pushrules/PushEvents.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/pushrules/PushEvents.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2021 New Vector Ltd
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.matrix.android.sdk.api.pushrules
 
 import org.matrix.android.sdk.api.pushrules.rest.PushRule

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/pushrules/PushEvents.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/pushrules/PushEvents.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.api.pushrules
+
+import org.matrix.android.sdk.api.pushrules.rest.PushRule
+import org.matrix.android.sdk.api.session.events.model.Event
+
+data class PushEvents(
+        val matchedEvents: List<Pair<Event, PushRule>>,
+        val roomsJoined: Collection<String>,
+        val roomsLeft: Collection<String>,
+        val redactedEventIds: List<String>
+)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/pushrules/PushRuleService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/pushrules/PushRuleService.kt
@@ -51,11 +51,7 @@ interface PushRuleService {
 //    fun fulfilledBingRule(event: Event, rules: List<PushRule>): PushRule?
 
     interface PushRuleListener {
-        fun onMatchRule(event: Event, actions: List<Action>)
-        fun onRoomJoined(roomId: String)
-        fun onRoomLeft(roomId: String)
-        fun onEventRedacted(redactedEventId: String)
-        fun batchFinish()
+        fun onEvents(pushEvents: PushEvents)
     }
 
     fun getKeywords(): LiveData<Set<String>>

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/DefaultPushRuleService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/DefaultPushRuleService.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Transformations
 import com.zhuinden.monarchy.Monarchy
 import org.matrix.android.sdk.api.pushrules.Action
+import org.matrix.android.sdk.api.pushrules.PushEvents
 import org.matrix.android.sdk.api.pushrules.PushRuleService
 import org.matrix.android.sdk.api.pushrules.RuleKind
 import org.matrix.android.sdk.api.pushrules.RuleScope
@@ -40,7 +41,6 @@ import org.matrix.android.sdk.internal.session.pushers.UpdatePushRuleActionsTask
 import org.matrix.android.sdk.internal.session.pushers.UpdatePushRuleEnableStatusTask
 import org.matrix.android.sdk.internal.task.TaskExecutor
 import org.matrix.android.sdk.internal.task.configureWith
-import timber.log.Timber
 import javax.inject.Inject
 
 @SessionScope
@@ -142,79 +142,6 @@ internal class DefaultPushRuleService @Inject constructor(
         return pushRuleFinder.fulfilledBingRule(event, rules)?.getActions().orEmpty()
     }
 
-//    fun processEvents(events: List<Event>) {
-//        var hasDoneSomething = false
-//        events.forEach { event ->
-//            fulfilledBingRule(event)?.let {
-//                hasDoneSomething = true
-//                dispatchBing(event, it)
-//            }
-//        }
-//        if (hasDoneSomething)
-//            dispatchFinish()
-//    }
-
-    fun dispatchBing(event: Event, rule: PushRule) {
-        synchronized(listeners) {
-            val actionsList = rule.getActions()
-            listeners.forEach {
-                try {
-                    it.onMatchRule(event, actionsList)
-                } catch (e: Throwable) {
-                    Timber.e(e, "Error while dispatching bing")
-                }
-            }
-        }
-    }
-
-    fun dispatchRoomJoined(roomId: String) {
-        synchronized(listeners) {
-            listeners.forEach {
-                try {
-                    it.onRoomJoined(roomId)
-                } catch (e: Throwable) {
-                    Timber.e(e, "Error while dispatching room joined")
-                }
-            }
-        }
-    }
-
-    fun dispatchRoomLeft(roomId: String) {
-        synchronized(listeners) {
-            listeners.forEach {
-                try {
-                    it.onRoomLeft(roomId)
-                } catch (e: Throwable) {
-                    Timber.e(e, "Error while dispatching room left")
-                }
-            }
-        }
-    }
-
-    fun dispatchRedactedEventId(redactedEventId: String) {
-        synchronized(listeners) {
-            listeners.forEach {
-                try {
-                    it.onEventRedacted(redactedEventId)
-                } catch (e: Throwable) {
-                    Timber.e(e, "Error while dispatching redacted event")
-                }
-            }
-        }
-    }
-
-    fun dispatchFinish() {
-        synchronized(listeners) {
-            listeners.forEach {
-                try {
-                    it.batchFinish()
-                } catch (e: Throwable) {
-                    Timber.e(e, "Error while dispatching finish")
-                }
-            }
-        }
-    }
-
     override fun getKeywords(): LiveData<Set<String>> {
         // Keywords are all content rules that don't start with '.'
         val liveData = monarchy.findAllMappedWithChanges(
@@ -227,6 +154,14 @@ internal class DefaultPushRuleService @Inject constructor(
         )
         return Transformations.map(liveData) { results ->
             results.firstOrNull().orEmpty().toSet()
+        }
+    }
+
+    fun dispatchEvents(pushEvents: PushEvents) {
+        synchronized(listeners) {
+            listeners.forEach {
+                it.onEvents(pushEvents)
+            }
         }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/DefaultPushRuleService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/DefaultPushRuleService.kt
@@ -41,6 +41,7 @@ import org.matrix.android.sdk.internal.session.pushers.UpdatePushRuleActionsTask
 import org.matrix.android.sdk.internal.session.pushers.UpdatePushRuleEnableStatusTask
 import org.matrix.android.sdk.internal.task.TaskExecutor
 import org.matrix.android.sdk.internal.task.configureWith
+import timber.log.Timber
 import javax.inject.Inject
 
 @SessionScope
@@ -160,7 +161,11 @@ internal class DefaultPushRuleService @Inject constructor(
     fun dispatchEvents(pushEvents: PushEvents) {
         synchronized(listeners) {
             listeners.forEach {
-                it.onEvents(pushEvents)
+                try {
+                    it.onEvents(pushEvents)
+                } catch (e: Throwable) {
+                    Timber.e(e, "Error while dispatching push events")
+                }
             }
         }
     }

--- a/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/push/fcm/VectorFirebaseMessagingService.kt
@@ -201,8 +201,7 @@ class VectorFirebaseMessagingService : FirebaseMessagingService() {
             resolvedEvent
                     ?.also { Timber.tag(loggerTag.value).d("Fast lane: notify drawer") }
                     ?.let {
-                        notificationDrawerManager.onNotifiableEventReceived(it)
-                        notificationDrawerManager.refreshNotificationDrawer()
+                        notificationDrawerManager.updateEvents { it.onNotifiableEventReceived(resolvedEvent) }
                     }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -2099,12 +2099,12 @@ class RoomDetailFragment @Inject constructor(
 // VectorInviteView.Callback
 
     override fun onAcceptInvite() {
-        notificationDrawerManager.clearMemberShipNotificationForRoom(roomDetailArgs.roomId)
+        notificationDrawerManager.updateEvents { it.clearMemberShipNotificationForRoom(roomDetailArgs.roomId) }
         roomDetailViewModel.handle(RoomDetailAction.AcceptInvite)
     }
 
     override fun onRejectInvite() {
-        notificationDrawerManager.clearMemberShipNotificationForRoom(roomDetailArgs.roomId)
+        notificationDrawerManager.updateEvents { it.clearMemberShipNotificationForRoom(roomDetailArgs.roomId) }
         roomDetailViewModel.handle(RoomDetailAction.RejectInvite)
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -479,7 +479,7 @@ class RoomListFragment @Inject constructor(
     }
 
     override fun onAcceptRoomInvitation(room: RoomSummary) {
-        notificationDrawerManager.clearMemberShipNotificationForRoom(room.roomId)
+        notificationDrawerManager.updateEvents { it.clearMemberShipNotificationForRoom(room.roomId) }
         roomListViewModel.handle(RoomListAction.AcceptInvitation(room))
     }
 
@@ -492,7 +492,7 @@ class RoomListFragment @Inject constructor(
     }
 
     override fun onRejectRoomInvitation(room: RoomSummary) {
-        notificationDrawerManager.clearMemberShipNotificationForRoom(room.roomId)
+        notificationDrawerManager.updateEvents { it.clearMemberShipNotificationForRoom(room.roomId) }
         roomListViewModel.handle(RoomListAction.RejectInvitation(room))
     }
 }

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationBroadcastReceiver.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationBroadcastReceiver.kt
@@ -49,26 +49,26 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
             NotificationUtils.SMART_REPLY_ACTION        ->
                 handleSmartReply(intent, context)
             NotificationUtils.DISMISS_ROOM_NOTIF_ACTION ->
-                intent.getStringExtra(KEY_ROOM_ID)?.let {
-                    notificationDrawerManager.clearMessageEventOfRoom(it)
+                intent.getStringExtra(KEY_ROOM_ID)?.let { roomId ->
+                    notificationDrawerManager.updateEvents { it.clearMessagesForRoom(roomId) }
                 }
             NotificationUtils.DISMISS_SUMMARY_ACTION    ->
                 notificationDrawerManager.clearAllEvents()
             NotificationUtils.MARK_ROOM_READ_ACTION     ->
-                intent.getStringExtra(KEY_ROOM_ID)?.let {
-                    notificationDrawerManager.clearMessageEventOfRoom(it)
-                    handleMarkAsRead(it)
+                intent.getStringExtra(KEY_ROOM_ID)?.let { roomId ->
+                    notificationDrawerManager.updateEvents { it.clearMessagesForRoom(roomId) }
+                    handleMarkAsRead(roomId)
                 }
             NotificationUtils.JOIN_ACTION               -> {
-                intent.getStringExtra(KEY_ROOM_ID)?.let {
-                    notificationDrawerManager.clearMemberShipNotificationForRoom(it)
-                    handleJoinRoom(it)
+                intent.getStringExtra(KEY_ROOM_ID)?.let { roomId ->
+                    notificationDrawerManager.updateEvents { it.clearMemberShipNotificationForRoom(roomId) }
+                    handleJoinRoom(roomId)
                 }
             }
             NotificationUtils.REJECT_ACTION             -> {
-                intent.getStringExtra(KEY_ROOM_ID)?.let {
-                    notificationDrawerManager.clearMemberShipNotificationForRoom(it)
-                    handleRejectRoom(it)
+                intent.getStringExtra(KEY_ROOM_ID)?.let { roomId ->
+                    notificationDrawerManager.updateEvents { it.clearMemberShipNotificationForRoom(roomId) }
+                    handleRejectRoom(roomId)
                 }
             }
         }

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationBroadcastReceiver.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationBroadcastReceiver.kt
@@ -145,8 +145,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
                 canBeReplaced = false
         )
 
-        notificationDrawerManager.onNotifiableEventReceived(notifiableMessageEvent)
-        notificationDrawerManager.refreshNotificationDrawer()
+        notificationDrawerManager.updateEvents { it.onNotifiableEventReceived(notifiableMessageEvent) }
 
         /*
         // TODO Error cannot be managed the same way than in Riot

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationEventQueue.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationEventQueue.kt
@@ -46,36 +46,11 @@ class NotificationEventQueue(
         }
     }
 
-    private fun MutableList<NotifiableEvent>.replace(eventId: String, block: (NotifiableEvent) -> NotifiableEvent) {
-        val indexToReplace = indexOfFirst { it.eventId == eventId }
-        if (indexToReplace == -1) {
-            return
-        }
-        set(indexToReplace, block(get(indexToReplace)))
-    }
-
     fun isEmpty() = queue.isEmpty()
 
     fun clearAndAdd(events: List<NotifiableEvent>) {
         queue.clear()
         queue.addAll(events)
-    }
-
-    fun findExistingById(notifiableEvent: NotifiableEvent): NotifiableEvent? {
-        return queue.firstOrNull { it.eventId == notifiableEvent.eventId }
-    }
-
-    fun findEdited(notifiableEvent: NotifiableEvent): NotifiableEvent? {
-        return notifiableEvent.editedEventId?.let { editedId ->
-            queue.firstOrNull {
-                it.eventId == editedId || it.editedEventId == editedId
-            }
-        }
-    }
-
-    fun replace(replace: NotifiableEvent, with: NotifiableEvent) {
-        queue.remove(replace)
-        queue.add(with)
     }
 
     fun clear() {
@@ -116,6 +91,22 @@ class NotificationEventQueue(
         }
     }
 
+    private fun findExistingById(notifiableEvent: NotifiableEvent): NotifiableEvent? {
+        return queue.firstOrNull { it.eventId == notifiableEvent.eventId }
+    }
+
+    private fun findEdited(notifiableEvent: NotifiableEvent): NotifiableEvent? {
+        return notifiableEvent.editedEventId?.let { editedId ->
+            queue.firstOrNull {
+                it.eventId == editedId || it.editedEventId == editedId
+            }
+        }
+    }
+
+    private fun replace(replace: NotifiableEvent, with: NotifiableEvent) {
+        queue.remove(replace)
+        queue.add(with)
+    }
 
     fun clearMemberShipNotificationForRoom(roomId: String) {
         Timber.v("clearMemberShipOfRoom $roomId")
@@ -128,4 +119,12 @@ class NotificationEventQueue(
     }
 
     fun rawEvents(): List<NotifiableEvent> = queue
+}
+
+private fun MutableList<NotifiableEvent>.replace(eventId: String, block: (NotifiableEvent) -> NotifiableEvent) {
+    val indexToReplace = indexOfFirst { it.eventId == eventId }
+    if (indexToReplace == -1) {
+        return
+    }
+    set(indexToReplace, block(get(indexToReplace)))
 }

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationEventQueue.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationEventQueue.kt
@@ -66,9 +66,10 @@ class NotificationEventQueue(
     }
 
     fun findEdited(notifiableEvent: NotifiableEvent): NotifiableEvent? {
-        return queue.firstOrNull {
-            it.eventId == notifiableEvent.editedEventId ||
-                    it.editedEventId == notifiableEvent.editedEventId // or edition of an edition
+        return notifiableEvent.editedEventId?.let { editedId ->
+            queue.firstOrNull {
+                it.eventId == editedId || it.editedEventId == editedId
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationEventQueue.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationEventQueue.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.notifications
+
+import timber.log.Timber
+
+class NotificationEventQueue(
+        private val queue: MutableList<NotifiableEvent> = mutableListOf()
+) {
+
+    fun markRedacted(eventIds: List<String>) {
+        eventIds.forEach { redactedId ->
+            queue.replace(redactedId) {
+                when (it) {
+                    is InviteNotifiableEvent  -> it.copy(isRedacted = true)
+                    is NotifiableMessageEvent -> it.copy(isRedacted = true)
+                    is SimpleNotifiableEvent  -> it.copy(isRedacted = true)
+                }
+            }
+        }
+    }
+
+    fun syncRoomEvents(roomsLeft: Collection<String>, roomsJoined: Collection<String>) {
+        if (roomsLeft.isNotEmpty() || roomsJoined.isNotEmpty()) {
+            queue.removeAll {
+                when (it) {
+                    is NotifiableMessageEvent -> roomsLeft.contains(it.roomId)
+                    is InviteNotifiableEvent  -> roomsLeft.contains(it.roomId) || roomsJoined.contains(it.roomId)
+                    else                      -> false
+                }
+            }
+        }
+    }
+
+    private fun MutableList<NotifiableEvent>.replace(eventId: String, block: (NotifiableEvent) -> NotifiableEvent) {
+        val indexToReplace = indexOfFirst { it.eventId == eventId }
+        if (indexToReplace == -1) {
+            return
+        }
+        set(indexToReplace, block(get(indexToReplace)))
+    }
+
+    fun isEmpty() = queue.isEmpty()
+
+    fun clearAndAdd(events: List<NotifiableEvent>) {
+        queue.clear()
+        queue.addAll(events)
+    }
+
+    fun findExistingById(notifiableEvent: NotifiableEvent): NotifiableEvent? {
+        return queue.firstOrNull { it.eventId == notifiableEvent.eventId }
+    }
+
+    fun findEdited(notifiableEvent: NotifiableEvent): NotifiableEvent? {
+        return queue.firstOrNull {
+            it.eventId == notifiableEvent.editedEventId ||
+                    it.editedEventId == notifiableEvent.editedEventId // or edition of an edition
+        }
+    }
+
+    fun replace(replace: NotifiableEvent, with: NotifiableEvent) {
+        queue.remove(replace)
+        queue.add(with)
+    }
+
+    fun clear() {
+        queue.clear()
+    }
+
+    fun add(notifiableEvent: NotifiableEvent) {
+        queue.add(notifiableEvent)
+    }
+
+    fun clearMemberShipNotificationForRoom(roomId: String) {
+        Timber.v("clearMemberShipOfRoom $roomId")
+        queue.removeAll { it is InviteNotifiableEvent && it.roomId == roomId }
+    }
+
+    fun clearMessagesForRoom(roomId: String) {
+        Timber.v("clearMessageEventOfRoom $roomId")
+        queue.removeAll { it is NotifiableMessageEvent && it.roomId == roomId }
+    }
+
+    fun rawEvents(): List<NotifiableEvent> = queue
+}

--- a/vector/src/main/java/im/vector/app/features/notifications/PushRuleTriggerListener.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/PushRuleTriggerListener.kt
@@ -44,16 +44,12 @@ class PushRuleTriggerListener @Inject constructor(
                     null
                 }
             }.forEach { notificationDrawerManager.onNotifiableEventReceived(it) }
-            pushEvents.roomsLeft.forEach { roomId ->
-                notificationDrawerManager.clearMessageEventOfRoom(roomId)
-                notificationDrawerManager.clearMemberShipNotificationForRoom(roomId)
+
+            notificationDrawerManager.updateEvents { queuedEvents ->
+                queuedEvents.syncRoomEvents(roomsLeft = pushEvents.roomsLeft, roomsJoined = pushEvents.roomsJoined)
+                queuedEvents.markRedacted(pushEvents.redactedEventIds)
             }
-            pushEvents.roomsJoined.forEach { roomId ->
-                notificationDrawerManager.clearMemberShipNotificationForRoom(roomId)
-            }
-            pushEvents.redactedEventIds.forEach {
-                notificationDrawerManager.onEventRedacted(it)
-            }
+
             notificationDrawerManager.refreshNotificationDrawer()
         } ?: Timber.e("Called without active session")
     }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsPinFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsPinFragment.kt
@@ -55,7 +55,7 @@ class VectorSettingsPinFragment @Inject constructor(
 
         useCompleteNotificationPref.setOnPreferenceChangeListener { _, _ ->
             // Refresh the drawer for an immediate effect of this change
-            notificationDrawerManager.refreshNotificationDrawer()
+            notificationDrawerManager.notificationStyleChanged()
             true
         }
     }

--- a/vector/src/test/java/im/vector/app/features/notifications/NotifiableEventProcessorTest.kt
+++ b/vector/src/test/java/im/vector/app/features/notifications/NotifiableEventProcessorTest.kt
@@ -19,6 +19,9 @@ package im.vector.app.features.notifications
 import im.vector.app.features.notifications.ProcessedEvent.Type
 import im.vector.app.test.fakes.FakeAutoAcceptInvites
 import im.vector.app.test.fakes.FakeOutdatedEventDetector
+import im.vector.app.test.fixtures.aNotifiableMessageEvent
+import im.vector.app.test.fixtures.aSimpleNotifiableEvent
+import im.vector.app.test.fixtures.anInviteNotifiableEvent
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.matrix.android.sdk.api.session.events.model.EventType
@@ -145,48 +148,3 @@ class NotifiableEventProcessorTest {
         ProcessedEvent(it.first, it.second)
     }
 }
-
-fun aSimpleNotifiableEvent(eventId: String, type: String? = null) = SimpleNotifiableEvent(
-        matrixID = null,
-        eventId = eventId,
-        editedEventId = null,
-        noisy = false,
-        title = "title",
-        description = "description",
-        type = type,
-        timestamp = 0,
-        soundName = null,
-        canBeReplaced = false,
-        isRedacted = false
-)
-
-fun anInviteNotifiableEvent(roomId: String) = InviteNotifiableEvent(
-        matrixID = null,
-        eventId = "event-id",
-        roomId = roomId,
-        roomName = "a room name",
-        editedEventId = null,
-        noisy = false,
-        title = "title",
-        description = "description",
-        type = null,
-        timestamp = 0,
-        soundName = null,
-        canBeReplaced = false,
-        isRedacted = false
-)
-
-fun aNotifiableMessageEvent(eventId: String, roomId: String) = NotifiableMessageEvent(
-        eventId = eventId,
-        editedEventId = null,
-        noisy = false,
-        timestamp = 0,
-        senderName = "sender-name",
-        senderId = "sending-id",
-        body = "message-body",
-        roomId = roomId,
-        roomName = "room-name",
-        roomIsDirect = false,
-        canBeReplaced = false,
-        isRedacted = false
-)

--- a/vector/src/test/java/im/vector/app/features/notifications/NotificationEventQueueTest.kt
+++ b/vector/src/test/java/im/vector/app/features/notifications/NotificationEventQueueTest.kt
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.notifications
+
+import im.vector.app.test.fixtures.aNotifiableMessageEvent
+import im.vector.app.test.fixtures.aSimpleNotifiableEvent
+import im.vector.app.test.fixtures.anInviteNotifiableEvent
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class NotificationEventQueueTest {
+
+    private val seenIdsCache = CircularCache.create<String>(5)
+
+    @Test
+    fun `given events when redacting some then marks matching event ids as redacted`() {
+        val queue = givenQueue(listOf(
+                aSimpleNotifiableEvent(eventId = "redacted-id-1"),
+                aNotifiableMessageEvent(eventId = "redacted-id-2"),
+                anInviteNotifiableEvent(eventId = "redacted-id-3"),
+                aSimpleNotifiableEvent(eventId = "kept-id"),
+        ))
+
+        queue.markRedacted(listOf("redacted-id-1", "redacted-id-2", "redacted-id-3"))
+
+        queue.rawEvents() shouldBeEqualTo listOf(
+                aSimpleNotifiableEvent(eventId = "redacted-id-1", isRedacted = true),
+                aNotifiableMessageEvent(eventId = "redacted-id-2", isRedacted = true),
+                anInviteNotifiableEvent(eventId = "redacted-id-3", isRedacted = true),
+                aSimpleNotifiableEvent(eventId = "kept-id", isRedacted = false),
+        )
+    }
+
+    @Test
+    fun `given invite event when leaving invited room and syncing then removes event`() {
+        val queue = givenQueue(listOf(anInviteNotifiableEvent(roomId = "a-room-id")))
+        val roomsLeft = listOf("a-room-id")
+
+        queue.syncRoomEvents(roomsLeft = roomsLeft, roomsJoined = emptyList())
+
+        queue.rawEvents() shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun `given invite event when joining invited room and syncing then removes event`() {
+        val queue = givenQueue(listOf(anInviteNotifiableEvent(roomId = "a-room-id")))
+        val joinedRooms = listOf("a-room-id")
+
+        queue.syncRoomEvents(roomsLeft = emptyList(), roomsJoined = joinedRooms)
+
+        queue.rawEvents() shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun `given message event when leaving message room and syncing then removes event`() {
+        val queue = givenQueue(listOf(aNotifiableMessageEvent(roomId = "a-room-id")))
+        val roomsLeft = listOf("a-room-id")
+
+        queue.syncRoomEvents(roomsLeft = roomsLeft, roomsJoined = emptyList())
+
+        queue.rawEvents() shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun `given events when syncing without rooms left or joined ids then does not change the events`() {
+        val queue = givenQueue(listOf(
+                aNotifiableMessageEvent(roomId = "a-room-id"),
+                anInviteNotifiableEvent(roomId = "a-room-id")
+        ))
+
+        queue.syncRoomEvents(roomsLeft = emptyList(), roomsJoined = emptyList())
+
+        queue.rawEvents() shouldBeEqualTo listOf(
+                aNotifiableMessageEvent(roomId = "a-room-id"),
+                anInviteNotifiableEvent(roomId = "a-room-id")
+        )
+    }
+
+    @Test
+    fun `given events then is not empty`() {
+        val queue = givenQueue(listOf(aSimpleNotifiableEvent()))
+
+        queue.isEmpty() shouldBeEqualTo false
+    }
+
+    @Test
+    fun `given no events then is empty`() {
+        val queue = givenQueue(emptyList())
+
+        queue.isEmpty() shouldBeEqualTo true
+    }
+
+    @Test
+    fun `given events when clearing and adding then removes previous events and adds only new events`() {
+        val queue = givenQueue(listOf(aSimpleNotifiableEvent()))
+
+        queue.clearAndAdd(listOf(anInviteNotifiableEvent()))
+
+        queue.rawEvents() shouldBeEqualTo listOf(anInviteNotifiableEvent())
+    }
+
+    @Test
+    fun `when clearing then is empty`() {
+        val queue = givenQueue(listOf(aSimpleNotifiableEvent()))
+
+        queue.clear()
+
+        queue.rawEvents() shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun `given no events when adding then adds event`() {
+        val queue = givenQueue(listOf())
+
+        queue.add(aSimpleNotifiableEvent(), seenEventIds = seenIdsCache)
+
+        queue.rawEvents() shouldBeEqualTo listOf(aSimpleNotifiableEvent())
+    }
+
+    @Test
+    fun `given no events when adding already seen event then ignores event`() {
+        val queue = givenQueue(listOf())
+        val notifiableEvent = aSimpleNotifiableEvent()
+        seenIdsCache.put(notifiableEvent.eventId)
+
+        queue.add(notifiableEvent, seenEventIds = seenIdsCache)
+
+        queue.rawEvents() shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun `given replaceable event when adding event with same id then updates existing event`() {
+        val replaceableEvent = aSimpleNotifiableEvent(canBeReplaced = true)
+        val updatedEvent = replaceableEvent.copy(title = "updated title")
+        val queue = givenQueue(listOf(replaceableEvent))
+
+        queue.add(updatedEvent, seenEventIds = seenIdsCache)
+
+        queue.rawEvents() shouldBeEqualTo listOf(updatedEvent)
+    }
+
+    @Test
+    fun `given non replaceable event when adding event with same id then ignores event`() {
+        val nonReplaceableEvent = aSimpleNotifiableEvent(canBeReplaced = false)
+        val updatedEvent = nonReplaceableEvent.copy(title = "updated title")
+        val queue = givenQueue(listOf(nonReplaceableEvent))
+
+        queue.add(updatedEvent, seenEventIds = seenIdsCache)
+
+        queue.rawEvents() shouldBeEqualTo listOf(nonReplaceableEvent)
+    }
+
+    @Test
+    fun `given event when adding new event with edited event id matching the existing event id then updates existing event`() {
+        val editedEvent = aSimpleNotifiableEvent(eventId = "id-to-edit")
+        val updatedEvent = editedEvent.copy(eventId = "1", editedEventId = "id-to-edit", title = "updated title")
+        val queue = givenQueue(listOf(editedEvent))
+
+        queue.add(updatedEvent, seenEventIds = seenIdsCache)
+
+        queue.rawEvents() shouldBeEqualTo listOf(updatedEvent)
+    }
+
+    @Test
+    fun `given event when adding new event with edited event id matching the existing event edited id then updates existing event`() {
+        val editedEvent = aSimpleNotifiableEvent(eventId = "0", editedEventId = "id-to-edit")
+        val updatedEvent = editedEvent.copy(eventId = "1", editedEventId = "id-to-edit", title = "updated title")
+        val queue = givenQueue(listOf(editedEvent))
+
+        queue.add(updatedEvent, seenEventIds = seenIdsCache)
+
+        queue.rawEvents() shouldBeEqualTo listOf(updatedEvent)
+    }
+
+    @Test
+    fun `when clearing membership notification then removes invite events with matching room id`() {
+        val roomId = "a-room-id"
+        val queue = givenQueue(listOf(
+                anInviteNotifiableEvent(roomId = roomId),
+                aNotifiableMessageEvent(roomId = roomId)
+        ))
+
+        queue.clearMemberShipNotificationForRoom(roomId)
+
+        queue.rawEvents() shouldBeEqualTo listOf(aNotifiableMessageEvent(roomId = roomId))
+    }
+
+    @Test
+    fun `when clearing messages for room then removes message events with matching room id`() {
+        val roomId = "a-room-id"
+        val queue = givenQueue(listOf(
+                anInviteNotifiableEvent(roomId = roomId),
+                aNotifiableMessageEvent(roomId = roomId)
+        ))
+
+        queue.clearMessagesForRoom(roomId)
+
+        queue.rawEvents() shouldBeEqualTo listOf(anInviteNotifiableEvent(roomId = roomId))
+    }
+
+    private fun givenQueue(events: List<NotifiableEvent>) = NotificationEventQueue(events.toMutableList())
+}

--- a/vector/src/test/java/im/vector/app/features/notifications/NotificationFactoryTest.kt
+++ b/vector/src/test/java/im/vector/app/features/notifications/NotificationFactoryTest.kt
@@ -20,6 +20,9 @@ import im.vector.app.features.notifications.ProcessedEvent.Type
 import im.vector.app.test.fakes.FakeNotificationUtils
 import im.vector.app.test.fakes.FakeRoomGroupMessageCreator
 import im.vector.app.test.fakes.FakeSummaryGroupMessageCreator
+import im.vector.app.test.fixtures.aNotifiableMessageEvent
+import im.vector.app.test.fixtures.aSimpleNotifiableEvent
+import im.vector.app.test.fixtures.anInviteNotifiableEvent
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 

--- a/vector/src/test/java/im/vector/app/test/fixtures/NotifiableEventFixture.kt
+++ b/vector/src/test/java/im/vector/app/test/fixtures/NotifiableEventFixture.kt
@@ -20,23 +20,33 @@ import im.vector.app.features.notifications.InviteNotifiableEvent
 import im.vector.app.features.notifications.NotifiableMessageEvent
 import im.vector.app.features.notifications.SimpleNotifiableEvent
 
-fun aSimpleNotifiableEvent(eventId: String, type: String? = null) = SimpleNotifiableEvent(
+fun aSimpleNotifiableEvent(
+        eventId: String = "simple-event-id",
+        type: String? = null,
+        isRedacted: Boolean = false,
+        canBeReplaced: Boolean = false,
+        editedEventId: String? = null
+) = SimpleNotifiableEvent(
         matrixID = null,
         eventId = eventId,
-        editedEventId = null,
+        editedEventId = editedEventId,
         noisy = false,
         title = "title",
         description = "description",
         type = type,
         timestamp = 0,
         soundName = null,
-        canBeReplaced = false,
-        isRedacted = false
+        canBeReplaced = canBeReplaced,
+        isRedacted = isRedacted
 )
 
-fun anInviteNotifiableEvent(roomId: String) = InviteNotifiableEvent(
+fun anInviteNotifiableEvent(
+        roomId: String = "an-invite-room-id",
+        eventId: String = "invite-event-id",
+        isRedacted: Boolean = false
+) = InviteNotifiableEvent(
         matrixID = null,
-        eventId = "event-id",
+        eventId = eventId,
         roomId = roomId,
         roomName = "a room name",
         editedEventId = null,
@@ -47,10 +57,14 @@ fun anInviteNotifiableEvent(roomId: String) = InviteNotifiableEvent(
         timestamp = 0,
         soundName = null,
         canBeReplaced = false,
-        isRedacted = false
+        isRedacted = isRedacted
 )
 
-fun aNotifiableMessageEvent(eventId: String, roomId: String) = NotifiableMessageEvent(
+fun aNotifiableMessageEvent(
+        eventId: String = "a-message-event-id",
+        roomId: String = "a-message-room-id",
+        isRedacted: Boolean = false
+) = NotifiableMessageEvent(
         eventId = eventId,
         editedEventId = null,
         noisy = false,
@@ -62,5 +76,5 @@ fun aNotifiableMessageEvent(eventId: String, roomId: String) = NotifiableMessage
         roomName = "room-name",
         roomIsDirect = false,
         canBeReplaced = false,
-        isRedacted = false
+        isRedacted = isRedacted
 )

--- a/vector/src/test/java/im/vector/app/test/fixtures/NotifiableEventFixture.kt
+++ b/vector/src/test/java/im/vector/app/test/fixtures/NotifiableEventFixture.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fixtures
+
+import im.vector.app.features.notifications.InviteNotifiableEvent
+import im.vector.app.features.notifications.NotifiableMessageEvent
+import im.vector.app.features.notifications.SimpleNotifiableEvent
+
+fun aSimpleNotifiableEvent(eventId: String, type: String? = null) = SimpleNotifiableEvent(
+        matrixID = null,
+        eventId = eventId,
+        editedEventId = null,
+        noisy = false,
+        title = "title",
+        description = "description",
+        type = type,
+        timestamp = 0,
+        soundName = null,
+        canBeReplaced = false,
+        isRedacted = false
+)
+
+fun anInviteNotifiableEvent(roomId: String) = InviteNotifiableEvent(
+        matrixID = null,
+        eventId = "event-id",
+        roomId = roomId,
+        roomName = "a room name",
+        editedEventId = null,
+        noisy = false,
+        title = "title",
+        description = "description",
+        type = null,
+        timestamp = 0,
+        soundName = null,
+        canBeReplaced = false,
+        isRedacted = false
+)
+
+fun aNotifiableMessageEvent(eventId: String, roomId: String) = NotifiableMessageEvent(
+        eventId = eventId,
+        editedEventId = null,
+        noisy = false,
+        timestamp = 0,
+        senderName = "sender-name",
+        senderId = "sending-id",
+        body = "message-body",
+        roomId = roomId,
+        roomName = "room-name",
+        roomIsDirect = false,
+        canBeReplaced = false,
+        isRedacted = false
+)


### PR DESCRIPTION
Some preparation/refactors around the `Push triggers` in order to support _suspending_ `NotifiableEventResolver.resolveEvent` which is required for including images in the notifications

*points to a feature branch

- `PushRuleListener` functions are replaced with a single `onEvents(PushEvents)` in order to allow any logic within the implementation to be asynchronous 
- All notification event changes are handled via the `notificationDrawerManager.updateEvents`, this ensures a single point of synchronisation and notification render pass (reduces the amount of render passes and synchronisation locks)
- Notification queue mutations are extracted to a dedicated class along with unit tests 
- Lifts the `NotifiableEvent` fixtures to a dedicated fixtures test package