### PR TITLE
Fixing missing dev tools light mode send button 

### DIFF
--- a/changelog.d/3674.bugfix
+++ b/changelog.d/3674.bugfix
@@ -1,0 +1,1 @@
+Fixing missing send button in light mode dev tools - send * event

--- a/vector/src/main/res/menu/menu_devtools.xml
+++ b/vector/src/main/res/menu/menu_devtools.xml
@@ -9,6 +9,7 @@
         tools:visible="true"
         app:showAsAction="ifRoom"
         android:icon="@drawable/ic_edit"
+        app:iconTint="?vctr_content_secondary"
         android:title="@string/edit" />
 
     <item
@@ -17,6 +18,7 @@
         tools:visible="true"
         app:showAsAction="ifRoom"
         android:icon="@drawable/ic_send"
+        app:iconTint="?vctr_content_secondary"
         android:title="@string/send" />
 
 </menu>


### PR DESCRIPTION
Fixes #3674 Missing send icon in the light mode dev tools send event screens

Reusing the existing tint colour from the theme (matches the home screen search) 

| BEFORE LIGHT | AFTER LIGHT |
| --- | --- |
|![Screenshot_20211103_160921](https://user-images.githubusercontent.com/1848238/140099325-026a28c3-4206-4cf1-873f-6e486add5e5f.png)|![after-light](https://user-images.githubusercontent.com/1848238/140099722-61e7312e-d047-44f0-8b68-8d7dbd3fc894.png)


| BEFORE DARK | AFTER DARK |
| --- | --- |
|![Screenshot_20211103_160909](https://user-images.githubusercontent.com/1848238/140099327-5e500c59-19b4-4ea8-acce-a53ed19c61e8.png)|![after-dark](https://user-images.githubusercontent.com/1848238/140099322-fa02aa5e-e853-48ba-b202-02022cde13da.png)





