### PR TITLE
Enable activity resizing

### DIFF
--- a/changelog.d/4811.feature
+++ b/changelog.d/4811.feature
@@ -1,0 +1,1 @@
+Enabling native support for window resizing

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -76,6 +76,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"
+        android:resizeableActivity="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Vector.Light"
@@ -400,7 +401,8 @@
                 android:value="androidx.startup"
                 tools:node="remove" />
             <!-- We init the lib ourself in EmojiCompatWrapper -->
-            <meta-data android:name="androidx.emoji2.text.EmojiCompatInitializer"
+            <meta-data
+                android:name="androidx.emoji2.text.EmojiCompatInitializer"
                 tools:node="remove" />
         </provider>
 


### PR DESCRIPTION
Aims to fix #4811 

Enables resizable activities for the entire application https://developer.android.com/guide/topics/manifest/activity-element#resizeableActivity

This _should_ :crossed_fingers: allow desktop android to resize/maximise windows without needing the device OEM to force the behaviour (like Samsung Dex)