### PR TITLE
Add lambda in executeRequest params to define a custom retry policy

### DIFF
--- a/changelog.d/4950.removal
+++ b/changelog.d/4950.removal
@@ -1,0 +1,1 @@
+`executeRequest` now takes a `canRetryOnFailure` lambda replacing the `canRetry` boolean. It allows to have a custom retry policy for a specific request error.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/SendToDeviceTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/SendToDeviceTask.kt
@@ -53,7 +53,7 @@ internal class DefaultSendToDeviceTask @Inject constructor(
 
         return executeRequest(
                 globalErrorReceiver,
-                canRetry = true,
+                canRetryOnFailure = { true },
                 maxRetriesCount = 3
         ) {
             cryptoApi.sendToDevice(

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/SendToDeviceTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/SendToDeviceTask.kt
@@ -20,6 +20,7 @@ import org.matrix.android.sdk.internal.crypto.api.CryptoApi
 import org.matrix.android.sdk.internal.crypto.model.MXUsersDevicesMap
 import org.matrix.android.sdk.internal.crypto.model.rest.SendToDeviceBody
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
+import org.matrix.android.sdk.internal.network.RequestRetryPolicy
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.task.Task
 import java.util.UUID
@@ -53,7 +54,7 @@ internal class DefaultSendToDeviceTask @Inject constructor(
 
         return executeRequest(
                 globalErrorReceiver,
-                canRetryOnFailure = { true },
+                getRequestRetryPolicy = { RequestRetryPolicy(true) },
                 maxRetriesCount = 3
         ) {
             cryptoApi.sendToDevice(

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/UploadSignaturesTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/UploadSignaturesTask.kt
@@ -37,7 +37,7 @@ internal class DefaultUploadSignaturesTask @Inject constructor(
         try {
             val response = executeRequest(
                     globalErrorReceiver,
-                    canRetry = true,
+                    canRetryOnFailure = { true },
                     maxRetriesCount = 10
             ) {
                 cryptoApi.uploadSignatures(params.signatures)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/UploadSignaturesTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/UploadSignaturesTask.kt
@@ -18,6 +18,7 @@ package org.matrix.android.sdk.internal.crypto.tasks
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.internal.crypto.api.CryptoApi
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
+import org.matrix.android.sdk.internal.network.RequestRetryPolicy
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.task.Task
 import javax.inject.Inject
@@ -37,7 +38,7 @@ internal class DefaultUploadSignaturesTask @Inject constructor(
         try {
             val response = executeRequest(
                     globalErrorReceiver,
-                    canRetryOnFailure = { true },
+                    getRequestRetryPolicy = { RequestRetryPolicy(true) },
                     maxRetriesCount = 10
             ) {
                 cryptoApi.uploadSignatures(params.signatures)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/Request.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/Request.kt
@@ -87,6 +87,7 @@ internal suspend inline fun <DATA> executeRequest(globalErrorReceiver: GlobalErr
             if (canRetryOnFailure(exception) && currentRetryCount < maxRetriesCount) {
                 delay(exception.getRetryDelay(currentDelay))
                 currentDelay = currentDelay.times(2L).coerceAtMost(maxDelayBeforeRetry)
+                // Try again (loop)
             } else {
                 throw when (exception) {
                     is IOException           -> Failure.NetworkConnection(exception)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/RequestExecutor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/RequestExecutor.kt
@@ -16,14 +16,13 @@
 
 package org.matrix.android.sdk.internal.network
 
-import org.matrix.android.sdk.internal.network.defaultRequestRetryPolicy as internalDefaultRequestRetryPolicy
 import org.matrix.android.sdk.internal.network.executeRequest as internalExecuteRequest
 
 internal interface RequestExecutor {
     suspend fun <DATA> executeRequest(globalErrorReceiver: GlobalErrorReceiver?,
                                       maxDelayBeforeRetry: Long = 32_000L,
                                       maxRetriesCount: Int = 4,
-                                      canRetryOnFailure: (Throwable) -> Boolean = internalDefaultRequestRetryPolicy,
+                                      canRetryOnFailure: (Throwable) -> Boolean = defaultRequestRetryPolicy,
                                       requestBlock: suspend () -> DATA): DATA
 }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/RequestExecutor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/RequestExecutor.kt
@@ -15,22 +15,24 @@
  */
 
 package org.matrix.android.sdk.internal.network
+
+import org.matrix.android.sdk.internal.network.defaultRequestRetryPolicy as internalDefaultRequestRetryPolicy
 import org.matrix.android.sdk.internal.network.executeRequest as internalExecuteRequest
 
 internal interface RequestExecutor {
     suspend fun <DATA> executeRequest(globalErrorReceiver: GlobalErrorReceiver?,
-                                      canRetry: Boolean = false,
                                       maxDelayBeforeRetry: Long = 32_000L,
                                       maxRetriesCount: Int = 4,
+                                      canRetryOnFailure: (Throwable) -> Boolean = internalDefaultRequestRetryPolicy,
                                       requestBlock: suspend () -> DATA): DATA
 }
 
 internal object DefaultRequestExecutor : RequestExecutor {
     override suspend fun <DATA> executeRequest(globalErrorReceiver: GlobalErrorReceiver?,
-                                               canRetry: Boolean,
                                                maxDelayBeforeRetry: Long,
                                                maxRetriesCount: Int,
+                                               canRetryOnFailure: (Throwable) -> Boolean,
                                                requestBlock: suspend () -> DATA): DATA {
-        return internalExecuteRequest(globalErrorReceiver, canRetry, maxDelayBeforeRetry, maxRetriesCount, requestBlock)
+        return internalExecuteRequest(globalErrorReceiver, maxDelayBeforeRetry, maxRetriesCount, canRetryOnFailure, requestBlock)
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/RequestExecutor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/RequestExecutor.kt
@@ -22,7 +22,7 @@ internal interface RequestExecutor {
     suspend fun <DATA> executeRequest(globalErrorReceiver: GlobalErrorReceiver?,
                                       maxDelayBeforeRetry: Long = 32_000L,
                                       maxRetriesCount: Int = 4,
-                                      canRetryOnFailure: (Throwable) -> Boolean = defaultRequestRetryPolicy,
+                                      getRetryPolicy: (Throwable) -> RequestRetryPolicy = defaultRequestRetryPolicy,
                                       requestBlock: suspend () -> DATA): DATA
 }
 
@@ -30,8 +30,8 @@ internal object DefaultRequestExecutor : RequestExecutor {
     override suspend fun <DATA> executeRequest(globalErrorReceiver: GlobalErrorReceiver?,
                                                maxDelayBeforeRetry: Long,
                                                maxRetriesCount: Int,
-                                               canRetryOnFailure: (Throwable) -> Boolean,
+                                               getRetryPolicy: (Throwable) -> RequestRetryPolicy,
                                                requestBlock: suspend () -> DATA): DATA {
-        return internalExecuteRequest(globalErrorReceiver, maxDelayBeforeRetry, maxRetriesCount, canRetryOnFailure, requestBlock)
+        return internalExecuteRequest(globalErrorReceiver, maxDelayBeforeRetry, maxRetriesCount, getRetryPolicy, requestBlock)
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/joining/InviteTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/joining/InviteTask.kt
@@ -39,7 +39,7 @@ internal class DefaultInviteTask @Inject constructor(
         val body = InviteBody(params.userId, params.reason)
         return executeRequest(
                 globalErrorReceiver,
-                canRetry = true,
+                canRetryOnFailure = { true },
                 maxRetriesCount = 3
         ) {
             roomAPI.invite(params.roomId, body)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/joining/InviteTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/joining/InviteTask.kt
@@ -17,6 +17,7 @@
 package org.matrix.android.sdk.internal.session.room.membership.joining
 
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
+import org.matrix.android.sdk.internal.network.RequestRetryPolicy
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.session.room.RoomAPI
 import org.matrix.android.sdk.internal.task.Task
@@ -39,7 +40,7 @@ internal class DefaultInviteTask @Inject constructor(
         val body = InviteBody(params.userId, params.reason)
         return executeRequest(
                 globalErrorReceiver,
-                canRetryOnFailure = { true },
+                getRequestRetryPolicy = { RequestRetryPolicy(true) },
                 maxRetriesCount = 3
         ) {
             roomAPI.invite(params.roomId, body)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/read/SetReadMarkersTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/read/SetReadMarkersTask.kt
@@ -98,7 +98,7 @@ internal class DefaultSetReadMarkersTask @Inject constructor(
         if (markers.isNotEmpty()) {
             executeRequest(
                     globalErrorReceiver,
-                    canRetry = true
+                    canRetryOnFailure = { true }
             ) {
                 if (markers[READ_MARKER] == null) {
                     if (readReceiptEventId != null) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/read/SetReadMarkersTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/read/SetReadMarkersTask.kt
@@ -28,6 +28,7 @@ import org.matrix.android.sdk.internal.database.query.where
 import org.matrix.android.sdk.internal.di.SessionDatabase
 import org.matrix.android.sdk.internal.di.UserId
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
+import org.matrix.android.sdk.internal.network.RequestRetryPolicy
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.session.room.RoomAPI
 import org.matrix.android.sdk.internal.session.sync.handler.room.ReadReceiptHandler
@@ -98,7 +99,7 @@ internal class DefaultSetReadMarkersTask @Inject constructor(
         if (markers.isNotEmpty()) {
             executeRequest(
                     globalErrorReceiver,
-                    canRetryOnFailure = { true }
+                    getRequestRetryPolicy = { RequestRetryPolicy(true) }
             ) {
                 if (markers[READ_MARKER] == null) {
                     if (readReceiptEventId != null) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/PaginationTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/PaginationTask.kt
@@ -44,7 +44,7 @@ internal class DefaultPaginationTask @Inject constructor(
         val filter = filterRepository.getRoomFilter()
         val chunk = executeRequest(
                 globalErrorReceiver,
-                canRetry = true
+                canRetryOnFailure = { true }
         ) {
             roomAPI.getRoomMessagesFrom(params.roomId, params.from, params.direction.value, params.limit, filter)
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/PaginationTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/PaginationTask.kt
@@ -17,6 +17,7 @@
 package org.matrix.android.sdk.internal.session.room.timeline
 
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
+import org.matrix.android.sdk.internal.network.RequestRetryPolicy
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.session.filter.FilterRepository
 import org.matrix.android.sdk.internal.session.room.RoomAPI
@@ -44,7 +45,7 @@ internal class DefaultPaginationTask @Inject constructor(
         val filter = filterRepository.getRoomFilter()
         val chunk = executeRequest(
                 globalErrorReceiver,
-                canRetryOnFailure = { true }
+                getRequestRetryPolicy = { RequestRetryPolicy(true) }
         ) {
             roomAPI.getRoomMessagesFrom(params.roomId, params.from, params.direction.value, params.limit, filter)
         }

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeRequestExecutor.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeRequestExecutor.kt
@@ -18,13 +18,14 @@ package org.matrix.android.sdk.test.fakes
 
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.RequestExecutor
+import org.matrix.android.sdk.internal.network.RequestRetryPolicy
 
 internal class FakeRequestExecutor : RequestExecutor {
 
     override suspend fun <DATA> executeRequest(globalErrorReceiver: GlobalErrorReceiver?,
                                                maxDelayBeforeRetry: Long,
                                                maxRetriesCount: Int,
-                                               canRetryOnFailure: (Throwable) -> Boolean,
+                                               getRetryPolicy: (Throwable) -> RequestRetryPolicy,
                                                requestBlock: suspend () -> DATA): DATA {
         return requestBlock()
     }

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeRequestExecutor.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeRequestExecutor.kt
@@ -22,9 +22,9 @@ import org.matrix.android.sdk.internal.network.RequestExecutor
 internal class FakeRequestExecutor : RequestExecutor {
 
     override suspend fun <DATA> executeRequest(globalErrorReceiver: GlobalErrorReceiver?,
-                                               canRetry: Boolean,
                                                maxDelayBeforeRetry: Long,
                                                maxRetriesCount: Int,
+                                               canRetryOnFailure: (Throwable) -> Boolean,
                                                requestBlock: suspend () -> DATA): DATA {
         return requestBlock()
     }


### PR DESCRIPTION
Previously, failed requests were retried according to a `canRetry` boolean passed in `executeRequest` method params. There is an exception for the 429 error with the `M_LIMIT_EXCEEDED` error code which were automatically retried without taking account of the `canRetry` flag.

The goal of this PR is to have more flexibility on the retry policy to be able to have a custom policy for a specific request. For example, a 429 error with a very long retry delay should no be retried but notify the user about the delay.

To keep the previous behaviour, the current retry policy has been kept and passed as the default value of the new `canRetryOnFailure` method parameter.