### PR TITLE
Manual upgrade of the emoji2 lib

### DIFF
--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -454,7 +454,7 @@ dependencies {
     // OSS License, gplay flavor only
     gplayImplementation 'com.google.android.gms:play-services-oss-licenses:17.0.0'
 
-    implementation "androidx.emoji2:emoji2:1.0.0"
+    implementation "androidx.emoji2:emoji2:1.0.1"
     implementation('com.github.BillCarsonFr:JsonViewer:0.7')
 
     // WebRTC


### PR DESCRIPTION
Dependabot does not care about this dependency, I do not know why.
