### PR TITLE
Sign out crash - Realm configuration mismatch 

### DIFF
--- a/changelog.d/4480.bugfix
+++ b/changelog.d/4480.bugfix
@@ -1,0 +1,1 @@
+Fixes intermittent crash on sign out due to the session being incorrectly recreated whilst being closed

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
@@ -174,8 +174,8 @@ internal class DefaultSession @Inject constructor(
             lifecycleObservers.forEach {
                 it.onSessionStarted(this)
             }
-            sessionListeners.dispatch { _, listener ->
-                listener.onSessionStarted(this)
+            dispatchTo(sessionListeners) { session, listener ->
+                listener.onSessionStarted(session)
             }
         }
     }
@@ -217,8 +217,8 @@ internal class DefaultSession @Inject constructor(
         // timelineEventDecryptor.destroy()
         uiHandler.post {
             lifecycleObservers.forEach { it.onSessionStopped(this) }
-            sessionListeners.dispatch { _, listener ->
-                listener.onSessionStopped(this)
+            dispatchTo(sessionListeners) { session, listener ->
+                listener.onSessionStopped(session)
             }
         }
         cryptoService.get().close()
@@ -249,8 +249,8 @@ internal class DefaultSession @Inject constructor(
             lifecycleObservers.forEach {
                 it.onClearCache(this)
             }
-            sessionListeners.dispatch { _, listener ->
-                listener.onClearCache(this)
+            dispatchTo(sessionListeners) { session, listener ->
+                listener.onClearCache(session)
             }
         }
         withContext(NonCancellable) {
@@ -260,8 +260,8 @@ internal class DefaultSession @Inject constructor(
     }
 
     override fun onGlobalError(globalError: GlobalError) {
-        sessionListeners.dispatch { _, listener ->
-            listener.onGlobalError(this, globalError)
+        dispatchTo(sessionListeners) { session, listener ->
+            listener.onGlobalError(session, globalError)
         }
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
@@ -20,14 +20,13 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import com.zhuinden.monarchy.Monarchy
 import org.matrix.android.sdk.api.pushrules.PushRuleService
 import org.matrix.android.sdk.api.pushrules.RuleScope
+import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.initsync.InitSyncStep
 import org.matrix.android.sdk.api.session.sync.model.GroupsSyncResponse
 import org.matrix.android.sdk.api.session.sync.model.RoomsSyncResponse
 import org.matrix.android.sdk.api.session.sync.model.SyncResponse
-import org.matrix.android.sdk.internal.SessionManager
 import org.matrix.android.sdk.internal.crypto.DefaultCryptoService
 import org.matrix.android.sdk.internal.di.SessionDatabase
-import org.matrix.android.sdk.internal.di.SessionId
 import org.matrix.android.sdk.internal.di.WorkManagerProvider
 import org.matrix.android.sdk.internal.session.SessionListeners
 import org.matrix.android.sdk.internal.session.dispatchTo
@@ -52,7 +51,7 @@ private const val GET_GROUP_DATA_WORKER = "GET_GROUP_DATA_WORKER"
 
 internal class SyncResponseHandler @Inject constructor(
         @SessionDatabase private val monarchy: Monarchy,
-        @SessionId private val sessionId: String,
+        private val session: Session,
         private val sessionListeners: SessionListeners,
         private val workManagerProvider: WorkManagerProvider,
         private val roomSyncHandler: RoomSyncHandler,
@@ -65,7 +64,6 @@ internal class SyncResponseHandler @Inject constructor(
         private val processEventForPushTask: ProcessEventForPushTask,
         private val pushRuleService: PushRuleService,
         private val presenceSyncHandler: PresenceSyncHandler,
-        private val sessionManager: SessionManager
 ) {
 
     suspend fun handleResponse(syncResponse: SyncResponse,
@@ -161,7 +159,6 @@ internal class SyncResponseHandler @Inject constructor(
     }
 
     private fun dispatchInvitedRoom(roomsSyncResponse: RoomsSyncResponse) {
-        val session = sessionManager.getSessionComponent(sessionId)?.session()
         roomsSyncResponse.invite.keys.forEach { roomId ->
             session.dispatchTo(sessionListeners) { session, listener ->
                 listener.onNewInvitedRoom(session, roomId)
@@ -182,7 +179,7 @@ internal class SyncResponseHandler @Inject constructor(
             return
         }
         Timber.v("There are ${groupIds.size} new groups to fetch data for.")
-        val getGroupDataWorkerParams = GetGroupDataWorker.Params(sessionId)
+        val getGroupDataWorkerParams = GetGroupDataWorker.Params(session.sessionId)
         val workData = WorkerParamsFactory.toData(getGroupDataWorkerParams)
 
         val getGroupWork = workManagerProvider.matrixPeriodicWorkRequestBuilder<GetGroupDataWorker>(1, TimeUnit.HOURS)


### PR DESCRIPTION
Fixes an intermittent crash on sign out caused by a race condition where we attempt to access an already closed session causing it to be recreated which in turn causes realm to crash because the new session is slightly different.


the race condition boils down to...

```kotlin
sessionComponents.remove(sessionId)

runOnUiThread {
  if (sessionParamsStore[sessionId] != null) {
    val session = sessionComponents.getOrCreate(sessionId).session()
    onStopped(session)
  }
} 

sessionParamsStore.delete(sessionId)
```


- The solution is to avoid using the `SessionManager` within the `SessionListeners` and instead pass the current session directly (to avoid creating a new one), which we were already doing in most cases


| BEFORE | AFTER |
| --- | --- |
|![before-signout](https://user-images.githubusercontent.com/1848238/142009024-0db7a195-4930-4238-bef3-715aea91fe1b.gif)|![after-signout-crash](https://user-images.githubusercontent.com/1848238/142009015-3da57d04-2b20-4123-9c76-0f4874dd39c1.gif)
