### PR TITLE
Wrong emojis in composer

### DIFF
--- a/changelog.d/4756.bugfix
+++ b/changelog.d/4756.bugfix
@@ -1,0 +1,1 @@
+Fixes newer emojis rendering strangely when inserting from the system keyboard

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/ComposerEditText.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/ComposerEditText.kt
@@ -24,18 +24,21 @@ import android.text.Editable
 import android.util.AttributeSet
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
+import androidx.appcompat.widget.AppCompatEditText
 import androidx.core.view.OnReceiveContentListener
 import androidx.core.view.ViewCompat
 import androidx.core.view.inputmethod.EditorInfoCompat
 import androidx.core.view.inputmethod.InputConnectionCompat
-import com.vanniktech.emoji.EmojiEditText
 import im.vector.app.core.extensions.ooi
 import im.vector.app.core.platform.SimpleTextWatcher
 import im.vector.app.features.html.PillImageSpan
 import timber.log.Timber
 
-class ComposerEditText @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = android.R.attr.editTextStyle) :
-        EmojiEditText(context, attrs, defStyleAttr) {
+class ComposerEditText @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = android.R.attr.editTextStyle
+) : AppCompatEditText(context, attrs, defStyleAttr) {
 
     interface Callback {
         fun onRichContentSelected(contentUri: Uri): Boolean


### PR DESCRIPTION
Fixes #4756 Inconsistent emoji input in the composer view

- Switches the `ComposeEditText` base view to the `AppCompatEditText` which now supports emojis out of the box

| BEFORE | AFTER |
| --- | --- |
|![before-new-emoji](https://user-images.githubusercontent.com/1848238/146574235-85f09a53-e200-4a9e-a52a-1f4817b664d8.gif)|![after-new-emoji](https://user-images.githubusercontent.com/1848238/146574229-8984f4bb-8653-4418-b596-52872af650fe.gif)
