### PR TITLE
Small layout issues

### DIFF
--- a/tools/check/forbidden_strings_in_code.txt
+++ b/tools/check/forbidden_strings_in_code.txt
@@ -159,9 +159,6 @@ Formatter\.formatShortFileSize===1
 # DISABLED
 # android\.text\.TextUtils
 
-### This is not a rule, but a warning: the number of "enum class" has changed. For Json classes, it is mandatory that they have `@JsonClass(generateAdapter = false)`. If the enum is not used as a Json class, change the value in file forbidden_strings_in_code.txt
-enum class===121
-
 ### Do not import temporary legacy classes
 import org.matrix.android.sdk.internal.legacy.riot===3
 import org.matrix.androidsdk.crypto.data===2

--- a/vector/src/main/java/im/vector/app/features/invite/InviteButtonStateBinder.kt
+++ b/vector/src/main/java/im/vector/app/features/invite/InviteButtonStateBinder.kt
@@ -40,9 +40,9 @@ object InviteButtonStateBinder {
 
         rejectView.isGone = requestInProgress
 
-        when {
-            changeMembershipState is ChangeMembershipState.FailedLeaving -> rejectView.render(ButtonStateView.State.Error)
-            else                                                         -> rejectView.render(ButtonStateView.State.Button)
+        when (changeMembershipState) {
+            is ChangeMembershipState.FailedLeaving -> rejectView.render(ButtonStateView.State.Error)
+            else                                   -> rejectView.render(ButtonStateView.State.Button)
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/invite/InviteButtonStateBinder.kt
+++ b/vector/src/main/java/im/vector/app/features/invite/InviteButtonStateBinder.kt
@@ -16,7 +16,7 @@
 
 package im.vector.app.features.invite
 
-import androidx.core.view.isInvisible
+import androidx.core.view.isGone
 import im.vector.app.core.platform.ButtonStateView
 import org.matrix.android.sdk.api.session.room.members.ChangeMembershipState
 
@@ -38,7 +38,7 @@ object InviteButtonStateBinder {
         }
         // ButtonStateView.State.Loaded not used because roomSummary will not be displayed as a room invitation anymore
 
-        rejectView.isInvisible = requestInProgress
+        rejectView.isGone = requestInProgress
 
         when {
             changeMembershipState is ChangeMembershipState.FailedLeaving -> rejectView.render(ButtonStateView.State.Error)

--- a/vector/src/main/res/layout/vector_invite_view.xml
+++ b/vector/src/main/res/layout/vector_invite_view.xml
@@ -64,8 +64,9 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        app:constraint_referenced_ids="inviteAcceptView,inviteRejectView"
+        app:constraint_referenced_ids="inviteRejectView,inviteAcceptView"
         app:flow_horizontalGap="4dp"
+        app:flow_horizontalStyle="packed"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/inviteLabelView" />

--- a/vector/src/main/res/layout/vector_invite_view.xml
+++ b/vector/src/main/res/layout/vector_invite_view.xml
@@ -59,38 +59,38 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/inviteIdentifierView" />
 
+    <androidx.constraintlayout.helper.widget.Flow
+        android:id="@+id/actionsFlow"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        app:constraint_referenced_ids="inviteAcceptView,inviteRejectView"
+        app:flow_horizontalGap="4dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/inviteLabelView" />
+
     <im.vector.app.core.platform.ButtonStateView
         android:id="@+id/inviteAcceptView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="4dp"
         android:minWidth="120dp"
         app:bsv_button_text="@string/action_accept"
         app:bsv_loaded_image_src="@drawable/ic_tick"
-        app:bsv_use_flat_button="false"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_chainStyle="packed"
-        app:layout_constraintStart_toEndOf="@id/inviteRejectView"
-        app:layout_constraintTop_toTopOf="@id/inviteRejectView" />
+        app:bsv_use_flat_button="false" />
 
     <im.vector.app.core.platform.ButtonStateView
         android:id="@+id/inviteRejectView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="4dp"
         android:minWidth="120dp"
         app:bsv_button_text="@string/action_reject"
         app:bsv_loaded_image_src="@drawable/ic_tick"
-        app:bsv_use_flat_button="true"
-        app:layout_constraintEnd_toStartOf="@id/inviteAcceptView"
-        app:layout_constraintHorizontal_chainStyle="packed"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/inviteLabelView" />
+        app:bsv_use_flat_button="true" />
 
     <Space
         android:layout_width="match_parent"
         android:layout_height="16dp"
-        app:layout_constraintTop_toBottomOf="@id/inviteAcceptView" />
+        app:layout_constraintTop_toBottomOf="@id/actionsFlow" />
 
 </merge>


### PR DESCRIPTION
2 tiny things:

- CI: Disable the check on `enum class`
- Center horizontally the loading wheel when accepting (or rejecting) an invitation

|Before|After|
|-|-|
|<img width="460" alt="image" src="https://user-images.githubusercontent.com/3940906/150837106-e02161d3-5c1b-4086-877e-f8f3e0e7c7d3.png">|<img width="455" alt="image" src="https://user-images.githubusercontent.com/3940906/150838566-d9753af8-09a7-48b1-805c-44ecb2e77cb3.png">|