### PR TITLE
Fixing onboarding crash when signing in/up on non `matrix.org` server with SSO

### DIFF
--- a/changelog.d/4969.bugfix
+++ b/changelog.d/4969.bugfix
@@ -1,0 +1,1 @@
+Fixes sign in/up crash when selecting ems and other server types which use SSO

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -826,13 +826,17 @@ class OnboardingViewModel @AssistedInject constructor(
             }
 
             withState {
-                when (it.onboardingFlow) {
-                    OnboardingFlow.SignIn -> handleUpdateSignMode(OnboardingAction.UpdateSignMode(SignMode.SignIn))
-                    OnboardingFlow.SignUp -> handleUpdateSignMode(OnboardingAction.UpdateSignMode(SignMode.SignUp))
-                    OnboardingFlow.SignInSignUp,
-                    null                  -> {
-                        _viewEvents.post(OnboardingViewEvents.OnLoginFlowRetrieved)
+                if (it.serverType == ServerType.MatrixOrg) {
+                    when (it.onboardingFlow) {
+                        OnboardingFlow.SignIn -> handleUpdateSignMode(OnboardingAction.UpdateSignMode(SignMode.SignIn))
+                        OnboardingFlow.SignUp -> handleUpdateSignMode(OnboardingAction.UpdateSignMode(SignMode.SignUp))
+                        OnboardingFlow.SignInSignUp,
+                        null                  -> {
+                            _viewEvents.post(OnboardingViewEvents.OnLoginFlowRetrieved)
+                        }
                     }
+                } else {
+                    _viewEvents.post(OnboardingViewEvents.OnLoginFlowRetrieved)
                 }
             }
         }


### PR DESCRIPTION
Fixes #4969 

The crash occurs because the updated login flow attempts to forward the user to the sign in or sign up pages after fetching the homeserver login configuration, this is only correct for the `matrix.org` server.

- Only applies the sign in/up forwarding if the current server selection is `matrix.org`, for other server types we instead allow the `OnLoginFlowRetrieved` event to continue the flow (this is what the `LoginViewModel` [originally did](https://github.com/vector-im/element-android/blob/develop/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt#L819) 

| OTHER BEFORE | OTHER AFTER |
| --- | --- |
|![before-sso-crash](https://user-images.githubusercontent.com/1848238/149921059-414e83ad-79d2-4ed0-bbba-be8a84202b80.gif)|![after-sso-fix](https://user-images.githubusercontent.com/1848238/149921057-b1a19862-030b-4e57-94bf-c997b93bd11b.gif)

| EMS BEFORE | EMS AFTER |
| --- | --- |
|![before-ems](https://user-images.githubusercontent.com/1848238/149924002-3261572a-9cb4-421e-b866-bb7c769d7ab1.gif)|![after-ems](https://user-images.githubusercontent.com/1848238/149923999-d89239ec-8789-41e3-81b6-36eaf7e7ce81.gif)


*matrix flow - no changes 

| SIGN UP MATRIX | SIGN IN MATRIX |
| --- | --- |
|![get-started-matrix](https://user-images.githubusercontent.com/1848238/149922181-044cd1cb-206e-43a3-9c41-b54900b0c6b0.gif)|![i-already-have-account-matrix](https://user-images.githubusercontent.com/1848238/149922179-ad0bf09e-3746-4b0c-8b19-0f381792a04f.gif)
