### PR TITLE
Disabling automatic carousel transitions on user interaction

### DIFF
--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashCarouselFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashCarouselFragment.kt
@@ -80,17 +80,27 @@ class FtueAuthSplashCarouselFragment @Inject constructor(
                     "Branch: ${BuildConfig.GIT_BRANCH_NAME}"
             views.loginSplashVersion.debouncedClicks { navigator.openDebug(requireContext()) }
         }
+        views.splashCarousel.registerAutomaticUntilInteractionTransitions()
+    }
 
-        views.splashCarousel.apply {
-            var scheduledTransition: Job? = null
-            registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
-                override fun onPageSelected(position: Int) {
-                    scheduledTransition?.cancel()
+    private fun ViewPager2.registerAutomaticUntilInteractionTransitions() {
+        var scheduledTransition: Job? = null
+        registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            private var hasUserManuallyInteractedWithCarousel: Boolean = false
+
+            override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
+                hasUserManuallyInteractedWithCarousel = !isFakeDragging
+            }
+
+            override fun onPageSelected(position: Int) {
+                scheduledTransition?.cancel()
+                if (hasUserManuallyInteractedWithCarousel) {
+                    // stop the automatic transitions
+                } else {
                     scheduledTransition = scheduleCarouselTransition()
                 }
-            })
-            scheduledTransition = scheduleCarouselTransition()
-        }
+            }
+        })
     }
 
     private fun ViewPager2.scheduleCarouselTransition(): Job {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashCarouselFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashCarouselFragment.kt
@@ -94,9 +94,8 @@ class FtueAuthSplashCarouselFragment @Inject constructor(
 
             override fun onPageSelected(position: Int) {
                 scheduledTransition?.cancel()
-                if (hasUserManuallyInteractedWithCarousel) {
-                    // stop the automatic transitions
-                } else {
+                // only schedule automatic transitions whilst the user has not interacted with the carousel
+                if (!hasUserManuallyInteractedWithCarousel) {
                     scheduledTransition = scheduleCarouselTransition()
                 }
             }


### PR DESCRIPTION
Part of #4584
 
- Disables the automatic carousel transitions once the user interacts with the carousel

| BEFORE | AFTER |
| --- | --- |
![before-carousel](https://user-images.githubusercontent.com/1848238/148987142-394509b5-82de-4884-b643-884e875e1394.gif)|![after-carousel](https://user-images.githubusercontent.com/1848238/148987137-b0af13be-8822-4bc7-ac94-448207684841.gif)
