### PR TITLE
Sync issue automation with element-web

### DIFF
--- a/.github/workflows/triage-labelled.yml
+++ b/.github/workflows/triage-labelled.yml
@@ -5,6 +5,31 @@ on:
     types: [labeled]
 
 jobs:
+  apply_Z-Labs_label:
+    name: Add Z-Labs label for features behind labs flags
+    runs-on: ubuntu-latest
+    if: >
+        contains(github.event.issue.labels.*.name, 'A-Maths') ||
+        contains(github.event.issue.labels.*.name, 'A-Message-Pinning') ||
+        contains(github.event.issue.labels.*.name, 'A-Threads') ||
+        contains(github.event.issue.labels.*.name, 'A-Polls') ||
+        contains(github.event.issue.labels.*.name, 'A-Location-Sharing') ||
+        contains(github.event.issue.labels.*.name, 'A-Message-Bubbles') ||
+        contains(github.event.issue.labels.*.name, 'Z-IA') ||
+        contains(github.event.issue.labels.*.name, 'A-Themes-Custom') ||
+        contains(github.event.issue.labels.*.name, 'A-E2EE-Dehydration') ||
+        contains(github.event.issue.labels.*.name, 'A-Tags')
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Z-Labs']
+            })
+
   move_needs_info_issues:
     name: X-Needs-Info issues to Need info column on triage board
     runs-on: ubuntu-latest
@@ -51,32 +76,56 @@ jobs:
           PROJECT_ID: "PN_kwDOAM0swc0sUA"
           GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
-  #  delight_issues_to_board:
-  #    name: Spaces issues to new Delight project board
-  #    runs-on: ubuntu-latest
-  #    # Skip in forks
-  #    if: >
-  #      github.repository == 'vector-im/element-android' &&
-  #      contains(github.event.issue.labels.*.name, 'A-Spaces') ||
-  #      contains(github.event.issue.labels.*.name, 'A-Space-Settings') ||
-  #      contains(github.event.issue.labels.*.name, 'A-Subspaces')
-  #    steps:
-  #      - uses: octokit/graphql-action@v2.x
-  #        with:
-  #          headers: '{"GraphQL-Features": "projects_next_graphql"}'
-  #          query: |
-  #            mutation add_to_project($projectid:ID!,$contentid:ID!) {
-  #              addProjectNextItem(input:{projectId:$projectid contentId:$contentid}) {
-  #                projectNextItem {
-  #                  id
-  #                }
-  #              }
-  #            }
-  #          projectid: ${{ env.PROJECT_ID }}
-  #          contentid: ${{ github.event.issue.node_id }}
-  #        env:
-  #          PROJECT_ID: "PN_kwDOAM0swc1HvQ"
-  #          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+  add_product_issues:
+    name: X-Needs-Product to Design project board
+    runs-on: ubuntu-latest
+    if: >
+        contains(github.event.issue.labels.*.name, 'X-Needs-Product')
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: add_to_project
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            mutation add_to_project($projectid:ID!,$contentid:ID!) {
+              addProjectNextItem(input:{projectId:$projectid contentId:$contentid}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }
+          projectid: ${{ env.PROJECT_ID }}
+          contentid: ${{ github.event.issue.node_id }}
+        env:
+          PROJECT_ID: "PN_kwDOAM0swc4AAg6N"
+          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+
+#  delight_issues_to_board:
+#    name: Spaces issues to new Delight project board
+#    runs-on: ubuntu-latest
+#    # Skip in forks
+#    if: >
+#      github.repository == 'vector-im/element-android' &&
+#      contains(github.event.issue.labels.*.name, 'A-Spaces') ||
+#      contains(github.event.issue.labels.*.name, 'A-Space-Settings') ||
+#      contains(github.event.issue.labels.*.name, 'A-Subspaces')
+#    steps:
+#      - uses: octokit/graphql-action@v2.x
+#        with:
+#          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+#          query: |
+#            mutation add_to_project($projectid:ID!,$contentid:ID!) {
+#              addProjectNextItem(input:{projectId:$projectid contentId:$contentid}) {
+#                projectNextItem {
+#                  id
+#                }
+#              }
+#            }
+#          projectid: ${{ env.PROJECT_ID }}
+#          contentid: ${{ github.event.issue.node_id }}
+#        env:
+#          PROJECT_ID: "PN_kwDOAM0swc1HvQ"
+#          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
   move_voice-message_issues:
     name: A-Voice Messages to voice message board

--- a/.github/workflows/triage-move-review-requests.yml
+++ b/.github/workflows/triage-move-review-requests.yml
@@ -1,0 +1,139 @@
+name: Move pull requests asking for review to the relevant project
+on:
+  pull_request_target:
+    types: [review_requested]
+
+jobs:
+  add_design_pr_to_project:
+    name: Move PRs asking for design review to the design board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: find_team_members
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            query find_team_members($team: String!) {
+              organization(login: "vector-im") {
+                team(slug: $team) {
+                  members {
+                    nodes {
+                      login
+                    }
+                  }
+                }
+              }
+            }
+          team: ${{ env.TEAM }}
+        env:
+          TEAM: "design"
+          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+      - id: any_matching_reviewers
+        run: |
+          # Fetch requested reviewers, and people who are on the team
+          echo '${{ tojson(fromjson(steps.find_team_members.outputs.data).organization.team.members.nodes[*].login) }}' | tee /tmp/team_members.json
+          echo '${{ tojson(github.event.pull_request.requested_reviewers[*].login) }}' | tee /tmp/reviewers.json
+          jq --raw-output .[] < /tmp/team_members.json | sort | tee /tmp/team_members.txt
+          jq --raw-output .[] < /tmp/reviewers.json | sort | tee /tmp/reviewers.txt
+
+          # Fetch requested team reviewers, and the name of the team
+          echo '${{ tojson(github.event.pull_request.requested_teams[*].slug) }}' | tee /tmp/team_reviewers.json
+          jq --raw-output .[] < /tmp/team_reviewers.json | sort | tee /tmp/team_reviewers.txt
+          echo '${{ env.TEAM }}' | tee /tmp/team.txt
+
+          # If either a reviewer matches a team member, or a team matches our team, say "true"
+          if [ $(join /tmp/team_members.txt /tmp/reviewers.txt | wc -l) != 0 ]; then
+            echo "::set-output name=match::true"
+          elif [ $(join /tmp/team.txt /tmp/team_reviewers.txt | wc -l) != 0 ]; then
+            echo "::set-output name=match::true"
+          else
+            echo "::set-output name=match::false"
+          fi
+        env:
+          TEAM: "design"
+      - uses: octokit/graphql-action@v2.x
+        id: add_to_project
+        if: steps.any_matching_reviewers.outputs.match == 'true'
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            mutation add_to_project($projectid:ID!, $contentid:ID!) {
+              addProjectNextItem(input:{projectId:$projectid contentId:$contentid}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }
+          projectid: ${{ env.PROJECT_ID }}
+          contentid: ${{ github.event.pull_request.node_id }}
+        env:
+          PROJECT_ID: "PN_kwDOAM0swc0sUA"
+          TEAM: "design"
+          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+
+  add_product_pr_to_project:
+    name: Move PRs asking for product review to the product board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: find_team_members
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            query find_team_members($team: String!) {
+              organization(login: "vector-im") {
+                team(slug: $team) {
+                  members {
+                    nodes {
+                      login
+                    }
+                  }
+                }
+              }
+            }
+          team: ${{ env.TEAM }}
+        env:
+          TEAM: "product"
+          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+      - id: any_matching_reviewers
+        run: |
+          # Fetch requested reviewers, and people who are on the team
+          echo '${{ tojson(fromjson(steps.find_team_members.outputs.data).organization.team.members.nodes[*].login) }}' | tee /tmp/team_members.json
+          echo '${{ tojson(github.event.pull_request.requested_reviewers[*].login) }}' | tee /tmp/reviewers.json
+          jq --raw-output .[] < /tmp/team_members.json | sort | tee /tmp/team_members.txt
+          jq --raw-output .[] < /tmp/reviewers.json | sort | tee /tmp/reviewers.txt
+
+          # Fetch requested team reviewers, and the name of the team
+          echo '${{ tojson(github.event.pull_request.requested_teams[*].slug) }}' | tee /tmp/team_reviewers.json
+          jq --raw-output .[] < /tmp/team_reviewers.json | sort | tee /tmp/team_reviewers.txt
+          echo '${{ env.TEAM }}' | tee /tmp/team.txt
+
+          # If either a reviewer matches a team member, or a team matches our team, say "true"
+          if [ $(join /tmp/team_members.txt /tmp/reviewers.txt | wc -l) != 0 ]; then
+            echo "::set-output name=match::true"
+          elif [ $(join /tmp/team.txt /tmp/team_reviewers.txt | wc -l) != 0 ]; then
+            echo "::set-output name=match::true"
+          else
+            echo "::set-output name=match::false"
+          fi
+        env:
+          TEAM: "product"
+      - uses: octokit/graphql-action@v2.x
+        id: add_to_project
+        if: steps.any_matching_reviewers.outputs.match == 'true'
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            mutation add_to_project($projectid:ID!, $contentid:ID!) {
+              addProjectNextItem(input:{projectId:$projectid contentId:$contentid}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }
+          projectid: ${{ env.PROJECT_ID }}
+          contentid: ${{ github.event.pull_request.node_id }}
+        env:
+          PROJECT_ID: "PN_kwDOAM0swc4AAg6N"
+          TEAM: "product"
+          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}

--- a/.github/workflows/triage-priority-bugs.yml
+++ b/.github/workflows/triage-priority-bugs.yml
@@ -38,7 +38,8 @@ jobs:
     # Skip in forks
     if: >
       github.repository == 'vector-im/element-android' &&
-      (contains(github.event.issue.labels.*.name, 'A-E2EE') ||
+      (contains(github.event.issue.labels.*.name, 'Z-UISI') ||
+        (contains(github.event.issue.labels.*.name, 'A-E2EE') ||
         contains(github.event.issue.labels.*.name, 'A-E2EE-Cross-Signing') ||
         contains(github.event.issue.labels.*.name, 'A-E2EE-Dehydration') ||
         contains(github.event.issue.labels.*.name, 'A-E2EE-Key-Backup') ||
@@ -50,7 +51,7 @@ jobs:
         contains(github.event.issue.labels.*.name, 'S-Major') &&
         contains(github.event.issue.labels.*.name, 'O-Frequent') ||
         contains(github.event.issue.labels.*.name, 'A11y') &&
-        contains(github.event.issue.labels.*.name, 'O-Frequent'))
+        contains(github.event.issue.labels.*.name, 'O-Frequent')))
     steps:
       - uses: alex-page/github-project-automation-plus@bb266ff4dde9242060e2d5418e120a133586d488
         with:

--- a/.github/workflows/triage-unlabelled.yml
+++ b/.github/workflows/triage-unlabelled.yml
@@ -34,3 +34,29 @@ jobs:
           project: Issue triage
           column: Triaged
           repo-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
+
+  remove_Z-Labs_label:
+    name: Remove Z-Labs label when features behind labs flags are removed
+    runs-on: ubuntu-latest
+    if: >
+        !(contains(github.event.issue.labels.*.name, 'A-Maths') ||
+        contains(github.event.issue.labels.*.name, 'A-Message-Pinning') ||
+        contains(github.event.issue.labels.*.name, 'A-Threads') ||
+        contains(github.event.issue.labels.*.name, 'A-Polls') ||
+        contains(github.event.issue.labels.*.name, 'A-Location-Sharing') ||
+        contains(github.event.issue.labels.*.name, 'A-Message-Bubbles') ||
+        contains(github.event.issue.labels.*.name, 'Z-IA') ||
+        contains(github.event.issue.labels.*.name, 'A-Themes-Custom') ||
+        contains(github.event.issue.labels.*.name, 'A-E2EE-Dehydration') ||
+        contains(github.event.issue.labels.*.name, 'A-Tags')) &&
+        contains(github.event.issue.labels.*.name, 'Z-Labs')
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: ['Z-Labs']
+            })

--- a/changelog.d/4949.misc
+++ b/changelog.d/4949.misc
@@ -1,0 +1,1 @@
+Sync issue automation with element-web


### PR DESCRIPTION
Add automation for
* labelling Labs issues
* moving design and product PRs
* moving product PRs to board
* move UISI issues to Crypto team

Fixes issue #4949

I think we have a repository conditional `github.repository == 'vector-im/element-android'` in all the places that need it. Worth double checking.

### Pull Request Checklist

<!--
 Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request
 Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked.
 -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
