### PR TITLE
Do not auto-retry on 429 in case of too long retry delay

### DIFF
--- a/changelog.d/4995.removal
+++ b/changelog.d/4995.removal
@@ -1,0 +1,1 @@
+429 are not automatically retried anymore in case of too long retry delay

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
@@ -35,6 +35,11 @@ fun Throwable.isTokenError() =
                 error.code == MatrixError.M_MISSING_TOKEN ||
                 error.code == MatrixError.ORG_MATRIX_EXPIRED_ACCOUNT)
 
+fun Throwable.isLimitExceededError() =
+        this is Failure.ServerError &&
+                httpCode == 429 &&
+                error.code == MatrixError.M_LIMIT_EXCEEDED
+
 fun Throwable.shouldBeRetried(): Boolean {
     return this is Failure.NetworkConnection ||
             this is IOException ||

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
@@ -32,8 +32,8 @@ fun Throwable.is401() =
 fun Throwable.isTokenError() =
         this is Failure.ServerError &&
                 (error.code == MatrixError.M_UNKNOWN_TOKEN ||
-                error.code == MatrixError.M_MISSING_TOKEN ||
-                error.code == MatrixError.ORG_MATRIX_EXPIRED_ACCOUNT)
+                        error.code == MatrixError.M_MISSING_TOKEN ||
+                        error.code == MatrixError.ORG_MATRIX_EXPIRED_ACCOUNT)
 
 fun Throwable.isLimitExceededError() =
         this is Failure.ServerError &&
@@ -43,7 +43,7 @@ fun Throwable.isLimitExceededError() =
 fun Throwable.shouldBeRetried(): Boolean {
     return this is Failure.NetworkConnection ||
             this is IOException ||
-            (this is Failure.ServerError && error.code == MatrixError.M_LIMIT_EXCEEDED)
+            this.isLimitExceededError()
 }
 
 /**

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/Request.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/Request.kt
@@ -33,7 +33,8 @@ import java.io.IOException
  *
  * @param globalErrorReceiver will be use to notify error such as invalid token error. See [GlobalError]
  * @param canRetry if set to true, the request will be executed again in case of error, after a delay
- * @param maxDelayBeforeRetry the max delay to wait before a retry
+ * @param maxDelayBeforeRetry the max delay to wait before a retry. Note that in the case of a 429, if the provided delay exceeds this value, the error will
+ * be propagated as it does not make sense to retry it with a shorter delay.
  * @param maxRetriesCount the max number of retries
  * @param requestBlock a suspend lambda to perform the network request
  */

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/Request.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/Request.kt
@@ -19,6 +19,7 @@ package org.matrix.android.sdk.internal.network
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import org.matrix.android.sdk.api.failure.Failure
+import org.matrix.android.sdk.api.failure.GlobalError
 import org.matrix.android.sdk.api.failure.getRetryDelay
 import org.matrix.android.sdk.api.failure.isLimitExceededError
 import org.matrix.android.sdk.api.failure.shouldBeRetried

--- a/vector/src/main/java/im/vector/app/core/error/ErrorFormatter.kt
+++ b/vector/src/main/java/im/vector/app/core/error/ErrorFormatter.kt
@@ -24,6 +24,7 @@ import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.failure.MatrixError
 import org.matrix.android.sdk.api.failure.MatrixIdFailure
 import org.matrix.android.sdk.api.failure.isInvalidPassword
+import org.matrix.android.sdk.api.failure.isLimitExceededError
 import org.matrix.android.sdk.api.session.identity.IdentityServiceError
 import java.net.HttpURLConnection
 import java.net.SocketTimeoutException
@@ -58,53 +59,53 @@ class DefaultErrorFormatter @Inject constructor(
             }
             is Failure.ServerError                 -> {
                 when {
-                    throwable.error.code == MatrixError.M_CONSENT_NOT_GIVEN       -> {
+                    throwable.error.code == MatrixError.M_CONSENT_NOT_GIVEN            -> {
                         // Special case for terms and conditions
                         stringProvider.getString(R.string.error_terms_not_accepted)
                     }
-                    throwable.isInvalidPassword()                                 -> {
+                    throwable.isInvalidPassword()                                      -> {
                         stringProvider.getString(R.string.auth_invalid_login_param)
                     }
-                    throwable.error.code == MatrixError.M_USER_IN_USE             -> {
+                    throwable.error.code == MatrixError.M_USER_IN_USE                  -> {
                         stringProvider.getString(R.string.login_signup_error_user_in_use)
                     }
-                    throwable.error.code == MatrixError.M_BAD_JSON                -> {
+                    throwable.error.code == MatrixError.M_BAD_JSON                     -> {
                         stringProvider.getString(R.string.login_error_bad_json)
                     }
-                    throwable.error.code == MatrixError.M_NOT_JSON                -> {
+                    throwable.error.code == MatrixError.M_NOT_JSON                     -> {
                         stringProvider.getString(R.string.login_error_not_json)
                     }
-                    throwable.error.code == MatrixError.M_THREEPID_DENIED         -> {
+                    throwable.error.code == MatrixError.M_THREEPID_DENIED              -> {
                         stringProvider.getString(R.string.login_error_threepid_denied)
                     }
-                    throwable.error.code == MatrixError.M_LIMIT_EXCEEDED          -> {
+                    throwable.isLimitExceededError()                                   -> {
                         limitExceededError(throwable.error)
                     }
-                    throwable.error.code == MatrixError.M_TOO_LARGE               -> {
+                    throwable.error.code == MatrixError.M_TOO_LARGE                    -> {
                         stringProvider.getString(R.string.error_file_too_big_simple)
                     }
-                    throwable.error.code == MatrixError.M_THREEPID_NOT_FOUND      -> {
+                    throwable.error.code == MatrixError.M_THREEPID_NOT_FOUND           -> {
                         stringProvider.getString(R.string.login_reset_password_error_not_found)
                     }
-                    throwable.error.code == MatrixError.M_USER_DEACTIVATED        -> {
+                    throwable.error.code == MatrixError.M_USER_DEACTIVATED             -> {
                         stringProvider.getString(R.string.auth_invalid_login_deactivated_account)
                     }
                     throwable.error.code == MatrixError.M_THREEPID_IN_USE &&
-                            throwable.error.message == "Email is already in use"  -> {
+                            throwable.error.message == "Email is already in use"       -> {
                         stringProvider.getString(R.string.account_email_already_used_error)
                     }
                     throwable.error.code == MatrixError.M_THREEPID_IN_USE &&
-                            throwable.error.message == "MSISDN is already in use" -> {
+                            throwable.error.message == "MSISDN is already in use"      -> {
                         stringProvider.getString(R.string.account_phone_number_already_used_error)
                     }
-                    throwable.error.code == MatrixError.M_THREEPID_AUTH_FAILED    -> {
+                    throwable.error.code == MatrixError.M_THREEPID_AUTH_FAILED         -> {
                         stringProvider.getString(R.string.error_threepid_auth_failed)
                     }
                     throwable.error.code == MatrixError.M_UNKNOWN &&
                             throwable.error.message == "Not allowed to join this room" -> {
                         stringProvider.getString(R.string.room_error_access_unauthorized)
                     }
-                    else                                                          -> {
+                    else                                                               -> {
                         throwable.error.message.takeIf { it.isNotEmpty() }
                                 ?: throwable.error.code.takeIf { it.isNotEmpty() }
                     }


### PR DESCRIPTION
Replace #4950 

Propagate the M_LIMIT_EXCEEDED error when the provided delay is too long (exceeds 32 seconds, eg. after three failed login attempts).