### PR TITLE
Make Space creation screens more consistent

### DIFF
--- a/changelog.d/5099.misc
+++ b/changelog.d/5099.misc
@@ -1,1 +1,0 @@
-Make Space creation screens more consistent

--- a/changelog.d/5099.misc
+++ b/changelog.d/5099.misc
@@ -1,0 +1,1 @@
+Make Space creation screens more consistent

--- a/changelog.d/5104.misc
+++ b/changelog.d/5104.misc
@@ -1,0 +1,1 @@
+Make Space creation screens more consistent

--- a/vector/src/main/res/layout/fragment_space_create_choose_private_model.xml
+++ b/vector/src/main/res/layout/fragment_space_create_choose_private_model.xml
@@ -13,7 +13,7 @@
 
         <TextView
             android:id="@+id/headerText"
-            style="@style/Widget.Vector.TextView.HeadlineMedium"
+            style="@style/Widget.Vector.TextView.Title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
@@ -53,11 +53,22 @@
             android:layout_marginBottom="16dp"
             app:icon="@drawable/ic_member_small"
             app:iconTint="?vctr_content_secondary"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/changeLaterText"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:subTitle="@string/create_spaces_private_teammates"
             app:title="@string/create_spaces_me_and_teammates" />
+
+        <TextView
+            android:id="@+id/changeLaterText"
+            style="@style/Widget.Vector.TextView.Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:gravity="center"
+            android:text="@string/create_spaces_you_can_change_later"
+            android:textColor="?vctr_content_secondary"
+            app:layout_constraintBottom_toBottomOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/vector/src/main/res/layout/fragment_space_create_choose_type.xml
+++ b/vector/src/main/res/layout/fragment_space_create_choose_type.xml
@@ -12,26 +12,14 @@
 
         <TextView
             android:id="@+id/headerText"
-            style="@style/Widget.Vector.TextView.Subtitle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="@string/create_spaces_type_header"
-            android:textColor="?vctr_content_secondary"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
             style="@style/Widget.Vector.TextView.Title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
             android:gravity="center"
             android:text="@string/create_spaces_choose_type_label"
             android:textColor="?vctr_content_primary"
             android:textStyle="bold"
-            app:layout_constraintBottom_toTopOf="@id/joinInfoHelpText"
-            app:layout_constraintTop_toBottomOf="@id/headerText"
-            app:layout_constraintVertical_bias="1" />
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/joinInfoHelpText"
@@ -42,7 +30,7 @@
             android:gravity="center"
             android:text="@string/create_spaces_join_info_help"
             android:textColor="?vctr_content_secondary"
-            app:layout_constraintBottom_toTopOf="@id/publicButton" />
+            app:layout_constraintTop_toBottomOf="@id/headerText" />
 
         <im.vector.app.features.spaces.create.WizardButtonView
             android:id="@+id/publicButton"

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3480,12 +3480,13 @@
     <string name="add_space">Add Space</string>
     <string name="your_public_space">Your public space</string>
     <string name="your_private_space">Your private space</string>
+    <!-- TODO TO BE REMOVED -->
     <string name="create_spaces_type_header">Spaces are a new way to group rooms and people</string>
     <string name="create_spaces_choose_type_label">What type of space do you want to create?</string>
     <string name="create_spaces_you_can_change_later">You can change this later</string>
     <string name="create_spaces_join_info_help">To join an existing space, you need an invite.</string>
     <string name="create_spaces_who_are_you_working_with">Who are you working with?</string>
-    <string name="create_spaces_make_sure_access">Make sure the right people have access to %s. You can change this later.</string>
+    <string name="create_spaces_make_sure_access">Make sure the right people have access to %s.</string>
     <string name="create_spaces_just_me">Just me</string>
     <string name="create_spaces_organise_rooms">A private space to organise your rooms</string>
     <string name="create_spaces_me_and_teammates">Me and teammates</string>


### PR DESCRIPTION
Changed the UI as described in #3942:

- Gave titles the same font size
- Removed the duplicate "Spaces are a new way [...]"
- Have "You can change this later" on both screens
- Have title and description on top of each screen

I did not center the header title ("Create a space" / "Your private space") as suggested since the header titles are usually left aligned throughout the app if I am not mistaken.

See:

**EDIT from bmarty: adding a table to wrap the screenshots**

|Create space|Create private space|
|-|-|
|![Screenshot_20220131_134640](https://user-images.githubusercontent.com/39308834/151798264-3dff2fff-c347-4fc3-8082-6af6fec4d8a7.png)|![Screenshot_20220131_134841](https://user-images.githubusercontent.com/39308834/151798270-8d2647d2-65a2-4cbc-b9d6-fc4c4a9087b9.png)|


### Pull Request Checklist

<!--
 Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request
 Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked.
 -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- ~~[ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)~~
