### PR TITLE
Fix EmojiPopupDismissListener not being triggered after dismissing the EmojiPopup

### DIFF
--- a/changelog.d/4991.bugfix
+++ b/changelog.d/4991.bugfix
@@ -1,0 +1,1 @@
+EmojiPopupDismissListener not being triggered after dismissing the EmojiPopup

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailFragment.kt
@@ -675,7 +675,7 @@ class RoomDetailFragment @Inject constructor(
      */
     private fun EmojiPopup.Builder.setOnEmojiPopupDismissListenerLifecycleAware(action: () -> Unit): EmojiPopup.Builder {
         return setOnEmojiPopupDismissListener {
-            if (lifecycle.currentState == Lifecycle.State.STARTED) {
+            if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
                 action()
             }
         }


### PR DESCRIPTION
Fix #4991 

Signed-off-by: Tiago Loureiro tiago@beeper.com


- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
