### PR TITLE
Always showing hang up button in VOIP calls

### DIFF
--- a/changelog.d/4144.bugfix
+++ b/changelog.d/4144.bugfix
@@ -1,0 +1,1 @@
+Allowing users to hang up VOIP calls during the initialisation phase (avoids getting stuck in the call screen if something goes wrong)

--- a/vector/src/main/java/im/vector/app/features/call/CallControlsView.kt
+++ b/vector/src/main/java/im/vector/app/features/call/CallControlsView.kt
@@ -97,6 +97,8 @@ class CallControlsView @JvmOverloads constructor(
                 views.ringingControlDecline.isVisible = true
                 views.connectedControls.isVisible = false
             }
+            CallState.CreateOffer,
+            CallState.Idle,
             is CallState.Connected,
             is CallState.Dialing,
             is CallState.Answering    -> {
@@ -105,7 +107,7 @@ class CallControlsView @JvmOverloads constructor(
                 views.videoToggleIcon.isVisible = state.isVideoCall
                 views.moreIcon.isVisible = callState is CallState.Connected && callState.iceConnectionState == MxPeerConnectionState.CONNECTED
             }
-            else                      -> {
+            is CallState.Ended        -> {
                 views.ringingControls.isVisible = false
                 views.connectedControls.isVisible = false
             }


### PR DESCRIPTION
Fixes the symptom of #4144 

- Updates the `VectorCallActivity` to always show the hang up button during the initial phases of a VOIP call (`Idle, Create Offer`, matching the `Dialing` behaviour) 

At least from the logs submitted in #4144 there was a native media player error which we're not able to propagate up to our `CallActivity` which means we end up stuck in the `Idle` call state. I can't seem to find a way to hook into player errors via the `RemoteAudioTrack` :thinking:  

The only way I've been able to reproduce this issue is by instantly recreating the call (`Activity.recreate`) when it starts. 

| BEFORE | AFTER |
| --- | --- |
|![before-stuck-voip](https://user-images.githubusercontent.com/1848238/143611425-4fe8cc97-b2a9-4f31-8c41-17211f06f0eb.gif)|![after-stuck-voip](https://user-images.githubusercontent.com/1848238/143611423-2097ef70-e0d1-4bf4-bfc3-e45f4a7c4582.gif)
