### PR TITLE
Developer mode sanity check & failure screenshots

### DIFF
--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -58,5 +58,14 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          script: ./gradlew $CI_GRADLE_ARG_PROPERTIES -PallWarningsAsErrors=false connectedGplayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=im.vector.app.ui.UiAllScreensSanityTest
+          script: |
+            ./gradlew $CI_GRADLE_ARG_PROPERTIES \
+            -PallWarningsAsErrors=false \
+            connectedGplayDebugAndroidTest \
+            -Pandroid.testInstrumentationRunnerArguments.class=im.vector.app.ui.UiAllScreensSanityTest \
+            || adb pull sdcard/Pictures/failure_screenshots
+      - uses: actions/upload-artifact@v2
+        with:
+          name: failure-screenshots
+          path: failure_screenshots
 

--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Run sanity tests on API ${{ matrix.api-level }}
         uses: reactivecircus/android-emulator-runner@v2
         with:
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           api-level: ${{ matrix.api-level }}
           script: |
             ./gradlew $CI_GRADLE_ARG_PROPERTIES \

--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -59,12 +59,7 @@ jobs:
         with:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           api-level: ${{ matrix.api-level }}
-          script: |
-            ./gradlew $CI_GRADLE_ARG_PROPERTIES \
-              -PallWarningsAsErrors=false \
-              connectedGplayDebugAndroidTest \
-              -Pandroid.testInstrumentationRunnerArguments.class=im.vector.app.ui.UiAllScreensSanityTest \
-              || adb pull sdcard/Pictures/failure_screenshots
+          script: ./gradlew $CI_GRADLE_ARG_PROPERTIES -PallWarningsAsErrors=false connectedGplayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=im.vector.app.ui.UiAllScreensSanityTest || adb pull sdcard/Pictures/failure_screenshots
       - uses: actions/upload-artifact@v2
         with:
           name: failure-screenshots

--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [28]
+        api-level: [29]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -61,10 +61,10 @@ jobs:
           api-level: ${{ matrix.api-level }}
           script: |
             ./gradlew $CI_GRADLE_ARG_PROPERTIES \
-            -PallWarningsAsErrors=false \
-            connectedGplayDebugAndroidTest \
-            -Pandroid.testInstrumentationRunnerArguments.class=im.vector.app.ui.UiAllScreensSanityTest \
-            || adb pull sdcard/Pictures/failure_screenshots
+              -PallWarningsAsErrors=false \
+              connectedGplayDebugAndroidTest \
+              -Pandroid.testInstrumentationRunnerArguments.class=im.vector.app.ui.UiAllScreensSanityTest \
+              || adb pull sdcard/Pictures/failure_screenshots
       - uses: actions/upload-artifact@v2
         with:
           name: failure-screenshots

--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -59,7 +59,9 @@ jobs:
         with:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           api-level: ${{ matrix.api-level }}
-          script: ./gradlew $CI_GRADLE_ARG_PROPERTIES -PallWarningsAsErrors=false connectedGplayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=im.vector.app.ui.UiAllScreensSanityTest || adb pull sdcard/Pictures/failure_screenshots
+          script: |
+            adb root
+            ./gradlew $CI_GRADLE_ARG_PROPERTIES -PallWarningsAsErrors=false connectedGplayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=im.vector.app.ui.UiAllScreensSanityTest || adb pull storage/emulated/0/Pictures/failure_screenshots
       - uses: actions/upload-artifact@v2
         with:
           name: failure-screenshots

--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [29]
+        api-level: [ 29 ]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -56,14 +56,24 @@ jobs:
           java-version: '11'
       - name: Run sanity tests on API ${{ matrix.api-level }}
         uses: reactivecircus/android-emulator-runner@v2
+        continue-on-error: true # allow pipeline to upload failure results
         with:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           api-level: ${{ matrix.api-level }}
+          emulator-build: 7425822  # workaround to emulator bug: https://github.com/ReactiveCircus/android-emulator-runner/issues/160
           script: |
             adb root
+            adb logcat -c
+            touch emulator.log
+            chmod 777 emulator.log
+            adb logcat >> emulator.log &
             ./gradlew $CI_GRADLE_ARG_PROPERTIES -PallWarningsAsErrors=false connectedGplayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=im.vector.app.ui.UiAllScreensSanityTest || adb pull storage/emulated/0/Pictures/failure_screenshots
-      - uses: actions/upload-artifact@v2
-        with:
-          name: failure-screenshots
-          path: failure_screenshots
 
+      - name: Upload Failing Test Report Log
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: sanity-error-results
+          path: |
+            emulator.log
+            failure_screenshots/

--- a/vector/src/androidTest/java/im/vector/app/EspressoExt.kt
+++ b/vector/src/androidTest/java/im/vector/app/EspressoExt.kt
@@ -54,6 +54,10 @@ object EspressoHelper {
     }
 }
 
+fun getString(@StringRes id: Int): String {
+    return EspressoHelper.getCurrentActivity()!!.resources.getString(id)
+}
+
 fun waitForView(viewMatcher: Matcher<View>, timeout: Long = 10_000, waitForDisplayed: Boolean = true): ViewAction {
     return object : ViewAction {
         override fun getConstraints(): Matcher<View> {

--- a/vector/src/androidTest/java/im/vector/app/espresso/tools/ScreenshotFailureRule.kt
+++ b/vector/src/androidTest/java/im/vector/app/espresso/tools/ScreenshotFailureRule.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.espresso.tools
+
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import timber.log.Timber
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.OutputStream
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+private val SCREENSHOT_FOLDER_LOCATION = "${Environment.DIRECTORY_PICTURES}/failure_screenshots"
+private val deviceLanguage = Locale.getDefault().language
+
+class ScreenshotFailureRule : TestWatcher() {
+    override fun failed(e: Throwable?, description: Description) {
+        val screenShotName = "$deviceLanguage-${description.methodName}-${SimpleDateFormat("EEE-MMMM-dd-HH:mm:ss").format(Date())}"
+        val bitmap = getInstrumentation().uiAutomation.takeScreenshot()
+        storeFailureScreenshot(bitmap, screenShotName)
+    }
+}
+
+/**
+ * Stores screenshots in sdcard/Pictures/failure_screenshots
+ */
+private fun storeFailureScreenshot(bitmap: Bitmap, screenshotName: String) {
+    val contentResolver = getInstrumentation().targetContext.applicationContext.contentResolver
+
+    val contentValues = ContentValues().apply {
+        put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+        put(MediaStore.Images.Media.DATE_TAKEN, System.currentTimeMillis())
+    }
+    if (android.os.Build.VERSION.SDK_INT >= 29) {
+        useMediaStoreScreenshotStorage(
+                contentValues,
+                contentResolver,
+                screenshotName,
+                SCREENSHOT_FOLDER_LOCATION,
+                bitmap
+        )
+    } else {
+        usePublicExternalScreenshotStorage(
+                contentValues,
+                contentResolver,
+                screenshotName,
+                SCREENSHOT_FOLDER_LOCATION,
+                bitmap
+        )
+    }
+}
+
+private fun useMediaStoreScreenshotStorage(
+        contentValues: ContentValues,
+        contentResolver: ContentResolver,
+        screenshotName: String,
+        screenshotLocation: String,
+        bitmap: Bitmap
+) {
+    contentValues.put(MediaStore.MediaColumns.DISPLAY_NAME, "$screenshotName.jpeg")
+    contentValues.put(MediaStore.Images.Media.RELATIVE_PATH, screenshotLocation)
+    val uri: Uri? = contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+    if (uri != null) {
+        contentResolver.openOutputStream(uri)?.let { saveScreenshotToStream(bitmap, it) }
+        contentResolver.update(uri, contentValues, null, null)
+    }
+}
+
+private fun usePublicExternalScreenshotStorage(
+        contentValues: ContentValues,
+        contentResolver: ContentResolver,
+        screenshotName: String,
+        screenshotLocation: String,
+        bitmap: Bitmap
+) {
+    val directory = File(Environment.getExternalStoragePublicDirectory(screenshotLocation).toString())
+    if (!directory.exists()) {
+        directory.mkdirs()
+    }
+    val file = File(directory, "$screenshotName.jpeg")
+    saveScreenshotToStream(bitmap, FileOutputStream(file))
+    contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+}
+
+private fun saveScreenshotToStream(bitmap: Bitmap, outputStream: OutputStream) {
+    outputStream.use {
+        try {
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 50, it)
+        } catch (e: IOException) {
+            Timber.e("Screenshot was not stored at this time")
+        }
+    }
+}
+

--- a/vector/src/androidTest/java/im/vector/app/espresso/tools/ScreenshotFailureRule.kt
+++ b/vector/src/androidTest/java/im/vector/app/espresso/tools/ScreenshotFailureRule.kt
@@ -115,4 +115,3 @@ private fun saveScreenshotToStream(bitmap: Bitmap, outputStream: OutputStream) {
         }
     }
 }
-

--- a/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -20,12 +20,14 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import im.vector.app.R
+import im.vector.app.espresso.tools.ScreenshotFailureRule
 import im.vector.app.features.MainActivity
 import im.vector.app.getString
 import im.vector.app.ui.robot.ElementRobot
 import im.vector.app.ui.robot.withDeveloperMode
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import java.util.UUID
 
@@ -37,7 +39,9 @@ import java.util.UUID
 class UiAllScreensSanityTest {
 
     @get:Rule
-    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+    val testRule = RuleChain
+            .outerRule(ActivityScenarioRule(MainActivity::class.java))
+            .around(ScreenshotFailureRule())
 
     private val elementRobot = ElementRobot()
 

--- a/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -19,8 +19,11 @@ package im.vector.app.ui
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import im.vector.app.R
 import im.vector.app.features.MainActivity
+import im.vector.app.getString
 import im.vector.app.ui.robot.ElementRobot
+import im.vector.app.ui.robot.withDeveloperMode
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -69,9 +72,26 @@ class UiAllScreensSanityTest {
             createNewRoom {
                 crawl()
                 createRoom {
-                    postMessage("Hello world!")
+                    val message = "Hello world!"
+                    postMessage(message)
                     crawl()
+                    crawlMessage(message)
                     openSettings { crawl() }
+                }
+            }
+        }
+
+        elementRobot.withDeveloperMode {
+            settings {
+                advancedSettings { crawlDeveloperOptions() }
+            }
+            roomList {
+                openRoom(getString(R.string.room_displayname_empty_room)) {
+                    val message = "Test view source"
+                    postMessage(message)
+                    openMessageMenu(message) {
+                        viewSource()
+                    }
                 }
             }
         }
@@ -89,3 +109,4 @@ class UiAllScreensSanityTest {
         elementRobot.signout(expectSignOutWarning = false)
     }
 }
+

--- a/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -113,4 +113,3 @@ class UiAllScreensSanityTest {
         elementRobot.signout(expectSignOutWarning = false)
     }
 }
-

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
@@ -141,3 +141,9 @@ class ElementRobot {
 }
 
 private fun Boolean.toWarningType() = if (this) "shown" else "skipped"
+
+fun ElementRobot.withDeveloperMode(block: ElementRobot.() -> Unit) {
+    settings { toggleDeveloperMode() }
+    block()
+    settings { toggleDeveloperMode() }
+}

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/MessageMenuRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/MessageMenuRobot.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.ui.robot
+
+import androidx.test.espresso.Espresso
+import com.adevinta.android.barista.interaction.BaristaClickInteractions
+import com.adevinta.android.barista.interaction.BaristaListInteractions
+import im.vector.app.R
+
+class MessageMenuRobot(
+        var autoClosed: Boolean = false
+) {
+
+    fun viewSource() {
+        BaristaClickInteractions.clickOn(R.string.view_source)
+        // wait for library
+        Thread.sleep(1000)
+        Espresso.pressBack()
+        autoClosed = true
+    }
+
+    fun editHistory() {
+        BaristaClickInteractions.clickOn(R.string.message_view_edit_history)
+        Espresso.pressBack()
+        autoClosed = true
+    }
+
+    fun addQuickReaction(quickReaction: String) {
+        BaristaClickInteractions.clickOn(quickReaction)
+        autoClosed = true
+    }
+
+    fun addReactionFromEmojiPicker() {
+        BaristaClickInteractions.clickOn(R.string.message_add_reaction)
+        // Wait for emoji to load, it's async now
+        Thread.sleep(2000)
+        BaristaListInteractions.clickListItem(R.id.emojiRecyclerView, 4)
+        autoClosed = true
+    }
+
+    fun edit() {
+        BaristaClickInteractions.clickOn(R.string.edit)
+        autoClosed = true
+    }
+}

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/MessageMenuRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/MessageMenuRobot.kt
@@ -16,44 +16,46 @@
 
 package im.vector.app.ui.robot
 
-import androidx.test.espresso.Espresso
-import com.adevinta.android.barista.interaction.BaristaClickInteractions
+import androidx.test.espresso.Espresso.pressBack
+import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.adevinta.android.barista.interaction.BaristaListInteractions
+import com.adevinta.android.barista.interaction.BaristaListInteractions.clickListItem
 import im.vector.app.R
+import java.lang.Thread.sleep
 
 class MessageMenuRobot(
         var autoClosed: Boolean = false
 ) {
 
     fun viewSource() {
-        BaristaClickInteractions.clickOn(R.string.view_source)
+        clickOn(R.string.view_source)
         // wait for library
-        Thread.sleep(1000)
-        Espresso.pressBack()
+        sleep(1000)
+        pressBack()
         autoClosed = true
     }
 
     fun editHistory() {
-        BaristaClickInteractions.clickOn(R.string.message_view_edit_history)
-        Espresso.pressBack()
+        clickOn(R.string.message_view_edit_history)
+        pressBack()
         autoClosed = true
     }
 
     fun addQuickReaction(quickReaction: String) {
-        BaristaClickInteractions.clickOn(quickReaction)
+        clickOn(quickReaction)
         autoClosed = true
     }
 
     fun addReactionFromEmojiPicker() {
-        BaristaClickInteractions.clickOn(R.string.message_add_reaction)
+        clickOn(R.string.message_add_reaction)
         // Wait for emoji to load, it's async now
-        Thread.sleep(2000)
-        BaristaListInteractions.clickListItem(R.id.emojiRecyclerView, 4)
+        sleep(2000)
+        clickListItem(R.id.emojiRecyclerView, 4)
         autoClosed = true
     }
 
     fun edit() {
-        BaristaClickInteractions.clickOn(R.string.edit)
+        clickOn(R.string.edit)
         autoClosed = true
     }
 }

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/MessageMenuRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/MessageMenuRobot.kt
@@ -18,7 +18,6 @@ package im.vector.app.ui.robot
 
 import androidx.test.espresso.Espresso.pressBack
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
-import com.adevinta.android.barista.interaction.BaristaListInteractions
 import com.adevinta.android.barista.interaction.BaristaListInteractions.clickListItem
 import im.vector.app.R
 import java.lang.Thread.sleep

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/RoomDetailRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/RoomDetailRobot.kt
@@ -44,6 +44,7 @@ class RoomDetailRobot {
         writeTo(R.id.composerEditText, content)
         waitUntilViewVisible(withId(R.id.sendButton))
         clickOn(R.id.sendButton)
+        waitUntilViewVisible(withText(content))
     }
 
     fun crawl() {

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/RoomDetailRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/RoomDetailRobot.kt
@@ -23,6 +23,7 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.adevinta.android.barista.interaction.BaristaClickInteractions
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.longClickOn
@@ -84,7 +85,7 @@ class RoomDetailRobot {
         waitUntilViewVisible(withId(R.id.sendButton))
         clickOn(R.id.sendButton)
         // Wait for the UI to update
-        sleep(1000)
+        waitUntilViewVisible(withText("Hello universe! (edited)"))
         // Open edit history
         openMessageMenu("Hello universe! (edited)") {
             editHistory()

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/RoomDetailRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/RoomDetailRobot.kt
@@ -31,7 +31,9 @@ import com.adevinta.android.barista.interaction.BaristaMenuClickInteractions.cli
 import com.adevinta.android.barista.interaction.BaristaMenuClickInteractions.openMenu
 import im.vector.app.R
 import im.vector.app.espresso.tools.waitUntilViewVisible
+import im.vector.app.features.home.room.detail.timeline.action.MessageActionsBottomSheet
 import im.vector.app.features.reactions.data.EmojiDataSource
+import im.vector.app.interactWithSheet
 import im.vector.app.waitForView
 import java.lang.Thread.sleep
 
@@ -39,6 +41,7 @@ class RoomDetailRobot {
 
     fun postMessage(content: String) {
         writeTo(R.id.composerEditText, content)
+        waitUntilViewVisible(withId(R.id.sendButton))
         clickOn(R.id.sendButton)
     }
 
@@ -63,7 +66,6 @@ class RoomDetailRobot {
         openMessageMenu(message) {
             addQuickReaction(quickReaction)
         }
-        waitUntilViewVisible(withId(R.id.composerEditText))
         // Open reactions
         longClickOn(quickReaction)
         // wait for bottom sheet
@@ -72,16 +74,13 @@ class RoomDetailRobot {
         openMessageMenu(message) {
             addReactionFromEmojiPicker()
         }
-        waitUntilViewVisible(withId(R.id.composerEditText))
         // Test Edit mode
         openMessageMenu(message) {
             edit()
         }
-        waitUntilViewVisible(withId(R.id.composerEditText))
         // TODO Cancel action
         writeTo(R.id.composerEditText, "Hello universe!")
         // Wait a bit for the keyboard layout to update
-        sleep(30)
         waitUntilViewVisible(withId(R.id.sendButton))
         clickOn(R.id.sendButton)
         // Wait for the UI to update
@@ -100,11 +99,12 @@ class RoomDetailRobot {
                                 ViewActions.longClick()
                         )
                 )
-        waitUntilViewVisible(withId(R.id.bottomSheetRecyclerView))
-        val messageMenuRobot = MessageMenuRobot()
-        block(messageMenuRobot)
-        if (!messageMenuRobot.autoClosed) {
-            pressBack()
+        interactWithSheet<MessageActionsBottomSheet>(contentMatcher = withId(R.id.bottomSheetRecyclerView)) {
+            val messageMenuRobot = MessageMenuRobot()
+            block(messageMenuRobot)
+            if (!messageMenuRobot.autoClosed) {
+                pressBack()
+            }
         }
     }
 

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/RoomListRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/RoomListRobot.kt
@@ -17,7 +17,6 @@
 package im.vector.app.ui.robot
 
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions
@@ -25,7 +24,6 @@ import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions
-import com.adevinta.android.barista.interaction.BaristaClickInteractions
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import im.vector.app.R
 import im.vector.app.espresso.tools.waitUntilActivityVisible

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/RoomListRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/RoomListRobot.kt
@@ -18,37 +18,47 @@ package im.vector.app.ui.robot
 
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions
 import com.adevinta.android.barista.interaction.BaristaClickInteractions
+import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import im.vector.app.R
 import im.vector.app.espresso.tools.waitUntilActivityVisible
 import im.vector.app.features.roomdirectory.RoomDirectoryActivity
 
 class RoomListRobot {
 
+    fun openRoom(roomName: String, block: RoomDetailRobot.() -> Unit) {
+        clickOn(roomName)
+        block(RoomDetailRobot())
+        pressBack()
+    }
+
     fun verifyCreatedRoom() {
-        Espresso.onView(ViewMatchers.withId(R.id.roomListView))
+        onView(ViewMatchers.withId(R.id.roomListView))
                 .perform(
                         RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
-                                ViewMatchers.hasDescendant(ViewMatchers.withText(R.string.room_displayname_empty_room)),
+                                ViewMatchers.hasDescendant(withText(R.string.room_displayname_empty_room)),
                                 ViewActions.longClick()
                         )
                 )
-        Espresso.pressBack()
+        pressBack()
     }
 
     fun newRoom(block: NewRoomRobot.() -> Unit) {
-        BaristaClickInteractions.clickOn(R.id.createGroupRoomButton)
+        clickOn(R.id.createGroupRoomButton)
         waitUntilActivityVisible<RoomDirectoryActivity> {
             BaristaVisibilityAssertions.assertDisplayed(R.id.publicRoomsList)
         }
         val newRoomRobot = NewRoomRobot()
         block(newRoomRobot)
         if (!newRoomRobot.createdRoom) {
-            Espresso.pressBack()
+            pressBack()
         }
     }
 }

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/settings/SettingsAdvancedRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/settings/SettingsAdvancedRobot.kt
@@ -17,8 +17,11 @@
 package im.vector.app.ui.robot.settings
 
 import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import im.vector.app.R
 import im.vector.app.espresso.tools.clickOnPreference
+import im.vector.app.espresso.tools.waitUntilViewVisible
 
 class SettingsAdvancedRobot {
 
@@ -28,20 +31,19 @@ class SettingsAdvancedRobot {
 
         clickOnPreference(R.string.settings_push_rules)
         pressBack()
+    }
 
-        /* TODO P2 test developer screens
-    // Enable developer mode
-    clickOnSwitchPreference("SETTINGS_DEVELOPER_MODE_PREFERENCE_KEY")
+    fun toggleDeveloperMode() {
+        clickOn(R.string.settings_developer_mode_summary)
+    }
 
-    clickOnPreference(R.string.settings_account_data)
-    clickOn("m.push_rules")
-    pressBack()
-    pressBack()
-    clickOnPreference(R.string.settings_key_requests)
-    pressBack()
-
-    // Disable developer mode
-    clickOnSwitchPreference("SETTINGS_DEVELOPER_MODE_PREFERENCE_KEY")
-     */
+    fun crawlDeveloperOptions() {
+        clickOnPreference(R.string.settings_account_data)
+        waitUntilViewVisible(withText("m.push_rules"))
+        clickOn("m.push_rules")
+        pressBack()
+        pressBack()
+        clickOnPreference(R.string.settings_key_requests)
+        pressBack()
     }
 }

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/settings/SettingsRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/settings/SettingsRobot.kt
@@ -21,6 +21,12 @@ import im.vector.app.clickOnAndGoBack
 
 class SettingsRobot {
 
+    fun toggleDeveloperMode() {
+        advancedSettings {
+            toggleDeveloperMode()
+        }
+    }
+
     fun general(block: SettingsGeneralRobot.() -> Unit) {
         clickOnAndGoBack(R.string.settings_general_title) { block(SettingsGeneralRobot()) }
     }
@@ -50,7 +56,9 @@ class SettingsRobot {
     }
 
     fun advancedSettings(block: SettingsAdvancedRobot.() -> Unit) {
-        clickOnAndGoBack(R.string.settings_advanced_settings) { block(SettingsAdvancedRobot()) }
+        clickOnAndGoBack(R.string.settings_advanced_settings) {
+            block(SettingsAdvancedRobot())
+        }
     }
 
     fun helpAndAbout(block: SettingsHelpRobot.() -> Unit) {


### PR DESCRIPTION
- Adds the sanity check for the developer mode options, fixes #4308 
```
- Advanced Settings 
  - Account Data
  - Key Requests

- Message Actions
  - View Source      
```
- Improved bottomsheet waiting 
- Updates the emulator options to use the recommended optimisations https://github.com/marketplace/actions/android-emulator-runner
- Captures screenshots on sanity failure and uploads as action artifacts  
