### PR TITLE
CallTileTimelineItem.CallStatus.MISSED renders both missed and reject…

### DIFF
--- a/changelog.d/5088.bugfix
+++ b/changelog.d/5088.bugfix
@@ -1,0 +1,1 @@
+Fixes call statuses in the timeline for missed/rejected calls and connected calls.

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/CallItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/CallItemFactory.kt
@@ -101,7 +101,11 @@ class CallItemFactory @Inject constructor(
                 createCallTileTimelineItem(
                         roomSummary = roomSummary,
                         callId = callEventGrouper.callId,
-                        callStatus = if (!callEventGrouper.callWasAnswered()) CallTileTimelineItem.CallStatus.MISSED else CallTileTimelineItem.CallStatus.ENDED,
+                        callStatus = if (callEventGrouper.callWasAnswered()) {
+                            CallTileTimelineItem.CallStatus.ENDED
+                        } else {
+                            CallTileTimelineItem.CallStatus.MISSED
+                        },
                         callKind = callKind,
                         callback = params.callback,
                         highlight = params.isHighlighted,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/CallItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/CallItemFactory.kt
@@ -101,7 +101,7 @@ class CallItemFactory @Inject constructor(
                 createCallTileTimelineItem(
                         roomSummary = roomSummary,
                         callId = callEventGrouper.callId,
-                        callStatus = if (callEventGrouper.callWasMissed()) CallTileTimelineItem.CallStatus.MISSED else CallTileTimelineItem.CallStatus.ENDED,
+                        callStatus = if (!callEventGrouper.callWasAnswered()) CallTileTimelineItem.CallStatus.MISSED else CallTileTimelineItem.CallStatus.ENDED,
                         callKind = callKind,
                         callback = params.callback,
                         highlight = params.isHighlighted,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineEventsGroups.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineEventsGroups.kt
@@ -108,11 +108,8 @@ class CallSignalingEventsGroup(private val group: TimelineEventsGroup) {
         }
     }
 
-    /**
-     * Returns true if there are only events from one side.
-     */
-    fun callWasMissed(): Boolean {
-        return group.events.distinctBy { it.senderInfo.userId }.size == 1
+    fun callWasAnswered(): Boolean {
+        return getAnswer() != null
     }
 
     private fun getAnswer(): TimelineEvent? {


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-android/issues/5088

The if statement switches between `CallStatus.MISSED` and `CallStatus.ENDED`. `CallStatus.MISSED` renders both missed calls and not answered calls. So i think the logic makes more sense to check that the call was not answered vs the old code which checks all events are from one side.