### PR TITLE
WIP and low priority: upgrade konfetti to 2.0.2

### DIFF
--- a/changelog.d/5079.misc
+++ b/changelog.d/5079.misc
@@ -1,0 +1,1 @@
+Upgrade konfetti lib from 1.3.2 to 2.0.2

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -446,7 +446,8 @@ dependencies {
     implementation 'me.leolin:ShortcutBadger:1.1.22@aar'
 
     // Chat effects
-    implementation 'nl.dionsegijn:konfetti:1.3.2'
+    implementation 'nl.dionsegijn:konfetti-xml:2.0.1'
+
     implementation 'com.github.jetradarmobile:android-snowfall:1.2.1'
     // DI
     implementation libs.dagger.hilt

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -446,7 +446,7 @@ dependencies {
     implementation 'me.leolin:ShortcutBadger:1.1.22@aar'
 
     // Chat effects
-    implementation 'nl.dionsegijn:konfetti-xml:2.0.1'
+    implementation 'nl.dionsegijn:konfetti-xml:2.0.2'
 
     implementation 'com.github.jetradarmobile:android-snowfall:1.2.1'
     // DI

--- a/vector/src/main/java/im/vector/app/core/animations/Konfetti.kt
+++ b/vector/src/main/java/im/vector/app/core/animations/Konfetti.kt
@@ -20,8 +20,13 @@ import android.content.Context
 import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
 import im.vector.app.R
+import nl.dionsegijn.konfetti.core.Angle
 import nl.dionsegijn.konfetti.core.Party
+import nl.dionsegijn.konfetti.core.Position
+import nl.dionsegijn.konfetti.core.Spread
 import nl.dionsegijn.konfetti.core.emitter.Emitter
+import nl.dionsegijn.konfetti.core.models.Shape
+import nl.dionsegijn.konfetti.core.models.Size
 import nl.dionsegijn.konfetti.xml.KonfettiView
 
 fun KonfettiView.play() {
@@ -35,33 +40,21 @@ fun KonfettiView.play() {
             R.color.palette_prune,
             R.color.palette_kiwi
     )
-    /*
-    build()
-            .addColors(confettiColors.toColorInt(context))
-            .setDirection(0.0, 359.0)
-            .setSpeed(2f, 5f)
-            .setFadeOutEnabled(true)
-            .setTimeToLive(2000L)
-            .addShapes(Shape.Square, Shape.Circle)
-            .addSizes(Size(12))
-            .setPosition(-50f, width + 50f, -50f, -50f)
-            .streamFor(150, 3000L)
-     */
-
+    val emitterConfig = Emitter(2000).perSecond(100)
     val party = Party(
+            emitter = emitterConfig,
             colors = confettiColors.toColorInt(context),
-            /*
-            // Keep other default setting for now.
-            timeToLive = 2000L,
-            fadeOutEnabled = true,
+            angle = Angle.Companion.BOTTOM,
+            spread = Spread.ROUND,
+            shapes = listOf(Shape.Square, Shape.Circle),
+            size = listOf(Size(12)),
             speed = 2f,
             maxSpeed = 5f,
-            damping = 0.9f,
-            spread = 360,
-            position = Position.Relative(0.5, 0.3),
-             */
-            emitter = Emitter(duration = 100).max(100)
+            fadeOutEnabled = true,
+            timeToLive = 2000L,
+            position = Position.Relative(0.0, 0.0).between(Position.Relative(1.0, 0.0)),
     )
+    reset()
     start(party)
 }
 

--- a/vector/src/main/java/im/vector/app/core/animations/Konfetti.kt
+++ b/vector/src/main/java/im/vector/app/core/animations/Konfetti.kt
@@ -20,9 +20,9 @@ import android.content.Context
 import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
 import im.vector.app.R
-import nl.dionsegijn.konfetti.KonfettiView
-import nl.dionsegijn.konfetti.models.Shape
-import nl.dionsegijn.konfetti.models.Size
+import nl.dionsegijn.konfetti.core.Party
+import nl.dionsegijn.konfetti.core.emitter.Emitter
+import nl.dionsegijn.konfetti.xml.KonfettiView
 
 fun KonfettiView.play() {
     val confettiColors = listOf(
@@ -35,6 +35,7 @@ fun KonfettiView.play() {
             R.color.palette_prune,
             R.color.palette_kiwi
     )
+    /*
     build()
             .addColors(confettiColors.toColorInt(context))
             .setDirection(0.0, 359.0)
@@ -45,6 +46,23 @@ fun KonfettiView.play() {
             .addSizes(Size(12))
             .setPosition(-50f, width + 50f, -50f, -50f)
             .streamFor(150, 3000L)
+     */
+
+    val party = Party(
+            colors = confettiColors.toColorInt(context),
+            /*
+            // Keep other default setting for now.
+            timeToLive = 2000L,
+            fadeOutEnabled = true,
+            speed = 2f,
+            maxSpeed = 5f,
+            damping = 0.9f,
+            spread = 360,
+            position = Position.Relative(0.5, 0.3),
+             */
+            emitter = Emitter(duration = 100).max(100)
+    )
+    start(party)
 }
 
 @ColorInt

--- a/vector/src/main/res/layout/fragment_ftue_account_created.xml
+++ b/vector/src/main/res/layout/fragment_ftue_account_created.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:background="?colorSecondary">
 
-    <nl.dionsegijn.konfetti.KonfettiView
+    <nl.dionsegijn.konfetti.xml.KonfettiView
         android:id="@+id/viewKonfetti"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/vector/src/main/res/layout/fragment_ftue_personalization_complete.xml
+++ b/vector/src/main/res/layout/fragment_ftue_personalization_complete.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <nl.dionsegijn.konfetti.KonfettiView
+    <nl.dionsegijn.konfetti.xml.KonfettiView
         android:id="@+id/viewKonfetti"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/vector/src/main/res/layout/fragment_timeline.xml
+++ b/vector/src/main/res/layout/fragment_timeline.xml
@@ -188,7 +188,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:tint="@android:color/black" />
 
-    <nl.dionsegijn.konfetti.KonfettiView
+    <nl.dionsegijn.konfetti.xml.KonfettiView
         android:id="@+id/viewKonfetti"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
Update Konfetti to the latest version

Compilation warning is now fixed, probably due to the update of library Jitsi.

The rendering is not strictly equivalent, but still acceptable to me.

|Before|After|
|-|-|
|![confetti_before](https://user-images.githubusercontent.com/3940906/161565163-108bbf21-40ac-4271-864e-6767471d0ab9.gif)|![confetti_after](https://user-images.githubusercontent.com/3940906/161565211-e5e51a08-2ff1-4e1f-a592-306da60cf14c.gif)|

We are using the "rain" party, but we could choose a different configuration, from the sample app:

<img width="360" alt="image" src="https://user-images.githubusercontent.com/3940906/161565900-1791d95f-c577-4e6d-ae29-c39b02029819.png">

Also reporting that on the celebration screen (after account creation), the confetti are displayed below the other views, which is a bit strange to me, and not equivalent to what we have in the timeline. This PR does not change that.