### PR TITLE
Adding `View source` to sanity check

### DIFF
--- a/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -83,6 +83,7 @@ class UiAllScreensSanityTest {
     // 2021-04-08 Testing 429 change
     @Test
     fun allScreensTest() {
+        uiTestBase.enableDeveloperMode()
         // Create an account
         val userId = "UiTest_" + UUID.randomUUID().toString()
         uiTestBase.createAccount(userId = userId)
@@ -211,6 +212,14 @@ class UiAllScreensSanityTest {
     private fun longClickOnMessageTest() {
         // Test quick reaction
         longClickOnMessage()
+
+        // Check View Source library
+        clickOn(R.string.view_source)
+        sleep(1000)
+        pressBack()
+
+        longClickOnMessage()
+
         // Add quick reaction
         clickOn("\uD83D\uDC4D️") // 👍
 

--- a/vector/src/androidTest/java/im/vector/app/ui/UiTestBase.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiTestBase.kt
@@ -16,10 +16,12 @@
 
 package im.vector.app.ui
 
+import androidx.preference.PreferenceManager
 import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.platform.app.InstrumentationRegistry
 import com.adevinta.android.barista.assertion.BaristaEnabledAssertions.assertDisabled
 import com.adevinta.android.barista.assertion.BaristaEnabledAssertions.assertEnabled
 import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
@@ -29,8 +31,17 @@ import im.vector.app.R
 import im.vector.app.espresso.tools.waitUntilActivityVisible
 import im.vector.app.features.home.HomeActivity
 import im.vector.app.waitForView
+import java.lang.Thread.sleep
 
 class UiTestBase {
+
+    fun enableDeveloperMode() {
+        PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getInstrumentation().targetContext)
+                .edit()
+                .putBoolean("SETTINGS_DEVELOPER_MODE_PREFERENCE_KEY", true)
+                .apply()
+    }
+
     fun createAccount(userId: String, password: String = "password", homeServerUrl: String = "http://10.0.2.2:8080") {
         initSession(true, userId, password, homeServerUrl)
     }
@@ -52,6 +63,7 @@ class UiTestBase {
         writeTo(R.id.loginServerUrlFormHomeServerUrl, homeServerUrl)
         assertEnabled(R.id.loginServerUrlFormSubmit)
         closeSoftKeyboard()
+        sleep(500)
         clickOn(R.id.loginServerUrlFormSubmit)
         onView(isRoot()).perform(waitForView(withId(R.id.loginSignupSigninSubmit)))
 
@@ -75,6 +87,7 @@ class UiTestBase {
         assertEnabled(R.id.loginSubmit)
 
         closeSoftKeyboard()
+        sleep(500)
         clickOn(R.id.loginSubmit)
 
         // Wait


### PR DESCRIPTION
Fixes #4308 

Adds `View Source` checking in the sanity test suite
- Also includes some extra sleeps to make the login flow less flaky when running locally (might be just my machine?)

*Added extra sleep for the gif to show the View Source screen for longer

| IN ACTION |
| --- |
|![view-source-sanity](https://user-images.githubusercontent.com/1848238/140122541-5eb7d0e9-d0ae-4a55-afed-2c439494fc1d.gif)
