### PR TITLE
Outgoing call ringtone using wrong audio device

### DIFF
--- a/changelog.d/4781.bugfix
+++ b/changelog.d/4781.bugfix
@@ -1,0 +1,1 @@
+Tentative fix for the speaker being used instead of earpiece for the outgoing call ringtone on lineage os

--- a/vector/src/main/java/im/vector/app/core/services/CallRingPlayer.kt
+++ b/vector/src/main/java/im/vector/app/core/services/CallRingPlayer.kt
@@ -28,6 +28,8 @@ import android.os.VibrationEffect
 import android.os.Vibrator
 import androidx.core.content.getSystemService
 import im.vector.app.R
+import im.vector.app.features.call.audio.CallAudioManager
+import im.vector.app.features.call.webrtc.WebRtcCallManager
 import im.vector.app.features.notifications.NotificationUtils
 import org.matrix.android.sdk.api.extensions.orFalse
 import timber.log.Timber
@@ -94,7 +96,8 @@ class CallRingPlayerIncoming(
 }
 
 class CallRingPlayerOutgoing(
-        context: Context
+        context: Context,
+        private val callManager: WebRtcCallManager
 ) {
 
     private val applicationContext = context.applicationContext
@@ -102,7 +105,7 @@ class CallRingPlayerOutgoing(
     private var player: MediaPlayer? = null
 
     fun start() {
-        applicationContext.getSystemService<AudioManager>()?.mode = AudioManager.MODE_IN_COMMUNICATION
+        callManager.setAudioModeToCallType()
         player?.release()
         player = createPlayer()
         if (player != null) {
@@ -117,6 +120,12 @@ class CallRingPlayerOutgoing(
                 Timber.e(failure, "## VOIP Failed to start ringing outgoing")
                 player = null
             }
+        }
+    }
+
+    private fun WebRtcCallManager.setAudioModeToCallType() {
+        currentCall.get()?.let {
+            audioManager.setMode(if (it.mxCall.isVideoCall) CallAudioManager.Mode.VIDEO_CALL else CallAudioManager.Mode.AUDIO_CALL)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/core/services/CallRingPlayer.kt
+++ b/vector/src/main/java/im/vector/app/core/services/CallRingPlayer.kt
@@ -28,7 +28,7 @@ import android.os.VibrationEffect
 import android.os.Vibrator
 import androidx.core.content.getSystemService
 import im.vector.app.R
-import im.vector.app.features.call.audio.CallAudioManager
+import im.vector.app.features.call.audio.CallAudioManager.Mode
 import im.vector.app.features.call.webrtc.WebRtcCallManager
 import im.vector.app.features.notifications.NotificationUtils
 import org.matrix.android.sdk.api.extensions.orFalse
@@ -124,9 +124,8 @@ class CallRingPlayerOutgoing(
     }
 
     private fun WebRtcCallManager.setAudioModeToCallType() {
-        currentCall.get()?.let {
-            audioManager.setMode(if (it.mxCall.isVideoCall) CallAudioManager.Mode.VIDEO_CALL else CallAudioManager.Mode.AUDIO_CALL)
-        }
+        val callMode = if (currentCall.get()?.mxCall?.isVideoCall.orFalse()) Mode.VIDEO_CALL else Mode.AUDIO_CALL
+        audioManager.setMode(callMode)
     }
 
     fun stop() {

--- a/vector/src/main/java/im/vector/app/core/services/CallService.kt
+++ b/vector/src/main/java/im/vector/app/core/services/CallService.kt
@@ -84,7 +84,7 @@ class CallService : VectorService() {
         super.onCreate()
         notificationManager = NotificationManagerCompat.from(this)
         callRingPlayerIncoming = CallRingPlayerIncoming(applicationContext, notificationUtils)
-        callRingPlayerOutgoing = CallRingPlayerOutgoing(applicationContext)
+        callRingPlayerOutgoing = CallRingPlayerOutgoing(applicationContext, callManager)
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
Tentatively fixes #4781 wrong audio device being used for outgoing call ringtone

- In #4781 it's reported that the correct audio device is used when the call starts, the attempted fix is to use the same audio device configuration for the outgoing ringtone as we do for the call itself. 

I haven't been able to reproduce this locally, I'm assuming it's something related to LineageOS