### PR TITLE
Increased push rules logging

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/ProcessEventForPushTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/notification/ProcessEventForPushTask.kt
@@ -74,6 +74,7 @@ internal class DefaultProcessEventForPushTask @Inject constructor(
                 event to it
             }
         }
+        Timber.d("[PushRules] matched ${matchedEvents.size} out of ${allEvents.size}")
 
         val allRedactedEvents = params.syncResponse.join
                 .asSequence()

--- a/vector/src/main/java/im/vector/app/features/notifications/PushRuleTriggerListener.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/PushRuleTriggerListener.kt
@@ -55,12 +55,12 @@ class PushRuleTriggerListener @Inject constructor(
 
     private suspend fun createNotifiableEvents(pushEvents: PushEvents, session: Session): List<NotifiableEvent> {
         return pushEvents.matchedEvents.mapNotNull { (event, pushRule) ->
-            Timber.v("Push rule match for event ${event.eventId}")
+            Timber.d("Push rule match for event ${event.eventId}")
             val action = pushRule.getActions().toNotificationAction()
             if (action.shouldNotify) {
                 resolver.resolveEvent(event, session, isNoisy = !action.soundName.isNullOrBlank())
             } else {
-                Timber.v("Matched push rule is set to not notify")
+                Timber.d("Matched push rule is set to not notify")
                 null
             }
         }


### PR DESCRIPTION
An attempt to help confirm the cause of #5038 

- Adds extra logging around the push rules and promotes some existing logs to `debug` from `verbose` to allow them to be included in rage shakes without having to enable verbose developer logs

output
```
[PushRules] Found 3 out of 3 to check for push rules with 17 rules
[PushRules] matched 3 out of 3
```
