### PR TITLE
Unable to upload .ogg to rooms

### DIFF
--- a/changelog.d/4552.bugfix
+++ b/changelog.d/4552.bugfix
@@ -1,0 +1,1 @@
+Fixes .ogg files failing to upload to rooms

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/content/ContentAttachmentData.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/content/ContentAttachmentData.kt
@@ -44,7 +44,8 @@ data class ContentAttachmentData(
         FILE,
         IMAGE,
         AUDIO,
-        VIDEO
+        VIDEO,
+        VOICE_MESSAGE
     }
 
     fun getSafeMimeType() = mimeType?.normalizeMimeType()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/UploadContentWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/UploadContentWorker.kt
@@ -280,7 +280,7 @@ internal class UploadContentWorker(val context: Context, params: WorkerParameter
                 }
 
                 // Delete the temporary voice message file
-                if (params.attachment.type == ContentAttachmentData.Type.AUDIO && params.attachment.mimeType == MimeTypes.Ogg) {
+                if (params.attachment.type == ContentAttachmentData.Type.VOICE_MESSAGE) {
                     context.contentResolver.delete(params.attachment.queryUri, null, null)
                 }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoEventFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoEventFactory.kt
@@ -205,10 +205,11 @@ internal class LocalEchoEventFactory @Inject constructor(
 
     fun createMediaEvent(roomId: String, attachment: ContentAttachmentData): Event {
         return when (attachment.type) {
-            ContentAttachmentData.Type.IMAGE -> createImageEvent(roomId, attachment)
-            ContentAttachmentData.Type.VIDEO -> createVideoEvent(roomId, attachment)
-            ContentAttachmentData.Type.AUDIO -> createAudioEvent(roomId, attachment)
-            ContentAttachmentData.Type.FILE  -> createFileEvent(roomId, attachment)
+            ContentAttachmentData.Type.IMAGE         -> createImageEvent(roomId, attachment)
+            ContentAttachmentData.Type.VIDEO         -> createVideoEvent(roomId, attachment)
+            ContentAttachmentData.Type.AUDIO         -> createAudioEvent(roomId, attachment)
+            ContentAttachmentData.Type.VOICE_MESSAGE -> createAudioEvent(roomId, attachment)
+            ContentAttachmentData.Type.FILE          -> createFileEvent(roomId, attachment)
         }
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoEventFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoEventFactory.kt
@@ -207,8 +207,8 @@ internal class LocalEchoEventFactory @Inject constructor(
         return when (attachment.type) {
             ContentAttachmentData.Type.IMAGE         -> createImageEvent(roomId, attachment)
             ContentAttachmentData.Type.VIDEO         -> createVideoEvent(roomId, attachment)
-            ContentAttachmentData.Type.AUDIO         -> createAudioEvent(roomId, attachment)
-            ContentAttachmentData.Type.VOICE_MESSAGE -> createAudioEvent(roomId, attachment)
+            ContentAttachmentData.Type.AUDIO         -> createAudioEvent(roomId, attachment, isVoiceMessage = false)
+            ContentAttachmentData.Type.VOICE_MESSAGE -> createAudioEvent(roomId, attachment, isVoiceMessage = true)
             ContentAttachmentData.Type.FILE          -> createFileEvent(roomId, attachment)
         }
     }
@@ -297,8 +297,7 @@ internal class LocalEchoEventFactory @Inject constructor(
         return createMessageEvent(roomId, content)
     }
 
-    private fun createAudioEvent(roomId: String, attachment: ContentAttachmentData): Event {
-        val isVoiceMessage = attachment.waveform != null
+    private fun createAudioEvent(roomId: String, attachment: ContentAttachmentData, isVoiceMessage: Boolean): Event {
         val content = MessageAudioContent(
                 msgType = MessageType.MSGTYPE_AUDIO,
                 body = attachment.name ?: "audio",

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentsMapper.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentsMapper.kt
@@ -49,11 +49,11 @@ fun MultiPickerFileType.toContentAttachmentData(): ContentAttachmentData {
     )
 }
 
-fun MultiPickerAudioType.toContentAttachmentData(): ContentAttachmentData {
+fun MultiPickerAudioType.toContentAttachmentData(isVoiceMessage: Boolean): ContentAttachmentData {
     if (mimeType == null) Timber.w("No mimeType")
     return ContentAttachmentData(
             mimeType = mimeType,
-            type = mapType(),
+            type = if (isVoiceMessage) ContentAttachmentData.Type.VOICE_MESSAGE else mapType(),
             size = size,
             name = displayName,
             duration = duration,

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentsMapper.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentsMapper.kt
@@ -75,7 +75,7 @@ fun MultiPickerBaseType.toContentAttachmentData(): ContentAttachmentData {
     return when (this) {
         is MultiPickerImageType -> toContentAttachmentData()
         is MultiPickerVideoType -> toContentAttachmentData()
-        is MultiPickerAudioType -> toContentAttachmentData()
+        is MultiPickerAudioType -> toContentAttachmentData(isVoiceMessage = false)
         is MultiPickerFileType  -> toContentAttachmentData()
         else                    -> throw IllegalStateException("Unknown file type")
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
@@ -714,7 +714,7 @@ class MessageComposerViewModel @AssistedInject constructor(
         } else {
             voiceMessageHelper.stopRecording()?.let { audioType ->
                 if (audioType.duration > 1000) {
-                    room.sendMedia(audioType.toContentAttachmentData(), false, emptySet())
+                    room.sendMedia(audioType.toContentAttachmentData(isVoiceMessage = true), false, emptySet())
                 } else {
                     voiceMessageHelper.deleteRecording()
                 }

--- a/vector/src/main/java/im/vector/app/features/voice/AbstractVoiceRecorder.kt
+++ b/vector/src/main/java/im/vector/app/features/voice/AbstractVoiceRecorder.kt
@@ -62,7 +62,7 @@ abstract class AbstractVoiceRecorder(
 
     override fun startRecord() {
         init()
-        outputFile = File(outputDirectory, "${UUID.randomUUID()}$filenameExt")
+        outputFile = File(outputDirectory, "${UUID.randomUUID()}.$filenameExt")
 
         val mr = mediaRecorder ?: return
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
Fixes #4552 .ogg files failing to upload

- We were inferring that uploaded `.ogg` audio files were our temporary voice messages and attempting to delete, android throws a security exception as we open external files as read only which caused the upload to fail entirely.
- Adds a dedicated `VOICE_MESSAGE` type in order to only delete the files which we control


| PENDING VOICE MESSAGE | FILE EXISTS | VOICE MESSAGE SENT | FILE DELETED |
| --- | --- | --- | --- |
|![Screenshot_20211124_103538](https://user-images.githubusercontent.com/1848238/143222863-993dc393-d2fa-40bc-8744-2afe6327348a.png)|![2021-11-24T10:36:15,422339591+00:00](https://user-images.githubusercontent.com/1848238/143222871-22af5a9e-ceb2-4b9d-ab64-a29608db24ee.png)|![Screenshot_20211124_103640](https://user-images.githubusercontent.com/1848238/143222878-2b870ea3-e4ea-4ea9-8a8c-e227700ecd05.png)|![2021-11-24T10:36:45,675599838+00:00](https://user-images.githubusercontent.com/1848238/143222886-4f20d9ec-072d-40a2-b951-bc5412ea15e5.png)


| BEFORE UPLOADING .OGG | AFTER UPLOADING .OGG | 
| --- | --- |
|![permission-denied](https://user-images.githubusercontent.com/1848238/143226060-0679ce9a-b44a-4ece-ab9e-176b25d5363e.gif)|![after-upload-ogg](https://user-images.githubusercontent.com/1848238/143226058-cbeabcee-2f93-40ac-a95b-9795265ee8d5.gif)
 
 