### PR TITLE
Emoji fix

### DIFF
--- a/changelog.d/4698.bugfix
+++ b/changelog.d/4698.bugfix
@@ -1,0 +1,1 @@
+Fix a crash in the timeline with some Emojis. Also migrate to androidx.emoji2

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -449,7 +449,7 @@ dependencies {
     // OSS License, gplay flavor only
     gplayImplementation 'com.google.android.gms:play-services-oss-licenses:17.0.0'
 
-    implementation "androidx.emoji:emoji-appcompat:1.1.0"
+    implementation "androidx.emoji2:emoji2:1.0.0"
     implementation('com.github.BillCarsonFr:JsonViewer:0.7')
 
     // WebRTC

--- a/vector/src/androidTest/java/im/vector/app/features/html/SpanUtilsTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/html/SpanUtilsTest.kt
@@ -96,5 +96,30 @@ class SpanUtilsTest : InstrumentedTest {
         spanUtils.canUseTextFuture(string) shouldBeEqualTo trueIfAlwaysAllowed()
     }
 
+    @Test
+    fun `test get binding options regular`() {
+        val string = SpannableString("Text")
+        val result = spanUtils.getBindingOptions(string)
+        result.canUseTextFuture shouldBeEqualTo true
+        result.preventMutation shouldBeEqualTo false
+    }
+
+    @Test
+    fun `test get binding options strikethrough`() {
+        val string = SpannableString("Text with strikethrough")
+        string.setSpan(StrikethroughSpan(), 10, 23, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        val result = spanUtils.getBindingOptions(string)
+        result.canUseTextFuture shouldBeEqualTo false
+        result.preventMutation shouldBeEqualTo false
+    }
+
+    @Test
+    fun `test get binding options MetricAffectingSpan`() {
+        val string = SpannableString("Emoji \uD83D\uDE2E\u200D\uD83D\uDCA8")
+        val result = spanUtils.getBindingOptions(string)
+        result.canUseTextFuture shouldBeEqualTo false
+        result.preventMutation shouldBeEqualTo true
+    }
+
     private fun trueIfAlwaysAllowed() = Build.VERSION.SDK_INT < Build.VERSION_CODES.P
 }

--- a/vector/src/androidTest/java/im/vector/app/features/html/SpanUtilsTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/html/SpanUtilsTest.kt
@@ -97,7 +97,7 @@ class SpanUtilsTest : InstrumentedTest {
     }
 
     @Test
-    fun `test get binding options regular`() {
+    fun testGetBindingOptionsRegular() {
         val string = SpannableString("Text")
         val result = spanUtils.getBindingOptions(string)
         result.canUseTextFuture shouldBeEqualTo true
@@ -105,7 +105,7 @@ class SpanUtilsTest : InstrumentedTest {
     }
 
     @Test
-    fun `test get binding options strikethrough`() {
+    fun testGetBindingOptionsStrikethrough() {
         val string = SpannableString("Text with strikethrough")
         string.setSpan(StrikethroughSpan(), 10, 23, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         val result = spanUtils.getBindingOptions(string)
@@ -114,7 +114,7 @@ class SpanUtilsTest : InstrumentedTest {
     }
 
     @Test
-    fun `test get binding options MetricAffectingSpan`() {
+    fun testGetBindingOptionsMetricAffectingSpan() {
         val string = SpannableString("Emoji \uD83D\uDE2E\u200D\uD83D\uDCA8")
         val result = spanUtils.getBindingOptions(string)
         result.canUseTextFuture shouldBeEqualTo false

--- a/vector/src/androidTest/java/im/vector/app/features/html/SpanUtilsTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/html/SpanUtilsTest.kt
@@ -39,6 +39,10 @@ class SpanUtilsTest : InstrumentedTest {
 
     private val spanUtils = SpanUtils()
 
+    private fun SpanUtils.canUseTextFuture(message: CharSequence): Boolean {
+        return getBindingOptions(message).canUseTextFuture
+    }
+
     @Test
     fun canUseTextFutureString() {
         spanUtils.canUseTextFuture("test").shouldBeTrue()

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -398,6 +398,9 @@
                 android:name="androidx.work.WorkManagerInitializer"
                 android:value="androidx.startup"
                 tools:node="remove" />
+            <!-- We init the lib ourself in EmojiCompatWrapper -->
+            <meta-data android:name="androidx.emoji2.text.EmojiCompatInitializer"
+                tools:node="remove" />
         </provider>
 
         <provider

--- a/vector/src/main/java/im/vector/app/EmojiCompatWrapper.kt
+++ b/vector/src/main/java/im/vector/app/EmojiCompatWrapper.kt
@@ -17,8 +17,8 @@ package im.vector.app
 
 import android.content.Context
 import androidx.core.provider.FontRequest
-import androidx.emoji.text.EmojiCompat
-import androidx.emoji.text.FontRequestEmojiCompatConfig
+import androidx.emoji2.text.EmojiCompat
+import androidx.emoji2.text.FontRequestEmojiCompatConfig
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -52,7 +52,7 @@ class EmojiCompatWrapper @Inject constructor(private val context: Context) {
     fun safeEmojiSpanify(sequence: CharSequence): CharSequence {
         if (initialized) {
             try {
-                return EmojiCompat.get().process(sequence)
+                return EmojiCompat.get().process(sequence) ?: sequence
             } catch (throwable: Throwable) {
                 // Defensive coding against error (should not happend as it is initialized)
                 Timber.e(throwable, "Failed to init EmojiCompat")

--- a/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
@@ -27,10 +27,13 @@ import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
+import im.vector.app.core.epoxy.util.preventMutation
 import im.vector.app.core.extensions.setTextOrHide
 import im.vector.app.features.home.AvatarRenderer
+import im.vector.app.features.home.room.detail.timeline.item.BindingOptions
 import im.vector.app.features.home.room.detail.timeline.tools.findPillsAndProcess
 import im.vector.app.features.media.ImageContentRenderer
+import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.util.MatrixItem
 
 /**
@@ -47,6 +50,9 @@ abstract class BottomSheetMessagePreviewItem : VectorEpoxyModel<BottomSheetMessa
 
     @EpoxyAttribute
     lateinit var body: CharSequence
+
+    @EpoxyAttribute
+    var bindingOptions: BindingOptions? = null
 
     @EpoxyAttribute
     var bodyDetails: CharSequence? = null
@@ -77,7 +83,11 @@ abstract class BottomSheetMessagePreviewItem : VectorEpoxyModel<BottomSheetMessa
         }
         holder.imagePreview.isVisible = data != null
         holder.body.movementMethod = movementMethod
-        holder.body.text = body
+        holder.body.text = if (bindingOptions?.preventMutation.orFalse()) {
+            body.preventMutation()
+        } else {
+            body
+        }
         holder.bodyDetails.setTextOrHide(bodyDetails)
         body.findPillsAndProcess(coroutineScope) { it.bind(holder.body) }
         holder.timestamp.setTextOrHide(time)

--- a/vector/src/main/java/im/vector/app/core/epoxy/util/Extensions.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/util/Extensions.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.epoxy.util
+
+import android.text.SpannableString
+
+fun CharSequence?.preventMutation(): CharSequence? = this?.let { SpannableString(it) }

--- a/vector/src/main/java/im/vector/app/core/linkify/VectorLinkify.kt
+++ b/vector/src/main/java/im/vector/app/core/linkify/VectorLinkify.kt
@@ -30,7 +30,7 @@ object VectorLinkify {
 
         if (keepExistingUrlSpan) {
             // Keep track of existing URLSpans, and mark them as important
-            spannable.forEachSpanIndexed { _, urlSpan, start, end ->
+            spannable.forEachUrlSpanIndexed { _, urlSpan, start, end ->
                 createdSpans.add(LinkSpec(URLSpan(urlSpan.url), start, end, important = true))
             }
         }
@@ -39,7 +39,7 @@ object VectorLinkify {
         LinkifyCompat.addLinks(spannable, Linkify.WEB_URLS or Linkify.EMAIL_ADDRESSES or Linkify.PHONE_NUMBERS)
 
         // we might want to modify some matches
-        spannable.forEachSpanIndexed { _, urlSpan, start, end ->
+        spannable.forEachUrlSpanIndexed { _, urlSpan, start, end ->
             spannable.removeSpan(urlSpan)
 
             // remove short PN, too much false positive
@@ -47,7 +47,7 @@ object VectorLinkify {
                 if (end - start > 6) { // Do not match under 7 digit
                     createdSpans.add(LinkSpec(URLSpan(urlSpan.url), start, end))
                 }
-                return@forEachSpanIndexed
+                return@forEachUrlSpanIndexed
             }
 
             // include mailto: if found before match
@@ -60,7 +60,7 @@ object VectorLinkify {
                     createdSpans.add(LinkSpec(URLSpan(urlSpan.url), start, end))
                 }
 
-                return@forEachSpanIndexed
+                return@forEachUrlSpanIndexed
             }
 
             // Handle url matches
@@ -70,7 +70,7 @@ object VectorLinkify {
                 // modify the span to include the slash
                 val spec = LinkSpec(URLSpan(urlSpan.url + "/"), start, end + 1)
                 createdSpans.add(spec)
-                return@forEachSpanIndexed
+                return@forEachUrlSpanIndexed
             }
             // Try to do something for ending ) issues/3020
             if (spannable[end - 1] == ')') {
@@ -87,7 +87,7 @@ object VectorLinkify {
                     val span = URLSpan(spannable.substring(start, end - 1))
                     val spec = LinkSpec(span, start, end - 1)
                     createdSpans.add(spec)
-                    return@forEachSpanIndexed
+                    return@forEachUrlSpanIndexed
                 }
             }
 
@@ -95,7 +95,7 @@ object VectorLinkify {
         }
 
         LinkifyCompat.addLinks(spannable, VectorAutoLinkPatterns.GEO_URI.toPattern(), "geo:", arrayOf("geo:"), geoMatchFilter, null)
-        spannable.forEachSpanIndexed { _, urlSpan, start, end ->
+        spannable.forEachUrlSpanIndexed { _, urlSpan, start, end ->
             spannable.removeSpan(urlSpan)
             createdSpans.add(LinkSpec(URLSpan(urlSpan.url), start, end))
         }
@@ -174,7 +174,7 @@ object VectorLinkify {
         return@MatchFilter true
     }
 
-    private inline fun Spannable.forEachSpanIndexed(action: (index: Int, urlSpan: URLSpan, start: Int, end: Int) -> Unit) {
+    private inline fun Spannable.forEachUrlSpanIndexed(action: (index: Int, urlSpan: URLSpan, start: Int, end: Int) -> Unit) {
         getSpans(0, length, URLSpan::class.java)
                 .forEachIndexed { index, urlSpan ->
                     val start = getSpanStart(urlSpan)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsEpoxyController.kt
@@ -37,6 +37,7 @@ import im.vector.app.features.home.room.detail.timeline.image.buildImageContentR
 import im.vector.app.features.home.room.detail.timeline.item.E2EDecoration
 import im.vector.app.features.home.room.detail.timeline.tools.createLinkMovementMethod
 import im.vector.app.features.home.room.detail.timeline.tools.linkify
+import im.vector.app.features.html.SpanUtils
 import im.vector.app.features.media.ImageContentRenderer
 import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.failure.Failure
@@ -53,6 +54,7 @@ class MessageActionsEpoxyController @Inject constructor(
         private val imageContentRenderer: ImageContentRenderer,
         private val dimensionConverter: DimensionConverter,
         private val errorFormatter: ErrorFormatter,
+        private val spanUtils: SpanUtils,
         private val eventDetailsFormatter: EventDetailsFormatter,
         private val dateFormatter: VectorDateFormatter
 ) : TypedEpoxyController<MessageActionState>() {
@@ -64,6 +66,8 @@ class MessageActionsEpoxyController @Inject constructor(
         // Message preview
         val date = state.timelineEvent()?.root?.originServerTs
         val formattedDate = dateFormatter.format(date, DateFormatKind.MESSAGE_DETAIL)
+        val body = state.messageBody.linkify(host.listener)
+        val bindingOptions = spanUtils.getBindingOptions(body)
         bottomSheetMessagePreviewItem {
             id("preview")
             avatarRenderer(host.avatarRenderer)
@@ -72,7 +76,8 @@ class MessageActionsEpoxyController @Inject constructor(
             imageContentRenderer(host.imageContentRenderer)
             data(state.timelineEvent()?.buildImageContentRendererData(host.dimensionConverter.dpToPx(66)))
             userClicked { host.listener?.didSelectMenuAction(EventSharedAction.OpenUserProfile(state.informationData.senderId)) }
-            body(state.messageBody.linkify(host.listener))
+            bindingOptions(bindingOptions)
+            body(body)
             bodyDetails(host.eventDetailsFormatter.format(state.timelineEvent()?.root))
             time(formattedDate)
         }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.features.home.room.detail.timeline.factory
 
+import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.TextPaint
@@ -515,7 +516,7 @@ class MessageItemFactory @Inject constructor(
 
     private fun annotateWithEdited(linkifiedBody: CharSequence,
                                    callback: TimelineEventController.Callback?,
-                                   informationData: MessageInformationData): SpannableStringBuilder {
+                                   informationData: MessageInformationData): Spannable {
         val spannable = SpannableStringBuilder()
         spannable.append(linkifiedBody)
         val editedSuffix = stringProvider.getString(R.string.edited_suffix)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -473,7 +473,7 @@ class MessageItemFactory @Inject constructor(
                                      highlight: Boolean,
                                      callback: TimelineEventController.Callback?,
                                      attributes: AbsMessageItem.Attributes): MessageTextItem? {
-        val canUseTextFuture = spanUtils.canUseTextFuture(body)
+        val bindingOptions = spanUtils.getBindingOptions(body)
         val linkifiedBody = body.linkify(callback)
 
         return MessageTextItem_().apply {
@@ -485,7 +485,7 @@ class MessageItemFactory @Inject constructor(
             }
         }
                 .useBigFont(linkifiedBody.length <= MAX_NUMBER_OF_EMOJI_FOR_BIG_FONT * 2 && containsOnlyEmojis(linkifiedBody.toString()))
-                .canUseTextFuture(canUseTextFuture)
+                .bindingOptions(bindingOptions)
                 .searchForPills(isFormatted)
                 .previewUrlRetriever(callback?.getPreviewUrlRetriever())
                 .imageContentRenderer(imageContentRenderer)
@@ -565,7 +565,7 @@ class MessageItemFactory @Inject constructor(
             textStyle = "italic"
         }
 
-        val canUseTextFuture = spanUtils.canUseTextFuture(htmlBody)
+        val bindingOptions = spanUtils.getBindingOptions(htmlBody)
         val message = formattedBody.linkify(callback)
 
         return MessageTextItem_()
@@ -575,7 +575,7 @@ class MessageItemFactory @Inject constructor(
                 .previewUrlCallback(callback)
                 .attributes(attributes)
                 .message(message)
-                .canUseTextFuture(canUseTextFuture)
+                .bindingOptions(bindingOptions)
                 .highlighted(highlight)
                 .movementMethod(createLinkMovementMethod(callback))
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/BindingOptions.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/BindingOptions.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home.room.detail.timeline.item
+
+data class BindingOptions(
+        val canUseTextFuture: Boolean,
+        val preventMutation: Boolean
+)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/BindingOptions.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/BindingOptions.kt
@@ -17,6 +17,8 @@
 package im.vector.app.features.home.room.detail.timeline.item
 
 data class BindingOptions(
-        val canUseTextFuture: Boolean,
-        val preventMutation: Boolean
+        // Allowed by default
+        val canUseTextFuture: Boolean = true,
+        // No need to prevent mutation by default
+        val preventMutation: Boolean = false
 )

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -26,12 +26,14 @@ import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.epoxy.onLongClickIgnoringLinks
+import im.vector.app.core.epoxy.util.preventMutation
 import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 import im.vector.app.features.home.room.detail.timeline.tools.findPillsAndProcess
 import im.vector.app.features.home.room.detail.timeline.url.PreviewUrlRetriever
 import im.vector.app.features.home.room.detail.timeline.url.PreviewUrlUiState
 import im.vector.app.features.home.room.detail.timeline.url.PreviewUrlView
 import im.vector.app.features.media.ImageContentRenderer
+import org.matrix.android.sdk.api.extensions.orFalse
 
 @EpoxyModelClass(layout = R.layout.item_timeline_event_base)
 abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
@@ -43,7 +45,7 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
     var message: CharSequence? = null
 
     @EpoxyAttribute
-    var canUseTextFuture: Boolean = true
+    var bindingOptions: BindingOptions? = null
 
     @EpoxyAttribute
     var useBigFont: Boolean = false
@@ -85,7 +87,7 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
                 it.bind(holder.messageView)
             }
         }
-        val textFuture = if (canUseTextFuture) {
+        val textFuture = if (bindingOptions?.canUseTextFuture.orFalse()) {
             PrecomputedTextCompat.getTextFuture(
                     message ?: "",
                     TextViewCompat.getTextMetricsParams(holder.messageView),
@@ -99,10 +101,14 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
         holder.messageView.onClick(attributes.itemClickListener)
         holder.messageView.onLongClickIgnoringLinks(attributes.itemLongClickListener)
 
-        if (canUseTextFuture) {
+        if (bindingOptions?.canUseTextFuture.orFalse()) {
             holder.messageView.setTextFuture(textFuture)
         } else {
-            holder.messageView.text = message
+            holder.messageView.text = if (bindingOptions?.preventMutation.orFalse()) {
+                message.preventMutation()
+            } else {
+                message
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/tools/EventRenderingTools.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/tools/EventRenderingTools.kt
@@ -16,7 +16,6 @@
 
 package im.vector.app.features.home.room.detail.timeline.tools
 
-import android.text.SpannableStringBuilder
 import android.text.style.ClickableSpan
 import android.view.MotionEvent
 import android.widget.TextView
@@ -45,7 +44,7 @@ fun CharSequence.findPillsAndProcess(scope: CoroutineScope, processBlock: (PillI
 
 fun CharSequence.linkify(callback: TimelineEventController.UrlClickCallback?): CharSequence {
     val text = this.toString()
-    val spannable = SpannableStringBuilder(this)
+    val spannable = toSpannable()
     MatrixLinkify.addLinks(spannable, object : MatrixPermalinkSpan.Callback {
         override fun onUrlClicked(url: String) {
             callback?.onUrlClicked(url, text)

--- a/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
@@ -18,8 +18,10 @@ package im.vector.app.features.html
 
 import android.os.Build
 import android.text.Spanned
+import android.text.style.MetricAffectingSpan
 import android.text.style.StrikethroughSpan
 import android.text.style.UnderlineSpan
+import androidx.emoji.text.EmojiCompat
 import javax.inject.Inject
 
 class SpanUtils @Inject constructor() {
@@ -30,12 +32,13 @@ class SpanUtils @Inject constructor() {
             return true
         }
 
-        if (charSequence !is Spanned) {
+        val emojiCharSequence = EmojiCompat.get().process(charSequence)
+        if (emojiCharSequence !is Spanned) {
             return true
         }
 
-        return charSequence
-                .getSpans(0, charSequence.length, Any::class.java)
-                .all { it !is StrikethroughSpan && it !is UnderlineSpan }
+        return emojiCharSequence
+                .getSpans(0, emojiCharSequence.length, Any::class.java)
+                .all { it !is StrikethroughSpan && it !is UnderlineSpan && it !is MetricAffectingSpan }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
@@ -21,7 +21,7 @@ import android.text.Spanned
 import android.text.style.MetricAffectingSpan
 import android.text.style.StrikethroughSpan
 import android.text.style.UnderlineSpan
-import androidx.emoji.text.EmojiCompat
+import androidx.emoji2.text.EmojiCompat
 import javax.inject.Inject
 
 class SpanUtils @Inject constructor() {

--- a/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
@@ -30,15 +30,12 @@ class SpanUtils @Inject constructor() {
         val emojiCharSequence = EmojiCompat.get().process(charSequence)
 
         if (emojiCharSequence !is Spanned) {
-            return BindingOptions(
-                    canUseTextFuture = true,
-                    preventMutation = false
-            )
+            return BindingOptions()
         }
 
         return BindingOptions(
                 canUseTextFuture = canUseTextFuture(emojiCharSequence),
-                preventMutation = preventMutation(emojiCharSequence)
+                preventMutation = mustPreventMutation(emojiCharSequence)
         )
     }
 
@@ -55,7 +52,7 @@ class SpanUtils @Inject constructor() {
     }
 
     // Workaround for setting text during binding which mutate the text itself
-    private fun preventMutation(spanned: Spanned): Boolean {
+    private fun mustPreventMutation(spanned: Spanned): Boolean {
         return spanned
                 .getSpans(0, spanned.length, Any::class.java)
                 .any { it is MetricAffectingSpan }

--- a/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
@@ -43,14 +43,14 @@ class SpanUtils @Inject constructor() {
     }
 
     // Workaround for https://issuetracker.google.com/issues/188454876
-    private fun canUseTextFuture(charSequence: Spanned): Boolean {
+    private fun canUseTextFuture(spanned: Spanned): Boolean {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
             // On old devices, it works correctly
             return true
         }
 
-        return charSequence
-                .getSpans(0, charSequence.length, Any::class.java)
+        return spanned
+                .getSpans(0, spanned.length, Any::class.java)
                 .all { it !is StrikethroughSpan && it !is UnderlineSpan && it !is MetricAffectingSpan }
     }
 


### PR DESCRIPTION
The main issue (#4691) is fixed, but now the app is crashing for another reason:

```
Thread: main, Exception: com.airbnb.epoxy.ImmutableModelException: The model was changed during the bind call. Position: 2 Model: MessageTextItem_{searchForPills=false, message=🚀, canUseTextFuture=false, useBigFont=true, previewUrlRetriever=im.vector.app.features.home.room.detail.timeline.url.PreviewUrlRetriever@b87961d, previewUrlCallback=RoomDetailFragment{6b98f58} (13eb1acc-4ef4-4db1-8d24-95e58efa694f id=0x7f090639), imageContentRenderer=im.vector.app.features.media.ImageContentRenderer@fe5f092, movementMethod=im.vector.app.core.utils.EvenBetterLinkMovementMethod@2861e82, attributes=Attributes(avatarSize=78, informationData=MessageInformationData(eventId=$UWClP7CkuMRG6Cm9jzbWftPf7lN0ovw5UkU8laaD2g8, senderId=@benoit.marty:matrix.org, sendState=SYNCED, time=12:35, ageLocalTS=1639395345987, avatarUrl=mxc://matrix.org/jRqrnjimPBqTSSdJlOupMqSx, memberName=benoit, showInformation=true, forceShowTimestamp=false, orderedReactionList=null, pollResponseAggregatedSummary=null, hasBeenEdited=false, hasPendingEdits=false, referencesInfoData=null, sentByMe=false, e2eDecoration=NONE, sendStateDecoration=NONE), avatarRenderer=im.vector.app.features.home.AvatarRenderer@af2c993, messageColorProvider=im.vector.app.features.home.room.detail.timeline.MessageColorProvider@d7ccdd0, itemLongClickListener=im.vector.app.features.home.room.detail.timeline.helper.MessageItemAttributesFactory$$ExternalSyntheticLambda0@3b931c9, itemClickListener=Function1<android.view.View, kotlin.Unit>, memberClickListener=Function1<android.view.View, kotlin.Unit>, reactionPillCallback=RoomDetailFragment{6b98f58} (13eb1acc-4ef4-4db1-8d24-95e58efa694f id=0x7f090639), avatarCallback=RoomDetailFragment{6b98f58} (13eb1acc-4ef4-4db1-8d24-95e58efa694f id=0x7f090639), readReceiptsCallback=RoomDetailFragment{6b98f58} (13eb1acc-4ef4-4db1-8d24-95e58efa694f id=0x7f090639), emojiTypeFace=android.graphics.Typeface@d9865418), highlighted=false, leftGuideline=99, dimensionConverter=null}MessageTextItem_{id=8001435373522078711, viewType=2131297544, shown=true, addedToAdapter=false}
Epoxy attribute fields on a model cannot be changed once the model is added to a controller. Check that these fields are not updated, or that the assigned objects are not mutated, outside of the buildModels method. The only exception is if the change is made inside an Interceptor callback. Consider using an interceptor if you need to change a model after it is added to the controller and before it is set on the adapter. If the model is already set on the adapter then you must call `requestModelBuild` instead to recreate all models.
    at com.airbnb.epoxy.EpoxyModel.validateStateHasNotChangedSinceAdded(EpoxyModel.java:466)
    at im.vector.app.features.home.room.detail.timeline.item.MessageTextItem_.handlePostBind(MessageTextItem_.java:59)
    at im.vector.app.features.home.room.detail.timeline.item.MessageTextItem_.handlePostBind(MessageTextItem_.java:29)
    at com.airbnb.epoxy.EpoxyViewHolder.bind(EpoxyViewHolder.java:77)
```

If I change [this line](https://github.com/vector-im/element-android/blob/main/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt#L476) to this:
```kotlin
val linkifiedBody = body // .linkify(callback)
```
there is no crash.

I'm still digging

**EDIT** Issues fixed now, thanks @ouchadam for the investigation and suggestion, and finally the review.

Fixes #4691 