### PR TITLE
Avoid leaking Activity Window when showing loading dialog

### DIFF
--- a/changelog.d/4713.misc
+++ b/changelog.d/4713.misc
@@ -1,0 +1,1 @@
+Avoids leaking the activity windows when loading dialogs are displaying

--- a/vector/src/main/java/im/vector/app/core/platform/VectorBaseFragment.kt
+++ b/vector/src/main/java/im/vector/app/core/platform/VectorBaseFragment.kt
@@ -151,6 +151,7 @@ abstract class VectorBaseFragment<VB : ViewBinding> : Fragment(), MavericksView 
     override fun onDestroyView() {
         Timber.i("onDestroyView Fragment ${javaClass.simpleName}")
         _binding = null
+        dismissLoadingDialog()
         super.onDestroyView()
     }
 


### PR DESCRIPTION
Fixes #4713 leaking activity windows

Currently when we display loading dialogs we don't take into account if they're still displaying when destroying the associated fragment, dismissing them when destroying them avoids leaking the parent activity window 