### PR TITLE
add viewbinding compileOnly dependency to gradle files

### DIFF
--- a/attachment-viewer/build.gradle
+++ b/attachment-viewer/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation project(":library:ui-styles")
 
     // make viewBinding classes accessible to Android Studio
-    compileOnly 'com.android.databinding:viewbinding:7.0.3'
+    compileOnly libs.android.viewbinding
 
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
 

--- a/attachment-viewer/build.gradle
+++ b/attachment-viewer/build.gradle
@@ -48,6 +48,9 @@ android {
 dependencies {
     implementation project(":library:ui-styles")
 
+    // make viewBinding classes accessible to Android Studio
+    compileOnly 'com.android.databinding:viewbinding:7.0.3'
+
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
 
     implementation libs.rx.rxKotlin

--- a/changelog.d/4421.misc
+++ b/changelog.d/4421.misc
@@ -1,0 +1,1 @@
+Add viewbinding dependency to gradle modules for a better Android Studio experience.

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -73,6 +73,10 @@ ext.libs = [
         google      : [
                 'material'                : "com.google.android.material:material:1.4.0"
         ],
+        android     : [
+                // Only used to make Android Studio happy in working with some of the modules
+                'viewbinding'             : "com.android.databinding:viewbinding:7.0.3"
+        ],
         dagger      : [
                 'dagger'                  : "com.google.dagger:dagger:$dagger",
                 'daggerCompiler'          : "com.google.dagger:dagger-compiler:$dagger",

--- a/library/ui-styles/build.gradle
+++ b/library/ui-styles/build.gradle
@@ -54,6 +54,8 @@ android {
 dependencies {
     implementation libs.androidx.appCompat
     implementation libs.google.material
+    // make viewBinding classes accessible to Android Studio
+    compileOnly 'com.android.databinding:viewbinding:7.0.3'
     // Pref theme
     implementation libs.androidx.preferenceKtx
     // PFLockScreen attrs

--- a/library/ui-styles/build.gradle
+++ b/library/ui-styles/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation libs.androidx.appCompat
     implementation libs.google.material
     // make viewBinding classes accessible to Android Studio
-    compileOnly 'com.android.databinding:viewbinding:7.0.3'
+    compileOnly libs.android.viewbinding
     // Pref theme
     implementation libs.androidx.preferenceKtx
     // PFLockScreen attrs

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -338,6 +338,8 @@ dependencies {
     implementation project(":attachment-viewer")
     implementation project(":library:ui-styles")
     implementation 'androidx.multidex:multidex:2.0.1'
+    // make viewBinding classes accessible to Android Studio
+    compileOnly libs.android.viewbinding
 
     implementation libs.jetbrains.coroutinesCore
     implementation libs.jetbrains.coroutinesAndroid


### PR DESCRIPTION
I was exploring the codebase and noticed the following error in the `attachement-viewer` and `ui-styles` modules:

```
Cannot access 'android.viewbinding.ViewBinding' which is a supertype of 'im.vector.lib.attachmentviewer.databinding.ItemVideoAttachmentBinding'. Check your module classpath for missing or conflicting dependencies
```

Adding an explicit compile time only dependency on the viewbinding dependency them solves this
problem.

See https://stackoverflow.com/a/63137481/1634837

### Pull Request Checklist

<!--
 Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request
 Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked.
 -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [x] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
