### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,7 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-name: "github-script"
-        versions: ["3.x"]
+      - dependency-name: "*github-script*"
   # Updates for Gradle dependencies used in the app
   - package-ecosystem: gradle
     directory: "/"


### PR DESCRIPTION
Ignore all versions of github-script while is not possible to ignore a specific version. Enhancement of #4989