### PR TITLE
Avoid allowing null String for state_key.

### DIFF
--- a/changelog.d/4895.removal
+++ b/changelog.d/4895.removal
@@ -1,0 +1,1 @@
+`StateService.sendStateEvent()` now takes a non-nullable String for the parameter `stateKey`. If null was used, just now use an empty string.

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/encryption/EncryptionTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/encryption/EncryptionTest.kt
@@ -62,7 +62,7 @@ class EncryptionTest : InstrumentedTest {
                 // Send an encryption Event as a State Event
                 room.sendStateEvent(
                         eventType = EventType.STATE_ROOM_ENCRYPTION,
-                        stateKey = null,
+                        stateKey = "",
                         body = EncryptionEventContent(algorithm = MXCRYPTO_ALGORITHM_MEGOLM).toContent()
                 )
             }

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/space/SpaceHierarchyTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/space/SpaceHierarchyTest.kt
@@ -542,7 +542,7 @@ class SpaceHierarchyTest : InstrumentedTest {
                     ?.setUserPowerLevel(aliceSession.myUserId, Role.Admin.value)
                     ?.toContent()
 
-            room.sendStateEvent(EventType.STATE_ROOM_POWER_LEVELS, null, newPowerLevelsContent!!)
+            room.sendStateEvent(EventType.STATE_ROOM_POWER_LEVELS, stateKey = "", newPowerLevelsContent!!)
             it.countDown()
         }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/state/StateService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/state/StateService.kt
@@ -68,8 +68,11 @@ interface StateService {
 
     /**
      * Send a state event to the room
+     * @param eventType The type of event to send.
+     * @param stateKey The state_key for the state to send. Can be an empty string.
+     * @param body The content object of the event; the fields in this object will vary depending on the type of event
      */
-    suspend fun sendStateEvent(eventType: String, stateKey: String?, body: JsonDict)
+    suspend fun sendStateEvent(eventType: String, stateKey: String, body: JsonDict)
 
     /**
      * Get a state event of the room

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoom.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoom.kt
@@ -130,7 +130,7 @@ internal class DefaultRoom(override val roomId: String,
             else                                   -> {
                 val params = SendStateTask.Params(
                         roomId = roomId,
-                        stateKey = null,
+                        stateKey = "",
                         eventType = EventType.STATE_ROOM_ENCRYPTION,
                         body = mapOf(
                                 "algorithm" to algorithm

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/state/DefaultStateService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/state/DefaultStateService.kt
@@ -68,7 +68,7 @@ internal class DefaultStateService @AssistedInject constructor(@Assisted private
 
     override suspend fun sendStateEvent(
             eventType: String,
-            stateKey: String?,
+            stateKey: String,
             body: JsonDict
     ) {
         val params = SendStateTask.Params(
@@ -92,7 +92,7 @@ internal class DefaultStateService @AssistedInject constructor(@Assisted private
         sendStateEvent(
                 eventType = EventType.STATE_ROOM_TOPIC,
                 body = mapOf("topic" to topic),
-                stateKey = null
+                stateKey = ""
         )
     }
 
@@ -100,7 +100,7 @@ internal class DefaultStateService @AssistedInject constructor(@Assisted private
         sendStateEvent(
                 eventType = EventType.STATE_ROOM_NAME,
                 body = mapOf("name" to name),
-                stateKey = null
+                stateKey = ""
         )
     }
 
@@ -117,7 +117,7 @@ internal class DefaultStateService @AssistedInject constructor(@Assisted private
                                 // Sort for the cleanup
                                 .sorted()
                 ).toContent(),
-                stateKey = null
+                stateKey = ""
         )
     }
 
@@ -125,7 +125,7 @@ internal class DefaultStateService @AssistedInject constructor(@Assisted private
         sendStateEvent(
                 eventType = EventType.STATE_ROOM_HISTORY_VISIBILITY,
                 body = mapOf("history_visibility" to readability),
-                stateKey = null
+                stateKey = ""
         )
     }
 
@@ -142,14 +142,14 @@ internal class DefaultStateService @AssistedInject constructor(@Assisted private
             sendStateEvent(
                     eventType = EventType.STATE_ROOM_JOIN_RULES,
                     body = body,
-                    stateKey = null
+                    stateKey = ""
             )
         }
         if (guestAccess != null) {
             sendStateEvent(
                     eventType = EventType.STATE_ROOM_GUEST_ACCESS,
                     body = mapOf("guest_access" to guestAccess),
-                    stateKey = null
+                    stateKey = ""
             )
         }
     }
@@ -159,7 +159,7 @@ internal class DefaultStateService @AssistedInject constructor(@Assisted private
         sendStateEvent(
                 eventType = EventType.STATE_ROOM_AVATAR,
                 body = mapOf("url" to response.contentUri),
-                stateKey = null
+                stateKey = ""
         )
     }
 
@@ -167,7 +167,7 @@ internal class DefaultStateService @AssistedInject constructor(@Assisted private
         sendStateEvent(
                 eventType = EventType.STATE_ROOM_AVATAR,
                 body = emptyMap(),
-                stateKey = null
+                stateKey = ""
         )
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/state/SendStateTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/state/SendStateTask.kt
@@ -26,7 +26,7 @@ import javax.inject.Inject
 internal interface SendStateTask : Task<SendStateTask.Params, Unit> {
     data class Params(
             val roomId: String,
-            val stateKey: String?,
+            val stateKey: String,
             val eventType: String,
             val body: JsonDict
     )
@@ -39,7 +39,7 @@ internal class DefaultSendStateTask @Inject constructor(
 
     override suspend fun execute(params: SendStateTask.Params) {
         return executeRequest(globalErrorReceiver) {
-            if (params.stateKey == null) {
+            if (params.stateKey.isEmpty()) {
                 roomAPI.sendStateEvent(
                         roomId = params.roomId,
                         stateEventType = params.eventType,

--- a/vector/src/main/java/im/vector/app/features/devtools/RoomDevToolViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/devtools/RoomDevToolViewModel.kt
@@ -174,8 +174,8 @@ class RoomDevToolViewModel @AssistedInject constructor(
                         ?: throw IllegalArgumentException(stringProvider.getString(R.string.dev_tools_error_no_content))
 
                 room.sendStateEvent(
-                        state.selectedEvent?.type ?: "",
-                        state.selectedEvent?.stateKey,
+                        state.selectedEvent?.type.orEmpty(),
+                        state.selectedEvent?.stateKey.orEmpty(),
                         json
 
                 )
@@ -213,7 +213,7 @@ class RoomDevToolViewModel @AssistedInject constructor(
                 if (isState) {
                     room.sendStateEvent(
                             eventType,
-                            state.sendEventDraft.stateKey,
+                            state.sendEventDraft.stateKey.orEmpty(),
                             json
                     )
                 } else {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
@@ -552,7 +552,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                 ?: return
 
         launchSlashCommandFlowSuspendable {
-            room.sendStateEvent(EventType.STATE_ROOM_POWER_LEVELS, null, newPowerLevelsContent)
+            room.sendStateEvent(EventType.STATE_ROOM_POWER_LEVELS, stateKey = "", newPowerLevelsContent)
         }
     }
 
@@ -619,7 +619,7 @@ class MessageComposerViewModel @AssistedInject constructor(
 
     private fun handleChangeRoomAvatarSlashCommand(changeAvatar: ParsedCommand.ChangeRoomAvatar) {
         launchSlashCommandFlowSuspendable {
-            room.sendStateEvent(EventType.STATE_ROOM_AVATAR, null, RoomAvatarContent(changeAvatar.url).toContent())
+            room.sendStateEvent(EventType.STATE_ROOM_AVATAR, stateKey = "", RoomAvatarContent(changeAvatar.url).toContent())
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewModel.kt
@@ -210,7 +210,7 @@ class RoomMemberProfileViewModel @AssistedInject constructor(
             viewModelScope.launch {
                 _viewEvents.post(RoomMemberProfileViewEvents.Loading())
                 try {
-                    room.sendStateEvent(EventType.STATE_ROOM_POWER_LEVELS, null, newPowerLevelsContent)
+                    room.sendStateEvent(EventType.STATE_ROOM_POWER_LEVELS, stateKey = "", newPowerLevelsContent)
                     _viewEvents.post(RoomMemberProfileViewEvents.OnSetPowerLevelSuccess)
                 } catch (failure: Throwable) {
                     _viewEvents.post(RoomMemberProfileViewEvents.Failure(failure))

--- a/vector/src/main/java/im/vector/app/features/roomprofile/permissions/RoomPermissionsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/permissions/RoomPermissionsViewModel.kt
@@ -124,7 +124,7 @@ class RoomPermissionsViewModel @AssistedInject constructor(@Assisted initialStat
                                 }
                         )
                     }
-                    room.sendStateEvent(EventType.STATE_ROOM_POWER_LEVELS, null, newPowerLevelsContent.toContent())
+                    room.sendStateEvent(EventType.STATE_ROOM_POWER_LEVELS, stateKey = "", newPowerLevelsContent.toContent())
                     setState {
                         copy(
                                 isLoading = false

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetPostAPIHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetPostAPIHandler.kt
@@ -319,7 +319,7 @@ class WidgetPostAPIHandler @AssistedInject constructor(@Assisted private val roo
         launchWidgetAPIAction(widgetPostAPIMediator, eventData) {
             room.sendStateEvent(
                     eventType = EventType.PLUMBING,
-                    stateKey = null,
+                    stateKey = "",
                     body = params
             )
         }


### PR DESCRIPTION
Should always be an empty String according to the Matrix specification.

There is no functional change, just a change in the SDK API for clarity regarding the Matrix specs.