### PR TITLE
Add an explicit reason when shortcut are disabled.

### DIFF
--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1080,6 +1080,9 @@
     <string name="room_settings_forget">Forget</string>
     <string name="room_settings_add_homescreen_shortcut">Add to Home screen</string>
 
+    <string name="shortcut_disabled_reason_room_left">The room has been left!</string>
+    <string name="shortcut_disabled_reason_sign_out">The session has been signed out!</string>
+
     <!-- home sliding menu -->
     <string name="room_sliding_menu_messages">Messages</string>
     <string name="room_sliding_menu_settings">Settings</string>


### PR DESCRIPTION
Also prefer using ShortcutManagerCompat to disable shortcuts

After a room for which a shortcut has been pinned is left, when clicking on the disabled shortcut, we can see a Toast with:

### Before

Default message from the system

<img width="323" alt="image" src="https://user-images.githubusercontent.com/3940906/140742913-ee385e68-7943-472b-8591-cf14c1cd9613.png">

### After

Explicit message

<img width="295" alt="image" src="https://user-images.githubusercontent.com/3940906/140742972-d519de68-bbf3-486d-a843-9ffaaf198cd6.png">
