### PR TITLE
Support misconfigured room encryption

### DIFF
--- a/changelog.d/4711.bugfix
+++ b/changelog.d/4711.bugfix
@@ -1,0 +1,1 @@
+Better handling of misconfigured room encryption

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/crypto/RoomEncryptionTrustLevel.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/crypto/RoomEncryptionTrustLevel.kt
@@ -27,5 +27,8 @@ enum class RoomEncryptionTrustLevel {
     Warning,
 
     // All devices in the room are verified -> the app should display a green shield
-    Trusted
+    Trusted,
+
+    // e2e is active but with an unsupported algorithm
+    E2EWithUnsupportedAlgorithm
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/crypto/RoomCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/crypto/RoomCryptoService.kt
@@ -27,7 +27,10 @@ interface RoomCryptoService {
     fun shouldEncryptForInvitedMembers(): Boolean
 
     /**
-     * Enable encryption of the room
+     * Enable encryption of the room.
+     * @param Use force to ensure that this algorithm will be used. Otherwise this call
+     * will throw if encryption is already setup or if the algorithm is not supported. Only to
+     * be used by admins to fix misconfigured encryption.
      */
     suspend fun enableEncryption(algorithm: String = MXCRYPTO_ALGORITHM_MEGOLM, force: Boolean = false)
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomEncryptionAlgorithm.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomEncryptionAlgorithm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 New Vector Ltd
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomEncryptionAlgorithm.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomEncryptionAlgorithm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Matrix.org Foundation C.I.C.
+ * Copyright (c) 2021 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,26 +14,15 @@
  * limitations under the License.
  */
 
-package org.matrix.android.sdk.api.session.room.crypto
+package org.matrix.android.sdk.api.session.room.model
 
 import org.matrix.android.sdk.internal.crypto.MXCRYPTO_ALGORITHM_MEGOLM
 
-interface RoomCryptoService {
+sealed class RoomEncryptionAlgorithm {
 
-    fun isEncrypted(): Boolean
+    abstract class SupportedAlgorithm(val alg: String) : RoomEncryptionAlgorithm()
 
-    fun encryptionAlgorithm(): String?
+    object Megolm : SupportedAlgorithm(MXCRYPTO_ALGORITHM_MEGOLM)
 
-    fun shouldEncryptForInvitedMembers(): Boolean
-
-    /**
-     * Enable encryption of the room
-     */
-    suspend fun enableEncryption(algorithm: String = MXCRYPTO_ALGORITHM_MEGOLM, force: Boolean = false)
-
-    /**
-     * Ensures all members of the room are loaded and outbound session keys are shared.
-     * If this method is not called, CryptoService will ensure it before sending events.
-     */
-    suspend fun prepareToEncrypt()
+    data class UnsupportedAlgorithm(val name: String?) : RoomEncryptionAlgorithm()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomSummary.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomSummary.kt
@@ -62,7 +62,8 @@ data class RoomSummary(
         val roomType: String? = null,
         val spaceParents: List<SpaceParentInfo>? = null,
         val spaceChildren: List<SpaceChildInfo>? = null,
-        val flattenParentIds: List<String> = emptyList()
+        val flattenParentIds: List<String> = emptyList(),
+        val roomEncryptionAlgorithm: RoomEncryptionAlgorithm? = null
 ) {
 
     val isVersioned: Boolean

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/CryptoSessionInfoProvider.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/CryptoSessionInfoProvider.kt
@@ -37,7 +37,6 @@ internal class CryptoSessionInfoProvider @Inject constructor(
     fun isRoomEncrypted(roomId: String): Boolean {
         val encryptionEvent = monarchy.fetchCopied { realm ->
             EventEntity.whereType(realm, roomId = roomId, type = EventType.STATE_ROOM_ENCRYPTION)
-                    .contains(EventEntityFields.CONTENT, "\"algorithm\":\"$MXCRYPTO_ALGORITHM_MEGOLM\"")
                     .isEmpty(EventEntityFields.STATE_KEY)
                     .findFirst()
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -177,7 +177,7 @@ internal class DefaultCryptoService @Inject constructor(
     private val isStarted = AtomicBoolean(false)
 
     fun onStateEvent(roomId: String, event: Event) {
-        when (event.getClearType()) {
+        when (event.type) {
             EventType.STATE_ROOM_ENCRYPTION         -> onRoomEncryptionEvent(roomId, event)
             EventType.STATE_ROOM_MEMBER             -> onRoomMembershipEvent(roomId, event)
             EventType.STATE_ROOM_HISTORY_VISIBILITY -> onRoomHistoryVisibilityEvent(roomId, event)
@@ -185,10 +185,13 @@ internal class DefaultCryptoService @Inject constructor(
     }
 
     fun onLiveEvent(roomId: String, event: Event) {
-        when (event.getClearType()) {
-            EventType.STATE_ROOM_ENCRYPTION         -> onRoomEncryptionEvent(roomId, event)
-            EventType.STATE_ROOM_MEMBER             -> onRoomMembershipEvent(roomId, event)
-            EventType.STATE_ROOM_HISTORY_VISIBILITY -> onRoomHistoryVisibilityEvent(roomId, event)
+        // handle state events
+        if (event.isStateEvent()) {
+            when (event.type) {
+                EventType.STATE_ROOM_ENCRYPTION         -> onRoomEncryptionEvent(roomId, event)
+                EventType.STATE_ROOM_MEMBER             -> onRoomMembershipEvent(roomId, event)
+                EventType.STATE_ROOM_HISTORY_VISIBILITY -> onRoomHistoryVisibilityEvent(roomId, event)
+            }
         }
     }
 
@@ -575,26 +578,31 @@ internal class DefaultCryptoService @Inject constructor(
         // (for now at least. Maybe we should alert the user somehow?)
         val existingAlgorithm = cryptoStore.getRoomAlgorithm(roomId)
 
-        if (!existingAlgorithm.isNullOrEmpty() && existingAlgorithm != algorithm) {
-            Timber.tag(loggerTag.value).e("setEncryptionInRoom() : Ignoring m.room.encryption event which requests a change of config in $roomId")
+        if (existingAlgorithm == algorithm) {
+            // ignore
+            Timber.tag(loggerTag.value).e("setEncryptionInRoom() : Ignoring m.room.encryption for same alg ($algorithm) in  $roomId")
             return false
         }
 
         val encryptingClass = MXCryptoAlgorithms.hasEncryptorClassForAlgorithm(algorithm)
+
+        // Always store even if not supported
+        cryptoStore.storeRoomAlgorithm(roomId, algorithm)
 
         if (!encryptingClass) {
             Timber.tag(loggerTag.value).e("setEncryptionInRoom() : Unable to encrypt room $roomId with $algorithm")
             return false
         }
 
-        cryptoStore.storeRoomAlgorithm(roomId, algorithm!!)
-
-        val alg: IMXEncrypting = when (algorithm) {
+        val alg: IMXEncrypting? = when (algorithm) {
             MXCRYPTO_ALGORITHM_MEGOLM -> megolmEncryptionFactory.create(roomId)
-            else                      -> olmEncryptionFactory.create(roomId)
+            MXCRYPTO_ALGORITHM_OLM    -> olmEncryptionFactory.create(roomId)
+            else                      -> null
         }
 
-        roomEncryptorsStore.put(roomId, alg)
+        if (alg != null) {
+            roomEncryptorsStore.put(roomId, alg)
+        }
 
         // if encryption was not previously enabled in this room, we will have been
         // ignoring new device events for these users so far. We may well have
@@ -927,6 +935,7 @@ internal class DefaultCryptoService @Inject constructor(
     }
 
     private fun onRoomHistoryVisibilityEvent(roomId: String, event: Event) {
+        if (!event.isStateEvent()) return
         val eventContent = event.content.toModel<RoomHistoryVisibilityContent>()
         eventContent?.historyVisibility?.let {
             cryptoStore.setShouldEncryptForInvitedMembers(roomId, it != RoomHistoryVisibility.JOINED)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/event/EncryptionEventContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/model/event/EncryptionEventContent.kt
@@ -27,7 +27,7 @@ data class EncryptionEventContent(
          * Required. The encryption algorithm to be used to encrypt messages sent in this room. Must be 'm.megolm.v1.aes-sha2'.
          */
         @Json(name = "algorithm")
-        val algorithm: String,
+        val algorithm: String?,
 
         /**
          * How long the session should be used before changing it. 604800000 (a week) is the recommended default.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
@@ -230,7 +230,7 @@ internal interface IMXCryptoStore {
      * @param roomId    the id of the room.
      * @param algorithm the algorithm.
      */
-    fun storeRoomAlgorithm(roomId: String, algorithm: String)
+    fun storeRoomAlgorithm(roomId: String, algorithm: String?)
 
     /**
      * Provides the algorithm used in a dedicated room.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -629,7 +629,7 @@ internal class RealmCryptoStore @Inject constructor(
         }
     }
 
-    override fun storeRoomAlgorithm(roomId: String, algorithm: String) {
+    override fun storeRoomAlgorithm(roomId: String, algorithm: String?) {
         doRealmTransaction(realmConfiguration) {
             CryptoRoomEntity.getOrCreate(it, roomId).algorithm = algorithm
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/RealmSessionStoreMigration.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/RealmSessionStoreMigration.kt
@@ -25,6 +25,7 @@ import org.matrix.android.sdk.api.session.room.model.RoomJoinRulesContent
 import org.matrix.android.sdk.api.session.room.model.VersioningState
 import org.matrix.android.sdk.api.session.room.model.create.RoomCreateContent
 import org.matrix.android.sdk.api.session.room.model.tag.RoomTag
+import org.matrix.android.sdk.internal.crypto.model.event.EncryptionEventContent
 import org.matrix.android.sdk.internal.database.model.ChunkEntityFields
 import org.matrix.android.sdk.internal.database.model.CurrentStateEventEntityFields
 import org.matrix.android.sdk.internal.database.model.EditAggregatedSummaryEntityFields
@@ -395,6 +396,7 @@ internal class RealmSessionStoreMigration @Inject constructor(
 
     private fun migrateTo20(realm: DynamicRealm) {
         Timber.d("Step 19 -> 20")
+
         realm.schema.get("ChunkEntity")?.apply {
             if (hasField("numberOfTimelineEvents")) {
                 removeField("numberOfTimelineEvents")
@@ -413,5 +415,29 @@ internal class RealmSessionStoreMigration @Inject constructor(
                 chunkEntities.deleteAllFromRealm()
             }
         }
+
+        realm.schema.get("RoomSummaryEntity")
+                ?.addField(RoomSummaryEntityFields.E2E_ALGORITHM, String::class.java)
+                ?.transform { obj ->
+
+                    val encryptionContentAdapter = MoshiProvider.providesMoshi().adapter(EncryptionEventContent::class.java)
+
+                    val encryptionEvent = realm.where("CurrentStateEventEntity")
+                            .equalTo(CurrentStateEventEntityFields.ROOM_ID, obj.getString(RoomSummaryEntityFields.ROOM_ID))
+                            .equalTo(CurrentStateEventEntityFields.TYPE, EventType.STATE_ROOM_ENCRYPTION)
+                            .findFirst()
+
+                    val encryptionEventRoot = encryptionEvent?.getObject(CurrentStateEventEntityFields.ROOT.`$`)
+                    val algorithm = encryptionEventRoot
+                            ?.getString(EventEntityFields.CONTENT)?.let {
+                                encryptionContentAdapter.fromJson(it)?.algorithm
+                            }
+
+                    obj.setString(RoomSummaryEntityFields.E2E_ALGORITHM, algorithm)
+                    obj.setBoolean(RoomSummaryEntityFields.IS_ENCRYPTED, encryptionEvent != null)
+                    encryptionEventRoot?.getLong(EventEntityFields.ORIGIN_SERVER_TS)?.let {
+                        obj.setLong(RoomSummaryEntityFields.ENCRYPTION_EVENT_TS, it)
+                    }
+                }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/RealmSessionStoreMigration.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/RealmSessionStoreMigration.kt
@@ -56,7 +56,7 @@ internal class RealmSessionStoreMigration @Inject constructor(
 ) : RealmMigration {
 
     companion object {
-        const val SESSION_STORE_SCHEMA_VERSION = 20L
+        const val SESSION_STORE_SCHEMA_VERSION = 21L
     }
 
     /**
@@ -89,6 +89,7 @@ internal class RealmSessionStoreMigration @Inject constructor(
         if (oldVersion <= 17) migrateTo18(realm)
         if (oldVersion <= 18) migrateTo19(realm)
         if (oldVersion <= 19) migrateTo20(realm)
+        if (oldVersion <= 20) migrateTo21(realm)
     }
 
     private fun migrateTo1(realm: DynamicRealm) {
@@ -415,6 +416,10 @@ internal class RealmSessionStoreMigration @Inject constructor(
                 chunkEntities.deleteAllFromRealm()
             }
         }
+    }
+
+    private fun migrateTo21(realm: DynamicRealm) {
+        Timber.d("Step 20 -> 21")
 
         realm.schema.get("RoomSummaryEntity")
                 ?.addField(RoomSummaryEntityFields.E2E_ALGORITHM, String::class.java)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/RoomSummaryMapper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/RoomSummaryMapper.kt
@@ -16,12 +16,14 @@
 
 package org.matrix.android.sdk.internal.database.mapper
 
+import org.matrix.android.sdk.api.session.room.model.RoomEncryptionAlgorithm
 import org.matrix.android.sdk.api.session.room.model.RoomJoinRules
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 import org.matrix.android.sdk.api.session.room.model.SpaceChildInfo
 import org.matrix.android.sdk.api.session.room.model.SpaceParentInfo
 import org.matrix.android.sdk.api.session.room.model.tag.RoomTag
 import org.matrix.android.sdk.api.session.typing.TypingUsersTracker
+import org.matrix.android.sdk.internal.crypto.MXCRYPTO_ALGORITHM_MEGOLM
 import org.matrix.android.sdk.internal.database.model.RoomSummaryEntity
 import org.matrix.android.sdk.internal.database.model.presence.toUserPresence
 import javax.inject.Inject
@@ -99,7 +101,13 @@ internal class RoomSummaryMapper @Inject constructor(private val timelineEventMa
                             worldReadable = it.childSummaryEntity?.joinRules == RoomJoinRules.PUBLIC
                     )
                 },
-                flattenParentIds = roomSummaryEntity.flattenParentIds?.split("|") ?: emptyList()
+                flattenParentIds = roomSummaryEntity.flattenParentIds?.split("|") ?: emptyList(),
+                roomEncryptionAlgorithm = when (val alg = roomSummaryEntity.e2eAlgorithm) {
+                    // I should probably use #hasEncryptorClassForAlgorithm but it says it supports
+                    // OLM which is some legacy? Now only megolm allowed in rooms
+                    MXCRYPTO_ALGORITHM_MEGOLM -> RoomEncryptionAlgorithm.Megolm
+                    else                      -> RoomEncryptionAlgorithm.UnsupportedAlgorithm(alg)
+                }
         )
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/RoomSummaryMapper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/RoomSummaryMapper.kt
@@ -16,6 +16,7 @@
 
 package org.matrix.android.sdk.internal.database.mapper
 
+import org.matrix.android.sdk.api.crypto.RoomEncryptionTrustLevel
 import org.matrix.android.sdk.api.session.room.model.RoomEncryptionAlgorithm
 import org.matrix.android.sdk.api.session.room.model.RoomJoinRules
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
@@ -70,7 +71,9 @@ internal class RoomSummaryMapper @Inject constructor(private val timelineEventMa
                 isEncrypted = roomSummaryEntity.isEncrypted,
                 encryptionEventTs = roomSummaryEntity.encryptionEventTs,
                 breadcrumbsIndex = roomSummaryEntity.breadcrumbsIndex,
-                roomEncryptionTrustLevel = roomSummaryEntity.roomEncryptionTrustLevel,
+                roomEncryptionTrustLevel = if (roomSummaryEntity.isEncrypted && roomSummaryEntity.e2eAlgorithm != MXCRYPTO_ALGORITHM_MEGOLM) {
+                    RoomEncryptionTrustLevel.E2EWithUnsupportedAlgorithm
+                } else roomSummaryEntity.roomEncryptionTrustLevel,
                 inviterId = roomSummaryEntity.inviterId,
                 hasFailedSending = roomSummaryEntity.hasFailedSending,
                 roomType = roomSummaryEntity.roomType,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/RoomSummaryEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/RoomSummaryEntity.kt
@@ -205,6 +205,11 @@ internal open class RoomSummaryEntity(
             if (value != field) field = value
         }
 
+    var e2eAlgorithm: String? = null
+        set(value) {
+            if (value != field) field = value
+        }
+
     var encryptionEventTs: Long? = 0
         set(value) {
             if (value != field) field = value

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoom.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoom.kt
@@ -119,15 +119,15 @@ internal class DefaultRoom(override val roomId: String,
         }
     }
 
-    override suspend fun enableEncryption(algorithm: String) {
+    override suspend fun enableEncryption(algorithm: String, force: Boolean) {
         when {
-            isEncrypted()                          -> {
+            (!force && isEncrypted() && encryptionAlgorithm() == MXCRYPTO_ALGORITHM_MEGOLM) -> {
                 throw IllegalStateException("Encryption is already enabled for this room")
             }
-            algorithm != MXCRYPTO_ALGORITHM_MEGOLM -> {
+            (!force && algorithm != MXCRYPTO_ALGORITHM_MEGOLM)                              -> {
                 throw InvalidParameterException("Only MXCRYPTO_ALGORITHM_MEGOLM algorithm is supported")
             }
-            else                                   -> {
+            else                                                                            -> {
                 val params = SendStateTask.Params(
                         roomId = roomId,
                         stateKey = null,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
@@ -221,6 +221,7 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
                 }
                 val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it }
                 val eventEntity = event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, insertType)
+                Timber.v("## received state event ${event.type} and key ${event.stateKey}")
                 CurrentStateEventEntity.getOrCreate(realm, roomId, event.stateKey, event.type).apply {
                     // Timber.v("## Space state event: $eventEntity")
                     eventId = event.eventId
@@ -393,6 +394,7 @@ internal class RoomSyncHandler @Inject constructor(private val readReceiptHandle
                     roomMemberEventHandler.handle(realm, roomEntity.roomId, event.stateKey, fixedContent, aggregator)
                 }
             }
+
             roomMemberContentsByUser.getOrPut(event.senderId) {
                 // If we don't have any new state on this user, get it from db
                 val rootStateEvent = CurrentStateEventEntity.getOrNull(realm, roomId, event.senderId, EventType.STATE_ROOM_MEMBER)?.root

--- a/vector/src/main/java/im/vector/app/core/ui/list/GenericFooterItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/GenericFooterItem.kt
@@ -24,6 +24,7 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
+import im.vector.app.core.epoxy.charsequence.EpoxyCharSequence
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 import im.vector.app.features.themes.ThemeUtils
@@ -38,7 +39,7 @@ import im.vector.app.features.themes.ThemeUtils
 abstract class GenericFooterItem : VectorEpoxyModel<GenericFooterItem.Holder>() {
 
     @EpoxyAttribute
-    var text: String? = null
+    var text: EpoxyCharSequence? = null
 
     @EpoxyAttribute
     var style: ItemStyle = ItemStyle.NORMAL_TEXT
@@ -56,7 +57,7 @@ abstract class GenericFooterItem : VectorEpoxyModel<GenericFooterItem.Holder>() 
     override fun bind(holder: Holder) {
         super.bind(holder)
 
-        holder.text.setTextOrHide(text)
+        holder.text.setTextOrHide(text?.charSequence)
         holder.text.typeface = style.toTypeFace()
         holder.text.textSize = style.toTextSize()
         holder.text.gravity = if (centered) Gravity.CENTER_HORIZONTAL else Gravity.START

--- a/vector/src/main/java/im/vector/app/core/ui/views/NotificationAreaView.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/views/NotificationAreaView.kt
@@ -74,7 +74,7 @@ class NotificationAreaView @JvmOverloads constructor(
             is State.Default                    -> renderDefault()
             is State.Hidden                     -> renderHidden()
             is State.NoPermissionToPost         -> renderNoPermissionToPost()
-            is State.UnsupportedAlgorithm       -> renderUnsupportedAlgorithm()
+            is State.UnsupportedAlgorithm       -> renderUnsupportedAlgorithm(newState)
             is State.Tombstone                  -> renderTombstone()
             is State.ResourceLimitExceededError -> renderResourceLimitExceededError(newState)
         }.exhaustive
@@ -108,12 +108,15 @@ class NotificationAreaView @JvmOverloads constructor(
         views.roomNotificationMessage.setTextColor(ThemeUtils.getColor(context, R.attr.vctr_content_secondary))
     }
 
-    private fun renderUnsupportedAlgorithm() {
+    private fun renderUnsupportedAlgorithm(e2eState: State.UnsupportedAlgorithm) {
         visibility = View.VISIBLE
         views.roomNotificationIcon.setImageResource(R.drawable.ic_shield_warning_small)
+        val text = if (e2eState.canRestore) {
+            R.string.room_unsupported_e2e_algorithm_as_admin
+        } else R.string.room_unsupported_e2e_algorithm
         val message = span {
             italic {
-                +resources.getString(R.string.room_unsupported_e2e_algorithm)
+                +resources.getString(text)
             }
         }
         views.roomNotificationMessage.onClick {
@@ -180,7 +183,7 @@ class NotificationAreaView @JvmOverloads constructor(
 
         // User can't post messages to room because his power level doesn't allow it.
         object NoPermissionToPost : State()
-        object UnsupportedAlgorithm : State()
+        data class UnsupportedAlgorithm(val canRestore: Boolean) : State()
 
         // View will be Gone
         object Hidden : State()

--- a/vector/src/main/java/im/vector/app/core/ui/views/NotificationAreaView.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/views/NotificationAreaView.kt
@@ -73,6 +73,7 @@ class NotificationAreaView @JvmOverloads constructor(
             is State.Default                    -> renderDefault()
             is State.Hidden                     -> renderHidden()
             is State.NoPermissionToPost         -> renderNoPermissionToPost()
+            is State.UnsupportedAlgorithm       -> renderUnsupportedAlgorithm()
             is State.Tombstone                  -> renderTombstone()
             is State.ResourceLimitExceededError -> renderResourceLimitExceededError(newState)
         }.exhaustive
@@ -100,6 +101,18 @@ class NotificationAreaView @JvmOverloads constructor(
         val message = span {
             italic {
                 +resources.getString(R.string.room_do_not_have_permission_to_post)
+            }
+        }
+        views.roomNotificationMessage.text = message
+        views.roomNotificationMessage.setTextColor(ThemeUtils.getColor(context, R.attr.vctr_content_secondary))
+    }
+
+    private fun renderUnsupportedAlgorithm() {
+        visibility = View.VISIBLE
+        views.roomNotificationIcon.setImageResource(R.drawable.ic_shield_warning_small)
+        val message = span {
+            italic {
+                +resources.getString(R.string.room_unsupported_e2e_algorithm)
             }
         }
         views.roomNotificationMessage.text = message
@@ -163,6 +176,7 @@ class NotificationAreaView @JvmOverloads constructor(
 
         // User can't post messages to room because his power level doesn't allow it.
         object NoPermissionToPost : State()
+        object UnsupportedAlgorithm : State()
 
         // View will be Gone
         object Hidden : State()

--- a/vector/src/main/java/im/vector/app/core/ui/views/NotificationAreaView.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/views/NotificationAreaView.kt
@@ -110,7 +110,7 @@ class NotificationAreaView @JvmOverloads constructor(
 
     private fun renderUnsupportedAlgorithm(e2eState: State.UnsupportedAlgorithm) {
         visibility = View.VISIBLE
-        views.roomNotificationIcon.setImageResource(R.drawable.ic_shield_warning_small)
+        views.roomNotificationIcon.setImageResource(R.drawable.ic_warning_badge)
         val text = if (e2eState.canRestore) {
             R.string.room_unsupported_e2e_algorithm_as_admin
         } else R.string.room_unsupported_e2e_algorithm

--- a/vector/src/main/java/im/vector/app/core/ui/views/NotificationAreaView.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/views/NotificationAreaView.kt
@@ -25,6 +25,7 @@ import android.widget.LinearLayout
 import androidx.core.content.ContextCompat
 import androidx.core.text.italic
 import im.vector.app.R
+import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.error.ResourceLimitErrorFormatter
 import im.vector.app.core.extensions.exhaustive
 import im.vector.app.core.utils.DimensionConverter
@@ -115,6 +116,9 @@ class NotificationAreaView @JvmOverloads constructor(
                 +resources.getString(R.string.room_unsupported_e2e_algorithm)
             }
         }
+        views.roomNotificationMessage.onClick {
+            delegate?.onMisconfiguredEncryptionClicked()
+        }
         views.roomNotificationMessage.text = message
         views.roomNotificationMessage.setTextColor(ThemeUtils.getColor(context, R.attr.vctr_content_secondary))
     }
@@ -193,5 +197,6 @@ class NotificationAreaView @JvmOverloads constructor(
      */
     interface Delegate {
         fun onTombstoneEventClicked()
+        fun onMisconfiguredEncryptionClicked()
     }
 }

--- a/vector/src/main/java/im/vector/app/core/ui/views/ShieldImageView.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/views/ShieldImageView.kt
@@ -61,6 +61,10 @@ class ShieldImageView @JvmOverloads constructor(
                         else R.drawable.ic_shield_trusted
                 )
             }
+            RoomEncryptionTrustLevel.E2EWithUnsupportedAlgorithm -> {
+                contentDescription = context.getString(R.string.a11y_trust_level_trusted)
+                setImageResource(R.drawable.ic_warning_badge)
+            }
         }
     }
 }
@@ -71,5 +75,6 @@ fun RoomEncryptionTrustLevel.toDrawableRes(): Int {
         RoomEncryptionTrustLevel.Default -> R.drawable.ic_shield_black
         RoomEncryptionTrustLevel.Warning -> R.drawable.ic_shield_warning
         RoomEncryptionTrustLevel.Trusted -> R.drawable.ic_shield_trusted
+        RoomEncryptionTrustLevel.E2EWithUnsupportedAlgorithm -> R.drawable.ic_warning_badge
     }
 }

--- a/vector/src/main/java/im/vector/app/features/devtools/RoomDevToolSendFormController.kt
+++ b/vector/src/main/java/im/vector/app/features/devtools/RoomDevToolSendFormController.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.devtools
 
 import com.airbnb.epoxy.TypedEpoxyController
 import im.vector.app.R
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.ui.list.genericFooterItem
 import im.vector.app.features.form.formEditTextItem
@@ -36,7 +37,7 @@ class RoomDevToolSendFormController @Inject constructor(
 
         genericFooterItem {
             id("topSpace")
-            text("")
+            text("".toEpoxyCharSequence())
         }
         formEditTextItem {
             id("event_type")

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
@@ -42,6 +42,7 @@ sealed class RoomDetailAction : VectorViewModelAction {
     object MarkAllAsRead : RoomDetailAction()
     data class DownloadOrOpen(val eventId: String, val senderId: String?, val messageFileContent: MessageWithAttachmentContent) : RoomDetailAction()
     object JoinAndOpenReplacementRoom : RoomDetailAction()
+    object OnClickMisconfiguredEncryption : RoomDetailAction()
     object AcceptInvite : RoomDetailAction()
     object RejectInvite : RoomDetailAction()
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -461,7 +461,8 @@ class RoomDetailFragment @Inject constructor(
                 is RoomDetailViewEvents.OpenRoom                         -> handleOpenRoom(it)
                 RoomDetailViewEvents.OpenInvitePeople                    -> navigator.openInviteUsersToRoom(requireContext(), roomDetailArgs.roomId)
                 RoomDetailViewEvents.OpenSetRoomAvatarDialog             -> galleryOrCameraDialogHelper.show()
-                RoomDetailViewEvents.OpenRoomSettings                    -> handleOpenRoomSettings()
+                RoomDetailViewEvents.OpenRoomSettings                    -> handleOpenRoomSettings(RoomProfileActivity.EXTRA_DIRECT_ACCESS_ROOM_SETTINGS)
+                RoomDetailViewEvents.OpenRoomProfile                     -> handleOpenRoomSettings()
                 is RoomDetailViewEvents.ShowRoomAvatarFullScreen         -> it.matrixItem?.let { item ->
                     navigator.openBigImageViewer(requireActivity(), it.view, item)
                 }
@@ -585,11 +586,11 @@ class RoomDetailFragment @Inject constructor(
         )
     }
 
-    private fun handleOpenRoomSettings() {
+    private fun handleOpenRoomSettings(directAccess: Int? = null) {
         navigator.openRoomProfile(
                 requireContext(),
                 roomDetailArgs.roomId,
-                RoomProfileActivity.EXTRA_DIRECT_ACCESS_ROOM_SETTINGS
+                directAccess
         )
     }
 
@@ -948,6 +949,10 @@ class RoomDetailFragment @Inject constructor(
         views.notificationAreaView.delegate = object : NotificationAreaView.Delegate {
             override fun onTombstoneEventClicked() {
                 roomDetailViewModel.handle(RoomDetailAction.JoinAndOpenReplacementRoom)
+            }
+
+            override fun onMisconfiguredEncryptionClicked() {
+                roomDetailViewModel.handle(RoomDetailAction.OnClickMisconfiguredEncryption)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -133,12 +133,14 @@ import im.vector.app.features.command.Command
 import im.vector.app.features.crypto.keysbackup.restore.KeysBackupRestoreActivity
 import im.vector.app.features.crypto.verification.VerificationBottomSheet
 import im.vector.app.features.home.AvatarRenderer
+import im.vector.app.features.home.room.detail.composer.CanSendStatus
 import im.vector.app.features.home.room.detail.composer.MessageComposerAction
 import im.vector.app.features.home.room.detail.composer.MessageComposerView
 import im.vector.app.features.home.room.detail.composer.MessageComposerViewEvents
 import im.vector.app.features.home.room.detail.composer.MessageComposerViewModel
 import im.vector.app.features.home.room.detail.composer.MessageComposerViewState
 import im.vector.app.features.home.room.detail.composer.SendMode
+import im.vector.app.features.home.room.detail.composer.boolean
 import im.vector.app.features.home.room.detail.composer.voice.VoiceMessageRecorderView
 import im.vector.app.features.home.room.detail.composer.voice.VoiceMessageRecorderView.RecordingUiState
 import im.vector.app.features.home.room.detail.readreceipts.DisplayReadReceiptsBottomSheet
@@ -392,7 +394,7 @@ class RoomDetailFragment @Inject constructor(
         }
 
         messageComposerViewModel.onEach(MessageComposerViewState::sendMode, MessageComposerViewState::canSendMessage) { mode, canSend ->
-            if (!canSend) {
+            if (!canSend.boolean()) {
                 return@onEach
             }
             when (mode) {
@@ -1268,7 +1270,7 @@ class RoomDetailFragment @Inject constructor(
                     val canSendMessage = withState(messageComposerViewModel) {
                         it.canSendMessage
                     }
-                    if (!canSendMessage) {
+                    if (!canSendMessage.boolean()) {
                         return false
                     }
                     return when (model) {
@@ -1446,10 +1448,18 @@ class RoomDetailFragment @Inject constructor(
                 views.voiceMessageRecorderView.render(messageComposerState.voiceRecordingUiState)
                 views.composerLayout.setRoomEncrypted(summary.isEncrypted)
                 // views.composerLayout.alwaysShowSendButton = false
-                if (messageComposerState.canSendMessage) {
-                    views.notificationAreaView.render(NotificationAreaView.State.Hidden)
-                } else {
-                    views.notificationAreaView.render(NotificationAreaView.State.NoPermissionToPost)
+                when (messageComposerState.canSendMessage) {
+                    CanSendStatus.Allowed                    -> {
+                        NotificationAreaView.State.Hidden
+                    }
+                    CanSendStatus.NoPermission               -> {
+                        NotificationAreaView.State.NoPermissionToPost
+                    }
+                    is CanSendStatus.UnSupportedE2eAlgorithm -> {
+                        NotificationAreaView.State.UnsupportedAlgorithm
+                    }
+                }.let {
+                    views.notificationAreaView.render(it)
                 }
             } else {
                 views.hideComposerViews()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -1461,7 +1461,7 @@ class RoomDetailFragment @Inject constructor(
                         NotificationAreaView.State.NoPermissionToPost
                     }
                     is CanSendStatus.UnSupportedE2eAlgorithm -> {
-                        NotificationAreaView.State.UnsupportedAlgorithm
+                        NotificationAreaView.State.UnsupportedAlgorithm(mainState.isAllowedToSetupEncryption)
                     }
                 }.let {
                     views.notificationAreaView.render(it)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewEvents.kt
@@ -48,6 +48,7 @@ sealed class RoomDetailViewEvents : VectorViewEvents {
     object OpenInvitePeople : RoomDetailViewEvents()
     object OpenSetRoomAvatarDialog : RoomDetailViewEvents()
     object OpenRoomSettings : RoomDetailViewEvents()
+    object OpenRoomProfile : RoomDetailViewEvents()
     data class ShowRoomAvatarFullScreen(val matrixItem: MatrixItem?, val view: View?) : RoomDetailViewEvents()
 
     object ShowWaitingView : RoomDetailViewEvents()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewModel.kt
@@ -211,11 +211,13 @@ class RoomDetailViewModel @AssistedInject constructor(
                     val canInvite = PowerLevelsHelper(it).isUserAbleToInvite(session.myUserId)
                     val isAllowedToManageWidgets = session.widgetService().hasPermissionsToHandleWidgets(room.roomId)
                     val isAllowedToStartWebRTCCall = PowerLevelsHelper(it).isUserAllowedToSend(session.myUserId, false, EventType.CALL_INVITE)
+                    val isAllowedToSetupEncryption = PowerLevelsHelper(it).isUserAllowedToSend(session.myUserId, true, EventType.STATE_ROOM_ENCRYPTION)
                     setState {
                         copy(
                                 canInvite = canInvite,
                                 isAllowedToManageWidgets = isAllowedToManageWidgets,
-                                isAllowedToStartWebRTCCall = isAllowedToStartWebRTCCall
+                                isAllowedToStartWebRTCCall = isAllowedToStartWebRTCCall,
+                                isAllowedToSetupEncryption = isAllowedToSetupEncryption
                         )
                     }
                 }.launchIn(viewModelScope)
@@ -309,6 +311,7 @@ class RoomDetailViewModel @AssistedInject constructor(
             is RoomDetailAction.DownloadOrOpen                   -> handleOpenOrDownloadFile(action)
             is RoomDetailAction.NavigateToEvent                  -> handleNavigateToEvent(action)
             is RoomDetailAction.JoinAndOpenReplacementRoom       -> handleJoinAndOpenReplacementRoom()
+            is RoomDetailAction.OnClickMisconfiguredEncryption   -> handleClickMisconfiguredE2E()
             is RoomDetailAction.ResendMessage                    -> handleResendEvent(action)
             is RoomDetailAction.RemoveFailedEcho                 -> handleRemove(action)
             is RoomDetailAction.MarkAllAsRead                    -> handleMarkAllAsRead()
@@ -611,6 +614,12 @@ class RoomDetailViewModel @AssistedInject constructor(
                     _viewEvents.post(RoomDetailViewEvents.OpenRoom(roomId, closeCurrentRoom = true))
                 }
             }
+        }
+    }
+
+    private fun handleClickMisconfiguredE2E() = withState { state ->
+        if (state.isAllowedToSetupEncryption) {
+            _viewEvents.post(RoomDetailViewEvents.OpenRoomProfile)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -64,6 +64,7 @@ data class RoomDetailViewState(
         val canInvite: Boolean = true,
         val isAllowedToManageWidgets: Boolean = false,
         val isAllowedToStartWebRTCCall: Boolean = true,
+        val isAllowedToSetupEncryption: Boolean = true,
         val hasFailedSending: Boolean = false,
         val jitsiState: JitsiState = JitsiState()
 ) : MavericksState {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewState.kt
@@ -43,10 +43,10 @@ sealed interface SendMode {
     data class Voice(val text: String) : SendMode
 }
 
-sealed class CanSendStatus {
-    object Allowed : CanSendStatus()
-    object NoPermission : CanSendStatus()
-    data class UnSupportedE2eAlgorithm(val algorithm: String?) : CanSendStatus()
+sealed interface CanSendStatus {
+    object Allowed : CanSendStatus
+    object NoPermission : CanSendStatus
+    data class UnSupportedE2eAlgorithm(val algorithm: String?) : CanSendStatus
 }
 
 fun CanSendStatus.boolean(): Boolean {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewState.kt
@@ -43,9 +43,23 @@ sealed interface SendMode {
     data class Voice(val text: String) : SendMode
 }
 
+sealed class CanSendStatus {
+    object Allowed : CanSendStatus()
+    object NoPermission : CanSendStatus()
+    data class UnSupportedE2eAlgorithm(val algorithm: String?) : CanSendStatus()
+}
+
+fun CanSendStatus.boolean(): Boolean {
+    return when (this) {
+        CanSendStatus.Allowed                    -> true
+        CanSendStatus.NoPermission               -> false
+        is CanSendStatus.UnSupportedE2eAlgorithm -> false
+    }
+}
+
 data class MessageComposerViewState(
         val roomId: String,
-        val canSendMessage: Boolean = true,
+        val canSendMessage: CanSendStatus = CanSendStatus.Allowed,
         val isSendButtonVisible: Boolean = false,
         val sendMode: SendMode = SendMode.Regular("", false),
         val voiceRecordingUiState: VoiceMessageRecorderView.RecordingUiState = VoiceMessageRecorderView.RecordingUiState.Idle
@@ -60,8 +74,8 @@ data class MessageComposerViewState(
 
     val isVoiceMessageIdle = !isVoiceRecording
 
-    val isComposerVisible = canSendMessage && !isVoiceRecording
-    val isVoiceMessageRecorderVisible = canSendMessage && !isSendButtonVisible
+    val isComposerVisible = canSendMessage.boolean() && !isVoiceRecording
+    val isVoiceMessageRecorderVisible = canSendMessage.boolean() && !isSendButtonVisible
 
     @Suppress("UNUSED") // needed by mavericks
     constructor(args: RoomDetailArgs) : this(roomId = args.roomId)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/edithistory/ViewEditHistoryEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/edithistory/ViewEditHistoryEpoxyController.kt
@@ -62,7 +62,7 @@ class ViewEditHistoryEpoxyController @Inject constructor(
             is Fail       -> {
                 genericFooterItem {
                     id("failure")
-                    text(host.stringProvider.getString(R.string.unknown_error))
+                    text(host.stringProvider.getString(R.string.unknown_error).toEpoxyCharSequence())
                 }
             }
             is Success    -> {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/EncryptionItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/EncryptionItemFactory.kt
@@ -65,7 +65,7 @@ class EncryptionItemFactory @Inject constructor(
         } else {
             title = stringProvider.getString(R.string.encryption_misconfigured)
             description = stringProvider.getString(R.string.encryption_unknown_algorithm_tile_description)
-            shield = StatusTileTimelineItem.ShieldUIState.RED
+            shield = StatusTileTimelineItem.ShieldUIState.ERROR
         }
         return StatusTileTimelineItem_()
                 .attributes(

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/EncryptionItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/EncryptionItemFactory.kt
@@ -63,7 +63,7 @@ class EncryptionItemFactory @Inject constructor(
             )
             shield = StatusTileTimelineItem.ShieldUIState.BLACK
         } else {
-            title = stringProvider.getString(R.string.encryption_not_enabled)
+            title = stringProvider.getString(R.string.encryption_misconfigured)
             description = stringProvider.getString(R.string.encryption_unknown_algorithm_tile_description)
             shield = StatusTileTimelineItem.ShieldUIState.RED
         }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/StatusTileTimelineItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/StatusTileTimelineItem.kt
@@ -57,6 +57,7 @@ abstract class StatusTileTimelineItem : AbsBaseMessageItem<StatusTileTimelineIte
             ShieldUIState.GREEN -> R.drawable.ic_shield_trusted
             ShieldUIState.BLACK -> R.drawable.ic_shield_black
             ShieldUIState.RED   -> R.drawable.ic_shield_warning
+            ShieldUIState.ERROR   -> R.drawable.ic_warning_badge
         }
 
         holder.titleView.setCompoundDrawablesWithIntrinsicBounds(
@@ -98,6 +99,7 @@ abstract class StatusTileTimelineItem : AbsBaseMessageItem<StatusTileTimelineIte
     enum class ShieldUIState {
         BLACK,
         RED,
-        GREEN
+        GREEN,
+        ERROR
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/reactions/ViewReactionsEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/reactions/ViewReactionsEpoxyController.kt
@@ -49,7 +49,7 @@ class ViewReactionsEpoxyController @Inject constructor(
             is Fail       -> {
                 genericFooterItem {
                     id("failure")
-                    text(host.stringProvider.getString(R.string.unknown_error))
+                    text(host.stringProvider.getString(R.string.unknown_error).toEpoxyCharSequence())
                 }
             }
             is Success    -> {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/widget/RoomWidgetsController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/widget/RoomWidgetsController.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.home.room.detail.widget
 
 import com.airbnb.epoxy.TypedEpoxyController
 import im.vector.app.R
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.ui.list.genericButtonItem
@@ -40,7 +41,7 @@ class RoomWidgetsController @Inject constructor(
         if (widgets.isEmpty()) {
             genericFooterItem {
                 id("empty")
-                text(host.stringProvider.getString(R.string.room_no_active_widgets))
+                text(host.stringProvider.getString(R.string.room_no_active_widgets).toEpoxyCharSequence())
             }
         } else {
             widgets.forEach { widget ->

--- a/vector/src/main/java/im/vector/app/features/reactions/EmojiSearchResultController.kt
+++ b/vector/src/main/java/im/vector/app/features/reactions/EmojiSearchResultController.kt
@@ -20,6 +20,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.epoxy.TypedEpoxyController
 import im.vector.app.EmojiCompatFontProvider
 import im.vector.app.R
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.ui.list.genericFooterItem
 import javax.inject.Inject
@@ -52,13 +53,13 @@ class EmojiSearchResultController @Inject constructor(
                 // display 'Type something to find'
                 genericFooterItem {
                     id("type.query.item")
-                    text(host.stringProvider.getString(R.string.reaction_search_type_hint))
+                    text(host.stringProvider.getString(R.string.reaction_search_type_hint).toEpoxyCharSequence())
                 }
             } else {
                 // Display no search Results
                 genericFooterItem {
                     id("no.results.item")
-                    text(host.stringProvider.getString(R.string.no_result_placeholder))
+                    text(host.stringProvider.getString(R.string.no_result_placeholder).toEpoxyCharSequence())
                 }
             }
         } else {

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileController.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileController.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.roommemberprofile
 
 import com.airbnb.epoxy.TypedEpoxyController
 import im.vector.app.R
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.epoxy.profiles.buildProfileAction
 import im.vector.app.core.epoxy.profiles.buildProfileSection
 import im.vector.app.core.resources.StringProvider
@@ -150,7 +151,7 @@ class RoomMemberProfileController @Inject constructor(
 
                     genericFooterItem {
                         id("verify_footer")
-                        text(host.stringProvider.getString(R.string.room_profile_encrypted_subtitle))
+                        text(host.stringProvider.getString(R.string.room_profile_encrypted_subtitle).toEpoxyCharSequence())
                         centered(false)
                     }
                 }
@@ -171,7 +172,7 @@ class RoomMemberProfileController @Inject constructor(
 
             genericFooterItem {
                 id("verify_footer_not_encrypted")
-                text(host.stringProvider.getString(R.string.room_profile_not_encrypted_subtitle))
+                text(host.stringProvider.getString(R.string.room_profile_not_encrypted_subtitle).toEpoxyCharSequence())
                 centered(false)
             }
         }

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileController.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileController.kt
@@ -95,11 +95,14 @@ class RoomMemberProfileController @Inject constructor(
 
     private fun buildSecuritySection(state: RoomMemberProfileViewState) {
         // Security
-        buildProfileSection(stringProvider.getString(R.string.room_profile_section_security))
         val host = this
 
         if (state.isRoomEncrypted) {
-            if (state.userMXCrossSigningInfo != null) {
+            if (!state.isAlgorithmSupported) {
+                // TODO find sensible message to display here
+                // For now we just remove the verify actions as well as the Security status
+            } else if (state.userMXCrossSigningInfo != null) {
+                buildProfileSection(stringProvider.getString(R.string.room_profile_section_security))
                 // Cross signing is enabled for this user
                 if (state.userMXCrossSigningInfo.isTrusted()) {
                     // User is trusted
@@ -152,6 +155,8 @@ class RoomMemberProfileController @Inject constructor(
                     }
                 }
             } else {
+                buildProfileSection(stringProvider.getString(R.string.room_profile_section_security))
+
                 buildProfileAction(
                         id = "learn_more",
                         title = stringProvider.getString(R.string.room_profile_section_security_learn_more),
@@ -162,6 +167,8 @@ class RoomMemberProfileController @Inject constructor(
                 )
             }
         } else {
+            buildProfileSection(stringProvider.getString(R.string.room_profile_section_security))
+
             genericFooterItem {
                 id("verify_footer_not_encrypted")
                 text(host.stringProvider.getString(R.string.room_profile_not_encrypted_subtitle))

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewModel.kt
@@ -52,6 +52,7 @@ import org.matrix.android.sdk.api.session.profile.ProfileService
 import org.matrix.android.sdk.api.session.room.Room
 import org.matrix.android.sdk.api.session.room.members.roomMemberQueryParams
 import org.matrix.android.sdk.api.session.room.model.Membership
+import org.matrix.android.sdk.api.session.room.model.RoomEncryptionAlgorithm
 import org.matrix.android.sdk.api.session.room.model.RoomType
 import org.matrix.android.sdk.api.session.room.powerlevels.PowerLevelsHelper
 import org.matrix.android.sdk.api.session.room.powerlevels.Role
@@ -344,7 +345,15 @@ class RoomMemberProfileViewModel @AssistedInject constructor(
                 }.launchIn(viewModelScope)
 
         roomSummaryLive.execute {
-            copy(isRoomEncrypted = it.invoke()?.isEncrypted == true)
+            val summary = it.invoke() ?: return@execute this
+            if (summary.isEncrypted) {
+                copy(
+                        isRoomEncrypted = true,
+                        isAlgorithmSupported = summary.roomEncryptionAlgorithm is RoomEncryptionAlgorithm.SupportedAlgorithm
+                )
+            } else {
+                copy(isRoomEncrypted = false)
+            }
         }
         roomSummaryLive.combine(powerLevelsContentLive) { roomSummary, powerLevelsContent ->
             val roomName = roomSummary.toMatrixItem().getBestName()

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewState.kt
@@ -33,6 +33,7 @@ data class RoomMemberProfileViewState(
         val isMine: Boolean = false,
         val isIgnored: Async<Boolean> = Uninitialized,
         val isRoomEncrypted: Boolean = false,
+        val isAlgorithmSupported: Boolean = true,
         val powerLevelsContent: PowerLevelsContent? = null,
         val userPowerLevelString: Async<String> = Uninitialized,
         val userMatrixItem: Async<MatrixItem> = Uninitialized,

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/devices/DeviceListEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/devices/DeviceListEpoxyController.kt
@@ -97,7 +97,7 @@ class DeviceListEpoxyController @Inject constructor(private val stringProvider: 
                     // Can this really happen?
                     genericFooterItem {
                         id("empty")
-                        text(host.stringProvider.getString(R.string.search_no_results))
+                        text(host.stringProvider.getString(R.string.search_no_results).toEpoxyCharSequence())
                     }
                 } else {
                     // Build list of device with status

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/devices/DeviceTrustInfoEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/devices/DeviceTrustInfoEpoxyController.kt
@@ -67,12 +67,12 @@ class DeviceTrustInfoEpoxyController @Inject constructor(private val stringProvi
                         // TODO FORMAT
                         text(host.stringProvider.getString(R.string.verification_profile_device_verified_because,
                                 data.userItem?.displayName ?: "",
-                                data.userItem?.id ?: ""))
+                                data.userItem?.id ?: "").toEpoxyCharSequence())
                     } else {
                         // TODO what if mine
                         text(host.stringProvider.getString(R.string.verification_profile_device_new_signing,
                                 data.userItem?.displayName ?: "",
-                                data.userItem?.id ?: ""))
+                                data.userItem?.id ?: "").toEpoxyCharSequence())
                     }
                 }
 //                    text(stringProvider.getString(R.string.verification_profile_device_untrust_info))
@@ -98,7 +98,7 @@ class DeviceTrustInfoEpoxyController @Inject constructor(private val stringProvi
                     id("warn")
                     centered(false)
                     textColor(host.colorProvider.getColorFromAttribute(R.attr.vctr_content_primary))
-                    text(host.stringProvider.getString(R.string.verification_profile_device_untrust_info))
+                    text(host.stringProvider.getString(R.string.verification_profile_device_untrust_info).toEpoxyCharSequence())
                 }
 
                 bottomSheetVerificationActionItem {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileAction.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileAction.kt
@@ -26,4 +26,5 @@ sealed class RoomProfileAction : VectorViewModelAction {
     data class ChangeRoomNotificationState(val notificationState: RoomNotificationState) : RoomProfileAction()
     object ShareRoomProfile : RoomProfileAction()
     object CreateShortcut : RoomProfileAction()
+    object RestoreEncryptionState : RoomProfileAction()
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileController.kt
@@ -120,15 +120,29 @@ class RoomProfileController @Inject constructor(
         }
 
         var encryptionMisconfigured = false
-        val learnMoreSubtitle = if (roomSummary.isEncrypted) {
+        val e2eInfoText = if (roomSummary.isEncrypted) {
             if (roomSummary.roomEncryptionAlgorithm is RoomEncryptionAlgorithm.SupportedAlgorithm) {
-                if (roomSummary.isDirect) R.string.direct_room_profile_encrypted_subtitle else R.string.room_profile_encrypted_subtitle
+                stringProvider.getString(
+                        if (roomSummary.isDirect) R.string.direct_room_profile_encrypted_subtitle
+                        else R.string.room_profile_encrypted_subtitle
+                )
             } else {
                 encryptionMisconfigured = true
-                if (roomSummary.isDirect) R.string.direct_room_profile_encrypted_misconfigured_subtitle else R.string.room_profile_encrypted_misconfigured_subtitle
+                buildString {
+                    append(stringProvider.getString(R.string.encryption_has_been_misconfigured))
+                    append(" ")
+                    apply {
+                        if (!data.canUpdateRoomState) {
+                            append(stringProvider.getString(R.string.contact_admin_to_restore_encryption))
+                        }
+                    }
+                }
             }
         } else {
-            if (roomSummary.isDirect) R.string.direct_room_profile_not_encrypted_subtitle else R.string.room_profile_not_encrypted_subtitle
+            stringProvider.getString(
+                    if (roomSummary.isDirect) R.string.direct_room_profile_not_encrypted_subtitle
+                    else R.string.room_profile_not_encrypted_subtitle
+            )
         }
         genericFooterItem {
             id("e2e info")
@@ -143,7 +157,7 @@ class RoomProfileController @Inject constructor(
                                 +" "
                             }
                         }
-                        +host.stringProvider.getString(learnMoreSubtitle)
+                        +e2eInfoText
                     }
             )
         }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileController.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.roomprofile
 
 import com.airbnb.epoxy.TypedEpoxyController
 import im.vector.app.R
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.epoxy.expandableTextItem
 import im.vector.app.core.epoxy.profiles.buildProfileAction
 import im.vector.app.core.epoxy.profiles.buildProfileSection
@@ -107,7 +108,7 @@ class RoomProfileController @Inject constructor(
                 data.recommendedRoomVersion != null) {
             genericFooterItem {
                 id("version_warning")
-                text(host.stringProvider.getString(R.string.room_using_unstable_room_version, roomVersion))
+                text(host.stringProvider.getString(R.string.room_using_unstable_room_version, roomVersion).toEpoxyCharSequence())
                 textColor(host.colorProvider.getColorFromAttribute(R.attr.colorError))
                 centered(false)
             }
@@ -158,7 +159,7 @@ class RoomProfileController @Inject constructor(
                             }
                         }
                         +e2eInfoText
-                    }
+                    }.toEpoxyCharSequence()
             )
         }
 

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileFragment.kt
@@ -121,6 +121,7 @@ class RoomProfileFragment @Inject constructor(
                 is RoomProfileViewEvents.Failure          -> showFailure(it.throwable)
                 is RoomProfileViewEvents.ShareRoomProfile -> onShareRoomProfile(it.permalink)
                 is RoomProfileViewEvents.OnShortcutReady  -> addShortcut(it)
+                RoomProfileViewEvents.DismissLoading      -> dismissLoadingDialog()
             }.exhaustive
         }
         roomListQuickActionsSharedActionViewModel
@@ -297,6 +298,10 @@ class RoomProfileFragment @Inject constructor(
 
     override fun onRoomPermissionsClicked() {
         roomProfileSharedActionViewModel.post(RoomProfileSharedAction.OpenRoomPermissionsSettings)
+    }
+
+    override fun restoreEncryptionState() {
+        roomProfileViewModel.handle(RoomProfileAction.RestoreEncryptionState)
     }
 
     override fun onRoomIdClicked() {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileViewEvents.kt
@@ -24,6 +24,7 @@ import im.vector.app.core.platform.VectorViewEvents
  */
 sealed class RoomProfileViewEvents : VectorViewEvents {
     data class Loading(val message: CharSequence? = null) : RoomProfileViewEvents()
+    object DismissLoading : RoomProfileViewEvents()
     data class Failure(val throwable: Throwable) : RoomProfileViewEvents()
 
     data class ShareRoomProfile(val permalink: String) : RoomProfileViewEvents()

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileViewModel.kt
@@ -29,7 +29,10 @@ import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.features.home.ShortcutCreator
 import im.vector.app.features.powerlevel.PowerLevelsFlowFactory
+import im.vector.app.features.session.coroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.query.QueryStringValue
 import org.matrix.android.sdk.api.session.Session
@@ -44,6 +47,7 @@ import org.matrix.android.sdk.flow.FlowRoom
 import org.matrix.android.sdk.flow.flow
 import org.matrix.android.sdk.flow.mapOptional
 import org.matrix.android.sdk.flow.unwrap
+import timber.log.Timber
 
 class RoomProfileViewModel @AssistedInject constructor(
         @Assisted private val initialState: RoomProfileViewState,
@@ -67,6 +71,19 @@ class RoomProfileViewModel @AssistedInject constructor(
         observeRoomCreateContent(flowRoom)
         observeBannedRoomMembers(flowRoom)
         observePermissions()
+        obeservePowerLevels()
+    }
+
+    private fun obeservePowerLevels() {
+        val powerLevelsContentLive = PowerLevelsFlowFactory(room).createFlow()
+        powerLevelsContentLive
+                .onEach {
+                    val powerLevelsHelper = PowerLevelsHelper(it)
+                    val canUpdateRoomState = powerLevelsHelper.isUserAllowedToSend(session.myUserId, true, EventType.STATE_ROOM_ENCRYPTION)
+                    setState {
+                        copy(canUpdateRoomState = canUpdateRoomState)
+                    }
+                }.launchIn(viewModelScope)
     }
 
     private fun observeRoomCreateContent(flowRoom: FlowRoom) {
@@ -119,6 +136,7 @@ class RoomProfileViewModel @AssistedInject constructor(
             is RoomProfileAction.ChangeRoomNotificationState -> handleChangeNotificationMode(action)
             is RoomProfileAction.ShareRoomProfile            -> handleShareRoomProfile()
             RoomProfileAction.CreateShortcut                 -> handleCreateShortcut()
+            RoomProfileAction.RestoreEncryptionState         -> restoreEncryptionState()
         }.exhaustive
     }
 
@@ -181,5 +199,18 @@ class RoomProfileViewModel @AssistedInject constructor(
                 ?.let { permalink ->
                     _viewEvents.post(RoomProfileViewEvents.ShareRoomProfile(permalink))
                 }
+    }
+
+    private fun restoreEncryptionState() {
+        _viewEvents.post(RoomProfileViewEvents.Loading())
+        session.coroutineScope.launch {
+            try {
+                room.enableEncryption(force = true)
+            } catch (failure: Throwable) {
+                Timber.e(failure, "Failed to restore encryption state in room ${room.roomId}")
+            } finally {
+                _viewEvents.post(RoomProfileViewEvents.DismissLoading)
+            }
+        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileViewModel.kt
@@ -71,10 +71,10 @@ class RoomProfileViewModel @AssistedInject constructor(
         observeRoomCreateContent(flowRoom)
         observeBannedRoomMembers(flowRoom)
         observePermissions()
-        obeservePowerLevels()
+        observePowerLevels()
     }
 
-    private fun obeservePowerLevels() {
+    private fun observePowerLevels() {
         val powerLevelsContentLive = PowerLevelsFlowFactory(room).createFlow()
         powerLevelsContentLive
                 .onEach {
@@ -208,6 +208,7 @@ class RoomProfileViewModel @AssistedInject constructor(
                 room.enableEncryption(force = true)
             } catch (failure: Throwable) {
                 Timber.e(failure, "Failed to restore encryption state in room ${room.roomId}")
+                _viewEvents.post(RoomProfileViewEvents.Failure(failure))
             } finally {
                 _viewEvents.post(RoomProfileViewEvents.DismissLoading)
             }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileViewState.kt
@@ -34,7 +34,8 @@ data class RoomProfileViewState(
         val isUsingUnstableRoomVersion: Boolean = false,
         val recommendedRoomVersion: String? = null,
         val canUpgradeRoom: Boolean = false,
-        val isTombstoned: Boolean = false
+        val isTombstoned: Boolean = false,
+        val canUpdateRoomState: Boolean = false
 ) : MavericksState {
 
     constructor(args: RoomProfileArgs) : this(roomId = args.roomId)

--- a/vector/src/main/java/im/vector/app/features/roomprofile/banned/RoomBannedMemberListController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/banned/RoomBannedMemberListController.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.roomprofile.banned
 
 import com.airbnb.epoxy.TypedEpoxyController
 import im.vector.app.R
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.epoxy.dividerItem
 import im.vector.app.core.epoxy.profiles.buildProfileSection
 import im.vector.app.core.epoxy.profiles.profileMatrixItemWithProgress
@@ -53,7 +54,7 @@ class RoomBannedMemberListController @Inject constructor(
 
             genericFooterItem {
                 id("footer")
-                text(quantityString)
+                text(quantityString.toEpoxyCharSequence())
             }
         } else {
             buildProfileSection(quantityString)

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/joinrule/RoomJoinRuleAdvancedController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/joinrule/RoomJoinRuleAdvancedController.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.roomprofile.settings.joinrule
 
 import com.airbnb.epoxy.TypedEpoxyController
 import im.vector.app.R
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.ui.list.ItemStyle
@@ -49,7 +50,7 @@ class RoomJoinRuleAdvancedController @Inject constructor(
 
         genericFooterItem {
             id("header")
-            text(host.stringProvider.getString(R.string.room_settings_room_access_title))
+            text(host.stringProvider.getString(R.string.room_settings_room_access_title).toEpoxyCharSequence())
             centered(false)
             style(ItemStyle.TITLE)
             textColor(host.colorProvider.getColorFromAttribute(R.attr.vctr_content_primary))
@@ -57,7 +58,7 @@ class RoomJoinRuleAdvancedController @Inject constructor(
 
         genericFooterItem {
             id("desc")
-            text(host.stringProvider.getString(R.string.decide_who_can_find_and_join))
+            text(host.stringProvider.getString(R.string.decide_who_can_find_and_join).toEpoxyCharSequence())
             centered(false)
         }
 

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/joinrule/advanced/ChooseRestrictedController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/joinrule/advanced/ChooseRestrictedController.kt
@@ -22,6 +22,7 @@ import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
 import im.vector.app.R
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.epoxy.loadingItem
 import im.vector.app.core.epoxy.noResultItem
 import im.vector.app.core.resources.StringProvider
@@ -76,7 +77,7 @@ class ChooseRestrictedController @Inject constructor(
         // when no filters
         genericFooterItem {
             id("h1")
-            text(host.stringProvider.getString(R.string.space_you_know_that_contains_this_room))
+            text(host.stringProvider.getString(R.string.space_you_know_that_contains_this_room).toEpoxyCharSequence())
             centered(false)
         }
 
@@ -93,7 +94,7 @@ class ChooseRestrictedController @Inject constructor(
         if (data.unknownRestricted.isNotEmpty()) {
             genericFooterItem {
                 id("others")
-                text(host.stringProvider.getString(R.string.other_spaces_or_rooms_you_might_not_know))
+                text(host.stringProvider.getString(R.string.other_spaces_or_rooms_you_might_not_know).toEpoxyCharSequence())
                 centered(false)
             }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
@@ -293,7 +293,7 @@ class DeviceVerificationInfoBottomSheetController @Inject constructor(
 
         genericFooterItem {
             id("infoCrypto${info.deviceId}")
-            text(host.stringProvider.getString(R.string.settings_failed_to_get_crypto_device_info))
+            text(host.stringProvider.getString(R.string.settings_failed_to_get_crypto_device_info).toEpoxyCharSequence())
         }
 
         info.deviceId?.let { addGenericDeviceManageActions(data, it) }

--- a/vector/src/main/java/im/vector/app/features/settings/devtools/AccountDataEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devtools/AccountDataEpoxyController.kt
@@ -54,7 +54,7 @@ class AccountDataEpoxyController @Inject constructor(
             is Fail    -> {
                 genericFooterItem {
                     id("fail")
-                    text(data.accountData.error.localizedMessage.toEpoxyCharSequence())
+                    text(data.accountData.error.localizedMessage?.toEpoxyCharSequence())
                 }
             }
             is Success -> {

--- a/vector/src/main/java/im/vector/app/features/settings/devtools/AccountDataEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devtools/AccountDataEpoxyController.kt
@@ -54,7 +54,7 @@ class AccountDataEpoxyController @Inject constructor(
             is Fail    -> {
                 genericFooterItem {
                     id("fail")
-                    text(data.accountData.error.localizedMessage)
+                    text(data.accountData.error.localizedMessage.toEpoxyCharSequence())
                 }
             }
             is Success -> {
@@ -62,7 +62,7 @@ class AccountDataEpoxyController @Inject constructor(
                 if (dataList.isEmpty()) {
                     genericFooterItem {
                         id("noResults")
-                        text(host.stringProvider.getString(R.string.no_result_placeholder))
+                        text(host.stringProvider.getString(R.string.no_result_placeholder).toEpoxyCharSequence())
                     }
                 } else {
                     dataList.forEach { accountData ->

--- a/vector/src/main/java/im/vector/app/features/settings/push/PushGateWayController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/push/PushGateWayController.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.settings.push
 
 import com.airbnb.epoxy.TypedEpoxyController
 import im.vector.app.R
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.ui.list.genericFooterItem
 import javax.inject.Inject
@@ -34,7 +35,7 @@ class PushGateWayController @Inject constructor(
             if (pushers.isEmpty()) {
                 genericFooterItem {
                     id("footer")
-                    text(host.stringProvider.getString(R.string.settings_push_gateway_no_pushers))
+                    text(host.stringProvider.getString(R.string.settings_push_gateway_no_pushers).toEpoxyCharSequence())
                 }
             } else {
                 pushers.forEach {
@@ -50,7 +51,7 @@ class PushGateWayController @Inject constructor(
         } ?: run {
             genericFooterItem {
                 id("loading")
-                text(host.stringProvider.getString(R.string.loading))
+                text(host.stringProvider.getString(R.string.loading).toEpoxyCharSequence())
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/settings/push/PushRulesController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/push/PushRulesController.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.settings.push
 
 import com.airbnb.epoxy.TypedEpoxyController
 import im.vector.app.R
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.ui.list.genericFooterItem
 import javax.inject.Inject
@@ -38,7 +39,7 @@ class PushRulesController @Inject constructor(
         } ?: run {
             genericFooterItem {
                 id("footer")
-                text(host.stringProvider.getString(R.string.settings_push_rules_no_rules))
+                text(host.stringProvider.getString(R.string.settings_push_rules_no_rules).toEpoxyCharSequence())
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/settings/threepids/ThreePidsSettingsController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/threepids/ThreePidsSettingsController.kt
@@ -87,7 +87,7 @@ class ThreePidsSettingsController @Inject constructor(
             is Fail    -> {
                 genericFooterItem {
                     id("fail")
-                    text(data.threePids.error.localizedMessage.toEpoxyCharSequence())
+                    text(data.threePids.error.localizedMessage?.toEpoxyCharSequence())
                 }
             }
             is Success -> {

--- a/vector/src/main/java/im/vector/app/features/settings/threepids/ThreePidsSettingsController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/threepids/ThreePidsSettingsController.kt
@@ -22,6 +22,7 @@ import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
 import im.vector.app.R
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.epoxy.loadingItem
 import im.vector.app.core.epoxy.noResultItem
 import im.vector.app.core.error.ErrorFormatter
@@ -86,7 +87,7 @@ class ThreePidsSettingsController @Inject constructor(
             is Fail    -> {
                 genericFooterItem {
                     id("fail")
-                    text(data.threePids.error.localizedMessage)
+                    text(data.threePids.error.localizedMessage.toEpoxyCharSequence())
                 }
             }
             is Success -> {

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryController.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.spaces
 import com.airbnb.epoxy.EpoxyController
 import im.vector.app.R
 import im.vector.app.RoomGroupingMethod
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.ui.list.genericFooterItem
@@ -66,7 +67,7 @@ class SpaceSummaryController @Inject constructor(
         if (!nonNullViewState.legacyGroups.isNullOrEmpty()) {
             genericFooterItem {
                 id("legacy_space")
-                text(" ")
+                text(" ".toEpoxyCharSequence())
             }
 
             genericHeaderItem {

--- a/vector/src/main/java/im/vector/app/features/spaces/create/SpaceAdd3pidEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/create/SpaceAdd3pidEpoxyController.kt
@@ -43,12 +43,12 @@ class SpaceAdd3pidEpoxyController @Inject constructor(
         genericFooterItem {
             id("info_help_header")
             style(ItemStyle.TITLE)
-            text(host.stringProvider.getString(R.string.create_spaces_invite_public_header))
+            text(host.stringProvider.getString(R.string.create_spaces_invite_public_header).toEpoxyCharSequence())
             textColor(host.colorProvider.getColorFromAttribute(R.attr.vctr_content_primary))
         }
         genericFooterItem {
             id("info_help_desc")
-            text(host.stringProvider.getString(R.string.create_spaces_invite_public_header_desc, data.name ?: ""))
+            text(host.stringProvider.getString(R.string.create_spaces_invite_public_header_desc, data.name ?: "").toEpoxyCharSequence())
             textColor(host.colorProvider.getColorFromAttribute(R.attr.vctr_content_secondary))
         }
 

--- a/vector/src/main/java/im/vector/app/features/spaces/create/SpaceDefaultRoomEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/create/SpaceDefaultRoomEpoxyController.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.spaces.create
 import com.airbnb.epoxy.TypedEpoxyController
 import com.google.android.material.textfield.TextInputLayout
 import im.vector.app.R
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.ui.list.ItemStyle
@@ -45,7 +46,7 @@ class SpaceDefaultRoomEpoxyController @Inject constructor(
                         host.stringProvider.getString(R.string.create_spaces_room_public_header, data.name)
                     } else {
                         host.stringProvider.getString(R.string.create_spaces_room_private_header)
-                    }
+                    }.toEpoxyCharSequence()
             )
             textColor(host.colorProvider.getColorFromAttribute(R.attr.vctr_content_primary))
         }
@@ -59,7 +60,7 @@ class SpaceDefaultRoomEpoxyController @Inject constructor(
                             } else {
                                 R.string.create_spaces_room_private_header_desc
                             }
-                    )
+                    ).toEpoxyCharSequence()
             )
             textColor(host.colorProvider.getColorFromAttribute(R.attr.vctr_content_secondary))
         }

--- a/vector/src/main/java/im/vector/app/features/spaces/create/SpaceDetailEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/create/SpaceDetailEpoxyController.kt
@@ -20,6 +20,7 @@ import com.airbnb.epoxy.TypedEpoxyController
 import com.airbnb.mvrx.Fail
 import im.vector.app.R
 import im.vector.app.core.epoxy.TextListener
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.ui.list.genericFooterItem
 import im.vector.app.features.form.formEditTextItem
@@ -61,7 +62,7 @@ class SpaceDetailEpoxyController @Inject constructor(
                         host.stringProvider.getString(R.string.create_spaces_details_public_header)
                     } else {
                         host.stringProvider.getString(R.string.create_spaces_details_private_header)
-                    }
+                    }.toEpoxyCharSequence()
             )
         }
 

--- a/vector/src/main/java/im/vector/app/features/spaces/manage/SpaceManageRoomsController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/manage/SpaceManageRoomsController.kt
@@ -21,6 +21,7 @@ import com.airbnb.epoxy.VisibilityState
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Incomplete
 import im.vector.app.R
+import im.vector.app.core.epoxy.charsequence.toEpoxyCharSequence
 import im.vector.app.core.epoxy.errorWithRetryItem
 import im.vector.app.core.epoxy.loadingItem
 import im.vector.app.core.error.ErrorFormatter
@@ -74,7 +75,7 @@ class SpaceManageRoomsController @Inject constructor(
         if (filteredResult.isEmpty()) {
             genericFooterItem {
                 id("empty_result")
-                text(host.stringProvider.getString(R.string.no_result_placeholder))
+                text(host.stringProvider.getString(R.string.no_result_placeholder).toEpoxyCharSequence())
             }
         } else {
             filteredResult.forEach { childInfo ->

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3426,6 +3426,7 @@
     <string name="a11y_trust_level_default">Default trust level</string>
     <string name="a11y_trust_level_warning">Warning trust level</string>
     <string name="a11y_trust_level_trusted">Trusted trust level</string>
+    <string name="a11y_trust_level_misconfigured">Misconfigured trust level</string>
     <string name="a11y_open_emoji_picker">Open Emoji picker</string>
     <string name="a11y_close_emoji_picker">Close Emoji picker</string>
     <string name="a11y_checked">Checked</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2792,8 +2792,8 @@
     <string name="room_profile_not_encrypted_subtitle">Messages in this room are not end-to-end encrypted.</string>
     <string name="direct_room_profile_not_encrypted_subtitle">Messages here are not end-to-end encrypted.</string>
     <string name="room_profile_encrypted_subtitle">Messages in this room are end-to-end encrypted.\n\nYour messages are secured with locks and only you and the recipient have the unique keys to unlock them.</string>
-    <string name="room_profile_encrypted_misconfigured_subtitle">Encryption has been misconfigured. Please contact an admin to restore the room to a valid state.</string>
-    <string name="direct_room_profile_encrypted_misconfigured_subtitle">Encryption has been misconfigured. Please contact an admin to restore room.</string>
+    <string name="encryption_has_been_misconfigured">Encryption has been misconfigured.</string>
+    <string name="contact_admin_to_restore_encryption">Please contact an admin to restore encryption to a valid state.</string>
     <string name="direct_room_profile_encrypted_subtitle">Messages here are end-to-end encrypted.\n\nYour messages are secured with locks and only you and the recipient have the unique keys to unlock them.</string>
     <string name="room_profile_section_security">Security</string>
     <string name="room_profile_section_restore_security">Restore Encryption</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -962,6 +962,7 @@
     <string name="room_delete_unsent_messages">Delete unsent messages</string>
     <string name="room_message_file_not_found">File not found</string>
     <string name="room_do_not_have_permission_to_post">You do not have permission to post to this room.</string>
+    <string name="room_unsupported_e2e_algorithm">Encryption has been misconfigured. You can\'t send messages, please contact an admin to restore the room to a valid state.</string>
     <plurals name="room_new_messages_notification">
         <item quantity="one">%d new message</item>
         <item quantity="other">%d new messages</item>
@@ -2790,8 +2791,11 @@
     <string name="room_profile_not_encrypted_subtitle">Messages in this room are not end-to-end encrypted.</string>
     <string name="direct_room_profile_not_encrypted_subtitle">Messages here are not end-to-end encrypted.</string>
     <string name="room_profile_encrypted_subtitle">Messages in this room are end-to-end encrypted.\n\nYour messages are secured with locks and only you and the recipient have the unique keys to unlock them.</string>
+    <string name="room_profile_encrypted_misconfigured_subtitle">Encryption has been misconfigured. Please contact an admin to restore the room to a valid state.</string>
+    <string name="direct_room_profile_encrypted_misconfigured_subtitle">Encryption has been misconfigured. Please contact an admin to restore room.</string>
     <string name="direct_room_profile_encrypted_subtitle">Messages here are end-to-end encrypted.\n\nYour messages are secured with locks and only you and the recipient have the unique keys to unlock them.</string>
     <string name="room_profile_section_security">Security</string>
+    <string name="room_profile_section_restore_security">Restore Encryption</string>
     <string name="room_profile_section_security_learn_more">Learn more</string>
     <string name="room_profile_section_more">More</string>
     <string name="room_profile_section_admin">Admin Actions</string>
@@ -3052,6 +3056,7 @@
     <string name="encryption_enabled_tile_description">Messages in this room are end-to-end encrypted. Learn more &amp; verify users in their profile.</string>
     <string name="direct_room_encryption_enabled_tile_description">Messages in this room are end-to-end encrypted.</string>
     <string name="encryption_not_enabled">Encryption not enabled</string>
+    <string name="encryption_misconfigured">Encryption is misconfigured</string>
     <string name="encryption_unknown_algorithm_tile_description">The encryption used by this room is not supported</string>
 
     <string name="room_created_summary_item">%s created and configured the room.</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -962,7 +962,8 @@
     <string name="room_delete_unsent_messages">Delete unsent messages</string>
     <string name="room_message_file_not_found">File not found</string>
     <string name="room_do_not_have_permission_to_post">You do not have permission to post to this room.</string>
-    <string name="room_unsupported_e2e_algorithm">Encryption has been misconfigured. You can\'t send messages, please contact an admin to restore the room to a valid state.</string>
+    <string name="room_unsupported_e2e_algorithm">Encryption has been misconfigured so you can\'t send messages. Please contact an admin to restore encryption to a valid state.</string>
+    <string name="room_unsupported_e2e_algorithm_as_admin">Encryption has been misconfigured so you can\'t send messages. Click to open settings.</string>
     <plurals name="room_new_messages_notification">
         <item quantity="one">%d new message</item>
         <item quantity="other">%d new messages</item>


### PR DESCRIPTION
Fixes #4711

Better handlind of misconfigured encryption in room.
More details here vector-im/element-meta#69

When encryption is misconfigured the text composer will be disabled to deny sending (would fail anyhow)

Admin would have a button in settings to restore encryption

<img width="699" alt="image" src="https://user-images.githubusercontent.com/9841565/146408651-caed95b0-3c0b-4bcf-88d6-13e6de28b5d0.png">


