### PR TITLE
Dismissing Fdroid variant `Listening for notifications` on sign out

### DIFF
--- a/changelog.d/4488.bugfix
+++ b/changelog.d/4488.bugfix
@@ -1,0 +1,1 @@
+Dismissing the Fdroid variant Listening for notifications on sign out, fixes crash when tapping the notification when signed out

--- a/vector/src/main/java/im/vector/app/core/di/ActiveSessionHolder.kt
+++ b/vector/src/main/java/im/vector/app/core/di/ActiveSessionHolder.kt
@@ -71,6 +71,7 @@ class ActiveSessionHolder @Inject constructor(private val sessionObservableStore
         keyRequestHandler.stop()
         incomingVerificationRequestHandler.stop()
         pushRuleTriggerListener.stop()
+        guardServiceStarter.stop()
     }
 
     fun hasActiveSession(): Boolean {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-android/issues/4488

- Stops the guard service on clearActiveSession (sign out), the service is already tied to `setActiveSession` 

| BEFORE | AFTER |
| --- | --- |
|![before-signout-notifications](https://user-images.githubusercontent.com/1848238/143559769-e49a27c1-7f55-4c16-b87b-bb0cfc6046bf.gif)|![after-signout-notification](https://user-images.githubusercontent.com/1848238/143559787-89967a33-27c2-490c-a0c8-e45104b8d601.gif)
