### PR TITLE
Emojis in code blocks crash

### DIFF
--- a/changelog.d/4789.bugfix
+++ b/changelog.d/4789.bugfix
@@ -1,0 +1,1 @@
+Fixing crashes when quickly scrolling or restoring the room timeline 

--- a/changelog.d/4794.bugfix
+++ b/changelog.d/4794.bugfix
@@ -1,0 +1,1 @@
+Fixing crash when viewing or submitting message with an emoji in a code block

--- a/vector/src/androidTest/java/im/vector/app/features/html/VectorCharSequenceFactoryTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/html/VectorCharSequenceFactoryTest.kt
@@ -38,26 +38,26 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(JUnit4::class)
 @FixMethodOrder(MethodSorters.JVM)
-class SpanUtilsTest : InstrumentedTest {
+class VectorCharSequenceFactoryTest : InstrumentedTest {
 
-    private val spanUtils = SpanUtils {
+    private val factory = VectorCharSequenceFactory {
         val emojiCompat = EmojiCompat.get()
         emojiCompat.waitForInit()
         emojiCompat.process(it) ?: it
     }
 
-    private fun SpanUtils.canUseTextFuture(message: CharSequence): Boolean {
-        return getBindingOptions(message).canUseTextFuture
+    private fun VectorCharSequenceFactory.canUseTextFuture(message: CharSequence): Boolean {
+        return create(message).bindingOptions.canUseTextFuture
     }
 
     @Test
     fun canUseTextFutureString() {
-        spanUtils.canUseTextFuture("test").shouldBeTrue()
+        factory.canUseTextFuture("test").shouldBeTrue()
     }
 
     @Test
     fun canUseTextFutureCharSequenceOK() {
-        spanUtils.canUseTextFuture(SpannableStringBuilder().append("hello")).shouldBeTrue()
+        factory.canUseTextFuture(SpannableStringBuilder().append("hello")).shouldBeTrue()
     }
 
     @Test
@@ -65,7 +65,7 @@ class SpanUtilsTest : InstrumentedTest {
         val string = SpannableString("Text with strikethrough, underline, red spans")
         string.setSpan(ForegroundColorSpan(Color.RED), 36, 39, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
 
-        spanUtils.canUseTextFuture(string) shouldBeEqualTo true
+        factory.canUseTextFuture(string) shouldBeEqualTo true
     }
 
     @Test
@@ -73,7 +73,7 @@ class SpanUtilsTest : InstrumentedTest {
         val string = SpannableString("Text with strikethrough, underline, red spans")
         string.setSpan(StrikethroughSpan(), 10, 23, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
 
-        spanUtils.canUseTextFuture(string) shouldBeEqualTo trueIfAlwaysAllowed()
+        factory.canUseTextFuture(string) shouldBeEqualTo trueIfAlwaysAllowed()
     }
 
     @Test
@@ -81,7 +81,7 @@ class SpanUtilsTest : InstrumentedTest {
         val string = SpannableString("Text with strikethrough, underline, red spans")
         string.setSpan(UnderlineSpan(), 25, 34, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
 
-        spanUtils.canUseTextFuture(string) shouldBeEqualTo trueIfAlwaysAllowed()
+        factory.canUseTextFuture(string) shouldBeEqualTo trueIfAlwaysAllowed()
     }
 
     @Test
@@ -90,7 +90,7 @@ class SpanUtilsTest : InstrumentedTest {
         string.setSpan(StrikethroughSpan(), 10, 23, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         string.setSpan(UnderlineSpan(), 25, 34, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
 
-        spanUtils.canUseTextFuture(string) shouldBeEqualTo trueIfAlwaysAllowed()
+        factory.canUseTextFuture(string) shouldBeEqualTo trueIfAlwaysAllowed()
     }
 
     @Test
@@ -100,32 +100,32 @@ class SpanUtilsTest : InstrumentedTest {
         string.setSpan(UnderlineSpan(), 25, 34, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         string.setSpan(ForegroundColorSpan(Color.RED), 36, 39, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
 
-        spanUtils.canUseTextFuture(string) shouldBeEqualTo trueIfAlwaysAllowed()
+        factory.canUseTextFuture(string) shouldBeEqualTo trueIfAlwaysAllowed()
     }
 
     @Test
     fun testGetBindingOptionsRegular() {
         val string = SpannableString("Text")
-        val result = spanUtils.getBindingOptions(string)
-        result.canUseTextFuture shouldBeEqualTo true
-        result.preventMutation shouldBeEqualTo false
+        val result = factory.create(string)
+        result.bindingOptions.canUseTextFuture shouldBeEqualTo true
+        result.bindingOptions.preventMutation shouldBeEqualTo false
     }
 
     @Test
     fun testGetBindingOptionsStrikethrough() {
         val string = SpannableString("Text with strikethrough")
         string.setSpan(StrikethroughSpan(), 10, 23, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        val result = spanUtils.getBindingOptions(string)
-        result.canUseTextFuture shouldBeEqualTo false
-        result.preventMutation shouldBeEqualTo false
+        val result = factory.create(string)
+        result.bindingOptions.canUseTextFuture shouldBeEqualTo false
+        result.bindingOptions.preventMutation shouldBeEqualTo false
     }
 
     @Test
     fun testGetBindingOptionsMetricAffectingSpan() {
         val string = SpannableString("Emoji \uD83D\uDE2E\u200D\uD83D\uDCA8")
-        val result = spanUtils.getBindingOptions(string)
-        result.canUseTextFuture shouldBeEqualTo false
-        result.preventMutation shouldBeEqualTo true
+        val result = factory.create(string)
+        result.bindingOptions.canUseTextFuture shouldBeEqualTo false
+        result.bindingOptions.preventMutation shouldBeEqualTo true
     }
 
     private fun trueIfAlwaysAllowed() = Build.VERSION.SDK_INT < Build.VERSION_CODES.P

--- a/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
@@ -19,6 +19,7 @@ package im.vector.app.core.epoxy.bottomsheet
 import android.text.method.MovementMethod
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
@@ -27,14 +28,13 @@ import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
-import im.vector.app.core.epoxy.util.preventMutation
 import im.vector.app.core.extensions.setTextOrHide
+import im.vector.app.core.extensions.setVectorText
 import im.vector.app.features.displayname.getBestName
 import im.vector.app.features.home.AvatarRenderer
-import im.vector.app.features.home.room.detail.timeline.item.BindingOptions
 import im.vector.app.features.home.room.detail.timeline.tools.findPillsAndProcess
+import im.vector.app.features.html.VectorCharSequence
 import im.vector.app.features.media.ImageContentRenderer
-import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.util.MatrixItem
 
 /**
@@ -50,10 +50,7 @@ abstract class BottomSheetMessagePreviewItem : VectorEpoxyModel<BottomSheetMessa
     lateinit var matrixItem: MatrixItem
 
     @EpoxyAttribute
-    lateinit var body: CharSequence
-
-    @EpoxyAttribute
-    var bindingOptions: BindingOptions? = null
+    lateinit var body: VectorCharSequence
 
     @EpoxyAttribute
     var bodyDetails: CharSequence? = null
@@ -84,13 +81,9 @@ abstract class BottomSheetMessagePreviewItem : VectorEpoxyModel<BottomSheetMessa
         }
         holder.imagePreview.isVisible = data != null
         holder.body.movementMethod = movementMethod
-        holder.body.text = if (bindingOptions?.preventMutation.orFalse()) {
-            body.preventMutation()
-        } else {
-            body
-        }
+        holder.body.setVectorText(body)
         holder.bodyDetails.setTextOrHide(bodyDetails)
-        body.findPillsAndProcess(coroutineScope) { it.bind(holder.body) }
+        body.value.findPillsAndProcess(coroutineScope) { it.bind(holder.body) }
         holder.timestamp.setTextOrHide(time)
     }
 
@@ -102,7 +95,7 @@ abstract class BottomSheetMessagePreviewItem : VectorEpoxyModel<BottomSheetMessa
     class Holder : VectorEpoxyHolder() {
         val avatar by bind<ImageView>(R.id.bottom_sheet_message_preview_avatar)
         val sender by bind<TextView>(R.id.bottom_sheet_message_preview_sender)
-        val body by bind<TextView>(R.id.bottom_sheet_message_preview_body)
+        val body by bind<AppCompatTextView>(R.id.bottom_sheet_message_preview_body)
         val bodyDetails by bind<TextView>(R.id.bottom_sheet_message_preview_body_details)
         val timestamp by bind<TextView>(R.id.bottom_sheet_message_preview_timestamp)
         val imagePreview by bind<ImageView>(R.id.bottom_sheet_message_preview_image)

--- a/vector/src/main/java/im/vector/app/core/extensions/TextView.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/TextView.kt
@@ -38,9 +38,8 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.util.preventMutation
 import im.vector.app.core.platform.showOptimizedSnackbar
 import im.vector.app.core.utils.copyToClipboard
-import im.vector.app.features.home.room.detail.timeline.item.BindingOptions
+import im.vector.app.features.html.VectorCharSequence
 import im.vector.app.features.themes.ThemeUtils
-import org.matrix.android.sdk.api.extensions.orFalse
 
 /**
  * Set a text in the TextView, or set visibility to GONE if the text is null
@@ -147,24 +146,24 @@ fun TextView.copyOnLongClick() {
 }
 
 /**
- * Safely set text containing emojis whilst still enabling text optimisations
+ * Safely set text with optimisations containing spans and emojis
  * For use in epoxy models
  */
-fun AppCompatTextView.setTextWithEmojiSupport(message: CharSequence?, bindingOptions: BindingOptions?) {
+fun AppCompatTextView.setVectorText(message: VectorCharSequence?) {
     setTextFuture(null)
     when {
-        message == null                            -> {
+        message?.value == null                  -> {
             text = null
         }
-        bindingOptions?.canUseTextFuture.orFalse() -> {
-            val textFuture = PrecomputedTextCompat.getTextFuture(message, TextViewCompat.getTextMetricsParams(this), null)
+        message.bindingOptions.canUseTextFuture -> {
+            val textFuture = PrecomputedTextCompat.getTextFuture(message.value, TextViewCompat.getTextMetricsParams(this), null)
             setTextFuture(textFuture)
         }
-        bindingOptions?.preventMutation.orFalse()  -> {
-            text = message.preventMutation()
+        message.bindingOptions.preventMutation  -> {
+            text = message.value.preventMutation()
         }
-        else                                       -> {
-            text = message
+        else                                    -> {
+            text = message.value
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsEpoxyController.kt
@@ -37,7 +37,7 @@ import im.vector.app.features.home.room.detail.timeline.image.buildImageContentR
 import im.vector.app.features.home.room.detail.timeline.item.E2EDecoration
 import im.vector.app.features.home.room.detail.timeline.tools.createLinkMovementMethod
 import im.vector.app.features.home.room.detail.timeline.tools.linkify
-import im.vector.app.features.html.SpanUtils
+import im.vector.app.features.html.VectorCharSequenceFactory
 import im.vector.app.features.media.ImageContentRenderer
 import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.failure.Failure
@@ -54,7 +54,7 @@ class MessageActionsEpoxyController @Inject constructor(
         private val imageContentRenderer: ImageContentRenderer,
         private val dimensionConverter: DimensionConverter,
         private val errorFormatter: ErrorFormatter,
-        private val spanUtils: SpanUtils,
+        private val vectorCharSequenceFactory: VectorCharSequenceFactory,
         private val eventDetailsFormatter: EventDetailsFormatter,
         private val dateFormatter: VectorDateFormatter
 ) : TypedEpoxyController<MessageActionState>() {
@@ -66,8 +66,7 @@ class MessageActionsEpoxyController @Inject constructor(
         // Message preview
         val date = state.timelineEvent()?.root?.originServerTs
         val formattedDate = dateFormatter.format(date, DateFormatKind.MESSAGE_DETAIL)
-        val body = state.messageBody.linkify(host.listener)
-        val bindingOptions = spanUtils.getBindingOptions(body)
+        val body = vectorCharSequenceFactory.create(state.messageBody.linkify(host.listener))
         bottomSheetMessagePreviewItem {
             id("preview")
             avatarRenderer(host.avatarRenderer)
@@ -76,7 +75,6 @@ class MessageActionsEpoxyController @Inject constructor(
             imageContentRenderer(host.imageContentRenderer)
             data(state.timelineEvent()?.buildImageContentRendererData(host.dimensionConverter.dpToPx(66)))
             userClicked { host.listener?.didSelectMenuAction(EventSharedAction.OpenUserProfile(state.informationData.senderId)) }
-            bindingOptions(bindingOptions)
             body(body)
             bodyDetails(host.eventDetailsFormatter.format(state.timelineEvent()?.root))
             time(formattedDate)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/EncryptedItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/EncryptedItemFactory.kt
@@ -26,6 +26,7 @@ import im.vector.app.features.home.room.detail.timeline.helper.MessageInformatio
 import im.vector.app.features.home.room.detail.timeline.helper.MessageItemAttributesFactory
 import im.vector.app.features.home.room.detail.timeline.item.MessageTextItem_
 import im.vector.app.features.home.room.detail.timeline.tools.createLinkMovementMethod
+import im.vector.app.features.html.VectorCharSequenceFactory
 import im.vector.app.features.settings.VectorPreferences
 import me.gujun.android.span.image
 import me.gujun.android.span.span
@@ -42,7 +43,8 @@ class EncryptedItemFactory @Inject constructor(private val messageInformationDat
                                                private val avatarSizeProvider: AvatarSizeProvider,
                                                private val drawableProvider: DrawableProvider,
                                                private val attributesFactory: MessageItemAttributesFactory,
-                                               private val vectorPreferences: VectorPreferences) {
+                                               private val vectorPreferences: VectorPreferences,
+                                               private val vectorCharSequenceFactory: VectorCharSequenceFactory) {
 
     fun create(params: TimelineItemFactoryParams): VectorEpoxyModel<*>? {
         val event = params.event
@@ -110,7 +112,7 @@ class EncryptedItemFactory @Inject constructor(private val messageInformationDat
                         .leftGuideline(avatarSizeProvider.leftGuideline)
                         .highlighted(params.isHighlighted)
                         .attributes(attributes)
-                        .message(spannableStr)
+                        .message(vectorCharSequenceFactory.create(spannableStr))
                         .movementMethod(createLinkMovementMethod(params.callback))
             }
             else                                             -> null

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -525,7 +525,7 @@ class MessageItemFactory @Inject constructor(
                                    informationData: MessageInformationData,
                                    highlight: Boolean,
                                    callback: TimelineEventController.Callback?,
-                                   attributes: AbsMessageItem.Attributes): MessageBlockCodeItem? {
+                                   attributes: AbsMessageItem.Attributes): MessageBlockCodeItem {
         return MessageBlockCodeItem_()
                 .apply {
                     if (informationData.hasBeenEdited) {
@@ -533,6 +533,7 @@ class MessageItemFactory @Inject constructor(
                         editedSpan(spannable)
                     }
                 }
+                .bindingOptions(spanUtils.getBindingOptions(formattedBody))
                 .leftGuideline(avatarSizeProvider.leftGuideline)
                 .attributes(attributes)
                 .highlighted(highlight)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageBlockCodeItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageBlockCodeItem.kt
@@ -23,24 +23,22 @@ import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
-import im.vector.app.core.extensions.setTextWithEmojiSupport
+import im.vector.app.core.extensions.setVectorText
+import im.vector.app.features.html.VectorCharSequence
 import me.saket.bettermovementmethod.BetterLinkMovementMethod
 
 @EpoxyModelClass(layout = R.layout.item_timeline_event_base)
 abstract class MessageBlockCodeItem : AbsMessageItem<MessageBlockCodeItem.Holder>() {
 
     @EpoxyAttribute
-    var message: CharSequence? = null
-
-    @EpoxyAttribute
-    var bindingOptions: BindingOptions? = null
+    var message: VectorCharSequence? = null
 
     @EpoxyAttribute
     var editedSpan: CharSequence? = null
 
     override fun bind(holder: Holder) {
         super.bind(holder)
-        holder.messageView.setTextWithEmojiSupport(message, bindingOptions)
+        holder.messageView.setVectorText(message)
         renderSendState(holder.messageView, holder.messageView)
         holder.messageView.onClick(attributes.itemClickListener)
         holder.messageView.setOnLongClickListener(attributes.itemLongClickListener)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageBlockCodeItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageBlockCodeItem.kt
@@ -17,11 +17,13 @@
 package im.vector.app.features.home.room.detail.timeline.item
 
 import android.widget.TextView
+import androidx.appcompat.widget.AppCompatTextView
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
+import im.vector.app.core.extensions.setTextWithEmojiSupport
 import me.saket.bettermovementmethod.BetterLinkMovementMethod
 
 @EpoxyModelClass(layout = R.layout.item_timeline_event_base)
@@ -31,11 +33,14 @@ abstract class MessageBlockCodeItem : AbsMessageItem<MessageBlockCodeItem.Holder
     var message: CharSequence? = null
 
     @EpoxyAttribute
+    var bindingOptions: BindingOptions? = null
+
+    @EpoxyAttribute
     var editedSpan: CharSequence? = null
 
     override fun bind(holder: Holder) {
         super.bind(holder)
-        holder.messageView.text = message
+        holder.messageView.setTextWithEmojiSupport(message, bindingOptions)
         renderSendState(holder.messageView, holder.messageView)
         holder.messageView.onClick(attributes.itemClickListener)
         holder.messageView.setOnLongClickListener(attributes.itemLongClickListener)
@@ -46,7 +51,7 @@ abstract class MessageBlockCodeItem : AbsMessageItem<MessageBlockCodeItem.Holder
     override fun getViewType() = STUB_ID
 
     class Holder : AbsMessageItem.Holder(STUB_ID) {
-        val messageView by bind<TextView>(R.id.codeBlockTextView)
+        val messageView by bind<AppCompatTextView>(R.id.codeBlockTextView)
         val editedView by bind<TextView>(R.id.codeBlockEditedView)
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -18,22 +18,19 @@ package im.vector.app.features.home.room.detail.timeline.item
 
 import android.text.method.MovementMethod
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.text.PrecomputedTextCompat
 import androidx.core.view.isVisible
-import androidx.core.widget.TextViewCompat
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.epoxy.onLongClickIgnoringLinks
-import im.vector.app.core.epoxy.util.preventMutation
+import im.vector.app.core.extensions.setTextWithEmojiSupport
 import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 import im.vector.app.features.home.room.detail.timeline.tools.findPillsAndProcess
 import im.vector.app.features.home.room.detail.timeline.url.PreviewUrlRetriever
 import im.vector.app.features.home.room.detail.timeline.url.PreviewUrlUiState
 import im.vector.app.features.home.room.detail.timeline.url.PreviewUrlView
 import im.vector.app.features.media.ImageContentRenderer
-import org.matrix.android.sdk.api.extensions.orFalse
 
 @EpoxyModelClass(layout = R.layout.item_timeline_event_base)
 abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
@@ -92,22 +89,7 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
         renderSendState(holder.messageView, holder.messageView)
         holder.messageView.onClick(attributes.itemClickListener)
         holder.messageView.onLongClickIgnoringLinks(attributes.itemLongClickListener)
-
-        message?.let { holder.messageView.setTextWithEmojiSupport(it, bindingOptions) }
-    }
-
-    private fun AppCompatTextView.setTextWithEmojiSupport(message: CharSequence, bindingOptions: BindingOptions?) {
-        if (bindingOptions?.canUseTextFuture.orFalse()) {
-            val textFuture = PrecomputedTextCompat.getTextFuture(message, TextViewCompat.getTextMetricsParams(this), null)
-            setTextFuture(textFuture)
-        } else {
-            setTextFuture(null)
-            text = if (bindingOptions?.preventMutation.orFalse()) {
-                message.preventMutation()
-            } else {
-                message
-            }
-        }
+        holder.messageView.setTextWithEmojiSupport(message, bindingOptions)
     }
 
     override fun unbind(holder: Holder) {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -101,6 +101,7 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
             val textFuture = PrecomputedTextCompat.getTextFuture(message, TextViewCompat.getTextMetricsParams(this), null)
             setTextFuture(textFuture)
         } else {
+            setTextFuture(null)
             text = if (bindingOptions?.preventMutation.orFalse()) {
                 message.preventMutation()
             } else {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -87,24 +87,21 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
                 it.bind(holder.messageView)
             }
         }
-        val textFuture = if (bindingOptions?.canUseTextFuture.orFalse()) {
-            PrecomputedTextCompat.getTextFuture(
-                    message ?: "",
-                    TextViewCompat.getTextMetricsParams(holder.messageView),
-                    null)
-        } else {
-            null
-        }
         super.bind(holder)
         holder.messageView.movementMethod = movementMethod
         renderSendState(holder.messageView, holder.messageView)
         holder.messageView.onClick(attributes.itemClickListener)
         holder.messageView.onLongClickIgnoringLinks(attributes.itemLongClickListener)
 
+        message?.let { holder.messageView.setTextWithEmojiSupport(it, bindingOptions) }
+    }
+
+    private fun AppCompatTextView.setTextWithEmojiSupport(message: CharSequence, bindingOptions: BindingOptions?) {
         if (bindingOptions?.canUseTextFuture.orFalse()) {
-            holder.messageView.setTextFuture(textFuture)
+            val textFuture = PrecomputedTextCompat.getTextFuture(message, TextViewCompat.getTextMetricsParams(this), null)
+            setTextFuture(textFuture)
         } else {
-            holder.messageView.text = if (bindingOptions?.preventMutation.orFalse()) {
+            text = if (bindingOptions?.preventMutation.orFalse()) {
                 message.preventMutation()
             } else {
                 message

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -24,12 +24,13 @@ import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.epoxy.onLongClickIgnoringLinks
-import im.vector.app.core.extensions.setTextWithEmojiSupport
+import im.vector.app.core.extensions.setVectorText
 import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 import im.vector.app.features.home.room.detail.timeline.tools.findPillsAndProcess
 import im.vector.app.features.home.room.detail.timeline.url.PreviewUrlRetriever
 import im.vector.app.features.home.room.detail.timeline.url.PreviewUrlUiState
 import im.vector.app.features.home.room.detail.timeline.url.PreviewUrlView
+import im.vector.app.features.html.VectorCharSequence
 import im.vector.app.features.media.ImageContentRenderer
 
 @EpoxyModelClass(layout = R.layout.item_timeline_event_base)
@@ -39,10 +40,7 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
     var searchForPills: Boolean = false
 
     @EpoxyAttribute
-    var message: CharSequence? = null
-
-    @EpoxyAttribute
-    var bindingOptions: BindingOptions? = null
+    var message: VectorCharSequence? = null
 
     @EpoxyAttribute
     var useBigFont: Boolean = false
@@ -79,7 +77,7 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
             holder.messageView.textSize = 14F
         }
         if (searchForPills) {
-            message?.findPillsAndProcess(coroutineScope) {
+            message?.value?.findPillsAndProcess(coroutineScope) {
                 // mmm.. not sure this is so safe in regards to cell reuse
                 it.bind(holder.messageView)
             }
@@ -89,7 +87,7 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
         renderSendState(holder.messageView, holder.messageView)
         holder.messageView.onClick(attributes.itemClickListener)
         holder.messageView.onLongClickIgnoringLinks(attributes.itemLongClickListener)
-        holder.messageView.setTextWithEmojiSupport(message, bindingOptions)
+        holder.messageView.setVectorText(message)
     }
 
     override fun unbind(holder: Holder) {

--- a/vector/src/main/java/im/vector/app/features/html/VectorCharSequenceFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/html/VectorCharSequenceFactory.kt
@@ -24,20 +24,22 @@ import im.vector.app.EmojiSpanify
 import im.vector.app.features.home.room.detail.timeline.item.BindingOptions
 import javax.inject.Inject
 
-class SpanUtils @Inject constructor(
+data class VectorCharSequence(val value: CharSequence, val bindingOptions: BindingOptions)
+
+class VectorCharSequenceFactory @Inject constructor(
         private val emojiSpanify: EmojiSpanify
 ) {
-    fun getBindingOptions(charSequence: CharSequence): BindingOptions {
-        val emojiCharSequence = emojiSpanify.spanify(charSequence)
-
-        if (emojiCharSequence !is Spanned) {
-            return BindingOptions()
+    fun create(input: CharSequence): VectorCharSequence {
+        val emojiCharSequence = emojiSpanify.spanify(input)
+        val bindingOptions = if (emojiCharSequence !is Spanned) {
+            BindingOptions()
+        } else {
+            BindingOptions(
+                    canUseTextFuture = canUseTextFuture(emojiCharSequence),
+                    preventMutation = mustPreventMutation(emojiCharSequence)
+            )
         }
-
-        return BindingOptions(
-                canUseTextFuture = canUseTextFuture(emojiCharSequence),
-                preventMutation = mustPreventMutation(emojiCharSequence)
-        )
+        return VectorCharSequence(emojiCharSequence, bindingOptions)
     }
 
     /**


### PR DESCRIPTION
Depends on #4790, Fixes #4794 Room crash when viewing/submitting emojis in code blocks (requires markdown to be enabled)

- Extracts a dedicated model `VectorCharSequence` to contain the binding options and remove duplication when applying the `setText` logic 

| BEFORE | AFTER | 
| --- | --- |
|![Screenshot_20211222_123031](https://user-images.githubusercontent.com/1848238/147093130-7a02aa06-c938-477c-ab8b-a7e7236020b0.png)|![Screenshot_20211222_101004](https://user-images.githubusercontent.com/1848238/147093132-b9f492ed-bf3f-42e4-8b24-76461b0f1920.png)
