### PR TITLE
Fix potential NPE on Optional objects

### DIFF
--- a/changelog.d/4428.bugfix
+++ b/changelog.d/4428.bugfix
@@ -1,0 +1,1 @@
+Fix potential NullPointerException crashes in Room and User account data sources

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/accountdata/RoomAccountDataDataSource.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/accountdata/RoomAccountDataDataSource.kt
@@ -43,7 +43,7 @@ internal class RoomAccountDataDataSource @Inject constructor(@SessionDatabase pr
 
     fun getLiveAccountDataEvent(roomId: String, type: String): LiveData<Optional<RoomAccountDataEvent>> {
         return Transformations.map(getLiveAccountDataEvents(roomId, setOf(type))) {
-            it.firstOrNull()?.toOptional()
+            it.firstOrNull().toOptional()
         }
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/accountdata/UserAccountDataDataSource.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/accountdata/UserAccountDataDataSource.kt
@@ -41,7 +41,7 @@ internal class UserAccountDataDataSource @Inject constructor(@SessionDatabase pr
 
     fun getLiveAccountDataEvent(type: String): LiveData<Optional<UserAccountDataEvent>> {
         return Transformations.map(getLiveAccountDataEvents(setOf(type))) {
-            it.firstOrNull()?.toOptional()
+            it.firstOrNull().toOptional()
         }
     }
 


### PR DESCRIPTION
`toOptional()` function was safe called (prefixed by `?.`) causing the resulting Optional object to be null instead of encapsulating the null value inside the Optional object (which is the purpose of this object).