### PR TITLE
Upgrade OLM to v3.2.7 and get it from our maven repository.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,12 +38,12 @@ allprojects {
 
     repositories {
         // For olm library. This has to be declared first, to ensure that Olm library is not downloaded from another repo
+        maven { url 'https://gitlab.matrix.org/api/v4/projects/27/packages/maven' }
+
         maven {
             url 'https://jitpack.io'
             content {
-                // Use this repo only for olm library
-                includeGroupByRegex "org\\.matrix\\.gitlab\\.matrix-org"
-                // And also for FilePicker
+                // Use this repo only for FilePicker
                 includeGroupByRegex "com\\.github\\.jaiselrahman"
                 // And monarchy
                 includeGroupByRegex "com\\.github\\.Zhuinden"

--- a/changelog.d/4647.misc
+++ b/changelog.d/4647.misc
@@ -1,0 +1,1 @@
+ Upgrade OLM to v3.2.7 and get it from our maven repository.

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -140,8 +140,8 @@ dependencies {
     implementation libs.arrow.core
     implementation libs.arrow.instances
 
-    // olm lib is now hosted by jitpack: https://jitpack.io/#org.matrix.gitlab.matrix-org/olm
-    implementation 'org.matrix.gitlab.matrix-org:olm:3.2.4'
+    // olm lib is now hosted by maven at https://gitlab.matrix.org/api/v4/projects/27/packages/maven
+    implementation 'org.matrix.android:olm:3.2.7'
 
     // DI
     implementation libs.dagger.dagger


### PR DESCRIPTION
Get OLM library from our maven repository, and upgrade it from 3.2.4 to 3.2.7

Related: https://gitlab.matrix.org/matrix-org/olm/-/issues/5 and following instruction from https://gitlab.matrix.org/matrix-org/olm/-/packages/43 .

Issue like that should not happen anymore #3150 #4271

Dependabot should be able to create PR for automatic update of the lib 🤞 