### PR TITLE
Unable to render messages

### DIFF
--- a/changelog.d/4733.bugfix
+++ b/changelog.d/4733.bugfix
@@ -1,0 +1,1 @@
+Fixes unable to render messages by allowing them to render whilst the emoji library is initialising

--- a/vector/src/main/java/im/vector/app/EmojiCompatWrapper.kt
+++ b/vector/src/main/java/im/vector/app/EmojiCompatWrapper.kt
@@ -23,8 +23,12 @@ import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
+fun interface EmojiSpanify {
+    fun spanify(sequence: CharSequence): CharSequence
+}
+
 @Singleton
-class EmojiCompatWrapper @Inject constructor(private val context: Context) {
+class EmojiCompatWrapper @Inject constructor(private val context: Context) : EmojiSpanify {
 
     private var initialized = false
 
@@ -49,7 +53,7 @@ class EmojiCompatWrapper @Inject constructor(private val context: Context) {
                 })
     }
 
-    fun safeEmojiSpanify(sequence: CharSequence): CharSequence {
+    override fun spanify(sequence: CharSequence): CharSequence {
         if (initialized) {
             try {
                 return EmojiCompat.get().process(sequence) ?: sequence

--- a/vector/src/main/java/im/vector/app/core/di/SingletonModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/SingletonModule.kt
@@ -26,6 +26,8 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import im.vector.app.EmojiCompatWrapper
+import im.vector.app.EmojiSpanify
 import im.vector.app.core.dispatchers.CoroutineDispatchers
 import im.vector.app.core.error.DefaultErrorFormatter
 import im.vector.app.core.error.ErrorFormatter
@@ -76,6 +78,9 @@ abstract class VectorBindModule {
 
     @Binds
     abstract fun bindDefaultClock(clock: DefaultClock): Clock
+
+    @Binds
+    abstract fun bindEmojiSpanify(emojiCompatWrapper: EmojiCompatWrapper): EmojiSpanify
 }
 
 @InstallIn(SingletonComponent::class)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/format/DisplayableEventFormatter.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/format/DisplayableEventFormatter.kt
@@ -17,7 +17,7 @@
 package im.vector.app.features.home.room.detail.timeline.format
 
 import dagger.Lazy
-import im.vector.app.EmojiCompatWrapper
+import im.vector.app.EmojiSpanify
 import im.vector.app.R
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.StringProvider
@@ -39,7 +39,7 @@ import javax.inject.Inject
 class DisplayableEventFormatter @Inject constructor(
         private val stringProvider: StringProvider,
         private val colorProvider: ColorProvider,
-        private val emojiCompatWrapper: EmojiCompatWrapper,
+        private val emojiSpanify: EmojiSpanify,
         private val noticeEventFormatter: NoticeEventFormatter,
         private val htmlRenderer: Lazy<EventHtmlRenderer>
 ) {
@@ -100,7 +100,7 @@ class DisplayableEventFormatter @Inject constructor(
             }
             EventType.REACTION              -> {
                 timelineEvent.root.getClearContent().toModel<ReactionContent>()?.relatesTo?.let {
-                    val emojiSpanned = emojiCompatWrapper.safeEmojiSpanify(stringProvider.getString(R.string.sent_a_reaction, it.key))
+                    val emojiSpanned = emojiSpanify.spanify(stringProvider.getString(R.string.sent_a_reaction, it.key))
                     simpleFormat(senderName, emojiSpanned, appendAuthor)
                 } ?: span { }
             }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/reactions/ViewReactionsEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/reactions/ViewReactionsEpoxyController.kt
@@ -20,7 +20,7 @@ import com.airbnb.epoxy.TypedEpoxyController
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Incomplete
 import com.airbnb.mvrx.Success
-import im.vector.app.EmojiCompatWrapper
+import im.vector.app.EmojiSpanify
 import im.vector.app.R
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.ui.list.genericFooterItem
@@ -32,8 +32,8 @@ import javax.inject.Inject
  */
 class ViewReactionsEpoxyController @Inject constructor(
         private val stringProvider: StringProvider,
-        private val emojiCompatWrapper: EmojiCompatWrapper) :
-    TypedEpoxyController<DisplayReactionsViewState>() {
+        private val emojiSpanify: EmojiSpanify) :
+        TypedEpoxyController<DisplayReactionsViewState>() {
 
     var listener: Listener? = null
 
@@ -56,7 +56,7 @@ class ViewReactionsEpoxyController @Inject constructor(
                     reactionInfoSimpleItem {
                         id(reactionInfo.eventId)
                         timeStamp(reactionInfo.timestamp)
-                        reactionKey(host.emojiCompatWrapper.safeEmojiSpanify(reactionInfo.reactionKey))
+                        reactionKey(host.emojiSpanify.spanify(reactionInfo.reactionKey))
                         authorDisplayName(reactionInfo.authorName ?: reactionInfo.authorId)
                         userClicked { host.listener?.didSelectUser(reactionInfo.authorId) }
                     }

--- a/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
@@ -21,13 +21,15 @@ import android.text.Spanned
 import android.text.style.MetricAffectingSpan
 import android.text.style.StrikethroughSpan
 import android.text.style.UnderlineSpan
-import androidx.emoji2.text.EmojiCompat
+import im.vector.app.EmojiCompatWrapper
 import im.vector.app.features.home.room.detail.timeline.item.BindingOptions
 import javax.inject.Inject
 
-class SpanUtils @Inject constructor() {
+class SpanUtils @Inject constructor(
+        private val emojiCompat: EmojiCompatWrapper
+) {
     fun getBindingOptions(charSequence: CharSequence): BindingOptions {
-        val emojiCharSequence = EmojiCompat.get().process(charSequence)
+        val emojiCharSequence = emojiCompat.safeEmojiSpanify(charSequence)
 
         if (emojiCharSequence !is Spanned) {
             return BindingOptions()

--- a/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
@@ -21,15 +21,15 @@ import android.text.Spanned
 import android.text.style.MetricAffectingSpan
 import android.text.style.StrikethroughSpan
 import android.text.style.UnderlineSpan
-import im.vector.app.EmojiCompatWrapper
+import im.vector.app.EmojiSpanify
 import im.vector.app.features.home.room.detail.timeline.item.BindingOptions
 import javax.inject.Inject
 
 class SpanUtils @Inject constructor(
-        private val emojiCompat: EmojiCompatWrapper
+        private val emojiSpanify: EmojiSpanify
 ) {
     fun getBindingOptions(charSequence: CharSequence): BindingOptions {
-        val emojiCharSequence = emojiCompat.safeEmojiSpanify(charSequence)
+        val emojiCharSequence = emojiSpanify.spanify(charSequence)
 
         if (emojiCharSequence !is Spanned) {
             return BindingOptions()

--- a/vector/src/main/java/im/vector/app/features/reactions/widget/ReactionButton.kt
+++ b/vector/src/main/java/im/vector/app/features/reactions/widget/ReactionButton.kt
@@ -24,7 +24,7 @@ import android.widget.LinearLayout
 import androidx.core.content.ContextCompat
 import androidx.core.content.withStyledAttributes
 import dagger.hilt.android.AndroidEntryPoint
-import im.vector.app.EmojiCompatWrapper
+import im.vector.app.EmojiSpanify
 import im.vector.app.R
 import im.vector.app.core.utils.DimensionConverter
 import im.vector.app.core.utils.TextUtils
@@ -39,9 +39,9 @@ import javax.inject.Inject
 class ReactionButton @JvmOverloads constructor(context: Context,
                                                attrs: AttributeSet? = null,
                                                defStyleAttr: Int = 0) :
-    LinearLayout(context, attrs, defStyleAttr), View.OnClickListener, View.OnLongClickListener {
+        LinearLayout(context, attrs, defStyleAttr), View.OnClickListener, View.OnLongClickListener {
 
-    @Inject lateinit var emojiCompatWrapper: EmojiCompatWrapper
+    @Inject lateinit var emojiSpanify: EmojiSpanify
 
     private val views: ReactionButtonBinding
 
@@ -57,7 +57,7 @@ class ReactionButton @JvmOverloads constructor(context: Context,
         set(value) {
             field = value
             // maybe cache this for performances?
-            val emojiSpanned = emojiCompatWrapper.safeEmojiSpanify(value)
+            val emojiSpanned = emojiSpanify.spanify(value)
             views.reactionText.text = emojiSpanned
         }
 


### PR DESCRIPTION
Fixes #4733 

The timeline is failing to render whilst the emoji library is initialising. Fixed by using our safe wrapper which we already use in other places with emoji capabilities 

```
E/ /Tag: failed to create message item
java.lang.IllegalStateException: Not initialized yet
	at androidx.core.util.Preconditions.checkState(Preconditions.java:1)
	at androidx.emoji2.text.EmojiCompat.process(EmojiCompat.java:3)
	at androidx.emoji2.text.EmojiCompat.process(EmojiCompat.java:2)
	at im.vector.app.features.html.SpanUtils.getBindingOptions(SpanUtils.kt:1)
	at im.vector.app.features.home.room.detail.timeline.factory.MessageItemFactory.buildMessageTextItem(MessageItemFactory.kt:1)
	at im.vector.app.features.home.room.detail.timeline.factory.MessageItemFactory.buildItemForTextContent(MessageItemFactory.kt:18)
	at im.vector.app.features.home.room.detail.timeline.factory.MessageItemFactory.create(MessageItemFactory.kt:33)
	at im.vector.app.features.home.room.detail.timeline.factory.TimelineItemFactory.create(TimelineItemFactory.kt:15)
	at im.vector.app.features.home.room.detail.timeline.TimelineEventController.buildCacheItem(TimelineEventController.kt:9)
	at im.vector.app.features.home.room.detail.timeline.TimelineEventController.buildCacheItemsIfNeeded(TimelineEventController.kt:27)
	at im.vector.app.features.home.room.detail.timeline.TimelineEventController.getModels(TimelineEventController.kt:1)
	at im.vector.app.features.home.room.detail.timeline.TimelineEventController.buildModels(TimelineEventController.kt:9)
	at com.airbnb.epoxy.EpoxyController$1.run(EpoxyController.java:6)
```

| BEFORE | AFTER |
| --- | --- |
|![Screenshot_20211217_091758](https://user-images.githubusercontent.com/1848238/146521585-847a8020-aa20-41a6-bca2-c6bcf9814667.png)|![Screenshot_20211217_091942](https://user-images.githubusercontent.com/1848238/146521584-bbf480ba-4c50-487b-b731-d7f6b6e6e624.png)
