### PR TITLE
Timeline editing and offline voice message fixes

### DIFF
--- a/changelog.d/3833.bugfix
+++ b/changelog.d/3833.bugfix
@@ -1,0 +1,1 @@
+Fixing queued voice message failing to send or retry

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/UploadContentWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/UploadContentWorker.kt
@@ -279,6 +279,11 @@ internal class UploadContentWorker(val context: Context, params: WorkerParameter
                     Timber.e(failure, "## Failed to update file cache")
                 }
 
+                // Delete the temporary voice message file
+                if (params.attachment.type == ContentAttachmentData.Type.AUDIO && params.attachment.mimeType == MimeTypes.Ogg) {
+                    context.contentResolver.delete(params.attachment.queryUri, null, null)
+                }
+
                 val uploadThumbnailResult = dealWithThumbnail(params)
 
                 handleSuccess(params,
@@ -298,11 +303,6 @@ internal class UploadContentWorker(val context: Context, params: WorkerParameter
             // Delete all temporary files
             filesToDelete.forEach {
                 tryOrNull { it.delete() }
-            }
-
-            // Delete the temporary voice message file
-            if (params.attachment.type == ContentAttachmentData.Type.AUDIO && params.attachment.mimeType == MimeTypes.Ogg) {
-                context.contentResolver.delete(params.attachment.queryUri, null, null)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewState.kt
@@ -58,10 +58,7 @@ data class MessageComposerViewState(
         VoiceMessageRecorderView.RecordingUiState.Started  -> true
     }
 
-    val isVoiceMessageIdle = when (voiceRecordingUiState) {
-        VoiceMessageRecorderView.RecordingUiState.None, VoiceMessageRecorderView.RecordingUiState.Cancelled -> false
-        else                                                                                                -> true
-    }
+    val isVoiceMessageIdle = !isVoiceRecording
 
     val isComposerVisible = canSendMessage && !isVoiceRecording
     val isVoiceMessageRecorderVisible = canSendMessage && !isSendButtonVisible

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/VoiceMessageHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/VoiceMessageHelper.kt
@@ -76,9 +76,8 @@ class VoiceMessageHelper @Inject constructor(
         }
         try {
             voiceMessageFile?.let {
-                val outputFileUri = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".fileProvider", it)
-                return outputFileUri
-                        ?.toMultiPickerAudioType(context)
+                val outputFileUri = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".fileProvider", it, "Voice message.${it.extension}")
+                return outputFileUri.toMultiPickerAudioType(context)
                         ?.apply {
                             waveform = if (amplitudeList.size < 50) {
                                 amplitudeList

--- a/vector/src/main/java/im/vector/app/features/voice/AbstractVoiceRecorder.kt
+++ b/vector/src/main/java/im/vector/app/features/voice/AbstractVoiceRecorder.kt
@@ -18,9 +18,12 @@ package im.vector.app.features.voice
 
 import android.content.Context
 import android.media.MediaRecorder
+import android.net.Uri
 import android.os.Build
+import org.matrix.android.sdk.api.session.content.ContentAttachmentData
 import java.io.File
 import java.io.FileOutputStream
+import java.util.UUID
 
 abstract class AbstractVoiceRecorder(
         private val context: Context,
@@ -59,7 +62,7 @@ abstract class AbstractVoiceRecorder(
 
     override fun startRecord() {
         init()
-        outputFile = File(outputDirectory, "Voice message.$filenameExt")
+        outputFile = File(outputDirectory, "${UUID.randomUUID()}$filenameExt")
 
         val mr = mediaRecorder ?: return
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -99,4 +102,13 @@ abstract class AbstractVoiceRecorder(
     override fun getVoiceMessageFile(): File? {
         return convertFile(outputFile)
     }
+}
+
+@Suppress("UNUSED") // preemptively added for https://github.com/vector-im/element-android/pull/4527
+private fun ContentAttachmentData.findVoiceFile(baseDirectory: File): File {
+    return File(baseDirectory, queryUri.takePathAfter(baseDirectory.name))
+}
+
+private fun Uri.takePathAfter(after: String): String {
+    return pathSegments.takeLastWhile { it != after }.joinToString(separator = "/") { it }
 }


### PR DESCRIPTION
Breaking down #4527 into smaller PRs

- Fixes https://github.com/vector-im/element-android/issues/3833
  - Makes each voice message file unique to avoid us deleting or overwriting any pending files
  - Provides a human readable name via the ContentResolver  
- Fixes edits not working (broken on develop only)

| BEFORE EDIT | AFTER EDIT |
| --- | --- |
|![before-edit-message](https://user-images.githubusercontent.com/1848238/143080543-30a8dbb1-946e-4bcf-b7fb-6478d8976d9c.png)|![after-edit-message](https://user-images.githubusercontent.com/1848238/143079954-82ba36c7-30cb-4709-960a-96d5771764ac.png)


| BEFORE PENDING OFFLINE | AFTER PENDING OFFLINE |
| --- | --- |
|![before-offline-vm](https://user-images.githubusercontent.com/1848238/143080582-b2a4f159-13b2-46f1-82e9-edbfbdb11eec.gif)|![after-offline-vm](https://user-images.githubusercontent.com/1848238/143079975-807afcea-a958-4eca-96fa-28e4dd942e2e.gif)


| AFTER FILENAME NAME | AFTER FILENAME DOWNLOAD | 
| --- | --- |
|![after-voice-message](https://user-images.githubusercontent.com/1848238/143029536-564e99c2-a0ee-4a42-af28-44b259da0523.png)|![after-downloaded-vm](https://user-images.githubusercontent.com/1848238/143029532-759e2045-3f48-434b-8b7e-9abb49bc1996.png)


