### PR TITLE
Proximity sensor not releasing

### DIFF
--- a/changelog.d/2467.bugfix
+++ b/changelog.d/2467.bugfix
@@ -1,0 +1,1 @@
+Fixing proximity sensor still being active after a call

--- a/vector/src/main/java/im/vector/app/features/call/CallProximityManager.kt
+++ b/vector/src/main/java/im/vector/app/features/call/CallProximityManager.kt
@@ -93,7 +93,9 @@ class CallProximityManager @Inject constructor(
         if (wakeLock == null) {
             wakeLock = powerManager.newWakeLock(PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK, generateWakeLockTag())
         }
-        wakeLock?.acquire(WAKE_LOCK_TIMEOUT_MILLIS)
+        wakeLock
+                ?.takeIf { !it.isHeld }
+                ?.acquire(WAKE_LOCK_TIMEOUT_MILLIS)
     }
 
     private fun onProximityFar() {


### PR DESCRIPTION
Fixes #2467 Proximity sensor not releasing

Wake locks are reference counted which means we would need to release as many times as we acquire in order to full release the proximity sensor. It's possible that the `onProximityNear` / `onProximityFar` may not trigger as cleanly as we expect on some devices which can cause multiple wakelock acquires 

- Guards the proximity wake lock acquiring by checking if we already have one active.

----

was able to reproduce the original issue by commenting out the `onProximityFar` and triggering the proximity sensor multiple times whilst in a call