### PR TITLE
Sign out - Sign in sanity check & nightly sanity check

### DIFF
--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   integration-tests:
     name: Sanity Tests (Synapse)
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +50,10 @@ jobs:
           pip install synapse matrix-synapse
           curl -sL https://raw.githubusercontent.com/matrix-org/synapse/develop/demo/start.sh --no-rate-limit \
             | sed s/127.0.0.1/0.0.0.0/g | bash
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
       - name: Run sanity tests on API ${{ matrix.api-level }}
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -1,9 +1,9 @@
 name: Sanity Test
 
 on:
-  pull_request: { }
-  push:
-    branches: [ main, develop ]
+  schedule:
+    # At 20:00 every day UTC
+    - cron: '0 20 * * *'
 
 # Enrich gradle.properties for CI/CD
 env:
@@ -21,6 +21,8 @@ jobs:
         api-level: [28]
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: develop
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -48,8 +48,8 @@ jobs:
           python3 -m venv .synapse
           source .synapse/bin/activate
           pip install synapse matrix-synapse
-          curl -sL https://raw.githubusercontent.com/matrix-org/synapse/develop/demo/start.sh --no-rate-limit \
-            | sed s/127.0.0.1/0.0.0.0/g | bash
+          curl -sL https://raw.githubusercontent.com/matrix-org/synapse/develop/demo/start.sh \
+            | sed s/127.0.0.1/0.0.0.0/g | sed 's/http:\/\/localhost/http:\/\/10.0.2.2/g' | bash -s -- --no-rate-limit
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/SessionManager.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/SessionManager.kt
@@ -51,6 +51,13 @@ internal class SessionManager @Inject constructor(private val matrixComponent: M
         }
     }
 
+    fun stopSession(sessionId: String) {
+        if (sessionComponents.containsKey(sessionId).not()) {
+            throw RuntimeException("You don't have a session for id $sessionId")
+        }
+        sessionComponents[sessionId]!!.session().stopSync()
+    }
+
     fun getOrCreateSessionComponent(sessionParams: SessionParams): SessionComponent {
         return sessionComponents.getOrPut(sessionParams.credentials.sessionId()) {
             DaggerSessionComponent

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/SessionManager.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/SessionManager.kt
@@ -52,10 +52,8 @@ internal class SessionManager @Inject constructor(private val matrixComponent: M
     }
 
     fun stopSession(sessionId: String) {
-        if (sessionComponents.containsKey(sessionId).not()) {
-            throw RuntimeException("You don't have a session for id $sessionId")
-        }
-        sessionComponents[sessionId]!!.session().stopSync()
+        val sessionComponent = sessionComponents[sessionId] ?: throw RuntimeException("You don't have a session for id $sessionId")
+        sessionComponent.session().stopSync()
     }
 
     fun getOrCreateSessionComponent(sessionParams: SessionParams): SessionComponent {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/account/DeactivateAccountTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/account/DeactivateAccountTask.kt
@@ -44,7 +44,7 @@ internal class DefaultDeactivateAccountTask @Inject constructor(
 
     override suspend fun execute(params: DeactivateAccountTask.Params) {
         val deactivateAccountParams = DeactivateAccountParams.create(params.userAuthParam, params.eraseAllData)
-
+        cleanupSession.stopActiveTasks()
         val canCleanup = try {
             executeRequest(globalErrorReceiver) {
                 accountAPI.deactivate(deactivateAccountParams)
@@ -71,7 +71,7 @@ internal class DefaultDeactivateAccountTask @Inject constructor(
             runCatching { identityDisconnectTask.execute(Unit) }
                     .onFailure { Timber.w(it, "Unable to disconnect identity server") }
 
-            cleanupSession.handle()
+            cleanupSession.cleanup()
         }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/cleanup/CleanupSession.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/cleanup/CleanupSession.kt
@@ -50,13 +50,19 @@ internal class CleanupSession @Inject constructor(
         @CryptoDatabase private val realmCryptoConfiguration: RealmConfiguration,
         @UserMd5 private val userMd5: String
 ) {
-    suspend fun handle() {
+
+    fun stopActiveTasks() {
+        Timber.d("Cleanup: cancel pending works...")
+        workManagerProvider.cancelAllWorks()
+
+        Timber.d("Cleanup: stop session...")
+        sessionManager.stopSession(sessionId)
+    }
+
+    suspend fun cleanup() {
         val sessionRealmCount = Realm.getGlobalInstanceCount(realmSessionConfiguration)
         val cryptoRealmCount = Realm.getGlobalInstanceCount(realmCryptoConfiguration)
         Timber.d("Realm instance ($sessionRealmCount - $cryptoRealmCount)")
-
-        Timber.d("Cleanup: cancel pending works...")
-        workManagerProvider.cancelAllWorks()
 
         Timber.d("Cleanup: release session...")
         sessionManager.releaseSession(sessionId)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/cleanup/CleanupSession.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/cleanup/CleanupSession.kt
@@ -55,14 +55,14 @@ internal class CleanupSession @Inject constructor(
         val cryptoRealmCount = Realm.getGlobalInstanceCount(realmCryptoConfiguration)
         Timber.d("Realm instance ($sessionRealmCount - $cryptoRealmCount)")
 
-        Timber.d("Cleanup: delete session params...")
-        sessionParamsStore.delete(sessionId)
-
         Timber.d("Cleanup: cancel pending works...")
         workManagerProvider.cancelAllWorks()
 
         Timber.d("Cleanup: release session...")
         sessionManager.releaseSession(sessionId)
+
+        Timber.d("Cleanup: delete session params...")
+        sessionParamsStore.delete(sessionId)
 
         Timber.d("Cleanup: clear session data...")
         clearSessionDataTask.execute(Unit)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/signout/SignOutTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/signout/SignOutTask.kt
@@ -43,6 +43,7 @@ internal class DefaultSignOutTask @Inject constructor(
     override suspend fun execute(params: SignOutTask.Params) {
         // It should be done even after a soft logout, to be sure the deviceId is deleted on the
         if (params.signOutFromHomeserver) {
+            cleanupSession.stopActiveTasks()
             Timber.d("SignOut: send request...")
             try {
                 executeRequest(globalErrorReceiver) {
@@ -67,6 +68,6 @@ internal class DefaultSignOutTask @Inject constructor(
                 .onFailure { Timber.w(it, "Unable to disconnect identity server") }
 
         Timber.d("SignOut: cleanup session...")
-        cleanupSession.handle()
+        cleanupSession.cleanup()
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncThread.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncThread.kt
@@ -160,6 +160,9 @@ internal class SyncThread @Inject constructor(private val syncTask: SyncTask,
                 synchronized(lock) { lock.wait() }
                 Timber.tag(loggerTag.value).d("...retry")
             } else if (!isTokenValid) {
+                if (state == SyncState.Killing) {
+                    continue
+                }
                 Timber.tag(loggerTag.value).d("Token is invalid. Waiting...")
                 updateStateTo(SyncState.InvalidToken)
                 synchronized(lock) { lock.wait() }

--- a/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -16,24 +16,14 @@
 
 package im.vector.app.ui
 
-import android.view.View
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
-import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
-import im.vector.app.EspressoHelper
-import im.vector.app.R
-import im.vector.app.espresso.tools.waitUntilViewVisible
 import im.vector.app.features.MainActivity
 import im.vector.app.ui.robot.ElementRobot
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import timber.log.Timber
-import java.lang.Thread.sleep
 import java.util.UUID
 
 /**
@@ -94,25 +84,8 @@ class UiAllScreensSanityTest {
 
         // Login again on the same account
         elementRobot.login(userId)
-
-        ignoreVerification()
+        elementRobot.dismissVerificationIfPresent()
         // TODO Deactivate account instead of logout?
         elementRobot.signout()
-    }
-
-    private fun ignoreVerification() {
-        kotlin.runCatching {
-            sleep(6000)
-            val activity = EspressoHelper.getCurrentActivity()!!
-            val popup = activity.findViewById<View>(com.tapadoo.alerter.R.id.llAlertBackground)!!
-            activity.runOnUiThread { popup.performClick() }
-
-            waitUntilViewVisible(withId(R.id.bottomSheetFragmentContainer))
-            waitUntilViewVisible(withText(R.string.skip))
-            clickOn(R.string.skip)
-            assertDisplayed(R.string.are_you_sure)
-            clickOn(R.string.skip)
-            waitUntilViewVisible(withId(R.id.bottomSheetFragmentContainer))
-        }.onFailure { Timber.w("Verification popup missing", it) }
     }
 }

--- a/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -80,12 +80,12 @@ class UiAllScreensSanityTest {
             verifyCreatedRoom()
         }
 
-        elementRobot.signout()
+        elementRobot.signout(expectSignOutWarning = true)
 
         // Login again on the same account
         elementRobot.login(userId)
         elementRobot.dismissVerificationIfPresent()
         // TODO Deactivate account instead of logout?
-        elementRobot.signout()
+        elementRobot.signout(expectSignOutWarning = false)
     }
 }

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
@@ -95,15 +95,19 @@ class ElementRobot {
         waitUntilViewVisible(withId(R.id.bottomNavigationView))
     }
 
-    fun signout() {
+    fun signout(expectSignOutWarning: Boolean) {
         clickOn(R.id.groupToolbarAvatarImageView)
         clickOn(R.id.homeDrawerHeaderSignoutView)
 
-        val hasSentMessages = kotlin.runCatching {
+        val isShowingSignOutWarning = kotlin.runCatching {
             waitUntilViewVisible(withId(R.id.exitAnywayButton))
         }.isSuccess
 
-        if (hasSentMessages) {
+        if (expectSignOutWarning != isShowingSignOutWarning) {
+            Timber.w("Unexpected sign out flow, expected warning to be: ${expectSignOutWarning.toWarningType()} but was ${isShowingSignOutWarning.toWarningType()}")
+        }
+
+        if (isShowingSignOutWarning) {
             // We have sent a message in a e2e room, accept to loose it
             clickOn(R.id.exitAnywayButton)
             // Dark pattern
@@ -135,3 +139,5 @@ class ElementRobot {
         }.onFailure { Timber.w("Verification popup missing", it) }
     }
 }
+
+private fun Boolean.toWarningType() = if (this) "shown" else "skipped"

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
@@ -16,7 +16,9 @@
 
 package im.vector.app.ui.robot
 
+import android.view.View
 import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
@@ -33,6 +35,7 @@ import im.vector.app.features.login.LoginActivity
 import im.vector.app.initialSyncIdlingResource
 import im.vector.app.ui.robot.settings.SettingsRobot
 import im.vector.app.withIdlingResource
+import timber.log.Timber
 
 class ElementRobot {
 
@@ -114,5 +117,21 @@ class ElementRobot {
         waitUntilActivityVisible<LoginActivity> {
             assertDisplayed(R.id.loginSplashLogo)
         }
+    }
+
+    fun dismissVerificationIfPresent() {
+        kotlin.runCatching {
+            Thread.sleep(6000)
+            val activity = EspressoHelper.getCurrentActivity()!!
+            val popup = activity.findViewById<View>(com.tapadoo.alerter.R.id.llAlertBackground)!!
+            activity.runOnUiThread { popup.performClick() }
+
+            waitUntilViewVisible(withId(R.id.bottomSheetFragmentContainer))
+            waitUntilViewVisible(ViewMatchers.withText(R.string.skip))
+            clickOn(R.string.skip)
+            assertDisplayed(R.string.are_you_sure)
+            clickOn(R.string.skip)
+            waitUntilViewVisible(withId(R.id.bottomSheetFragmentContainer))
+        }.onFailure { Timber.w("Verification popup missing", it) }
     }
 }

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
@@ -17,14 +17,14 @@
 package im.vector.app.ui.robot
 
 import androidx.test.espresso.Espresso.pressBack
-import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions
+import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
+import com.adevinta.android.barista.interaction.BaristaDialogInteractions.clickDialogNegativeButton
+import com.adevinta.android.barista.interaction.BaristaDialogInteractions.clickDialogPositiveButton
 import com.adevinta.android.barista.interaction.BaristaDrawerInteractions.openDrawer
 import im.vector.app.EspressoHelper
 import im.vector.app.R
-import im.vector.app.activityIdlingResource
 import im.vector.app.espresso.tools.waitUntilActivityVisible
 import im.vector.app.espresso.tools.waitUntilViewVisible
 import im.vector.app.features.createdirect.CreateDirectRoomActivity
@@ -36,22 +36,27 @@ import im.vector.app.withIdlingResource
 
 class ElementRobot {
 
-    fun login(userId: String) {
+    fun signUp(userId: String) {
         val onboardingRobot = OnboardingRobot()
         onboardingRobot.createAccount(userId = userId)
+        waitForHome()
+    }
 
-        withIdlingResource(activityIdlingResource(HomeActivity::class.java)) {
-            BaristaVisibilityAssertions.assertDisplayed(R.id.roomListContainer)
-            ViewActions.closeSoftKeyboard()
+    fun login(userId: String) {
+        val onboardingRobot = OnboardingRobot()
+        onboardingRobot.login(userId = userId)
+        waitForHome()
+    }
+
+    private fun waitForHome() {
+        waitUntilActivityVisible<HomeActivity> {
+            waitUntilViewVisible(withId(R.id.roomListContainer))
         }
-
         val activity = EspressoHelper.getCurrentActivity()!!
         val uiSession = (activity as HomeActivity).activeSessionHolder.getActiveSession()
-
         withIdlingResource(initialSyncIdlingResource(uiSession)) {
-            BaristaVisibilityAssertions.assertDisplayed(R.id.roomListContainer)
+            waitUntilViewVisible(withId(R.id.bottomNavigationView))
         }
-        waitUntilViewVisible(withId(R.id.bottomNavigationView))
     }
 
     fun settings(block: SettingsRobot.() -> Unit) {
@@ -88,9 +93,26 @@ class ElementRobot {
     }
 
     fun signout() {
-        OnboardingRobot().signout()
+        clickOn(R.id.groupToolbarAvatarImageView)
+        clickOn(R.id.homeDrawerHeaderSignoutView)
+
+        val hasSentMessages = kotlin.runCatching {
+            waitUntilViewVisible(withId(R.id.exitAnywayButton))
+        }.isSuccess
+
+        if (hasSentMessages) {
+            // We have sent a message in a e2e room, accept to loose it
+            clickOn(R.id.exitAnywayButton)
+            // Dark pattern
+            waitUntilViewVisible(withId(android.R.id.button2))
+            clickDialogNegativeButton()
+        } else {
+            waitUntilViewVisible(withId(android.R.id.button1))
+            clickDialogPositiveButton()
+        }
+
         waitUntilActivityVisible<LoginActivity> {
-            BaristaVisibilityAssertions.assertDisplayed(R.id.loginSplashLogo)
+            assertDisplayed(R.id.loginSplashLogo)
         }
     }
 }

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/OnboardingRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/OnboardingRobot.kt
@@ -26,8 +26,6 @@ import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assert
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.adevinta.android.barista.interaction.BaristaEditTextInteractions.writeTo
 import im.vector.app.R
-import im.vector.app.espresso.tools.waitUntilActivityVisible
-import im.vector.app.features.home.HomeActivity
 import im.vector.app.waitForView
 
 class OnboardingRobot {

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/OnboardingRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/OnboardingRobot.kt
@@ -24,7 +24,6 @@ import com.adevinta.android.barista.assertion.BaristaEnabledAssertions.assertDis
 import com.adevinta.android.barista.assertion.BaristaEnabledAssertions.assertEnabled
 import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
-import com.adevinta.android.barista.interaction.BaristaDialogInteractions
 import com.adevinta.android.barista.interaction.BaristaEditTextInteractions.writeTo
 import im.vector.app.R
 import im.vector.app.espresso.tools.waitUntilActivityVisible
@@ -78,20 +77,5 @@ class OnboardingRobot {
 
         closeSoftKeyboard()
         clickOn(R.id.loginSubmit)
-
-        // Wait
-        waitUntilActivityVisible<HomeActivity> {
-            assertDisplayed(R.id.homeDetailFragmentContainer)
-        }
-    }
-
-    fun signout() {
-        clickOn(R.id.groupToolbarAvatarImageView)
-        clickOn(R.id.homeDrawerHeaderSignoutView)
-
-        // We have sent a message in a e2e room, accept to loose it
-        clickOn(R.id.exitAnywayButton)
-        // Dark pattern
-        BaristaDialogInteractions.clickDialogNegativeButton()
     }
 }


### PR DESCRIPTION
- Reintroduces the sign out/re-signin flow to the sanity tests 
- Fixes multiple sign outs occurring whilst signing out during a sync task execution 
- Changes the Sanity check to execute on a nightly basis instead of on each pull request push
  - Updates the action runner to the use hardware accelerated OSX runner 
  - Fixes bad argument placement for the `--no-rate-limit` option

| GIF | 
| --- | 
|![after-sanity-2](https://user-images.githubusercontent.com/1848238/140768328-d25ce38b-f401-4a31-86fd-5ee81ce241a1.gif)
