### PR TITLE
Automatic carousel rotation

### DIFF
--- a/library/ui-styles/src/main/res/drawable/bg_carousel_page_1.xml
+++ b/library/ui-styles/src/main/res/drawable/bg_carousel_page_1.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
+        android:angle="@integer/rtl_mirror_flip"
         android:endColor="#3372C7DA"
         android:startColor="#33BBE7CF" />
 </shape>

--- a/library/ui-styles/src/main/res/drawable/bg_carousel_page_2.xml
+++ b/library/ui-styles/src/main/res/drawable/bg_carousel_page_2.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
+        android:angle="@integer/rtl_mirror_flip"
         android:endColor="#33B972DA"
         android:startColor="#3372C7DA" />
 </shape>

--- a/library/ui-styles/src/main/res/drawable/bg_carousel_page_3.xml
+++ b/library/ui-styles/src/main/res/drawable/bg_carousel_page_3.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
+        android:angle="@integer/rtl_mirror_flip"
         android:endColor="#330DBD8B"
         android:startColor="#33B972DA" />
 </shape>

--- a/library/ui-styles/src/main/res/drawable/bg_carousel_page_4.xml
+++ b/library/ui-styles/src/main/res/drawable/bg_carousel_page_4.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
+        android:angle="@integer/rtl_mirror_flip"
         android:endColor="#33BBE7CF"
         android:startColor="#330DBD8B" />
 </shape>

--- a/vector/src/debug/java/im/vector/app/features/debug/features/DebugFeaturesStateFactory.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/DebugFeaturesStateFactory.kt
@@ -38,6 +38,11 @@ class DebugFeaturesStateFactory @Inject constructor(
                         label = "FTUE Splash - I already have an account",
                         factory = VectorFeatures::isAlreadyHaveAccountSplashEnabled,
                         key = DebugFeatureKeys.alreadyHaveAnAccount
+                ),
+                createBooleanFeature(
+                        label = "FTUE Splash - Carousel",
+                        factory = VectorFeatures::isSplashCarouselEnabled,
+                        key = DebugFeatureKeys.splashCarousel
                 )
         ))
     }

--- a/vector/src/main/java/im/vector/app/core/extensions/Integer.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/Integer.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.extensions
+
+fun Int.incrementAndWrap(max: Int, min: Int = 0, amount: Int = 1) = if (this == max) min else this + amount

--- a/vector/src/main/java/im/vector/app/core/extensions/Integer.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/Integer.kt
@@ -16,4 +16,11 @@
 
 package im.vector.app.core.extensions
 
-fun Int.incrementAndWrap(max: Int, min: Int = 0, amount: Int = 1) = if (this == max) min else this + amount
+fun Int.incrementByOneAndWrap(max: Int, min: Int = 0): Int {
+    val incrementedValue = this + 1
+    return if (incrementedValue > max) {
+        min
+    } else {
+        incrementedValue
+    }
+}

--- a/vector/src/main/java/im/vector/app/core/extensions/ViewPager2.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/ViewPager2.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.extensions
+
+import android.animation.Animator
+import android.animation.TimeInterpolator
+import android.animation.ValueAnimator
+import android.view.animation.AccelerateDecelerateInterpolator
+import androidx.viewpager2.widget.ViewPager2
+
+fun ViewPager2.setCurrentItem(
+        item: Int,
+        duration: Long,
+        interpolator: TimeInterpolator = AccelerateDecelerateInterpolator(),
+        pagePxWidth: Int = width // Default value taken from getWidth() from ViewPager2 view
+) {
+    val pxToDrag: Int = pagePxWidth * (item - currentItem)
+    val animator = ValueAnimator.ofInt(0, pxToDrag)
+    var previousValue = 0
+    animator.addUpdateListener { valueAnimator ->
+        val currentValue = valueAnimator.animatedValue as Int
+        val currentPxToDrag = (currentValue - previousValue).toFloat()
+        kotlin.runCatching {
+            fakeDragBy(-currentPxToDrag)
+            previousValue = currentValue
+        }.onFailure { animator.cancel() }
+    }
+    animator.addListener(object : Animator.AnimatorListener {
+        override fun onAnimationStart(animation: Animator?) {
+            beginFakeDrag()
+        }
+
+        override fun onAnimationEnd(animation: Animator?) {
+            endFakeDrag()
+        }
+
+        override fun onAnimationCancel(animation: Animator?) = Unit
+        override fun onAnimationRepeat(animation: Animator?) = Unit
+    })
+    animator.interpolator = interpolator
+    animator.duration = duration
+    animator.start()
+}

--- a/vector/src/main/java/im/vector/app/core/extensions/ViewPager2.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/ViewPager2.kt
@@ -27,7 +27,7 @@ fun ViewPager2.setCurrentItem(
         item: Int,
         duration: Long,
         interpolator: TimeInterpolator = AccelerateDecelerateInterpolator(),
-        pagePxWidth: Int = width // Default value taken from getWidth() from ViewPager2 view
+        pagePxWidth: Int = width,
 ) {
     val pxToDrag: Int = pagePxWidth * (item - currentItem)
     val animator = ValueAnimator.ofInt(0, pxToDrag)
@@ -47,10 +47,12 @@ fun ViewPager2.setCurrentItem(
     }
     animator.addListener(object : Animator.AnimatorListener {
         override fun onAnimationStart(animation: Animator?) {
+            isUserInputEnabled = false
             beginFakeDrag()
         }
 
         override fun onAnimationEnd(animation: Animator?) {
+            isUserInputEnabled = true
             endFakeDrag()
         }
 

--- a/vector/src/main/java/im/vector/app/core/extensions/ViewPager2.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/ViewPager2.kt
@@ -19,6 +19,7 @@ package im.vector.app.core.extensions
 import android.animation.Animator
 import android.animation.TimeInterpolator
 import android.animation.ValueAnimator
+import android.view.View
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.viewpager2.widget.ViewPager2
 
@@ -31,11 +32,16 @@ fun ViewPager2.setCurrentItem(
     val pxToDrag: Int = pagePxWidth * (item - currentItem)
     val animator = ValueAnimator.ofInt(0, pxToDrag)
     var previousValue = 0
+    val isRtl = this.layoutDirection == View.LAYOUT_DIRECTION_RTL
+
     animator.addUpdateListener { valueAnimator ->
         val currentValue = valueAnimator.animatedValue as Int
         val currentPxToDrag = (currentValue - previousValue).toFloat()
         kotlin.runCatching {
-            fakeDragBy(-currentPxToDrag)
+            when {
+                isRtl -> fakeDragBy(currentPxToDrag)
+                else  -> fakeDragBy(-currentPxToDrag)
+            }
             previousValue = currentValue
         }.onFailure { animator.cancel() }
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashCarouselFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashCarouselFragment.kt
@@ -28,7 +28,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.tabs.TabLayoutMediator
 import im.vector.app.BuildConfig
 import im.vector.app.R
-import im.vector.app.core.extensions.incrementAndWrap
+import im.vector.app.core.extensions.incrementByOneAndWrap
 import im.vector.app.core.extensions.setCurrentItem
 import im.vector.app.core.flow.tickerFlow
 import im.vector.app.databinding.FragmentFtueSplashCarouselBinding
@@ -83,7 +83,7 @@ class FtueAuthSplashCarouselFragment @Inject constructor(
         views.splashCarousel.apply {
             val itemCount = carouselAdapter.itemCount
             tickerFlow(lifecycleScope, delayMillis = CAROUSEL_ROTATION_DELAY_MS)
-                    .onEach { setCurrentItem(currentItem.incrementAndWrap(max = itemCount - 1), duration = CAROUSEL_TRANSITION_TIME_MS) }
+                    .onEach { setCurrentItem(currentItem.incrementByOneAndWrap(max = itemCount - 1), duration = CAROUSEL_TRANSITION_TIME_MS) }
                     .launchIn(lifecycleScope)
         }
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashCarouselFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashCarouselFragment.kt
@@ -22,19 +22,28 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
+import androidx.lifecycle.lifecycleScope
 import com.airbnb.mvrx.withState
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.tabs.TabLayoutMediator
 import im.vector.app.BuildConfig
 import im.vector.app.R
+import im.vector.app.core.extensions.incrementAndWrap
+import im.vector.app.core.extensions.setCurrentItem
+import im.vector.app.core.flow.tickerFlow
 import im.vector.app.databinding.FragmentFtueSplashCarouselBinding
 import im.vector.app.features.VectorFeatures
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingFlow
 import im.vector.app.features.settings.VectorPreferences
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import org.matrix.android.sdk.api.failure.Failure
 import java.net.UnknownHostException
 import javax.inject.Inject
+
+private const val CAROUSEL_ROTATION_DELAY_MS = 5000L
+private const val CAROUSEL_TRANSITION_TIME_MS = 500L
 
 class FtueAuthSplashCarouselFragment @Inject constructor(
         private val vectorPreferences: VectorPreferences,
@@ -52,7 +61,8 @@ class FtueAuthSplashCarouselFragment @Inject constructor(
     }
 
     private fun setupViews() {
-        views.splashCarousel.adapter = carouselController.adapter
+        val carouselAdapter = carouselController.adapter
+        views.splashCarousel.adapter = carouselAdapter
         TabLayoutMediator(views.carouselIndicator, views.splashCarousel) { _, _ -> }.attach()
         carouselController.setData(SplashCarouselState())
 
@@ -68,6 +78,13 @@ class FtueAuthSplashCarouselFragment @Inject constructor(
             views.loginSplashVersion.text = "Version : ${BuildConfig.VERSION_NAME}#${BuildConfig.BUILD_NUMBER}\n" +
                     "Branch: ${BuildConfig.GIT_BRANCH_NAME}"
             views.loginSplashVersion.debouncedClicks { navigator.openDebug(requireContext()) }
+        }
+
+        views.splashCarousel.apply {
+            val itemCount = carouselAdapter.itemCount
+            tickerFlow(lifecycleScope, delayMillis = CAROUSEL_ROTATION_DELAY_MS)
+                    .onEach { setCurrentItem(currentItem.incrementAndWrap(max = itemCount - 1), duration = CAROUSEL_TRANSITION_TIME_MS) }
+                    .launchIn(lifecycleScope)
         }
     }
 


### PR DESCRIPTION
Part of #4584

- Adds automatic 5 second rotation to the Ftue auth carousel
- Also included a super handy extension from [SO](https://stackoverflow.com/questions/57505875/change-viewpager2-scroll-speed-when-sliding-programmatically/59235979#59235979) to control the view pager page transition speed as it's too fast out of the box
- Fixes the carousel direction for RTL locales

| GIF | RTL
| --- | --- |
|![device-2021-12-16-144427](https://user-images.githubusercontent.com/1848238/146399095-f75eb89d-bf78-419c-8f3a-2c6a49c25e0c.gif)|![after-rtl](https://user-images.githubusercontent.com/1848238/148559619-10ff05ce-fdc6-40bd-b202-fe75ffa5ad0a.gif)

