### PR TITLE
Keep device screen on during voice message playback and recording

### DIFF
--- a/changelog.d/4022.bugfix
+++ b/changelog.d/4022.bugfix
@@ -1,0 +1,1 @@
+Keeping device screen on whilst recording and playing back voice messages

--- a/vector/src/main/java/im/vector/app/core/extensions/Activity.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/Activity.kt
@@ -19,6 +19,7 @@ package im.vector.app.core.extensions
 import android.app.Activity
 import android.content.Intent
 import android.os.Parcelable
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
@@ -111,4 +112,12 @@ fun AppCompatActivity.hideKeyboard() {
 fun Activity.restart() {
     startActivity(intent)
     finish()
+}
+
+fun Activity.keepScreenOn() {
+    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+}
+
+fun Activity.endKeepScreenOn() {
+    window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailActivity.kt
@@ -48,8 +48,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
-private const val ROOM_DETAILS_SCREEN_ON_TRACKER = "room_details_screen_on"
-
 @AndroidEntryPoint
 class RoomDetailActivity :
         VectorBaseActivity<ActivityRoomDetailBinding>(),
@@ -74,6 +72,13 @@ class RoomDetailActivity :
                 f.interactionListener = null
             }
             super.onFragmentPaused(fm, f)
+        }
+    }
+
+    private val playbackActivityListener = VoiceMessagePlaybackTracker.ActivityListener { isPlayingOrRecording ->
+        when (isPlayingOrRecording) {
+            true  -> keepScreenOn()
+            false -> endKeepScreenOn()
         }
     }
 
@@ -122,12 +127,7 @@ class RoomDetailActivity :
         }
         views.drawerLayout.addDrawerListener(drawerListener)
 
-        playbackTracker.trackActivity(ROOM_DETAILS_SCREEN_ON_TRACKER) { isActive ->
-            when (isActive) {
-                true  -> keepScreenOn()
-                false -> endKeepScreenOn()
-            }
-        }
+        playbackTracker.trackActivity(playbackActivityListener)
     }
 
     private fun handleRoomLeft(roomLeft: RequireActiveMembershipViewEvents.RoomLeft) {
@@ -150,7 +150,7 @@ class RoomDetailActivity :
     override fun onDestroy() {
         supportFragmentManager.unregisterFragmentLifecycleCallbacks(fragmentLifecycleCallbacks)
         views.drawerLayout.removeDrawerListener(drawerListener)
-        playbackTracker.unTrackActivity(ROOM_DETAILS_SCREEN_ON_TRACKER)
+        playbackTracker.unTrackActivity(playbackActivityListener)
         super.onDestroy()
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailActivity.kt
@@ -75,11 +75,14 @@ class RoomDetailActivity :
         }
     }
 
+    private var lastKnownPlayingOrRecordingState: Boolean? = null
     private val playbackActivityListener = VoiceMessagePlaybackTracker.ActivityListener { isPlayingOrRecording ->
+        if (lastKnownPlayingOrRecordingState == isPlayingOrRecording) return@ActivityListener
         when (isPlayingOrRecording) {
             true  -> keepScreenOn()
             false -> endKeepScreenOn()
         }
+        lastKnownPlayingOrRecordingState = isPlayingOrRecording
     }
 
     override fun getCoordinatorLayout() = views.coordinatorLayout

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/VoiceMessageHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/VoiceMessageHelper.kt
@@ -74,6 +74,7 @@ class VoiceMessageHelper @Inject constructor(
             voiceRecorder.stopRecord()
             voiceRecorder.getVoiceMessageFile()
         }
+
         try {
             voiceMessageFile?.let {
                 val outputFileUri = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".fileProvider", it, "Voice message.${it.extension}")
@@ -153,6 +154,7 @@ class VoiceMessageHelper @Inject constructor(
     }
 
     fun stopPlayback() {
+        playbackTracker.stopPlayback(VoiceMessagePlaybackTracker.RECORDING_ID)
         mediaPlayer?.stop()
         stopPlaybackTicker()
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/VoiceMessagePlaybackTracker.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/VoiceMessagePlaybackTracker.kt
@@ -26,15 +26,15 @@ class VoiceMessagePlaybackTracker @Inject constructor() {
 
     private val mainHandler = Handler(Looper.getMainLooper())
     private val listeners = mutableMapOf<String, Listener>()
-    private val activityListeners = mutableMapOf<String, ActivityListener>()
+    private val activityListeners = mutableListOf<ActivityListener>()
     private val states = mutableMapOf<String, Listener.State>()
 
-    fun trackActivity(key: String, listener: ActivityListener) {
-        activityListeners[key] = listener
+    fun trackActivity(listener: ActivityListener) {
+        activityListeners.add(listener)
     }
 
-    fun unTrackActivity(id: String) {
-        activityListeners.remove(id)
+    fun unTrackActivity(listener: ActivityListener) {
+        activityListeners.remove(listener)
     }
 
     fun track(id: String, listener: Listener) {
@@ -61,10 +61,10 @@ class VoiceMessagePlaybackTracker @Inject constructor() {
      */
     private fun setState(key: String, state: Listener.State) {
         states[key] = state
-        val isActive = states.values.any { it is Listener.State.Playing || it is Listener.State.Recording }
+        val isPlayingOrRecording = states.values.any { it is Listener.State.Playing || it is Listener.State.Recording }
         mainHandler.post {
             listeners[key]?.onUpdate(state)
-            activityListeners.forEach { it.value.onUpdate(isActive) }
+            activityListeners.forEach { it.onUpdate(isPlayingOrRecording) }
         }
     }
 
@@ -138,6 +138,6 @@ class VoiceMessagePlaybackTracker @Inject constructor() {
     }
 
     fun interface ActivityListener {
-        fun onUpdate(isActive: Boolean)
+        fun onUpdate(isPlayingOrRecording: Boolean)
     }
 }


### PR DESCRIPTION
Fixes #4022 Forces the device screen to stay awake during voice message playback and recording, this state is only active for the room details activity.

No gifs this time as it requires unplugging the device

