### PR TITLE
Speed up event match regex evaluation for big messages

### DIFF
--- a/changelog.d/5008.bugfix
+++ b/changelog.d/5008.bugfix
@@ -1,0 +1,1 @@
+Big messages taking inappropriately long to evaluate .m.rule.roomnotif push rules

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/pushrules/EventMatchCondition.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/pushrules/EventMatchCondition.kt
@@ -56,7 +56,12 @@ class EventMatchCondition(
             if (wordsOnly) {
                 value.caseInsensitiveFind(pattern)
             } else {
-                val modPattern = if (pattern.hasSpecialGlobChar()) pattern.simpleGlobToRegExp() else "*$pattern*".simpleGlobToRegExp()
+                val modPattern = if (pattern.hasSpecialGlobChar())
+                    // Regex.containsMatchIn() is way faster without leading and trailing
+                    // stars, that don't make any difference for the evaluation result
+                    pattern.removePrefix("*").removeSuffix("*").simpleGlobToRegExp()
+                else
+                    pattern.simpleGlobToRegExp()
                 val regex = Regex(modPattern, RegexOption.DOT_MATCHES_ALL)
                 regex.containsMatchIn(value)
             }


### PR DESCRIPTION
`regex.containsMatchIn()` for `.*@room.*` can take significantly longer
than checking for `@room` (some real-world events I was getting took
around 15 seconds with this, significantly slowing down the sync
parsing).

Checking `containsMatchIn()` does not lead to different results when
having leading and trailing stars however, it will match in the same
cases as when these are omitted.

For testing purposes, I sent myself some Lorem Ipsum with 5000 words
(not containing any `@room`).
Without this change, the regex evaluation takes about 16 seconds.
With this change, the regex evaluation now takes significantly less then
a second.

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>

### Pull Request Checklist

<!--
 Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request
 Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked.
 -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
