### PR TITLE
Fix possible crash when having identical subspaces in multiple root spaces

### DIFF
--- a/changelog.d/4693.bugfix
+++ b/changelog.d/4693.bugfix
@@ -1,0 +1,1 @@
+Fix possible crash when having identical subspaces in multiple root spaces

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryController.kt
@@ -170,7 +170,7 @@ class SpaceSummaryController @Inject constructor(
                     if (hasChildren && expanded) {
                         // it's expanded
                         subSpaces?.forEach { child ->
-                            buildSubSpace(summaries, expandedStates, selected, child, 1, 3)
+                            buildSubSpace(groupSummary.roomId, summaries, expandedStates, selected, child, 1, 3)
                         }
                     }
                 }
@@ -181,7 +181,8 @@ class SpaceSummaryController @Inject constructor(
         }
     }
 
-    private fun buildSubSpace(summaries: List<RoomSummary>?,
+    private fun buildSubSpace(idPrefix: String,
+                              summaries: List<RoomSummary>?,
                               expandedStates: Map<String, Boolean>,
                               selected: RoomGroupingMethod,
                               info: SpaceChildInfo, currentDepth: Int, maxDepth: Int) {
@@ -195,9 +196,11 @@ class SpaceSummaryController @Inject constructor(
         val expanded = expandedStates[childSummary.roomId] == true
         val isSelected = selected is RoomGroupingMethod.BySpace && childSummary.roomId == selected.space()?.roomId
 
+        val id = "$idPrefix:${childSummary.roomId}"
+
         subSpaceSummaryItem {
             avatarRenderer(host.avatarRenderer)
-            id(childSummary.roomId)
+            id(id)
             hasChildren(!subSpaces.isNullOrEmpty())
             selected(isSelected)
             expanded(expanded)
@@ -216,7 +219,7 @@ class SpaceSummaryController @Inject constructor(
 
         if (expanded) {
             subSpaces?.forEach {
-                buildSubSpace(summaries, expandedStates, selected, it, currentDepth + 1, maxDepth)
+                buildSubSpace(id, summaries, expandedStates, selected, it, currentDepth + 1, maxDepth)
             }
         }
     }


### PR DESCRIPTION
When you have two root spaces with the same space as subspace, and you expand both root spaces, you end up with two times the same id in the list. This has two problems:

- The expand animation is slightly broken, if you expand the second root space first and then the first one
- If you select one of these items with same id, the app crashes:
    java.lang.IllegalStateException: Two different ViewHolders have the same stable ID. Stable IDs in your adapter MUST BE unique and SHOULD NOT change.

As solution, just prefix the epoxy item ids with the parent spaces.

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>

### Pull Request Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [x] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
