### PR TITLE
Ignore dependabot upgrade for @github-script@v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "github-script"
+        versions: ["3.x"]
   # Updates for Gradle dependencies used in the app
   - package-ecosystem: gradle
     directory: "/"

--- a/changelog.d/4988.misc
+++ b/changelog.d/4988.misc
@@ -1,0 +1,1 @@
+Exclude dependabot upgrade for @github-script@v3


### PR DESCRIPTION
Closes #4988 issue to disable @github-script@v3 updates