### PR TITLE
Fix unread messages indicator on room list if no messages

### DIFF
--- a/changelog.d/4749.bugfix
+++ b/changelog.d/4749.bugfix
@@ -1,0 +1,1 @@
+Fix for broken unread message indicator on the room list when there are no messages in the room.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
@@ -136,7 +136,7 @@ internal class RoomSummaryUpdater @Inject constructor(
 
         roomSummaryEntity.hasUnreadMessages = roomSummaryEntity.notificationCount > 0 ||
                 // avoid this call if we are sure there are unread events
-                !isEventRead(realm.configuration, userId, roomId, latestPreviewableEvent?.eventId)
+                latestPreviewableEvent?.let { !isEventRead(realm.configuration, userId, roomId, it.eventId) } ?: false
 
         roomSummaryEntity.setDisplayName(roomDisplayNameResolver.resolve(realm, roomId))
         roomSummaryEntity.avatarUrl = roomAvatarResolver.resolve(realm, roomId)


### PR DESCRIPTION
If there are no messages in a room lastPreviewableEvent will be null. We should not indicate there is an unread if we don't have a lastPreviewableEvent.

Fixes #4749 