### PR TITLE
Force HTTP/1.1

### DIFF
--- a/changelog.d/4669.bugfix
+++ b/changelog.d/4669.bugfix
@@ -1,0 +1,1 @@
+Fix sync timeout after returning from background

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/di/NetworkModule.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/di/NetworkModule.kt
@@ -22,6 +22,7 @@ import dagger.Module
 import dagger.Provides
 import okhttp3.ConnectionSpec
 import okhttp3.OkHttpClient
+import okhttp3.Protocol
 import okhttp3.logging.HttpLoggingInterceptor
 import org.matrix.android.sdk.BuildConfig
 import org.matrix.android.sdk.api.MatrixConfiguration
@@ -71,6 +72,7 @@ internal object NetworkModule {
         val spec = ConnectionSpec.Builder(matrixConfiguration.connectionSpec).build()
 
         return OkHttpClient.Builder()
+                .protocols(listOf(Protocol.HTTP_1_1))
                 .connectTimeout(30, TimeUnit.SECONDS)
                 .readTimeout(60, TimeUnit.SECONDS)
                 .writeTimeout(60, TimeUnit.SECONDS)


### PR DESCRIPTION
Quite frequently when I am on mobile data I will experience #4669. The incremental sync state will be idle, but the progress bar will be visible for one minute before throwing a timeout exception and displaying a connectivity error bar

I found some open OkHttp issues that were possibly related (3146, 3278 and 4455). I didn't drop links because I don't know if they're the cause, but these led me to disabling HTTP/2 which seems to resolve the issue.

I have attached a recording with the following setup:
- Phone1 as a mobile hotspot
- Phone2 in airplane mode connected to hotspot, proxying connections through a laptop to record traffic

I'm running two builds of element in split screen on phone2. The top app (dark mode) is this PR, the bottom app (light mode) is v1.3.14 from the Play Store. The apps show a blue airplane mode bar instead of a red connectivity error bar because I'm connecting through the hotspot.

Based on the proxy traffic it appears that phone1 briefly loses internet connectivity and the HTTP/2 sync request gets stuck for some reason.

It may be possible to fix this without disabling HTTP/2, e.g. listening for connectivity changes and evicting the OkHttp connection pool.

https://user-images.githubusercontent.com/220908/149430467-5a1c40ee-660f-4269-aad1-28b835c5b1e9.mp4

---

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [X] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
