### PR TITLE
Timeline recycling crash

### DIFF
--- a/changelog.d/5091.bugfix
+++ b/changelog.d/5091.bugfix
@@ -1,0 +1,1 @@
+Fixing crashes when quickly scrolling or restoring the room timeline  

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -109,6 +109,7 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
             val textFuture = PrecomputedTextCompat.getTextFuture(message, TextViewCompat.getTextMetricsParams(this), null)
             setTextFuture(textFuture)
         } else {
+            setTextFuture(null)
             text = message
         }
     }


### PR DESCRIPTION
It looks like the originally intended fix from #4790 was accidentally merged out

The theory is `setText / text = message / setting text with emojis` is attempting to use a previously set `text future` from a recycled text view. This doesn't usually cause a problem but the emoji layer is particularly strict with futures. 
