### PR TITLE
Missing fdroid notifications

### DIFF
--- a/changelog.d/5003.bugfix
+++ b/changelog.d/5003.bugfix
@@ -1,0 +1,1 @@
+Fixing missing notifications in FDroid variants using `optimised for battery` background sync mode

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncWorker.kt
@@ -151,6 +151,7 @@ internal class SyncWorker(context: Context, workerParameters: WorkerParameters, 
                             sessionId = sessionId,
                             timeout = serverTimeoutInSeconds,
                             delay = delayInSeconds,
+                            periodic = true,
                             forceImmediate = forceImmediate
                     )
             )


### PR DESCRIPTION
Fixes #5003 Fdroid notifications no longer working.

The workaround is to switch the background mode to `optimised for realtime` 

- We've had a small regression in the automatic background sync worker where the `periodic` flag was no longer being set and instead using the default value of `false`
- The named arguments should help combat this in the future!

https://github.com/vector-im/element-android/pull/4614/files#diff-0b0656b4f8d1f73f2a4d5844acec8bf35b732e315e5355800f74145c7fc82fa1L117