### PR TITLE
Get Olm from Jitpack - DO NOT MERGE

### DIFF
--- a/dependencies_groups.gradle
+++ b/dependencies_groups.gradle
@@ -12,13 +12,19 @@ ext.groups = [
                         'com.github.vector-im',
                         'com.github.yalantis',
                         'com.github.Zhuinden',
+                        'com.github.Zhuinden',
+                        // Get Olm From Jitpack
+                        'org.matrix.gitlab.matrix-org',
                 ]
         ],
         olm         : [
                 regex: [
                 ],
                 group: [
-                        'org.matrix.android',
+                        // Altered, to ensure there is no mistake.
+                        // If I just comment it, the list of groups will be empty,
+                        // and this repo will be used to look for evey dependencies
+                        'ALTERED.org.matrix.android.ATLERED',
                 ]
         ],
         jitsi       : [

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -141,7 +141,9 @@ dependencies {
     implementation libs.arrow.instances
 
     // olm lib is now hosted by maven at https://gitlab.matrix.org/api/v4/projects/27/packages/maven
-    implementation 'org.matrix.android:olm:3.2.7'
+    // implementation 'org.matrix.android:olm:3.2.7'
+    // Get Olm from Jitpack
+    implementation 'org.matrix.gitlab.matrix-org:olm:3.2.7'
 
     // DI
     implementation libs.dagger.dagger


### PR DESCRIPTION
Try to build again using Olm from Jitpack.
This is to help building the F-Droid version, which cannot use the maven repository which now host Olm (the repository is not whitelisted by F-Droid team)