### PR TITLE
Supporting images in notifications 

### DIFF
--- a/changelog.d/4402.feature
+++ b/changelog.d/4402.feature
@@ -1,0 +1,1 @@
+Adds support for images inside message notifications

--- a/vector/src/main/java/im/vector/app/core/extensions/BasicExtensions.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/BasicExtensions.kt
@@ -66,3 +66,7 @@ fun String?.insertBeforeLast(insert: String, delimiter: String = "."): String {
         replaceRange(idx, idx, insert)
     }
 }
+
+inline fun <reified R> Any?.takeAs(): R? {
+    return takeIf { it is R } as R?
+}

--- a/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
@@ -208,11 +208,15 @@ class NotifiableEventResolver @Inject constructor(
     }
 
     private suspend fun TimelineEvent.downloadAndExportImage(session: Session): Uri? {
-        return getLastMessageContent()?.takeAs<MessageWithAttachmentContent>()?.let { imageMessage ->
-            val fileService = session.fileService()
-            fileService.downloadFile(imageMessage)
-            fileService.getTemporarySharableURI(imageMessage)
-        }
+        return kotlin.runCatching {
+            getLastMessageContent()?.takeAs<MessageWithAttachmentContent>()?.let { imageMessage ->
+                val fileService = session.fileService()
+                fileService.downloadFile(imageMessage)
+                fileService.getTemporarySharableURI(imageMessage)
+            }
+        }.onFailure {
+            Timber.e(it, "Failed to download and export image for notification")
+        }.getOrNull()
     }
 
     private fun resolveStateRoomEvent(event: Event, session: Session, canBeReplaced: Boolean, isNoisy: Boolean): NotifiableEvent? {

--- a/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
@@ -252,4 +252,3 @@ class NotifiableEventResolver @Inject constructor(
         return null
     }
 }
-

--- a/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
@@ -30,6 +30,7 @@ import org.matrix.android.sdk.api.session.crypto.MXCryptoError
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.isEdition
+import org.matrix.android.sdk.api.session.events.model.isImageMessage
 import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.model.RoomMemberContent
@@ -202,7 +203,7 @@ class NotifiableEventResolver @Inject constructor(
     private suspend fun TimelineEvent.fetchImageIfPresent(session: Session): Uri? {
         return when {
             root.isEncrypted() && root.mxDecryptionResult == null -> null
-            root.getClearType() == EventType.MESSAGE              -> downloadAndExportImage(session)
+            root.isImageMessage()                                 -> downloadAndExportImage(session)
             else                                                  -> null
         }
     }

--- a/vector/src/main/java/im/vector/app/features/notifications/NotifiableMessageEvent.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotifiableMessageEvent.kt
@@ -15,6 +15,7 @@
  */
 package im.vector.app.features.notifications
 
+import android.net.Uri
 import org.matrix.android.sdk.api.session.events.model.EventType
 
 data class NotifiableMessageEvent(
@@ -26,6 +27,7 @@ data class NotifiableMessageEvent(
         val senderName: String?,
         val senderId: String?,
         val body: String?,
+        val imageUri: Uri?,
         val roomId: String,
         val roomName: String?,
         val roomIsDirect: Boolean = false,

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationBroadcastReceiver.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationBroadcastReceiver.kt
@@ -138,6 +138,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
                         ?: context?.getString(R.string.notification_sender_me),
                 senderId = session.myUserId,
                 body = message,
+                imageUri = null,
                 roomId = room.roomId,
                 roomName = room.roomSummary()?.displayName ?: room.roomId,
                 roomIsDirect = room.roomSummary()?.isDirect == true,

--- a/vector/src/main/java/im/vector/app/features/notifications/RoomGroupMessageCreator.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/RoomGroupMessageCreator.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.notifications
 import android.content.Context
 import android.graphics.Bitmap
 import android.os.Build
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.Person
 import androidx.core.content.pm.ShortcutInfoCompat
@@ -103,6 +104,7 @@ class RoomGroupMessageCreator @Inject constructor(
 
     private fun NotificationCompat.MessagingStyle.addMessagesFromEvents(events: List<NotifiableMessageEvent>) {
         events.forEach { event ->
+            Log.e("!!!", "event: $event")
             val senderPerson = if (event.outGoingMessage) {
                 null
             } else {
@@ -114,7 +116,14 @@ class RoomGroupMessageCreator @Inject constructor(
             }
             when {
                 event.isSmartReplyError() -> addMessage(stringProvider.getString(R.string.notification_inline_reply_failed), event.timestamp, senderPerson)
-                else                      -> addMessage(event.body, event.timestamp, senderPerson)
+                else                      -> {
+                    val message = NotificationCompat.MessagingStyle.Message(event.body, event.timestamp, senderPerson).also { message ->
+                        event.imageUri?.let {
+                            message.setData("image/", it)
+                        }
+                    }
+                    addMessage(message)
+                }
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/notifications/RoomGroupMessageCreator.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/RoomGroupMessageCreator.kt
@@ -19,7 +19,6 @@ package im.vector.app.features.notifications
 import android.content.Context
 import android.graphics.Bitmap
 import android.os.Build
-import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.Person
 import androidx.core.content.pm.ShortcutInfoCompat
@@ -104,7 +103,6 @@ class RoomGroupMessageCreator @Inject constructor(
 
     private fun NotificationCompat.MessagingStyle.addMessagesFromEvents(events: List<NotifiableMessageEvent>) {
         events.forEach { event ->
-            Log.e("!!!", "event: $event")
             val senderPerson = if (event.outGoingMessage) {
                 null
             } else {

--- a/vector/src/test/java/im/vector/app/test/fixtures/NotifiableEventFixture.kt
+++ b/vector/src/test/java/im/vector/app/test/fixtures/NotifiableEventFixture.kt
@@ -76,5 +76,6 @@ fun aNotifiableMessageEvent(
         roomName = "room-name",
         roomIsDirect = false,
         canBeReplaced = false,
-        isRedacted = isRedacted
+        isRedacted = isRedacted,
+        imageUri = null
 )


### PR DESCRIPTION
Fixes #1697, relies on #4401 refactor 

Adds image support to the message notifications

- Downloads the image as part of the notification event resolving chain
- Temporarily exposes the image via `FileProvider Uri` in order to allow the notifications to read and display the image

| EXPANDED GROUP WITH TEXT | EXPANDED GROUP | GROUP COLLAPSED  |  GROUP SUMMARY | SINGLE | ROOM LIST |
| --- | --- | --- | --- | --- | --- |
|![Screenshot_20211103_154653](https://user-images.githubusercontent.com/1848238/140094474-5906eaf3-7055-4fc4-8ac2-9c46d5156b96.png)|![Screenshot_20211103_154629](https://user-images.githubusercontent.com/1848238/140094480-1e42dd01-7a72-4ec5-b0fc-95928fc659ab.png)|![Screenshot_20211103_154620](https://user-images.githubusercontent.com/1848238/140094484-dafa73b1-ea77-4eb1-881d-7aebaaabb18e.png)|![Screenshot_20211103_154612](https://user-images.githubusercontent.com/1848238/140094486-45ef8e54-fec1-4bea-bbda-96561a4b3fdc.png)|![Screenshot_20211103_154705](https://user-images.githubusercontent.com/1848238/140094962-46c46276-05d4-4f34-bd09-99d86ac35cc4.png)|![after-room-list](https://user-images.githubusercontent.com/1848238/140094489-ee015378-d5a6-4b1a-afb8-e38444da8951.png)
