### PR TITLE
Disable automatic opt-in screen display

### DIFF
--- a/changelog.d/4559.feature
+++ b/changelog.d/4559.feature
@@ -1,0 +1,1 @@
+Setup Analytics framework using PostHog. Analytics are disabled by default. Opt-in screen not automatically displayed yet.

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -83,9 +83,12 @@ class HomeActivityViewModel @AssistedInject constructor(
         observeInitialSync()
         checkSessionPushIsOn()
         observeCrossSigningReset()
-        observeAnalytics()
+        // Disable Analytics opt-in automatic display
+        // Waiting for translation and for analytic events to be actually sent
+        // observeAnalytics()
     }
 
+    @Suppress("unused")
     private fun observeAnalytics() {
         if (analyticsConfig.isEnabled) {
             analyticsStore.didAskUserConsentFlow


### PR DESCRIPTION
Still possible to opt-in from the settings.
Also add changelog for the previous PR.

Tested OK using the Analytics debug screen.