### PR TITLE
Locking phones to portrait during FTUE onboarding

### DIFF
--- a/library/ui-styles/src/main/res/values-sw600dp/tablet.xml
+++ b/library/ui-styles/src/main/res/values-sw600dp/tablet.xml
@@ -2,5 +2,6 @@
 <resources>
 
     <dimen name="width_percent">0.6</dimen>
+    <bool name="is_tablet">true</bool>
 
 </resources>

--- a/library/ui-styles/src/main/res/values/tablet.xml
+++ b/library/ui-styles/src/main/res/values/tablet.xml
@@ -2,5 +2,6 @@
 <resources>
 
     <dimen name="width_percent">1</dimen>
+    <bool name="is_tablet">false</bool>
 
 </resources>

--- a/vector/src/main/java/im/vector/app/core/platform/ScreenOrientationLocker.kt
+++ b/vector/src/main/java/im/vector/app/core/platform/ScreenOrientationLocker.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.platform
+
+import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
+import android.content.res.Resources
+import androidx.appcompat.app.AppCompatActivity
+import im.vector.app.R
+import javax.inject.Inject
+
+class ScreenOrientationLocker @Inject constructor(
+        private val resources: Resources
+) {
+
+    // Some screens do not provide enough value for us to provide phone landscape experiences
+    @SuppressLint("SourceLockedOrientationActivity")
+    fun lockPhonesToPortrait(activity: AppCompatActivity) {
+        when (resources.getBoolean(R.bool.is_tablet)) {
+            true  -> {
+                // do nothing
+            }
+            false -> {
+                activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            }
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/analytics/ui/consent/AnalyticsOptInActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/ui/consent/AnalyticsOptInActivity.kt
@@ -20,14 +20,18 @@ import com.airbnb.mvrx.viewModel
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.core.extensions.addFragment
 import im.vector.app.core.extensions.exhaustive
+import im.vector.app.core.platform.ScreenOrientationLocker
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.databinding.ActivitySimpleBinding
+import javax.inject.Inject
 
 /**
  * Simple container for AnalyticsOptInFragment
  */
 @AndroidEntryPoint
 class AnalyticsOptInActivity : VectorBaseActivity<ActivitySimpleBinding>() {
+
+    @Inject lateinit var orientationLocker: ScreenOrientationLocker
 
     private val viewModel: AnalyticsConsentViewModel by viewModel()
 
@@ -36,6 +40,7 @@ class AnalyticsOptInActivity : VectorBaseActivity<ActivitySimpleBinding>() {
     override fun getCoordinatorLayout() = views.coordinatorLayout
 
     override fun initUiAndData() {
+        orientationLocker.lockPhonesToPortrait(this)
         if (isFirstCreation()) {
             addFragment(views.simpleFragmentContainer, AnalyticsOptInFragment::class.java)
         }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingVariantFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingVariantFactory.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.features.onboarding
 
+import im.vector.app.core.platform.ScreenOrientationLocker
 import im.vector.app.databinding.ActivityLoginBinding
 import im.vector.app.features.VectorFeatures
 import im.vector.app.features.login2.LoginViewModel2
@@ -24,6 +25,7 @@ import javax.inject.Inject
 
 class OnboardingVariantFactory @Inject constructor(
         private val vectorFeatures: VectorFeatures,
+        private val orientationLocker: ScreenOrientationLocker,
 ) {
 
     fun create(activity: OnboardingActivity,
@@ -37,7 +39,8 @@ class OnboardingVariantFactory @Inject constructor(
                 onboardingViewModel = onboardingViewModel.value,
                 activity = activity,
                 supportFragmentManager = activity.supportFragmentManager,
-                vectorFeatures = vectorFeatures
+                vectorFeatures = vectorFeatures,
+                orientationLocker = orientationLocker
         )
         VectorFeatures.OnboardingVariant.LOGIN_2   -> Login2Variant(
                 views = views,

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -15,6 +15,7 @@
  */
 
 package im.vector.app.features.onboarding.ftueauth
+
 import android.content.Intent
 import android.view.View
 import android.view.ViewGroup
@@ -31,6 +32,7 @@ import im.vector.app.core.extensions.POP_BACK_STACK_EXCLUSIVE
 import im.vector.app.core.extensions.addFragment
 import im.vector.app.core.extensions.addFragmentToBackstack
 import im.vector.app.core.extensions.exhaustive
+import im.vector.app.core.platform.ScreenOrientationLocker
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.databinding.ActivityLoginBinding
 import im.vector.app.features.VectorFeatures
@@ -62,7 +64,8 @@ class FtueAuthVariant(
         private val onboardingViewModel: OnboardingViewModel,
         private val activity: VectorBaseActivity<ActivityLoginBinding>,
         private val supportFragmentManager: FragmentManager,
-        private val vectorFeatures: VectorFeatures
+        private val vectorFeatures: VectorFeatures,
+        private val orientationLocker: ScreenOrientationLocker,
 ) : OnboardingVariant {
 
     private val enterAnim = R.anim.enter_fade_in
@@ -91,6 +94,7 @@ class FtueAuthVariant(
         }
 
         with(activity) {
+            orientationLocker.lockPhonesToPortrait(this)
             onboardingViewModel.onEach {
                 updateWithState(it)
             }


### PR DESCRIPTION
Part of #4584 

- Makes use of a resource bucket flag to determine if the device is big enough to be considered a tablet and in turn, enable a landscape experience in the FTUE auth onboarding flow


| BEFORE PHONE | AFTER PHONE | AFTER LOGIN | AFTER TABLET |
| --- | --- | --- | --- |
|![before-rotation](https://user-images.githubusercontent.com/1848238/148992078-02c1ea01-beeb-47b5-8eab-ad55a5487409.gif)|![after-rotation](https://user-images.githubusercontent.com/1848238/148992075-61403f61-d115-4786-9080-7f061b5f0ac0.gif)|![after-login](https://user-images.githubusercontent.com/1848238/148994843-a093db96-7cea-45ed-baf4-cd5c8b95928d.gif)|![tablet-rotation](https://user-images.githubusercontent.com/1848238/148996853-5e48c536-ca24-405e-8ae9-64802319d897.gif)





