### PR TITLE
UI test clean ups

### DIFF
--- a/vector/src/androidTest/java/im/vector/app/EspressoExt.kt
+++ b/vector/src/androidTest/java/im/vector/app/EspressoExt.kt
@@ -195,6 +195,9 @@ fun activityIdlingResource(activityClass: Class<*>): IdlingResource {
                         println("*** [$name]  onActivityLifecycleChanged callback: $callback")
                         callback?.onTransitionToIdle()
                     }
+                    else -> {
+                        // do nothing, we're blocking until the activity resumes
+                    }
                 }
             }
         }

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/MessageMenuRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/MessageMenuRobot.kt
@@ -17,12 +17,16 @@
 package im.vector.app.ui.robot
 
 import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.adevinta.android.barista.interaction.BaristaListInteractions.clickListItem
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import im.vector.app.R
+import im.vector.app.espresso.tools.waitUntilActivityVisible
+import im.vector.app.espresso.tools.waitUntilViewVisible
 import im.vector.app.features.home.room.detail.timeline.edithistory.ViewEditHistoryBottomSheet
+import im.vector.app.features.reactions.EmojiReactionPickerActivity
 import im.vector.app.interactWithSheet
 import java.lang.Thread.sleep
 
@@ -54,7 +58,10 @@ class MessageMenuRobot(
     fun addReactionFromEmojiPicker() {
         clickOn(R.string.message_add_reaction)
         // Wait for emoji to load, it's async now
-        sleep(2000)
+        waitUntilActivityVisible<EmojiReactionPickerActivity> {
+            waitUntilViewVisible(withId(R.id.emojiRecyclerView))
+            waitUntilViewVisible(withText("😀"))
+        }
         clickListItem(R.id.emojiRecyclerView, 4)
         autoClosed = true
     }

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/RoomDetailRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/RoomDetailRobot.kt
@@ -20,13 +20,13 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.longClick
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.adevinta.android.barista.interaction.BaristaClickInteractions
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
-import com.adevinta.android.barista.interaction.BaristaClickInteractions.longClickOn
 import com.adevinta.android.barista.interaction.BaristaEditTextInteractions.writeTo
 import com.adevinta.android.barista.interaction.BaristaMenuClickInteractions.clickMenu
 import com.adevinta.android.barista.interaction.BaristaMenuClickInteractions.openMenu
@@ -70,6 +70,7 @@ class RoomDetailRobot {
         openMessageMenu(message) {
             addQuickReaction(quickReaction)
         }
+        waitUntilViewVisible(withText(quickReaction))
         println("Open reactions bottom sheet")
         // Open reactions
         longClickReaction(quickReaction)
@@ -103,7 +104,7 @@ class RoomDetailRobot {
 
     private fun longClickReaction(quickReaction: String) {
         withRetry {
-            longClickOn(quickReaction)
+            onView(withText(quickReaction)).perform(longClick())
         }
     }
 


### PR DESCRIPTION
Ui test cleanups 

- Fixes the missing `when` cases when compiling the UI tests with warnings enabled
- Replaces hardcoded timeout for the reaction picker with `waitUntil*`, some times the CI tests fail because the emojis aren't loaded in time
- Replaces `Barista.longClickOn` with the stock espresso long click which we're also using to open the reaction menu, the UI tests have been failing on the CI at the point of long clicking a previously added reaction
- Adds a wait for ensure the message reaction is present before attempting to long click it  