### PR TITLE
Clean group key share + logs + robustness

### DIFF
--- a/changelog.d/4459.misc
+++ b/changelog.d/4459.misc
@@ -1,0 +1,2 @@
+Improve group key sharing speed for huge groups
+Improve e2e logging

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -1315,7 +1315,7 @@ internal class DefaultCryptoService @Inject constructor(
             }.fold(
                     { callback.onSuccess(Unit) },
                     {
-                        Timber.e("## CRYPTO | prepareToEncrypt() failed.")
+                        Timber.e(it, "## CRYPTO | prepareToEncrypt() failed.")
                         callback.onFailure(it)
                     }
             )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/MXOlmDevice.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/MXOlmDevice.kt
@@ -119,7 +119,7 @@ internal class MXOlmDevice @Inject constructor(
     /**
      * @return The current (unused, unpublished) one-time keys for this account.
      */
-    fun getOneTimeKeys(): Map<String, Map<String, String>>? {
+    @Synchronized fun getOneTimeKeys(): Map<String, Map<String, String>>? {
         try {
             return store.getOlmAccount().oneTimeKeys()
         } catch (e: Exception) {
@@ -132,7 +132,7 @@ internal class MXOlmDevice @Inject constructor(
     /**
      * @return The maximum number of one-time keys the olm account can store.
      */
-    fun getMaxNumberOfOneTimeKeys(): Long {
+    @Synchronized fun getMaxNumberOfOneTimeKeys(): Long {
         return store.getOlmAccount().maxOneTimeKeys()
     }
 
@@ -153,7 +153,7 @@ internal class MXOlmDevice @Inject constructor(
      * @param message the message to be signed.
      * @return the base64-encoded signature.
      */
-    fun signMessage(message: String): String? {
+    @Synchronized fun signMessage(message: String): String? {
         try {
             return store.getOlmAccount().signMessage(message)
         } catch (e: Exception) {
@@ -166,7 +166,7 @@ internal class MXOlmDevice @Inject constructor(
     /**
      * Marks all of the one-time keys as published.
      */
-    fun markKeysAsPublished() {
+    @Synchronized fun markKeysAsPublished() {
         try {
             store.getOlmAccount().markOneTimeKeysAsPublished()
             store.saveOlmAccount()
@@ -180,7 +180,7 @@ internal class MXOlmDevice @Inject constructor(
      *
      * @param numKeys number of keys to generate
      */
-    fun generateOneTimeKeys(numKeys: Int) {
+    @Synchronized fun generateOneTimeKeys(numKeys: Int) {
         try {
             store.getOlmAccount().generateOneTimeKeys(numKeys)
             store.saveOlmAccount()
@@ -197,7 +197,7 @@ internal class MXOlmDevice @Inject constructor(
      * @param theirOneTimeKey  the remote user's one-time Curve25519 key
      * @return the session id for the outbound session.
      */
-    fun createOutboundSession(theirIdentityKey: String, theirOneTimeKey: String): String? {
+    @Synchronized fun createOutboundSession(theirIdentityKey: String, theirOneTimeKey: String): String? {
         Timber.v("## createOutboundSession() ; theirIdentityKey $theirIdentityKey theirOneTimeKey $theirOneTimeKey")
         var olmSession: OlmSession? = null
 
@@ -235,7 +235,7 @@ internal class MXOlmDevice @Inject constructor(
      * @param ciphertext             base64-encoded body from the received message.
      * @return {{payload: string, session_id: string}} decrypted payload, and session id of new session.
      */
-    fun createInboundSession(theirDeviceIdentityKey: String, messageType: Int, ciphertext: String): Map<String, String>? {
+    @Synchronized fun createInboundSession(theirDeviceIdentityKey: String, messageType: Int, ciphertext: String): Map<String, String>? {
         Timber.v("## createInboundSession() : theirIdentityKey: $theirDeviceIdentityKey")
 
         var olmSession: OlmSession? = null
@@ -674,7 +674,7 @@ internal class MXOlmDevice @Inject constructor(
      * @return the decrypting result. Nil if the sessionId is unknown.
      */
     @Throws(MXCryptoError::class)
-    fun decryptGroupMessage(body: String,
+    @Synchronized fun decryptGroupMessage(body: String,
                             roomId: String,
                             timeline: String?,
                             sessionId: String,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/MXOlmDevice.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/MXOlmDevice.kt
@@ -119,7 +119,7 @@ internal class MXOlmDevice @Inject constructor(
     /**
      * @return The current (unused, unpublished) one-time keys for this account.
      */
-    @Synchronized fun getOneTimeKeys(): Map<String, Map<String, String>>? {
+    fun getOneTimeKeys(): Map<String, Map<String, String>>? {
         try {
             return store.getOlmAccount().oneTimeKeys()
         } catch (e: Exception) {
@@ -132,7 +132,7 @@ internal class MXOlmDevice @Inject constructor(
     /**
      * @return The maximum number of one-time keys the olm account can store.
      */
-    @Synchronized fun getMaxNumberOfOneTimeKeys(): Long {
+    fun getMaxNumberOfOneTimeKeys(): Long {
         return store.getOlmAccount().maxOneTimeKeys()
     }
 
@@ -153,7 +153,7 @@ internal class MXOlmDevice @Inject constructor(
      * @param message the message to be signed.
      * @return the base64-encoded signature.
      */
-    @Synchronized fun signMessage(message: String): String? {
+    fun signMessage(message: String): String? {
         try {
             return store.getOlmAccount().signMessage(message)
         } catch (e: Exception) {
@@ -166,7 +166,7 @@ internal class MXOlmDevice @Inject constructor(
     /**
      * Marks all of the one-time keys as published.
      */
-    @Synchronized fun markKeysAsPublished() {
+    fun markKeysAsPublished() {
         try {
             store.getOlmAccount().markOneTimeKeysAsPublished()
             store.saveOlmAccount()
@@ -180,7 +180,7 @@ internal class MXOlmDevice @Inject constructor(
      *
      * @param numKeys number of keys to generate
      */
-    @Synchronized fun generateOneTimeKeys(numKeys: Int) {
+    fun generateOneTimeKeys(numKeys: Int) {
         try {
             store.getOlmAccount().generateOneTimeKeys(numKeys)
             store.saveOlmAccount()
@@ -197,7 +197,7 @@ internal class MXOlmDevice @Inject constructor(
      * @param theirOneTimeKey  the remote user's one-time Curve25519 key
      * @return the session id for the outbound session.
      */
-    @Synchronized fun createOutboundSession(theirIdentityKey: String, theirOneTimeKey: String): String? {
+    fun createOutboundSession(theirIdentityKey: String, theirOneTimeKey: String): String? {
         Timber.v("## createOutboundSession() ; theirIdentityKey $theirIdentityKey theirOneTimeKey $theirOneTimeKey")
         var olmSession: OlmSession? = null
 
@@ -235,7 +235,7 @@ internal class MXOlmDevice @Inject constructor(
      * @param ciphertext             base64-encoded body from the received message.
      * @return {{payload: string, session_id: string}} decrypted payload, and session id of new session.
      */
-    @Synchronized fun createInboundSession(theirDeviceIdentityKey: String, messageType: Int, ciphertext: String): Map<String, String>? {
+    fun createInboundSession(theirDeviceIdentityKey: String, messageType: Int, ciphertext: String): Map<String, String>? {
         Timber.v("## createInboundSession() : theirIdentityKey: $theirDeviceIdentityKey")
 
         var olmSession: OlmSession? = null

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/MXOlmDevice.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/MXOlmDevice.kt
@@ -674,7 +674,7 @@ internal class MXOlmDevice @Inject constructor(
      * @return the decrypting result. Nil if the sessionId is unknown.
      */
     @Throws(MXCryptoError::class)
-    @Synchronized fun decryptGroupMessage(body: String,
+    fun decryptGroupMessage(body: String,
                             roomId: String,
                             timeline: String?,
                             sessionId: String,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/SimpleSendToDeviceWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/SimpleSendToDeviceWorker.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.crypto
+
+import android.content.Context
+import androidx.work.WorkerParameters
+import com.squareup.moshi.JsonClass
+import org.matrix.android.sdk.api.failure.shouldBeRetried
+import org.matrix.android.sdk.internal.crypto.model.MXUsersDevicesMap
+import org.matrix.android.sdk.internal.crypto.model.toDebugString
+import org.matrix.android.sdk.internal.crypto.tasks.SendToDeviceTask
+import org.matrix.android.sdk.internal.crypto.tasks.createUniqueTxnId
+import org.matrix.android.sdk.internal.session.SessionComponent
+import org.matrix.android.sdk.internal.worker.SessionSafeCoroutineWorker
+import org.matrix.android.sdk.internal.worker.SessionWorkerParams
+import timber.log.Timber
+import javax.inject.Inject
+
+internal class SimpleSendToDeviceWorker(context: Context,
+                                        params: WorkerParameters) :
+        SessionSafeCoroutineWorker<SimpleSendToDeviceWorker.Params>(context, params, Params::class.java) {
+
+    @JsonClass(generateAdapter = true)
+    internal data class Params(
+            override val sessionId: String,
+            val eventType: String,
+            val contentMap: Map<String /* userId */, Map<String /* deviceId */, Any>>,
+            val txnId: String? = null,
+            override val lastFailureMessage: String? = null
+    ) : SessionWorkerParams
+
+    @Inject lateinit var sendToDeviceTask: SendToDeviceTask
+
+    override fun injectWith(injector: SessionComponent) {
+        injector.inject(this)
+    }
+
+    override suspend fun doSafeWork(params: Params): Result {
+        // params.txnId should be provided in all cases now. But Params can be deserialized by
+        // the WorkManager from data serialized in a previous version of the application, so without the txnId field.
+        // So if not present, we create a txnId
+        val txnId = params.txnId ?: createUniqueTxnId()
+        val eventType: String = params.eventType
+
+        val sendToDeviceMap = MXUsersDevicesMap<Any>().apply { addEntriesFromRawMap(params.contentMap) }
+
+        try {
+            Timber.d("## CRYPTO | Worker shareUserDevicesKey() $txnId: Sharing megolm session with ${sendToDeviceMap.toDebugString()} ")
+            sendToDeviceTask.execute(
+                    SendToDeviceTask.Params(
+                            eventType = eventType,
+                            contentMap = sendToDeviceMap,
+                            transactionId = txnId
+                    )
+            )
+            Timber.d("## CRYPTO | Worker shareUserDevicesKey() $txnId ... success")
+            return Result.success()
+        } catch (throwable: Throwable) {
+            return if (throwable.shouldBeRetried()) {
+                Timber.d("## CRYPTO | Worker shareUserDevicesKey() $txnId ... schedule retry")
+                Result.retry()
+            } else {
+                Timber.d("## CRYPTO | Worker shareUserDevicesKey() $txnId ... failure")
+                buildErrorResult(params, throwable.localizedMessage ?: "error")
+            }
+        }
+    }
+
+    override fun buildErrorParams(params: Params, message: String): Params {
+        return params.copy(lastFailureMessage = params.lastFailureMessage ?: message)
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/actions/EnsureOlmSessionsForDevicesAction.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/actions/EnsureOlmSessionsForDevicesAction.kt
@@ -37,14 +37,12 @@ internal class EnsureOlmSessionsForDevicesAction @Inject constructor(
         val devicesWithoutSession = ArrayList<CryptoDeviceInfo>()
         val devicesWithSession = MXUsersDevicesMap<MXOlmSessionResult>()
 
-//        val results = MXUsersDevicesMap<MXOlmSessionResult>()
-
         for ((userId, deviceInfos) in devicesByUser) {
             for (deviceInfo in deviceInfos) {
                 val deviceId = deviceInfo.deviceId
                 val key = deviceInfo.identityKey()
                 if (key == null) {
-                    Timber.w("## CRYPTO | Ignoring device (${deviceInfo.userId}|$deviceId) without identity key ")
+                    Timber.w("## CRYPTO | Ignoring device (${deviceInfo.userId}|$deviceId) without identity key")
                     continue
                 }
 
@@ -108,52 +106,8 @@ internal class EnsureOlmSessionsForDevicesAction @Inject constructor(
                 Timber.i("## CRYPTO | skipping otk for $userId|$deviceId because unsupported algorithm")
             }
         }
-//        oneTimeKeys.forEach { userId, deviceId, oneTimeKey ->
-//            if (oneTimeKey.type == oneTimeKeyAlgorithm) {
-//                devicesByUser[userId]?.firstOrNull { it.deviceId == deviceId }?.let { cryptoDeviceInfo ->
-//                    Timber.d("## CRYPTO | creating outbound session for $userId|$deviceId ...")
-//                    val createdSession = verifyKeyAndStartSession(oneTimeKey, userId, cryptoDeviceInfo)
-//                    if (createdSession != null) {
-//                        Timber.d("## CRYPTO | ... created outbound session $createdSession for $userId|$deviceId")
-//                        devicesWithSession.setObject(userId, deviceId, MXOlmSessionResult(cryptoDeviceInfo, createdSession))
-//                    } else {
-//                        Timber.d("## CRYPTO | ... Failed to create outbound session for $userId|$deviceId")
-//                    }
-//                }
-//            } else {
-//                // Skipping this key
-//                Timber.i("## CRYPTO | skiping otk for $userId|$deviceId because unsupported algorithm")
-//            }
-//        }
 
         return devicesWithSession
-//        for ((userId, deviceInfos) in devicesByUser) {
-//            for (deviceInfo in deviceInfos) {
-//                var oneTimeKey: MXKey? = null
-//                val deviceIds = oneTimeKeys.getUserDeviceIds(userId)
-//                if (null != deviceIds) {
-//                    for (deviceId in deviceIds) {
-//                        val olmSessionResult = results.getObject(userId, deviceId)
-//                        if (olmSessionResult!!.sessionId != null && !force) {
-//                            // We already have a result for this device
-//                            continue
-//                        }
-//                        val key = oneTimeKeys.getObject(userId, deviceId)
-//                        if (key?.type == oneTimeKeyAlgorithm) {
-//                            oneTimeKey = key
-//                        }
-//                        if (oneTimeKey == null) {
-//                            Timber.w("## CRYPTO | ensureOlmSessionsForDevices() : No one-time keys " + oneTimeKeyAlgorithm +
-//                                    " for device " + userId + "|" + deviceId)
-//                            continue
-//                        }
-//                        // Update the result for this device in results
-//                        olmSessionResult.sessionId = verifyKeyAndStartSession(oneTimeKey, userId, deviceInfo)
-//                    }
-//                }
-//            }
-//        }
-//        return results
     }
 
     private fun verifyKeyAndStartSession(oneTimeKey: MXKey, userId: String, deviceInfo: CryptoDeviceInfo): String? {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/algorithms/megolm/MXMegolmDecryption.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/algorithms/megolm/MXMegolmDecryption.kt
@@ -335,7 +335,7 @@ internal class MXMegolmDecryption(private val userId: String,
             runCatching { deviceListManager.downloadKeys(listOf(userId), false) }
                     .mapCatching {
                         val deviceId = request.deviceId
-                        val deviceInfo = cryptoStore.getUserDevice(userId, deviceId ?: "")
+                        val deviceInfo = it.getObject(userId, deviceId) // cryptoStore.getUserDevice(userId, deviceId ?: "")
                         if (deviceInfo == null) {
                             throw RuntimeException()
                         } else {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/algorithms/megolm/MXMegolmEncryptionFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/algorithms/megolm/MXMegolmEncryptionFactory.kt
@@ -27,7 +27,9 @@ import org.matrix.android.sdk.internal.crypto.repository.WarnOnUnknownDeviceRepo
 import org.matrix.android.sdk.internal.crypto.store.IMXCryptoStore
 import org.matrix.android.sdk.internal.crypto.tasks.SendToDeviceTask
 import org.matrix.android.sdk.internal.di.DeviceId
+import org.matrix.android.sdk.internal.di.SessionId
 import org.matrix.android.sdk.internal.di.UserId
+import org.matrix.android.sdk.internal.di.WorkManagerProvider
 import javax.inject.Inject
 
 internal class MXMegolmEncryptionFactory @Inject constructor(
@@ -38,27 +40,31 @@ internal class MXMegolmEncryptionFactory @Inject constructor(
         private val ensureOlmSessionsForDevicesAction: EnsureOlmSessionsForDevicesAction,
         @UserId private val userId: String,
         @DeviceId private val deviceId: String?,
+        @SessionId private val sessionId: String,
         private val sendToDeviceTask: SendToDeviceTask,
         private val messageEncrypter: MessageEncrypter,
         private val warnOnUnknownDevicesRepository: WarnOnUnknownDeviceRepository,
         private val coroutineDispatchers: MatrixCoroutineDispatchers,
+        private val workManagerProvider: WorkManagerProvider,
         private val cryptoCoroutineScope: CoroutineScope) {
 
     fun create(roomId: String): MXMegolmEncryption {
         return MXMegolmEncryption(
                 roomId = roomId,
+                matrixSessionId = sessionId,
                 olmDevice = olmDevice,
                 defaultKeysBackupService = defaultKeysBackupService,
                 cryptoStore = cryptoStore,
                 deviceListManager = deviceListManager,
                 ensureOlmSessionsForDevicesAction = ensureOlmSessionsForDevicesAction,
-                userId = userId,
-                deviceId = deviceId!!,
+                myUserId = userId,
+                myDeviceId = deviceId!!,
                 sendToDeviceTask = sendToDeviceTask,
                 messageEncrypter = messageEncrypter,
                 warnOnUnknownDevicesRepository = warnOnUnknownDevicesRepository,
                 coroutineDispatchers = coroutineDispatchers,
-                cryptoCoroutineScope = cryptoCoroutineScope
+                cryptoCoroutineScope = cryptoCoroutineScope,
+                workManagerProvider = workManagerProvider
         )
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/CryptoDeviceInfo.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/CryptoDeviceInfo.kt
@@ -75,3 +75,5 @@ data class CryptoDeviceInfo(
 internal fun CryptoDeviceInfo.toRest(): DeviceKeys {
     return CryptoInfoMapper.map(this)
 }
+
+internal fun CryptoDeviceInfo.toShortDebugString() = "$userId|$deviceId"

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/MXUsersDevicesMap.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/MXUsersDevicesMap.kt
@@ -136,10 +136,10 @@ inline fun <T> MXUsersDevicesMap<T>.forEach(action: (String, String, T) -> Unit)
     }
 }
 
-fun <T> MXUsersDevicesMap<T>.toDebugString() =
+internal  fun <T> MXUsersDevicesMap<T>.toDebugString() =
         map.entries.joinToString { "${it.key} [${it.value.keys.joinToString { it }}]" }
 
-fun <T> MXUsersDevicesMap<T>.toDebugCount() =
+internal fun <T> MXUsersDevicesMap<T>.toDebugCount() =
         map.entries.fold(0) { acc, new ->
             acc + new.value.keys.size
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/MXUsersDevicesMap.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/MXUsersDevicesMap.kt
@@ -115,6 +115,12 @@ class MXUsersDevicesMap<E> {
         }
     }
 
+    fun addEntriesFromRawMap(other: Map<String /* userId */, Map<String /* deviceId */, E>>) {
+        other.forEach { (userID, deviceList) ->
+            setObjects(userID, deviceList)
+        }
+    }
+
     override fun toString(): String {
         return "MXUsersDevicesMap $map"
     }
@@ -129,3 +135,11 @@ inline fun <T> MXUsersDevicesMap<T>.forEach(action: (String, String, T) -> Unit)
         }
     }
 }
+
+fun <T> MXUsersDevicesMap<T>.toDebugString() =
+        map.entries.joinToString { "${it.key} [${it.value.keys.joinToString { it }}]" }
+
+fun <T> MXUsersDevicesMap<T>.toDebugCount() =
+        map.entries.fold(0) { acc, new ->
+            acc + new.value.keys.size
+        }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionComponent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionComponent.kt
@@ -25,6 +25,7 @@ import org.matrix.android.sdk.internal.crypto.CancelGossipRequestWorker
 import org.matrix.android.sdk.internal.crypto.CryptoModule
 import org.matrix.android.sdk.internal.crypto.SendGossipRequestWorker
 import org.matrix.android.sdk.internal.crypto.SendGossipWorker
+import org.matrix.android.sdk.internal.crypto.SimpleSendToDeviceWorker
 import org.matrix.android.sdk.internal.crypto.crosssigning.UpdateTrustWorker
 import org.matrix.android.sdk.internal.crypto.verification.SendVerificationMessageWorker
 import org.matrix.android.sdk.internal.di.MatrixComponent
@@ -141,6 +142,8 @@ internal interface SessionComponent {
     fun inject(worker: SendGossipWorker)
 
     fun inject(worker: UpdateTrustWorker)
+
+    fun inject(worker: SimpleSendToDeviceWorker)
 
     @Component.Factory
     interface Factory {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/CryptoSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/CryptoSyncHandler.kt
@@ -46,6 +46,7 @@ internal class CryptoSyncHandler @Inject constructor(private val cryptoService: 
                     event.getClearContent()?.toModel<MessageContent>()?.msgType == "m.bad.encrypted") {
                 Timber.e("## CRYPTO | handleToDeviceEvent() : Warning: Unable to decrypt to-device event : ${event.content}")
             } else {
+                Timber.i("## CRYPTO | Decrypted to device event from ${event.senderId} of type:${event.type}")
                 verificationService.onToDeviceEvent(event)
                 cryptoService.onToDeviceEvent(event)
             }


### PR DESCRIPTION
Some quick improvment for key sharing.

1) Some cleaning on key share by slice, stop using reccursion use chunks
2) More reliable key delivery by using a fallback worker in case the initial send to device failed
2) Added a bit more logs, and more consistent with what js sdk is logging to improve RS handling.
3) ~~Also added some basic @Synchronized when using olm lib as it's not thread safe (account access should be locked, inboud session also)...~~
