### PR TITLE
Olm lib is now hosted in MavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,14 +36,6 @@ allprojects {
     apply plugin: "org.jlleitschuh.gradle.ktlint"
 
     repositories {
-        // For olm library.
-        maven {
-            url 'https://gitlab.matrix.org/api/v4/projects/27/packages/maven'
-            content {
-                groups.olm.regex.each { includeGroupByRegex it }
-                groups.olm.group.each { includeGroup it }
-            }
-        }
         maven {
             url 'https://jitpack.io'
             content {

--- a/changelog.d/4882.misc
+++ b/changelog.d/4882.misc
@@ -1,0 +1,1 @@
+ Olm lib is now hosted in MavenCentral - upgrade to 3.2.10

--- a/dependencies_groups.gradle
+++ b/dependencies_groups.gradle
@@ -14,13 +14,6 @@ ext.groups = [
                         'com.github.Zhuinden',
                 ]
         ],
-        olm         : [
-                regex: [
-                ],
-                group: [
-                        'org.matrix.android',
-                ]
-        ],
         jitsi       : [
                 regex: [
                 ],
@@ -166,6 +159,7 @@ ext.groups = [
                         'org.junit.jupiter',
                         'org.junit.platform',
                         'org.jvnet.staxex',
+                        'org.matrix.android',
                         'org.mockito',
                         'org.mongodb',
                         'org.objenesis',

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -140,8 +140,8 @@ dependencies {
     implementation libs.arrow.core
     implementation libs.arrow.instances
 
-    // olm lib is now hosted by maven at https://gitlab.matrix.org/api/v4/projects/27/packages/maven
-    implementation 'org.matrix.android:olm:3.2.7'
+    // olm lib is now hosted in MavenCentral
+    implementation 'org.matrix.android:olm-sdk:3.2.10'
 
     // DI
     implementation libs.dagger.dagger


### PR DESCRIPTION
And upgrade to Olm <del>3.2.9</del> **3.2.10**

Sanity test pass.