### PR TITLE
Reduced onboarding steps

### DIFF
--- a/changelog.d/4382.feature
+++ b/changelog.d/4382.feature
@@ -1,0 +1,1 @@
+Updates onboarding splash screen to have a dedicated sign in button and removes the dual purpose sign in/up stage

--- a/vector/src/main/java/im/vector/app/features/login/LoginAction.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginAction.kt
@@ -23,7 +23,7 @@ import org.matrix.android.sdk.api.auth.registration.RegisterThreePid
 import org.matrix.android.sdk.internal.network.ssl.Fingerprint
 
 sealed class LoginAction : VectorViewModelAction {
-    data class OnGetStarted(val resetLoginConfig: Boolean) : LoginAction()
+    data class OnSplashResult(val resetLoginConfig: Boolean, val entry: OnboardingEntry) : LoginAction()
 
     data class UpdateServerType(val serverType: ServerType) : LoginAction()
     data class UpdateHomeServer(val homeServerUrl: String) : LoginAction()

--- a/vector/src/main/java/im/vector/app/features/login/LoginActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginActivity.kt
@@ -147,10 +147,6 @@ open class LoginActivity : VectorBaseActivity<ActivityLoginBinding>(), ToolbarCo
                         })
             is LoginViewEvents.OnServerSelectionDone                      -> onServerSelectionDone(loginViewEvents)
             is LoginViewEvents.OnSignModeSelected                         -> onSignModeSelected(loginViewEvents)
-            is LoginViewEvents.OnLoginFlowRetrieved                       ->
-                addFragmentToBackstack(R.id.loginFragmentContainer,
-                        LoginSignUpSignInSelectionFragment::class.java,
-                        option = commonOption)
             is LoginViewEvents.OnWebLoginError                            -> onWebLoginError(loginViewEvents)
             is LoginViewEvents.OnForgetPasswordClicked                    ->
                 addFragmentToBackstack(R.id.loginFragmentContainer,

--- a/vector/src/main/java/im/vector/app/features/login/LoginSplashFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginSplashFragment.kt
@@ -22,6 +22,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
+import com.airbnb.mvrx.withState
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import im.vector.app.BuildConfig
 import im.vector.app.R
@@ -50,6 +51,7 @@ class LoginSplashFragment @Inject constructor(
 
     private fun setupViews() {
         views.loginSplashSubmit.debouncedClicks { getStarted() }
+        views.loginSplashAlreadyHaveAccount.debouncedClicks { alreadyHaveAnAccount() }
 
         if (BuildConfig.DEBUG || vectorPreferences.developerMode()) {
             views.loginSplashVersion.isVisible = true
@@ -61,7 +63,11 @@ class LoginSplashFragment @Inject constructor(
     }
 
     private fun getStarted() {
-        loginViewModel.handle(LoginAction.OnGetStarted(resetLoginConfig = false))
+        loginViewModel.handle(LoginAction.OnSplashResult(resetLoginConfig = false, entry = OnboardingEntry.SignUp))
+    }
+
+    private fun alreadyHaveAnAccount() {
+        loginViewModel.handle(LoginAction.OnSplashResult(resetLoginConfig = false, entry = OnboardingEntry.SignIn))
     }
 
     override fun resetViewModel() {
@@ -77,7 +83,8 @@ class LoginSplashFragment @Inject constructor(
                     .setTitle(R.string.dialog_title_error)
                     .setMessage(getString(R.string.login_error_homeserver_from_url_not_found, url))
                     .setPositiveButton(R.string.login_error_homeserver_from_url_not_found_enter_manual) { _, _ ->
-                        loginViewModel.handle(LoginAction.OnGetStarted(resetLoginConfig = true))
+                        val entry = withState(loginViewModel) { it.onboardingEntry }
+                        loginViewModel.handle(LoginAction.OnSplashResult(resetLoginConfig = true, entry = entry))
                     }
                     .setNegativeButton(R.string.cancel, null)
                     .show()

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewEvents.kt
@@ -34,7 +34,6 @@ sealed class LoginViewEvents : VectorViewEvents {
 
     object OpenServerSelection : LoginViewEvents()
     data class OnServerSelectionDone(val serverType: ServerType) : LoginViewEvents()
-    object OnLoginFlowRetrieved : LoginViewEvents()
     data class OnSignModeSelected(val signMode: SignMode) : LoginViewEvents()
     object OnForgetPasswordClicked : LoginViewEvents()
     object OnResetPasswordSendThreePidDone : LoginViewEvents()

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewState.kt
@@ -32,6 +32,8 @@ data class LoginViewState(
 
         // User choices
         @PersistState
+        val onboardingEntry: OnboardingEntry = OnboardingEntry.Splash,
+        @PersistState
         val serverType: ServerType = ServerType.Unknown,
         @PersistState
         val signMode: SignMode = SignMode.Unknown,

--- a/vector/src/main/java/im/vector/app/features/login/OnboardingEntry.kt
+++ b/vector/src/main/java/im/vector/app/features/login/OnboardingEntry.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.login
+
+enum class OnboardingEntry {
+    Splash,
+
+    // Account creation
+    SignUp,
+
+    // Login
+    SignIn,
+}

--- a/vector/src/main/res/layout/fragment_login_splash.xml
+++ b/vector/src/main/res/layout/fragment_login_splash.xml
@@ -183,11 +183,25 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/login_splash_submit"
+        android:textAllCaps="true"
         android:transitionName="loginSubmitTransition"
         app:layout_constraintBottom_toTopOf="@+id/loginSplashSpace5"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/loginSplashSpace4" />
+
+    <TextView
+        android:id="@+id/loginSplashAlreadyHaveAccount"
+        style="@style/Widget.Vector.Button.Text.Login"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/login_splash_already_have_account"
+        android:textAllCaps="true"
+        android:transitionName="loginSubmitTransition"
+        app:layout_constraintBottom_toTopOf="@+id/loginSplashSpace5"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/loginSplashSubmit" />
 
     <Space
         android:id="@+id/loginSplashSpace5"

--- a/vector/src/main/res/layout/fragment_login_splash_2.xml
+++ b/vector/src/main/res/layout/fragment_login_splash_2.xml
@@ -202,7 +202,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_marginTop="14dp"
-            android:text="@string/login_i_already_have_an_account" />
+            android:text="@string/login_splash_already_have_account" />
 
     </LinearLayout>
 

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2509,6 +2509,7 @@
     <string name="login_splash_text2">Keep conversations private with encryption</string>
     <string name="login_splash_text3">Extend &amp; customise your experience</string>
     <string name="login_splash_submit">Get started</string>
+    <string name="login_splash_already_have_account">I already have an account</string>
 
     <string name="login_server_title">Select a server</string>
     <string name="login_server_text">Just like email, accounts have one home, although you can talk to anyone</string>

--- a/vector/src/main/res/values/strings_login_v2.xml
+++ b/vector/src/main/res/values/strings_login_v2.xml
@@ -24,7 +24,6 @@
     <string name="login_if_you_re_not_sure_select_this_option">If you\'re not sure, select this option</string>
     <string name="login_element_matrix_server_and_others">Element Matrix Server and others</string>
     <string name="login_create_a_new_account">Create a new account</string>
-    <string name="login_i_already_have_an_account">I already have an account</string>
 
     <string name="login_unknown_user_warning">Warning: no profile information can be retrieved with this Matrix identifier. Please check that there is no mistake.</string>
 


### PR DESCRIPTION
Fixes #4382 Adding sign in to onboarding splash screen

- Removes the Sign In/Sign Up step from the onboarding in favour of the `GET STARTED` and `I ALREADY HAVE AN ACCOUNT` controlling the proceeding flow

- This may be temporary, currently evaluating using `login2` instead 

| SIGN UP | SIGN IN |
| --- | --- |
|![after-sign-up](https://user-images.githubusercontent.com/1848238/144094196-3a5f5b87-27db-4543-9c30-012c51c31e50.gif)|![after-sign-in](https://user-images.githubusercontent.com/1848238/144094198-168442c5-9aab-4a60-a768-20fde6024cc8.gif)


EDIT:  chatted with @daniellekirkwood and @amshakal we'll go ahead with this small change as part of the main login flow with 
the aim to have this change in users hands in the next release with the large remaining chunk of FTUE work taking place within `Login2`  
