### PR TITLE
Fixed voice messages on Android 28 and below

### DIFF
--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
@@ -718,7 +718,7 @@ class MessageComposerViewModel @AssistedInject constructor(
         if (isCancelled) {
             voiceMessageHelper.deleteRecording()
         } else {
-            voiceMessageHelper.stopRecording()?.let { audioType ->
+            voiceMessageHelper.stopRecording(convertForSending = true)?.let { audioType ->
                 if (audioType.duration > 1000) {
                     room.sendMedia(audioType.toContentAttachmentData(isVoiceMessage = true), false, emptySet())
                 } else {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/VoiceMessageHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/VoiceMessageHelper.kt
@@ -76,13 +76,17 @@ class VoiceMessageHelper @Inject constructor(
         startRecordingAmplitudes()
     }
 
-    fun stopRecording(): MultiPickerAudioType? {
+    fun stopRecording(convertForSending: Boolean): MultiPickerAudioType? {
         tryOrNull("Cannot stop media recording amplitude") {
             stopRecordingAmplitudes()
         }
         val voiceMessageFile = tryOrNull("Cannot stop media recorder!") {
             voiceRecorder.stopRecord()
-            voiceRecorder.getVoiceMessageFile()
+            if (convertForSending) {
+                voiceRecorder.getVoiceMessageFile()
+            } else {
+                voiceRecorder.getCurrentRecord()
+            }
         }
 
         try {
@@ -234,7 +238,7 @@ class VoiceMessageHelper @Inject constructor(
     }
 
     fun stopAllVoiceActions(deleteRecord: Boolean = true): MultiPickerAudioType? {
-        val audioType = stopRecording()
+        val audioType = stopRecording(convertForSending = false)
         stopPlayback()
         if (deleteRecord) {
             deleteRecording()


### PR DESCRIPTION
- Fixing voice messages from _erroring_ on android 28 and below due to attempting to convert already converted audio files. This was caused by the draft flow converting the audio files to `.ogg` but expecting them to still be `.mp4` 

Fixed by only converting to .ogg as part of the sending process

*nexus 4 5.1.1

| AFTER DRAFT | AFTER PLAYBACK |
| --- | --- | 
|![Screenshot_20211201_152808](https://user-images.githubusercontent.com/1848238/144263158-17274b5c-3579-43b8-b6ce-e29999121e28.png)|![Screenshot_20211201_152823](https://user-images.githubusercontent.com/1848238/144263155-69a0bdc5-aa0b-41be-ae4f-30653c11b923.png)
