### PR TITLE
Fixing duplicated/empty notifications when joining/muting/leaving a VOIP call

### DIFF
--- a/changelog.d/4804.bugfix
+++ b/changelog.d/4804.bugfix
@@ -1,0 +1,1 @@
+Fixing encrypted non message events showing up as notification messages (eg when a participant joins, mutes or leaves a voice call)


### PR DESCRIPTION
Fixes #4804 mute events displaying blank notifications

- It turns out the app was assuming all encrypted events were messages, which meant we were showing invalid notifications
- The fix is to only create `NotifiableMessageEvent` when the decrypted or clear content type is a `message`
- This also ends up fixing the debug and duplicated VOIP notifications appearing as w were using the same filtering logic for the timeline as the notifications

| BEFORE | AFTER |
| --- | --- |
|![before-muting](https://user-images.githubusercontent.com/1848238/147348731-ca400f69-e4d2-4a0e-baad-ff7a1f3c2f54.gif)|![Screenshot_20211224_111636](https://user-images.githubusercontent.com/1848238/147348734-0e69407b-52ae-4672-a3ba-311360889297.png)
