### PR TITLE
Fixing Android 8.1.1 / 27 and below emoji crash

### DIFF
--- a/changelog.d/4769.bugfix
+++ b/changelog.d/4769.bugfix
@@ -1,0 +1,1 @@
+Fixing emoji related crashes on android 8.1.1 and below

--- a/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/html/SpanUtils.kt
@@ -16,7 +16,6 @@
 
 package im.vector.app.features.html
 
-import android.os.Build
 import android.text.Spanned
 import android.text.style.MetricAffectingSpan
 import android.text.style.StrikethroughSpan
@@ -41,13 +40,11 @@ class SpanUtils @Inject constructor(
         )
     }
 
-    // Workaround for https://issuetracker.google.com/issues/188454876
+    /**
+     * TextFutures do not support StrikethroughSpan, UnderlineSpan or MetricAffectingSpan
+     * Workaround for https://issuetracker.google.com/issues/188454876
+     */
     private fun canUseTextFuture(spanned: Spanned): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-            // On old devices, it works correctly
-            return true
-        }
-
         return spanned
                 .getSpans(0, spanned.length, Any::class.java)
                 .all { it !is StrikethroughSpan && it !is UnderlineSpan && it !is MetricAffectingSpan }


### PR DESCRIPTION
Fixes #4769 emojis still crashing on android 8.1.1 and below

From the user rageshake reports we can still see emoji crashes in 1.3.11, the original fix #4698 is still valid, we were however bypassing it for android versions 8.1.1 android below


*an 8.1.1 emulator with google play services

| BEFORE | AFTER |
| --- | --- |
|![Screenshot_1639994544](https://user-images.githubusercontent.com/1848238/146750919-c7b7bb2a-4c04-415f-b41e-353d84370bda.png)|![Screenshot_1639994587](https://user-images.githubusercontent.com/1848238/146750916-637f623e-6757-4e16-abd2-cd2668026bd5.png)


