### PR TITLE
Voice related sealed class cleanup

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/send/UserDraft.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/send/UserDraft.kt
@@ -23,11 +23,11 @@ package org.matrix.android.sdk.api.session.room.send
  * EDIT: draft of an edition of a message
  * REPLY: draft of a reply of another message
  */
-sealed class UserDraft(open val text: String) {
-    data class Regular(override val text: String) : UserDraft(text)
-    data class Quote(val linkedEventId: String, override val text: String) : UserDraft(text)
-    data class Edit(val linkedEventId: String, override val text: String) : UserDraft(text)
-    data class Reply(val linkedEventId: String, override val text: String) : UserDraft(text)
+sealed interface UserDraft {
+    data class Regular(val text: String) : UserDraft
+    data class Quote(val linkedEventId: String, val text: String) : UserDraft
+    data class Edit(val linkedEventId: String, val text: String) : UserDraft
+    data class Reply(val linkedEventId: String, val text: String) : UserDraft
 
     fun isValid(): Boolean {
         return when (this) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/send/UserDraft.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/send/UserDraft.kt
@@ -24,14 +24,14 @@ package org.matrix.android.sdk.api.session.room.send
  * REPLY: draft of a reply of another message
  */
 sealed class UserDraft(open val text: String) {
-    data class REGULAR(override val text: String) : UserDraft(text)
-    data class QUOTE(val linkedEventId: String, override val text: String) : UserDraft(text)
-    data class EDIT(val linkedEventId: String, override val text: String) : UserDraft(text)
-    data class REPLY(val linkedEventId: String, override val text: String) : UserDraft(text)
+    data class Regular(override val text: String) : UserDraft(text)
+    data class Quote(val linkedEventId: String, override val text: String) : UserDraft(text)
+    data class Edit(val linkedEventId: String, override val text: String) : UserDraft(text)
+    data class Reply(val linkedEventId: String, override val text: String) : UserDraft(text)
 
     fun isValid(): Boolean {
         return when (this) {
-            is REGULAR -> text.isNotBlank()
+            is Regular -> text.isNotBlank()
             else       -> true
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/DraftMapper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/DraftMapper.kt
@@ -26,20 +26,20 @@ internal object DraftMapper {
 
     fun map(entity: DraftEntity): UserDraft {
         return when (entity.draftMode) {
-            DraftEntity.MODE_REGULAR -> UserDraft.REGULAR(entity.content)
-            DraftEntity.MODE_EDIT    -> UserDraft.EDIT(entity.linkedEventId, entity.content)
-            DraftEntity.MODE_QUOTE   -> UserDraft.QUOTE(entity.linkedEventId, entity.content)
-            DraftEntity.MODE_REPLY   -> UserDraft.REPLY(entity.linkedEventId, entity.content)
+            DraftEntity.MODE_REGULAR -> UserDraft.Regular(entity.content)
+            DraftEntity.MODE_EDIT    -> UserDraft.Edit(entity.linkedEventId, entity.content)
+            DraftEntity.MODE_QUOTE   -> UserDraft.Quote(entity.linkedEventId, entity.content)
+            DraftEntity.MODE_REPLY   -> UserDraft.Reply(entity.linkedEventId, entity.content)
             else                     -> null
-        } ?: UserDraft.REGULAR("")
+        } ?: UserDraft.Regular("")
     }
 
     fun map(domain: UserDraft): DraftEntity {
         return when (domain) {
-            is UserDraft.REGULAR -> DraftEntity(content = domain.text, draftMode = DraftEntity.MODE_REGULAR, linkedEventId = "")
-            is UserDraft.EDIT    -> DraftEntity(content = domain.text, draftMode = DraftEntity.MODE_EDIT, linkedEventId = domain.linkedEventId)
-            is UserDraft.QUOTE   -> DraftEntity(content = domain.text, draftMode = DraftEntity.MODE_QUOTE, linkedEventId = domain.linkedEventId)
-            is UserDraft.REPLY   -> DraftEntity(content = domain.text, draftMode = DraftEntity.MODE_REPLY, linkedEventId = domain.linkedEventId)
+            is UserDraft.Regular -> DraftEntity(content = domain.text, draftMode = DraftEntity.MODE_REGULAR, linkedEventId = "")
+            is UserDraft.Edit    -> DraftEntity(content = domain.text, draftMode = DraftEntity.MODE_EDIT, linkedEventId = domain.linkedEventId)
+            is UserDraft.Quote -> DraftEntity(content = domain.text, draftMode = DraftEntity.MODE_QUOTE, linkedEventId = domain.linkedEventId)
+            is UserDraft.Reply -> DraftEntity(content = domain.text, draftMode = DraftEntity.MODE_REPLY, linkedEventId = domain.linkedEventId)
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -391,10 +391,10 @@ class RoomDetailFragment @Inject constructor(
                 return@onEach
             }
             when (mode) {
-                is SendMode.REGULAR -> renderRegularMode(mode.text)
-                is SendMode.EDIT    -> renderSpecialMode(mode.timelineEvent, R.drawable.ic_edit, R.string.edit, mode.text)
-                is SendMode.QUOTE   -> renderSpecialMode(mode.timelineEvent, R.drawable.ic_quote, R.string.quote, mode.text)
-                is SendMode.REPLY   -> renderSpecialMode(mode.timelineEvent, R.drawable.ic_reply, R.string.reply, mode.text)
+                is SendMode.Regular -> renderRegularMode(mode.text)
+                is SendMode.Edit    -> renderSpecialMode(mode.timelineEvent, R.drawable.ic_edit, R.string.edit, mode.text)
+                is SendMode.Quote -> renderSpecialMode(mode.timelineEvent, R.drawable.ic_quote, R.string.quote, mode.text)
+                is SendMode.Reply -> renderSpecialMode(mode.timelineEvent, R.drawable.ic_reply, R.string.reply, mode.text)
             }
         }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
@@ -405,7 +405,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                     _viewEvents.post(MessageComposerViewEvents.MessageSent)
                     popDraft()
                 }
-                is SendMode.Quote -> {
+                is SendMode.Quote   -> {
                     val messageContent = state.sendMode.timelineEvent.getLastMessageContent()
                     val textMsg = messageContent?.body
 
@@ -426,7 +426,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                     _viewEvents.post(MessageComposerViewEvents.MessageSent)
                     popDraft()
                 }
-                is SendMode.Reply -> {
+                is SendMode.Reply   -> {
                     state.sendMode.timelineEvent.let {
                         room.replyToMessage(it, action.text.toString(), action.autoMarkdown)
                         _viewEvents.post(MessageComposerViewEvents.MessageSent)
@@ -457,22 +457,22 @@ class MessageComposerViewModel @AssistedInject constructor(
                     // Create a sendMode from a draft and retrieve the TimelineEvent
                     sendMode = when (currentDraft) {
                         is UserDraft.Regular -> SendMode.Regular(currentDraft.text, false)
-                        is UserDraft.Quote -> {
+                        is UserDraft.Quote   -> {
                             room.getTimeLineEvent(currentDraft.linkedEventId)?.let { timelineEvent ->
                                 SendMode.Quote(timelineEvent, currentDraft.text)
                             }
                         }
-                        is UserDraft.Reply -> {
+                        is UserDraft.Reply   -> {
                             room.getTimeLineEvent(currentDraft.linkedEventId)?.let { timelineEvent ->
                                 SendMode.Reply(timelineEvent, currentDraft.text)
                             }
                         }
-                        is UserDraft.Edit  -> {
+                        is UserDraft.Edit    -> {
                             room.getTimeLineEvent(currentDraft.linkedEventId)?.let { timelineEvent ->
                                 SendMode.Edit(timelineEvent, currentDraft.text)
                             }
                         }
-                        else               -> null
+                        else                 -> null
                     } ?: SendMode.Regular("", fromSharing = false)
             )
         }
@@ -691,7 +691,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                     setState { copy(sendMode = it.sendMode.copy(text = action.draft)) }
                     room.saveDraft(UserDraft.Quote(it.sendMode.timelineEvent.root.eventId!!, action.draft))
                 }
-                it.sendMode is SendMode.Edit  -> {
+                it.sendMode is SendMode.Edit                                -> {
                     setState { copy(sendMode = it.sendMode.copy(text = action.draft)) }
                     room.saveDraft(UserDraft.Edit(it.sendMode.timelineEvent.root.eventId!!, action.draft))
                 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewState.kt
@@ -29,17 +29,17 @@ import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
  *
  * Depending on the state the bottom toolbar will change (icons/preview/actions...)
  */
-sealed class SendMode(open val text: String) {
+sealed interface SendMode {
     data class Regular(
-            override val text: String,
+            val text: String,
             val fromSharing: Boolean,
             // This is necessary for forcing refresh on selectSubscribe
             private val ts: Long = System.currentTimeMillis()
-    ) : SendMode(text)
+    ) : SendMode
 
-    data class Quote(val timelineEvent: TimelineEvent, override val text: String) : SendMode(text)
-    data class Edit(val timelineEvent: TimelineEvent, override val text: String) : SendMode(text)
-    data class Reply(val timelineEvent: TimelineEvent, override val text: String) : SendMode(text)
+    data class Quote(val timelineEvent: TimelineEvent, val text: String) : SendMode
+    data class Edit(val timelineEvent: TimelineEvent, val text: String) : SendMode
+    data class Reply(val timelineEvent: TimelineEvent, val text: String) : SendMode
 }
 
 data class MessageComposerViewState(

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewState.kt
@@ -30,23 +30,23 @@ import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
  * Depending on the state the bottom toolbar will change (icons/preview/actions...)
  */
 sealed class SendMode(open val text: String) {
-    data class REGULAR(
+    data class Regular(
             override val text: String,
             val fromSharing: Boolean,
             // This is necessary for forcing refresh on selectSubscribe
             private val ts: Long = System.currentTimeMillis()
     ) : SendMode(text)
 
-    data class QUOTE(val timelineEvent: TimelineEvent, override val text: String) : SendMode(text)
-    data class EDIT(val timelineEvent: TimelineEvent, override val text: String) : SendMode(text)
-    data class REPLY(val timelineEvent: TimelineEvent, override val text: String) : SendMode(text)
+    data class Quote(val timelineEvent: TimelineEvent, override val text: String) : SendMode(text)
+    data class Edit(val timelineEvent: TimelineEvent, override val text: String) : SendMode(text)
+    data class Reply(val timelineEvent: TimelineEvent, override val text: String) : SendMode(text)
 }
 
 data class MessageComposerViewState(
         val roomId: String,
         val canSendMessage: Boolean = true,
         val isSendButtonVisible: Boolean = false,
-        val sendMode: SendMode = SendMode.REGULAR("", false),
+        val sendMode: SendMode = SendMode.Regular("", false),
         val voiceRecordingUiState: VoiceMessageRecorderView.RecordingUiState = VoiceMessageRecorderView.RecordingUiState.None
 ) : MavericksState {
 


### PR DESCRIPTION
Extracted from #4527 

- Renames the `UserDraft` and `SendMode` child class names to `CamelCase`
- Removes unused base properties from the sealed classes
- Switches sealed classes to interfaces to help enforce no base properties 