### PR TITLE
Timeline recycling crash

### DIFF
--- a/changelog.d/4789.bugfix
+++ b/changelog.d/4789.bugfix
@@ -1,0 +1,1 @@
+Fixing crashes when quickly scrolling or restoring the room timeline 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -96,13 +96,12 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
         renderSendState(holder.messageView, holder.messageView)
         holder.messageView.onClick(attributes.itemClickListener)
         holder.messageView.onLongClickIgnoringLinks(attributes.itemLongClickListener)
-
-        message?.let { holder.messageView.setTextWithEmojiSupport(it.charSequence, bindingOptions) }
+        holder.messageView.setTextWithEmojiSupport(message?.charSequence, bindingOptions)
         markwonPlugins?.forEach { plugin -> plugin.afterSetText(holder.messageView) }
     }
 
-    private fun AppCompatTextView.setTextWithEmojiSupport(message: CharSequence, bindingOptions: BindingOptions?) {
-        if (bindingOptions?.canUseTextFuture.orFalse()) {
+    private fun AppCompatTextView.setTextWithEmojiSupport(message: CharSequence?, bindingOptions: BindingOptions?) {
+        if (bindingOptions?.canUseTextFuture.orFalse() && message != null) {
             val textFuture = PrecomputedTextCompat.getTextFuture(message, TextViewCompat.getTextMetricsParams(this), null)
             setTextFuture(textFuture)
         } else {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -16,7 +16,6 @@
 
 package im.vector.app.features.home.room.detail.timeline.item
 
-import android.text.Spanned
 import android.text.method.MovementMethod
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.text.PrecomputedTextCompat

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -92,27 +92,23 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
                 it.bind(holder.messageView)
             }
         }
-        val textFuture = if (bindingOptions?.canUseTextFuture.orFalse()) {
-            PrecomputedTextCompat.getTextFuture(
-                    message?.charSequence ?: "",
-                    TextViewCompat.getTextMetricsParams(holder.messageView),
-                    null)
-        } else {
-            null
-        }
-        markwonPlugins?.forEach { plugin -> plugin.beforeSetText(holder.messageView, message?.charSequence as Spanned) }
         super.bind(holder)
         holder.messageView.movementMethod = movementMethod
         renderSendState(holder.messageView, holder.messageView)
         holder.messageView.onClick(attributes.itemClickListener)
         holder.messageView.onLongClickIgnoringLinks(attributes.itemLongClickListener)
 
-        if (bindingOptions?.canUseTextFuture.orFalse()) {
-            holder.messageView.setTextFuture(textFuture)
-        } else {
-            holder.messageView.text = message?.charSequence
-        }
+        message?.let { holder.messageView.setTextWithEmojiSupport(it.charSequence, bindingOptions) }
         markwonPlugins?.forEach { plugin -> plugin.afterSetText(holder.messageView) }
+    }
+
+    private fun AppCompatTextView.setTextWithEmojiSupport(message: CharSequence, bindingOptions: BindingOptions?) {
+        if (bindingOptions?.canUseTextFuture.orFalse()) {
+            val textFuture = PrecomputedTextCompat.getTextFuture(message, TextViewCompat.getTextMetricsParams(this), null)
+            setTextFuture(textFuture)
+        } else {
+            text = message
+        }
     }
 
     override fun unbind(holder: Holder) {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.features.home.room.detail.timeline.item
 
+import android.text.Spanned
 import android.text.method.MovementMethod
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.text.PrecomputedTextCompat
@@ -90,6 +91,9 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
                 // mmm.. not sure this is so safe in regards to cell reuse
                 it.bind(holder.messageView)
             }
+        }
+        message?.charSequence.let { charSequence ->
+            markwonPlugins?.forEach { plugin -> plugin.beforeSetText(holder.messageView, charSequence as Spanned) }
         }
         super.bind(holder)
         holder.messageView.movementMethod = movementMethod


### PR DESCRIPTION
Tentatively fixes #4789 Timeline crashes when quickly scrolling or restoring state.

I was unable to reproduce this crash locally, the stack trace looks to be the same as when a `TextView` is modified after setting a `TextFuture`

```
Thread: main, Exception: java.lang.IllegalArgumentException: PrecomputedText's Parameters don't match the parameters of this TextView.
    at android.widget.TextView.setText(TextView.java:6206)
    at android.widget.TextView.setText(TextView.java:6124)
    at android.widget.TextView.setText(TextView.java:6076)
    at androidx.core.widget.TextViewCompat.setPrecomputedText(TextViewCompat.java:907)
    at androidx.appcompat.widget.AppCompatTextView.consumeTextFutureAndSetBlocking(AppCompatTextView.java:542)
    at androidx.appcompat.widget.AppCompatTextView.getText(AppCompatTextView.java:551)
    at androidx.emoji2.viewsintegration.EmojiInputFilter.filter(EmojiInputFilter.java:64)
    at android.widget.TextView.setText(TextView.java:6160)
    at android.widget.TextView.setText(TextView.java:6124)
    at android.widget.TextView.setText(TextView.java:6076)
```

My theory is that `RecyclerView` is recycling `TextViews` with non consumed futures which causes them to throw when the `TextView` options are rebound. This PR aims to solve the issue by resetting any present futures before calling `setText` which will allow `AppCompatTextView.consumeTextFutureAndSetBlocking` to be skipped if the view is rebound with `setText` directly (such is the case when emojis are present)
