### PR TITLE
Avoiding duplicate message long press events 

### DIFF
--- a/changelog.d/4324.bugfix
+++ b/changelog.d/4324.bugfix
@@ -1,0 +1,1 @@
+Fixes message menu showing when copying message urls

--- a/vector/src/main/java/im/vector/app/core/epoxy/Listener.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/Listener.kt
@@ -17,6 +17,7 @@
 package im.vector.app.core.epoxy
 
 import android.view.View
+import android.widget.TextView
 import im.vector.app.core.utils.DebouncedClickListener
 
 /**
@@ -29,6 +30,26 @@ fun View.onClick(listener: ClickListener?) {
         setOnClickListener(null)
     } else {
         setOnClickListener(DebouncedClickListener(listener))
+    }
+}
+
+fun TextView.onLongClickIgnoringLinks(listener: View.OnLongClickListener?) {
+    if (listener == null) {
+        setOnLongClickListener(null)
+    } else {
+        setOnLongClickListener(object : View.OnLongClickListener {
+            override fun onLongClick(v: View): Boolean {
+                if (hasLongPressedLink()) {
+                    return false
+                }
+                return listener.onLongClick(v)
+            }
+
+            /**
+             * Infer that a Clickable span has been click by the presence of a selection
+             */
+            private fun hasLongPressedLink() = selectionStart != -1 || selectionEnd != -1
+        })
     }
 }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -25,6 +25,7 @@ import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.core.epoxy.onClick
+import im.vector.app.core.epoxy.onLongClickIgnoringLinks
 import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 import im.vector.app.features.home.room.detail.timeline.tools.findPillsAndProcess
 import im.vector.app.features.home.room.detail.timeline.url.PreviewUrlRetriever
@@ -94,10 +95,9 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
         }
         super.bind(holder)
         holder.messageView.movementMethod = movementMethod
-
         renderSendState(holder.messageView, holder.messageView)
         holder.messageView.onClick(attributes.itemClickListener)
-        holder.messageView.setOnLongClickListener(attributes.itemLongClickListener)
+        holder.messageView.onLongClickIgnoringLinks(attributes.itemLongClickListener)
 
         if (canUseTextFuture) {
             holder.messageView.setTextFuture(textFuture)
@@ -133,6 +133,7 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
             previewUrlView?.render(state, safeImageContentRenderer)
         }
     }
+
     companion object {
         private const val STUB_ID = R.id.messageContentTextStub
     }


### PR DESCRIPTION
Fixes #4324 URL long presses opening menu and copying

- Infers that a Clickable span has been pressed by the presence of a selection (from this handy SO https://stackoverflow.com/a/35696744)

| BEFORE | AFTER |
| --- | --- |
|![before](https://user-images.githubusercontent.com/1848238/144444423-7b29209b-179d-4171-bca7-265eaf40b4c8.gif)|![after](https://user-images.githubusercontent.com/1848238/144444404-46664802-5f8c-486b-81e9-cde60afd2ad4.gif)


This does pose the question of whether we should have link copying at all as the message menu already contains a `Copy` item cc @daniellekirkwood 
