### PR TITLE
Emojis in emotes causing crashes on Android 12+

### DIFF
--- a/changelog.d/4743.bugfix
+++ b/changelog.d/4743.bugfix
@@ -1,0 +1,1 @@
+Fixes crash when launching rooms which contain emojis in the notice content on android 12+

--- a/changelog.d/4743.bugfix
+++ b/changelog.d/4743.bugfix
@@ -1,1 +1,1 @@
-Fixes crash when launching rooms which contain emojis in the notice content on android 12+
+Fixes crash when launching rooms which contain emojis in the emote content on android 12+

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -613,7 +613,7 @@ class MessageItemFactory @Inject constructor(
         val formattedBody = SpannableStringBuilder()
         formattedBody.append("* ${informationData.memberName} ")
         formattedBody.append(messageContent.getHtmlBody())
-
+        val bindingOptions = spanUtils.getBindingOptions(formattedBody)
         val message = formattedBody.linkify(callback)
 
         return MessageTextItem_()
@@ -625,6 +625,7 @@ class MessageItemFactory @Inject constructor(
                         message(message)
                     }
                 }
+                .bindingOptions(bindingOptions)
                 .leftGuideline(avatarSizeProvider.leftGuideline)
                 .previewUrlRetriever(callback?.getPreviewUrlRetriever())
                 .imageContentRenderer(imageContentRenderer)


### PR DESCRIPTION
Fixes #4743 

A follow up to the original emoji fix #4698, we had a missing case (the emote section eg `/me :tada:`) 


| BEFORE | AFTER |
| --- | --- |
|![before-emoji-crash](https://user-images.githubusercontent.com/1848238/146430061-2d209831-7d68-4ffb-9f6c-6727941d46bf.gif)|![after-emoji-crash](https://user-images.githubusercontent.com/1848238/146430064-b7194ff7-c092-4d5e-b284-3142657115f2.gif)
