### PR TITLE
Typo in carousel title

### DIFF
--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2517,7 +2517,7 @@
     <string name="timeline_unread_messages">Unread messages</string>
 
     <!--  Onboarding -->
-    <string name="ftue_auth_carousel_1_title">Own your conversions.</string>
+    <string name="ftue_auth_carousel_1_title">Own your conversations.</string>
     <string name="ftue_auth_carousel_1_body">End-to-end encrypted messaging for secure and independent communication, connected via Matrix.</string>
     <string name="ftue_auth_carousel_2_title">You\'re in control.</string>
     <string name="ftue_auth_carousel_2_body">Element lets you choose where you messages are stored, keeping you in control of your data.</string>


### PR DESCRIPTION
Fixes #4903 

Haven't created a changelog entry as the feature isn't enabled/live yet