### PR TITLE
There is no need to call job.cancel() when we are using viewModelScope()

### DIFF
--- a/changelog.d/4602.misc
+++ b/changelog.d/4602.misc
@@ -1,0 +1,1 @@
+There is no need to call job.cancel() when we are using viewModelScope()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchViewModel.kt
@@ -143,7 +143,6 @@ class SearchViewModel @AssistedInject constructor(
     }
 
     override fun onCleared() {
-        currentTask?.cancel()
         super.onCleared()
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/RoomDirectoryViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/RoomDirectoryViewModel.kt
@@ -233,7 +233,6 @@ class RoomDirectoryViewModel @AssistedInject constructor(
     }
 
     override fun onCleared() {
-        currentJob?.cancel()
         super.onCleared()
     }
 }


### PR DESCRIPTION
Fixing issue #4602 