### PR TITLE
Small UI fix in room member profile hearder

### DIFF
--- a/changelog.d/4700.bugfix
+++ b/changelog.d/4700.bugfix
@@ -1,0 +1,1 @@
+Fix name and shield are truncated in the room detail screen

--- a/vector/src/main/res/layout/view_stub_room_member_profile_header.xml
+++ b/vector/src/main/res/layout/view_stub_room_member_profile_header.xml
@@ -23,7 +23,7 @@
             android:layout_height="128dp"
             android:layout_marginBottom="16dp"
             android:contentDescription="@string/avatar"
-            app:layout_constraintBottom_toTopOf="@id/memberProfileNameView"
+            app:layout_constraintBottom_toTopOf="@id/memberProfileLinearLayout"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
@@ -70,7 +70,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="8dp"
-                android:gravity="center|start"
+                android:gravity="center"
                 android:textStyle="bold"
                 tools:text=" dezdezdzedez dezjdioezdiozeiodzendez" />
 

--- a/vector/src/main/res/layout/view_stub_room_member_profile_header.xml
+++ b/vector/src/main/res/layout/view_stub_room_member_profile_header.xml
@@ -45,32 +45,36 @@
             tools:src="@drawable/ic_presence_offline"
             tools:visibility="visible" />
 
-        <im.vector.app.core.ui.views.ShieldImageView
-            android:id="@+id/memberProfileDecorationImageView"
-            android:layout_width="30dp"
-            android:layout_height="30dp"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="2dp"
-            android:layout_marginEnd="8dp"
-            app:layout_constraintBottom_toBottomOf="@id/memberProfileNameView"
-            app:layout_constraintEnd_toStartOf="@id/memberProfileNameView"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/memberProfileNameView" />
-
-        <TextView
-            android:id="@+id/memberProfileNameView"
-            style="@style/Widget.Vector.TextView.Title"
+        <LinearLayout
+            android:id="@+id/memberProfileLinearLayout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:gravity="center"
-            android:textStyle="bold"
+            android:orientation="horizontal"
             app:layout_constraintBottom_toTopOf="@id/memberProfileIdView"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/memberProfileDecorationImageView"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/memberProfileAvatarView"
-            tools:text="@sample/users.json/data/displayName" />
+            android:gravity="center">
+
+            <im.vector.app.core.ui.views.ShieldImageView
+                android:id="@+id/memberProfileDecorationImageView"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="2dp"
+                android:layout_marginEnd="8dp" />
+
+            <TextView
+                android:id="@+id/memberProfileNameView"
+                style="@style/Widget.Vector.TextView.Title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:gravity="center|start"
+                android:textStyle="bold"
+                tools:text=" dezdezdzedez dezjdioezdiozeiodzendez" />
+
+        </LinearLayout>
 
         <TextView
             android:id="@+id/memberProfileIdView"
@@ -84,7 +88,7 @@
             app:layout_constraintBottom_toTopOf="@id/memberProfilePowerLevelView"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/memberProfileNameView"
+            app:layout_constraintTop_toBottomOf="@id/memberProfileLinearLayout"
             tools:text="@sample/users.json/data/id" />
 
         <TextView

--- a/vector/src/main/res/layout/view_stub_room_member_profile_header.xml
+++ b/vector/src/main/res/layout/view_stub_room_member_profile_header.xml
@@ -49,12 +49,12 @@
             android:id="@+id/memberProfileLinearLayout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:gravity="center"
             android:orientation="horizontal"
             app:layout_constraintBottom_toTopOf="@id/memberProfileIdView"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/memberProfileAvatarView"
-            android:gravity="center">
+            app:layout_constraintTop_toBottomOf="@id/memberProfileAvatarView">
 
             <im.vector.app.core.ui.views.ShieldImageView
                 android:id="@+id/memberProfileDecorationImageView"
@@ -72,7 +72,7 @@
                 android:layout_marginEnd="8dp"
                 android:gravity="center"
                 android:textStyle="bold"
-                tools:text=" dezdezdzedez dezjdioezdiozeiodzendez" />
+                tools:text="@sample/users.json/data/displayName" />
 
         </LinearLayout>
 

--- a/vector/src/main/res/layout/view_stub_room_member_profile_header.xml
+++ b/vector/src/main/res/layout/view_stub_room_member_profile_header.xml
@@ -12,8 +12,8 @@
         android:id="@+id/memberProfileInfoContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
         app:layout_constraintBottom_toTopOf="@id/memberProfileNameView"
         app:layout_constraintTop_toTopOf="@id/memberProfileNameView">
 
@@ -49,6 +49,7 @@
             android:id="@+id/memberProfileDecorationImageView"
             android:layout_width="30dp"
             android:layout_height="30dp"
+            android:layout_marginStart="8dp"
             android:layout_marginTop="2dp"
             android:layout_marginEnd="8dp"
             app:layout_constraintBottom_toBottomOf="@id/memberProfileNameView"
@@ -60,8 +61,9 @@
         <TextView
             android:id="@+id/memberProfileNameView"
             style="@style/Widget.Vector.TextView.Title"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
             android:gravity="center"
             android:textStyle="bold"
             app:layout_constraintBottom_toTopOf="@id/memberProfileIdView"


### PR DESCRIPTION
In the room member profile header, when the name is too long the name and the shield are not completely visible.

Screen after the fix: 
![Screenshot_1639393847](https://user-images.githubusercontent.com/15031750/145855709-a9d9834e-5e5d-4c05-978c-40e307880cb0.png)
