### PR TITLE
Enhance Linter Github Actions Reporting

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Run code quality check suite
         run: ./tools/check/check_code_quality.sh
 
+# ktlint for all the modules
   ktlint:
     name: Kotlin Linter
     runs-on: ubuntu-latest
@@ -23,12 +24,55 @@ jobs:
         run: |
           ./gradlew ktlintCheck --continue
       - name: Upload reports
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: ktlinting-report
-          path: vector/build/reports/ktlint/*.*
+          path: |
+            */build/reports/ktlint/ktlint*/ktlint*.txt
+      - name: Handle Results
+        if: always()
+        id: get-comment-body
+        run: |
+          results="$(cat */*/build/reports/ktlint/ktlint*/ktlint*.txt */build/reports/ktlint/ktlint*/ktlint*.txt | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")"
+          if [ -z  "$results" ]; then
+            body="👍 ✅ 👍"
+          else
+            body="👎 ❌ 👎 \`Failed${results}\`"
+            body="${body//'%'/'%25'}"
+            body="${body//$'\n'/'%0A'}"
+            body="${body//$'\r'/'%0D'}"
+            body="$( echo $body | sed 's/\/home\/runner\/work\/element-android\/element-android\//\`<br\/>\`/g')"
+            body="$( echo $body | sed 's/\/src\/main\/java\// 🔸 /g')"
+            body="$( echo $body | sed 's/im\/vector\/app\///g')"
+            body="$( echo $body | sed 's/im\/vector\/lib\/attachmentviewer\///g')"
+            body="$( echo $body | sed 's/im\/vector\/lib\/multipicker\///g')"
+            body="$( echo $body | sed 's/im\/vector\/lib\///g')"
+            body="$( echo $body | sed 's/org\/matrix\/android\/sdk\///g')"
+            body="$( echo $body | sed 's/\/src\/androidTest\/java\// 🔸 /g')"
+          fi
+          echo "::set-output name=body::$body"
+      - name: Find Comment
+        if: always()
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Ktlint Results
+      - name: Publish ktlint results to PR
+        if: always()
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ### Ktlint Results
 
-# Lint for main module and all the other modules
+            ${{ steps.get-comment-body.outputs.body }}
+          edit-mode: replace
+
+# Lint for main module
   android-lint:
     name: Android Linter
     runs-on: ubuntu-latest
@@ -74,7 +118,6 @@ jobs:
         run: ./gradlew clean lint${{ matrix.target }}Release --stacktrace
       - name: Upload ${{ matrix.target }} linting report
         uses: actions/upload-artifact@v2
-        if: always()
         with:
           name: release-lint-report-${{ matrix.target }}
           path: |

--- a/changelog.d/4864.misc
+++ b/changelog.d/4864.misc
@@ -1,0 +1,1 @@
+Fix github actions ktlint reports and publish results on PR as comment

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/LiveDataTestObserver.java
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/LiveDataTestObserver.java
@@ -208,4 +208,4 @@ public final class LiveDataTestObserver<T> implements Observer<T> {
     liveData.observeForever(observer);
     return observer;
   }
-} 
+}


### PR DESCRIPTION
Improve Github Actions Linter reports:

- Add **ktlint** Artifact report
<img width="899" alt="Screenshot 2022-01-05 at 19 37 37" src="https://user-images.githubusercontent.com/60798129/148263198-37db7273-2fe2-468b-b422-fd066a9785fb.png">


- **kotlint reports will be also added as comment in the PR**
  - It will print exactly the lines that have problem
  - It will trim the output so the developer will be able to immediately find the class with the error
  - Support for all the different modules along with tests 
  - The same comment will be reused
  <img width="1192" alt="Screenshot 2022-01-05 at 22 41 08" src="https://user-images.githubusercontent.com/60798129/148286322-157239e3-b22f-4b58-addb-2e3e141b7489.png">
  <img width="1028" alt="Screenshot 2022-01-05 at 22 56 08" src="https://user-images.githubusercontent.com/60798129/148288248-db6a45d0-42f2-4df9-830e-5986e3986201.png">
- It is also able to identify the success and print the result appropriately
  <img width="985" alt="Screenshot 2022-01-05 at 22 58 50" src="https://user-images.githubusercontent.com/60798129/148288587-1fa32099-660e-47eb-84b9-54027d4d9cdf.png">
 