### PR TITLE
Fix "@JvmStatic used for @Provides function in an object class" Lint warning

### DIFF
--- a/vector/lint.xml
+++ b/vector/lint.xml
@@ -84,4 +84,7 @@
     <!-- Bug in lint agp 4.1 incorrectly thinks kotlin forEach is using java 8 API's. -->
     <!-- FIXME this workaround should be removed in a near future -->
     <issue id="NewApi" severity="warning" />
+
+    <!-- DI -->
+    <issue id="JvmStaticProvidesInObjectDetector" severity="error" />
 </lint>

--- a/vector/src/fdroid/java/im/vector/app/di/FlavorModule.kt
+++ b/vector/src/fdroid/java/im/vector/app/di/FlavorModule.kt
@@ -25,16 +25,12 @@ import im.vector.app.core.services.GuardServiceStarter
 import im.vector.app.fdroid.service.FDroidGuardServiceStarter
 import im.vector.app.features.settings.VectorPreferences
 
-@Module
 @InstallIn(SingletonComponent::class)
-abstract class FlavorModule {
+@Module
+object FlavorModule {
 
-    companion object {
-
-        @Provides
-        @JvmStatic
-        fun provideGuardServiceStarter(preferences: VectorPreferences, appContext: Context): GuardServiceStarter {
-            return FDroidGuardServiceStarter(preferences, appContext)
-        }
+    @Provides
+    fun provideGuardServiceStarter(preferences: VectorPreferences, appContext: Context): GuardServiceStarter {
+        return FDroidGuardServiceStarter(preferences, appContext)
     }
 }

--- a/vector/src/gplay/java/im/vector/app/di/FlavorModule.kt
+++ b/vector/src/gplay/java/im/vector/app/di/FlavorModule.kt
@@ -24,14 +24,10 @@ import im.vector.app.core.services.GuardServiceStarter
 
 @InstallIn(SingletonComponent::class)
 @Module
-abstract class FlavorModule {
+object FlavorModule {
 
-    companion object {
-
-        @Provides
-        @JvmStatic
-        fun provideGuardServiceStarter(): GuardServiceStarter {
-            return object : GuardServiceStarter {}
-        }
+    @Provides
+    fun provideGuardServiceStarter(): GuardServiceStarter {
+        return object : GuardServiceStarter {}
     }
 }

--- a/vector/src/main/java/im/vector/app/core/di/HomeModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/HomeModule.kt
@@ -28,7 +28,6 @@ import im.vector.app.features.home.room.detail.timeline.helper.TimelineAsyncHelp
 @InstallIn(ActivityComponent::class)
 object HomeModule {
     @Provides
-    @JvmStatic
     @TimelineEventControllerHandler
     fun providesTimelineBackgroundHandler(): Handler {
         return TimelineAsyncHelper.getBackgroundHandler()

--- a/vector/src/main/java/im/vector/app/core/di/ScreenModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/ScreenModule.kt
@@ -30,11 +30,9 @@ import im.vector.app.core.glide.GlideApp
 object ScreenModule {
 
     @Provides
-    @JvmStatic
     fun providesGlideRequests(context: AppCompatActivity) = GlideApp.with(context)
 
     @Provides
-    @JvmStatic
     @ActivityScoped
     fun providesSharedViewPool() = RecyclerView.RecycledViewPool()
 }

--- a/vector/src/main/java/im/vector/app/core/di/SingletonModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/SingletonModule.kt
@@ -73,69 +73,58 @@ abstract class VectorBindModule {
 object VectorStaticModule {
 
     @Provides
-    @JvmStatic
     fun providesContext(application: Application): Context {
         return application.applicationContext
     }
 
     @Provides
-    @JvmStatic
     fun providesResources(context: Context): Resources {
         return context.resources
     }
 
     @Provides
-    @JvmStatic
     fun providesSharedPreferences(context: Context): SharedPreferences {
         return context.getSharedPreferences("im.vector.riot", MODE_PRIVATE)
     }
 
     @Provides
-    @JvmStatic
     fun providesMatrix(context: Context): Matrix {
         return Matrix.getInstance(context)
     }
 
     @Provides
-    @JvmStatic
     fun providesCurrentSession(activeSessionHolder: ActiveSessionHolder): Session {
         // TODO: handle session injection better
         return activeSessionHolder.getActiveSession()
     }
 
     @Provides
-    @JvmStatic
     fun providesLegacySessionImporter(matrix: Matrix): LegacySessionImporter {
         return matrix.legacySessionImporter()
     }
 
     @Provides
-    @JvmStatic
     fun providesAuthenticationService(matrix: Matrix): AuthenticationService {
         return matrix.authenticationService()
     }
 
     @Provides
-    @JvmStatic
     fun providesRawService(matrix: Matrix): RawService {
         return matrix.rawService()
     }
 
     @Provides
-    @JvmStatic
     fun providesHomeServerHistoryService(matrix: Matrix): HomeServerHistoryService {
         return matrix.homeServerHistoryService()
     }
 
     @Provides
-    @JvmStatic
     @Singleton
     fun providesApplicationCoroutineScope(): CoroutineScope {
         return CoroutineScope(SupervisorJob() + Dispatchers.Main)
     }
 
     @Provides
-    @JvmStatic
     fun providesCoroutineDispatchers(): CoroutineDispatchers {
         return CoroutineDispatchers(io = Dispatchers.IO, computation = Dispatchers.Default)
     }

--- a/vector/src/main/java/im/vector/app/features/home/HomeModule.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeModule.kt
@@ -28,7 +28,6 @@ import im.vector.app.features.home.room.detail.timeline.helper.TimelineAsyncHelp
 object HomeModule {
 
     @Provides
-    @JvmStatic
     @TimelineEventControllerHandler
     fun providesTimelineBackgroundHandler(): Handler {
         return TimelineAsyncHelper.getBackgroundHandler()


### PR DESCRIPTION
See https://github.com/google/dagger/releases/tag/dagger-2.25.2 point 2.ii. : @Module object classes no longer need @JvmStatic on the provides methods.
Ensure this warning does not appear again.