### PR TITLE
Unable to change avatar due to `NetworkOnMainThread`

### DIFF
--- a/changelog.d/4767.bugfix
+++ b/changelog.d/4767.bugfix
@@ -1,0 +1,1 @@
+Fixing unable to change change avatar in some scenarios

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/profile/DefaultProfileService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/profile/DefaultProfileService.kt
@@ -68,7 +68,7 @@ internal class DefaultProfileService @Inject constructor(private val taskExecuto
     }
 
     override suspend fun updateAvatar(userId: String, newAvatarUri: Uri, fileName: String) {
-        withContext(coroutineDispatchers.main) {
+        withContext(coroutineDispatchers.io) {
             val response = fileUploader.uploadFromUri(newAvatarUri, fileName, MimeTypes.Jpeg)
             setAvatarUrlTask.execute(SetAvatarUrlTask.Params(userId = userId, newAvatarUrl = response.contentUri))
             userStore.updateAvatar(userId, response.contentUri)


### PR DESCRIPTION
Fixes #4767 Unable to change avatar

We had a report of `NetworkOnMainThread` whilst changing avatar, I've been unable to reproduce the issue but did notice we have an unnecessary main thread dispatcher being used (looks like it was introduced as part of the suspend migration).

- Switches the `main` dispatcher to `io`, the user has also confirmed this fixed their issue
- Bundles the file reading + temp file creation into the same io context 

| |
| --- |
|![changing-avatar](https://user-images.githubusercontent.com/1848238/146909084-71fde02c-2517-42a5-93f2-f7402537ed24.gif)
