### PR TITLE
Use ShareCompat.IntentBuilder for sharing content

### DIFF
--- a/changelog.d/4745.misc
+++ b/changelog.d/4745.misc
@@ -1,0 +1,1 @@
+Open share UI provides by the system when sharing media or text.

--- a/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
@@ -305,26 +305,28 @@ fun shareMedia(context: Context, file: File, mediaMimeType: String?) {
         return
     }
 
-    val sendIntent = ShareCompat.IntentBuilder(context)
+    val chooserIntent = ShareCompat.IntentBuilder(context)
             .setType(mediaMimeType)
             .setStream(mediaUri)
-            .intent
+            .setChooserTitle(R.string.share)
+            .createChooserIntent()
 
-    sendShareIntent(context, sendIntent)
+    createChooser(context, chooserIntent)
 }
 
 fun shareText(context: Context, text: String) {
-    val sendIntent = ShareCompat.IntentBuilder(context)
+    val chooserIntent = ShareCompat.IntentBuilder(context)
             .setType("text/plain")
             .setText(text)
-            .intent
+            .setChooserTitle(R.string.share)
+            .createChooserIntent()
 
-    sendShareIntent(context, sendIntent)
+    createChooser(context, chooserIntent)
 }
 
-private fun sendShareIntent(context: Context, intent: Intent) {
+private fun createChooser(context: Context, intent: Intent) {
     try {
-        context.startActivity(Intent.createChooser(intent, context.getString(R.string.share)))
+        context.startActivity(intent)
     } catch (activityNotFoundException: ActivityNotFoundException) {
         context.toast(R.string.error_no_external_application_found)
     }

--- a/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
@@ -314,10 +314,10 @@ fun shareMedia(context: Context, file: File, mediaMimeType: String?) {
 }
 
 fun shareText(context: Context, text: String) {
-    val sendIntent = Intent()
-    sendIntent.action = Intent.ACTION_SEND
-    sendIntent.type = "text/plain"
-    sendIntent.putExtra(Intent.EXTRA_TEXT, text)
+    val sendIntent = ShareCompat.IntentBuilder(context)
+            .setType("text/plain")
+            .setText(text)
+            .intent
 
     sendShareIntent(context, sendIntent)
 }

--- a/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/ExternalApplicationsUtil.kt
@@ -308,7 +308,7 @@ fun shareMedia(context: Context, file: File, mediaMimeType: String?) {
     val sendIntent = ShareCompat.IntentBuilder(context)
             .setType(mediaMimeType)
             .setStream(mediaUri)
-            .getIntent()
+            .intent
 
     sendShareIntent(context, sendIntent)
 }


### PR DESCRIPTION
### Description

- The implementation of **sharing text** and **sharing media** is updated to use the `ShareCompat.IntentBuilder` API.
- The UI does not change.

### Pull Request Checklist

<!--
 Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request
 Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked.
 -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots ~or videos if containing UI changes~
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

### Screenshots

- Screenshot of the system share chooser UI for sharing a file.
  ![share-file](https://user-images.githubusercontent.com/144518/146510636-b8e884ed-9e31-438d-a1dd-1bb1eb7a4b25.png)
- Screenshot of the system share chooser UI for sharing an image.
  ![share-image](https://user-images.githubusercontent.com/144518/146510643-e5e24f10-6fbe-4fcc-96d0-1f3c207081fb.png)
- Screenshot of the system share chooser UI for sharing plain text.
  ![share-text](https://user-images.githubusercontent.com/144518/146510653-adb23110-607f-433e-9ac2-d123d35bb393.png)
