### PR TITLE
Add signing config for the release. No secret added

### DIFF
--- a/changelog.d/4926.misc
+++ b/changelog.d/4926.misc
@@ -1,0 +1,1 @@
+Add signing config for the release buildType. No secret added

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,9 @@ vector.httpLogLevel=BASIC
 # Note: to debug, you can put and uncomment the following lines in the file ~/.gradle/gradle.properties to override the value above
 #vector.debugPrivateData=true
 #vector.httpLogLevel=BODY
+
+# Dummy values for signing secrets
+signing.element.storePath=pathTo.keystore
+signing.element.storePassword=Secret
+signing.element.keyId=Secret
+signing.element.keyPassword=Secret

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -215,6 +215,12 @@ android {
             storeFile file('./signature/debug.keystore')
             storePassword 'android'
         }
+        release {
+            keyAlias project.property("signing.element.keyId")
+            keyPassword project.property("signing.element.keyPassword")
+            storeFile file(project.property("signing.element.storePath"))
+            storePassword project.property("signing.element.storePassword")
+        }
     }
 
     buildTypes {
@@ -245,6 +251,7 @@ android {
                 optimizeCode true
                 proguardFiles 'proguard-rules.pro'
             }
+            signingConfig signingConfigs.release
         }
     }
 


### PR DESCRIPTION
To be able to test the release build sooner during the release process.
