### PR TITLE
Emoji insertion leftover characters 

### DIFF
--- a/changelog.d/3449.bugfix
+++ b/changelog.d/3449.bugfix
@@ -1,0 +1,1 @@
+Fixes left over text when inserting emojis via the ':' menu and replaces the last typed ':' rather than the one at the end of the message

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/AutoCompleter.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/AutoCompleter.kt
@@ -182,7 +182,7 @@ class AutoCompleter @AssistedInject constructor(
                 .with(object : AutocompleteCallback<String> {
                     override fun onPopupItemClicked(editable: Editable, item: String): Boolean {
                         // Detect last ":" and remove it
-                        var startIndex = editable.lastIndexOf(":")
+                        var startIndex = editable.subSequence(0, editText.selectionStart).lastIndexOf(":")
                         if (startIndex == -1) {
                             startIndex = 0
                         }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/AutoCompleter.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/AutoCompleter.kt
@@ -181,7 +181,7 @@ class AutoCompleter @AssistedInject constructor(
                 .with(backgroundDrawable)
                 .with(object : AutocompleteCallback<String> {
                     override fun onPopupItemClicked(editable: Editable, item: String): Boolean {
-                        // Detect last ":" and remove it
+                        // Infer that the last ":" before the current cursor position is the original popup trigger
                         var startIndex = editable.subSequence(0, editText.selectionStart).lastIndexOf(":")
                         if (startIndex == -1) {
                             startIndex = 0

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/AutoCompleter.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/AutoCompleter.kt
@@ -194,7 +194,8 @@ class AutoCompleter @AssistedInject constructor(
                         }
 
                         // Replace the word by its completion
-                        editable.replace(startIndex, endIndex, item)
+                        editable.delete(startIndex, endIndex)
+                        editable.insert(startIndex, item)
                         return true
                     }
 


### PR DESCRIPTION
Fixes #3449 Leftover characters when inserting emojis by text.

This was a really strange issue, it seemed to only affect single character look ups eg `:a` but didn't affect all emojis equally, `:z` worked without issue. There's no obvious place where we're incorrectly manipulating the message text content and replacing the `replace` with a `delete + insert` also fixed the issue... perhaps some lingering spans in some cases?  

- Also fixed the emoji replacement always using the last `:` by taking into account the current cursor position

| BEFORE INSERT EMOJI | AFTER INSERT EMOJI |
| --- | --- |
|![before-emoji-text](https://user-images.githubusercontent.com/1848238/143578862-3884250b-ea91-4315-96f6-61cec3b0da6b.gif)|![after-emoji-text](https://user-images.githubusercontent.com/1848238/143578857-84ae8a94-2efb-478d-b439-8b0d1c1df08b.gif)

| BEFORE POSITION | AFTER POSITION |
| --- | --- |
![before-emoji-position](https://user-images.githubusercontent.com/1848238/143578869-2b13ee73-ccaf-493e-a5c1-ea18eeb8a9a1.gif)|![after-emoji-position](https://user-images.githubusercontent.com/1848238/143578866-98ba2ec4-9d46-4c96-84b0-7bd3b30844d5.gif)




