### PR TITLE
Enabling FTUE_AUTH onboarding variant

### DIFF
--- a/changelog.d/4872.misc
+++ b/changelog.d/4872.misc
@@ -1,0 +1,1 @@
+Enabling new FTUE Auth onboarding base, includes the "I already have an account" button in the splash

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -140,7 +140,7 @@ android {
         buildConfigField "String", "BUILD_NUMBER", "\"${buildNumber}\""
         resValue "string", "build_number", "\"${buildNumber}\""
 
-        buildConfigField "im.vector.app.features.VectorFeatures.OnboardingVariant", "ONBOARDING_VARIANT", "im.vector.app.features.VectorFeatures.OnboardingVariant.LEGACY"
+        buildConfigField "im.vector.app.features.VectorFeatures.OnboardingVariant", "ONBOARDING_VARIANT", "im.vector.app.features.VectorFeatures.OnboardingVariant.FTUE_AUTH"
 
         buildConfigField "im.vector.app.features.crypto.keysrequest.OutboundSessionKeySharingStrategy", "outboundSessionKeySharingStrategy", "im.vector.app.features.crypto.keysrequest.OutboundSessionKeySharingStrategy.WhenTyping"
 


### PR DESCRIPTION
Switches the build config to point to the `FTUE_AUTH` onboarding variant, this variant is a copy of the current (legacy login) with separate feature flags for future changes, eg  #4727 and #4585 

- The `FTUE_AUTH` flow also includes #4668  

| BEFORE SPLASH | AFTER SPLASH | 
| --- | --- |
|![Screenshot_20220106_172749](https://user-images.githubusercontent.com/1848238/148425932-e74c0d5d-afd4-43af-9f3b-b184c2dae7e5.png)|![Screenshot_20220106_173520](https://user-images.githubusercontent.com/1848238/148425830-b6d901ae-5bf2-42d0-a1cd-fac87cbfd4fa.png)


| BEFORE FEATURES | AFTER FEATURES |
| --- | --- |
|![Screenshot_20220106_172757](https://user-images.githubusercontent.com/1848238/148425930-764a631f-4483-45c2-b070-ee4f3bf97bcb.png)|![Screenshot_20220106_173528](https://user-images.githubusercontent.com/1848238/148425828-d23dd56d-59cc-4f8c-b94f-a1462f213bcc.png)
