### PR TITLE
Non dismissing notifications

### DIFF
--- a/vector/src/main/java/im/vector/app/VectorApplication.kt
+++ b/vector/src/main/java/im/vector/app/VectorApplication.kt
@@ -175,8 +175,7 @@ class VectorApplication :
             }
 
             override fun onPause(owner: LifecycleOwner) {
-                Timber.i("App entered background") // call persistInfo
-                notificationDrawerManager.persistInfo()
+                Timber.i("App entered background")
                 FcmHelper.onEnterBackground(appContext, vectorPreferences, activeSessionHolder)
             }
         })

--- a/vector/src/main/java/im/vector/app/features/MainActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/MainActivity.kt
@@ -116,7 +116,6 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
     private fun clearNotifications() {
         // Dismiss all notifications
         notificationDrawerManager.clearAllEvents()
-        notificationDrawerManager.persistInfo()
 
         // Also clear the dynamic shortcuts
         shortcutsHandler.clearShortcuts()

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
@@ -161,7 +161,7 @@ class NotificationDrawerManager @Inject constructor(private val context: Context
             notificationState.clearAndAddRenderedEvents(eventsToRender)
             val session = currentSession ?: return
             renderEvents(session, eventsToRender)
-            notificationState.persistState(context, session)
+            notificationState.persist(context, session)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
@@ -86,7 +86,7 @@ class NotificationDrawerManager @Inject constructor(private val context: Context
             Timber.d("onNotifiableEventReceived(): is push: ${notifiableEvent.canBeReplaced}")
         }
 
-        add(notifiableEvent, notificationState.seenEventIds)
+        add(notifiableEvent)
     }
 
     /**

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationEventPersistence.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationEventPersistence.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.notifications
+
+import android.content.Context
+import org.matrix.android.sdk.api.session.Session
+import timber.log.Timber
+import java.io.File
+import java.io.FileOutputStream
+
+// TODO Multi-account
+private const val ROOMS_NOTIFICATIONS_FILE_NAME = "im.vector.notifications.cache"
+private const val KEY_ALIAS_SECRET_STORAGE = "notificationMgr"
+
+object NotificationEventPersistence {
+
+    fun loadEvents(context: Context, currentSession: Session?): NotificationEventQueue {
+        try {
+            val file = File(context.applicationContext.cacheDir, ROOMS_NOTIFICATIONS_FILE_NAME)
+            if (file.exists()) {
+                file.inputStream().use {
+                    val events: ArrayList<NotifiableEvent>? = currentSession?.loadSecureSecret(it, KEY_ALIAS_SECRET_STORAGE)
+                    if (events != null) {
+                        return NotificationEventQueue(events.toMutableList())
+                    }
+                }
+            }
+        } catch (e: Throwable) {
+            Timber.e(e, "## Failed to load cached notification info")
+        }
+        return NotificationEventQueue()
+    }
+
+    fun persistEvents(queuedEvents: NotificationEventQueue, context: Context, currentSession: Session) {
+        synchronized(queuedEvents) {
+            if (queuedEvents.isEmpty()) {
+                deleteCachedRoomNotifications(context)
+                return
+            }
+            try {
+                val file = File(context.applicationContext.cacheDir, ROOMS_NOTIFICATIONS_FILE_NAME)
+                if (!file.exists()) file.createNewFile()
+                FileOutputStream(file).use {
+                    currentSession.securelyStoreObject(queuedEvents.rawEvents(), KEY_ALIAS_SECRET_STORAGE, it)
+                }
+            } catch (e: Throwable) {
+                Timber.e(e, "## Failed to save cached notification info")
+            }
+        }
+    }
+
+    private fun deleteCachedRoomNotifications(context: Context) {
+        val file = File(context.applicationContext.cacheDir, ROOMS_NOTIFICATIONS_FILE_NAME)
+        if (file.exists()) {
+            file.delete()
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationEventPersistence.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationEventPersistence.kt
@@ -28,21 +28,21 @@ private const val KEY_ALIAS_SECRET_STORAGE = "notificationMgr"
 
 object NotificationEventPersistence {
 
-    fun loadEvents(context: Context, currentSession: Session?): NotificationEventQueue {
+    fun loadEvents(context: Context, currentSession: Session?, factory: (List<NotifiableEvent>) -> NotificationEventQueue): NotificationEventQueue {
         try {
             val file = File(context.applicationContext.cacheDir, ROOMS_NOTIFICATIONS_FILE_NAME)
             if (file.exists()) {
                 file.inputStream().use {
                     val events: ArrayList<NotifiableEvent>? = currentSession?.loadSecureSecret(it, KEY_ALIAS_SECRET_STORAGE)
                     if (events != null) {
-                        return NotificationEventQueue(events.toMutableList())
+                        return factory(events)
                     }
                 }
             }
         } catch (e: Throwable) {
             Timber.e(e, "## Failed to load cached notification info")
         }
-        return NotificationEventQueue()
+        return factory(emptyList())
     }
 
     fun persistEvents(queuedEvents: NotificationEventQueue, context: Context, currentSession: Session) {

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationEventQueue.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationEventQueue.kt
@@ -19,7 +19,14 @@ package im.vector.app.features.notifications
 import timber.log.Timber
 
 class NotificationEventQueue(
-        private val queue: MutableList<NotifiableEvent> = mutableListOf()
+        private val queue: MutableList<NotifiableEvent> = mutableListOf(),
+
+        /**
+         * An in memory FIFO cache of the seen events.
+         * Acts as a notification debouncer to stop already dismissed push notifications from
+         * displaying again when the /sync response is delayed.
+         */
+        private val seenEventIds: CircularCache<String>
 ) {
 
     fun markRedacted(eventIds: List<String>) {
@@ -57,7 +64,7 @@ class NotificationEventQueue(
         queue.clear()
     }
 
-    fun add(notifiableEvent: NotifiableEvent, seenEventIds: CircularCache<String>) {
+    fun add(notifiableEvent: NotifiableEvent) {
         val existing = findExistingById(notifiableEvent)
         val edited = findEdited(notifiableEvent)
         when {

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationEventQueue.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationEventQueue.kt
@@ -18,8 +18,8 @@ package im.vector.app.features.notifications
 
 import timber.log.Timber
 
-class NotificationEventQueue(
-        private val queue: MutableList<NotifiableEvent> = mutableListOf(),
+data class NotificationEventQueue(
+        private val queue: MutableList<NotifiableEvent>,
 
         /**
          * An in memory FIFO cache of the seen events.

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationState.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationState.kt
@@ -18,13 +18,6 @@ package im.vector.app.features.notifications
 
 import android.content.Context
 import org.matrix.android.sdk.api.session.Session
-import timber.log.Timber
-import java.io.File
-import java.io.FileOutputStream
-
-// TODO Mutliaccount
-private const val ROOMS_NOTIFICATIONS_FILE_NAME = "im.vector.notifications.cache"
-private const val KEY_ALIAS_SECRET_STORAGE = "notificationMgr"
 
 class NotificationState(
         /**
@@ -65,57 +58,20 @@ class NotificationState(
 
     fun hasAlreadyRendered(eventsToRender: List<ProcessedEvent<NotifiableEvent>>) = renderedEvents == eventsToRender
 
-    fun persistState(context: Context, currentSession: Session) {
-        synchronized(queuedEvents) {
-            if (queuedEvents.isEmpty()) {
-                deleteCachedRoomNotifications(context)
-                return
-            }
-            try {
-                val file = File(context.applicationContext.cacheDir, ROOMS_NOTIFICATIONS_FILE_NAME)
-                if (!file.exists()) file.createNewFile()
-                FileOutputStream(file).use {
-                    currentSession.securelyStoreObject(queuedEvents.rawEvents(), KEY_ALIAS_SECRET_STORAGE, it)
-                }
-            } catch (e: Throwable) {
-                Timber.e(e, "## Failed to save cached notification info")
-            }
-        }
-    }
-
-    private fun deleteCachedRoomNotifications(context: Context) {
-        val file = File(context.applicationContext.cacheDir, ROOMS_NOTIFICATIONS_FILE_NAME)
-        if (file.exists()) {
-            file.delete()
-        }
+    fun persist(context: Context, session: Session) {
+        NotificationEventPersistence.persistEvents(queuedEvents, context, session)
     }
 
     companion object {
 
         fun createInitialNotificationState(context: Context, currentSession: Session?): NotificationState {
-            val queuedEvents = loadEventInfo(context, currentSession)
+            val queuedEvents = NotificationEventPersistence.loadEvents(context, currentSession)
             return NotificationState(
                     queuedEvents = queuedEvents,
                     renderedEvents = queuedEvents.rawEvents().map { ProcessedEvent(ProcessedEvent.Type.KEEP, it) }.toMutableList(),
                     seenEventIds = CircularCache.create(cacheSize = 25)
             )
         }
-
-        private fun loadEventInfo(context: Context, currentSession: Session?): NotificationEventQueue {
-            try {
-                val file = File(context.applicationContext.cacheDir, ROOMS_NOTIFICATIONS_FILE_NAME)
-                if (file.exists()) {
-                    file.inputStream().use {
-                        val events: ArrayList<NotifiableEvent>? = currentSession?.loadSecureSecret(it, KEY_ALIAS_SECRET_STORAGE)
-                        if (events != null) {
-                            return NotificationEventQueue(events.toMutableList())
-                        }
-                    }
-                }
-            } catch (e: Throwable) {
-                Timber.e(e, "## Failed to load cached notification info")
-            }
-            return NotificationEventQueue()
-        }
     }
 }
+

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationState.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationState.kt
@@ -16,9 +16,6 @@
 
 package im.vector.app.features.notifications
 
-import android.content.Context
-import org.matrix.android.sdk.api.session.Session
-
 class NotificationState(
         /**
          * The notifiable events queued for rendering or currently rendered
@@ -53,18 +50,9 @@ class NotificationState(
 
     fun hasAlreadyRendered(eventsToRender: List<ProcessedEvent<NotifiableEvent>>) = renderedEvents == eventsToRender
 
-    fun persist(context: Context, session: Session) {
-        NotificationEventPersistence.persistEvents(queuedEvents, context, session)
-    }
-
-    companion object {
-
-        fun createInitialNotificationState(context: Context, currentSession: Session?): NotificationState {
-            val queuedEvents = NotificationEventPersistence.loadEvents(context, currentSession, factory = { rawEvents ->
-                NotificationEventQueue(rawEvents.toMutableList(), seenEventIds = CircularCache.create(cacheSize = 25))
-            })
-            val renderedEvents = queuedEvents.rawEvents().map { ProcessedEvent(ProcessedEvent.Type.KEEP, it) }.toMutableList()
-            return NotificationState(queuedEvents, renderedEvents)
+    fun queuedEvents(block: (NotificationEventQueue) -> Unit) {
+        synchronized(queuedEvents) {
+            block(queuedEvents)
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationState.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationState.kt
@@ -39,7 +39,8 @@ class NotificationState(
         private val renderedEvents: MutableList<ProcessedEvent<NotifiableEvent>>,
 ) {
 
-    fun <T> updateQueuedEvents(drawerManager: NotificationDrawerManager, action: NotificationDrawerManager.(NotificationEventQueue, List<ProcessedEvent<NotifiableEvent>>) -> T): T {
+    fun <T> updateQueuedEvents(drawerManager: NotificationDrawerManager,
+                               action: NotificationDrawerManager.(NotificationEventQueue, List<ProcessedEvent<NotifiableEvent>>) -> T): T {
         return synchronized(queuedEvents) {
             action(drawerManager, queuedEvents, renderedEvents)
         }

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationState.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationState.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.notifications
+
+import android.content.Context
+import org.matrix.android.sdk.api.session.Session
+import timber.log.Timber
+import java.io.File
+import java.io.FileOutputStream
+
+// TODO Mutliaccount
+private const val ROOMS_NOTIFICATIONS_FILE_NAME = "im.vector.notifications.cache"
+private const val KEY_ALIAS_SECRET_STORAGE = "notificationMgr"
+
+class NotificationState(
+        /**
+         * The notifiable events to render
+         * this is our source of truth for notifications, any changes to this list will be rendered as notifications
+         * when events are removed the previously rendered notifications will be cancelled
+         * when adding or updating, the notifications will be notified
+         *
+         * Events are unique by their properties, we should be careful not to insert multiple events with the same event-id
+         */
+        private val queuedEvents: NotificationEventQueue,
+
+        /**
+         * The last known rendered notifiable events
+         * we keep track of them in order to know which events have been removed from the eventList
+         * allowing us to cancel any notifications previous displayed by now removed events
+         */
+        private val renderedEvents: MutableList<ProcessedEvent<NotifiableEvent>>,
+
+        /**
+         * An in memory FIFO cache of the seen events.
+         * Acts as a notification debouncer to stop already dismissed push notifications from
+         * displaying again when the /sync response is delayed.
+         */
+        val seenEventIds: CircularCache<String>
+) {
+
+    fun <T> updateQueuedEvents(drawerManager: NotificationDrawerManager, action: NotificationDrawerManager.(NotificationEventQueue, List<ProcessedEvent<NotifiableEvent>>) -> T): T {
+        return synchronized(queuedEvents) {
+            action(drawerManager, queuedEvents, renderedEvents)
+        }
+    }
+
+    fun clearAndAddRenderedEvents(eventsToRender: List<ProcessedEvent<NotifiableEvent>>) {
+        renderedEvents.clear()
+        renderedEvents.addAll(eventsToRender)
+    }
+
+    fun hasAlreadyRendered(eventsToRender: List<ProcessedEvent<NotifiableEvent>>) = renderedEvents == eventsToRender
+
+    fun persistState(context: Context, currentSession: Session) {
+        synchronized(queuedEvents) {
+            if (queuedEvents.isEmpty()) {
+                deleteCachedRoomNotifications(context)
+                return
+            }
+            try {
+                val file = File(context.applicationContext.cacheDir, ROOMS_NOTIFICATIONS_FILE_NAME)
+                if (!file.exists()) file.createNewFile()
+                FileOutputStream(file).use {
+                    currentSession.securelyStoreObject(queuedEvents.rawEvents(), KEY_ALIAS_SECRET_STORAGE, it)
+                }
+            } catch (e: Throwable) {
+                Timber.e(e, "## Failed to save cached notification info")
+            }
+        }
+    }
+
+    private fun deleteCachedRoomNotifications(context: Context) {
+        val file = File(context.applicationContext.cacheDir, ROOMS_NOTIFICATIONS_FILE_NAME)
+        if (file.exists()) {
+            file.delete()
+        }
+    }
+
+    companion object {
+
+        fun createInitialNotificationState(context: Context, currentSession: Session?): NotificationState {
+            val queuedEvents = loadEventInfo(context, currentSession)
+            return NotificationState(
+                    queuedEvents = queuedEvents,
+                    renderedEvents = queuedEvents.rawEvents().map { ProcessedEvent(ProcessedEvent.Type.KEEP, it) }.toMutableList(),
+                    seenEventIds = CircularCache.create(cacheSize = 25)
+            )
+        }
+
+        private fun loadEventInfo(context: Context, currentSession: Session?): NotificationEventQueue {
+            try {
+                val file = File(context.applicationContext.cacheDir, ROOMS_NOTIFICATIONS_FILE_NAME)
+                if (file.exists()) {
+                    file.inputStream().use {
+                        val events: ArrayList<NotifiableEvent>? = currentSession?.loadSecureSecret(it, KEY_ALIAS_SECRET_STORAGE)
+                        if (events != null) {
+                            return NotificationEventQueue(events.toMutableList())
+                        }
+                    }
+                }
+            } catch (e: Throwable) {
+                Timber.e(e, "## Failed to load cached notification info")
+            }
+            return NotificationEventQueue()
+        }
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/notifications/NotificationEventQueueTest.kt
+++ b/vector/src/test/java/im/vector/app/features/notifications/NotificationEventQueueTest.kt
@@ -126,7 +126,7 @@ class NotificationEventQueueTest {
     fun `given no events when adding then adds event`() {
         val queue = givenQueue(listOf())
 
-        queue.add(aSimpleNotifiableEvent(), seenEventIds = seenIdsCache)
+        queue.add(aSimpleNotifiableEvent())
 
         queue.rawEvents() shouldBeEqualTo listOf(aSimpleNotifiableEvent())
     }
@@ -137,7 +137,7 @@ class NotificationEventQueueTest {
         val notifiableEvent = aSimpleNotifiableEvent()
         seenIdsCache.put(notifiableEvent.eventId)
 
-        queue.add(notifiableEvent, seenEventIds = seenIdsCache)
+        queue.add(notifiableEvent)
 
         queue.rawEvents() shouldBeEqualTo emptyList()
     }
@@ -148,7 +148,7 @@ class NotificationEventQueueTest {
         val updatedEvent = replaceableEvent.copy(title = "updated title")
         val queue = givenQueue(listOf(replaceableEvent))
 
-        queue.add(updatedEvent, seenEventIds = seenIdsCache)
+        queue.add(updatedEvent)
 
         queue.rawEvents() shouldBeEqualTo listOf(updatedEvent)
     }
@@ -159,7 +159,7 @@ class NotificationEventQueueTest {
         val updatedEvent = nonReplaceableEvent.copy(title = "updated title")
         val queue = givenQueue(listOf(nonReplaceableEvent))
 
-        queue.add(updatedEvent, seenEventIds = seenIdsCache)
+        queue.add(updatedEvent)
 
         queue.rawEvents() shouldBeEqualTo listOf(nonReplaceableEvent)
     }
@@ -170,7 +170,7 @@ class NotificationEventQueueTest {
         val updatedEvent = editedEvent.copy(eventId = "1", editedEventId = "id-to-edit", title = "updated title")
         val queue = givenQueue(listOf(editedEvent))
 
-        queue.add(updatedEvent, seenEventIds = seenIdsCache)
+        queue.add(updatedEvent)
 
         queue.rawEvents() shouldBeEqualTo listOf(updatedEvent)
     }
@@ -181,7 +181,7 @@ class NotificationEventQueueTest {
         val updatedEvent = editedEvent.copy(eventId = "1", editedEventId = "id-to-edit", title = "updated title")
         val queue = givenQueue(listOf(editedEvent))
 
-        queue.add(updatedEvent, seenEventIds = seenIdsCache)
+        queue.add(updatedEvent)
 
         queue.rawEvents() shouldBeEqualTo listOf(updatedEvent)
     }
@@ -212,5 +212,5 @@ class NotificationEventQueueTest {
         queue.rawEvents() shouldBeEqualTo listOf(anInviteNotifiableEvent(roomId = roomId))
     }
 
-    private fun givenQueue(events: List<NotifiableEvent>) = NotificationEventQueue(events.toMutableList())
+    private fun givenQueue(events: List<NotifiableEvent>) = NotificationEventQueue(events.toMutableList(), seenEventIds = seenIdsCache)
 }


### PR DESCRIPTION
Fixes #4505 Notifications not automatically dismissing, this is caused by the in memory tracking being out of sync.

The most likely trigger of this issue is the android OS reclaiming memory and killing the Element app whilst it's idle in the background (which is perfectly normal)  

- The loading of the persisted events was happening before the current session was active which meant we weren't able to read any previously persisted events.
- Preloads the in memory cache of rendered events with the last known persisted events (this fixes the original issue)
- Persists the event queue every time we receive a new event instead of when the app moves to the background, this allows us to handle crash cashes where the app doesn't gracefully move to the background 
- Also extracts out the `NotificationState` and persistence to their own classes/files

| BEFORE | AFTER | 
| --- | --- |
|![before-notifications-staying](https://user-images.githubusercontent.com/1848238/142424383-967ad5fe-f2ec-4d0c-a180-a51ddc666bdb.gif)|![after-dismiss-notification](https://user-images.githubusercontent.com/1848238/142424376-f1de447a-1eb2-4a65-b30a-3ad3d372a32e.gif)
