### PR TITLE
Attempting to fix missing dependabot updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,12 @@ allprojects {
     apply plugin: "org.jlleitschuh.gradle.ktlint"
 
     repositories {
+        mavenCentral {
+            content {
+                groups.mavenCentral.regex.each { includeGroupByRegex it }
+                groups.mavenCentral.group.each { includeGroup it }
+            }
+        }
         maven {
             url 'https://jitpack.io'
             content {
@@ -57,12 +63,6 @@ allprojects {
             content {
                 groups.google.regex.each { includeGroupByRegex it }
                 groups.google.group.each { includeGroup it }
-            }
-        }
-        mavenCentral {
-            content {
-                groups.mavenCentral.regex.each { includeGroupByRegex it }
-                groups.mavenCentral.group.each { includeGroup it }
             }
         }
         //noinspection JcenterRepositoryObsolete


### PR DESCRIPTION
From the dependabot logs we've noticed we're mainly scanning jitpack for dependency updates, it appears that dependabot is only scanning the first 2 defined maven repositories.

- Moving maven central to the first position in an attempt to use the broadest scope first

```
updater | INFO <job_273791762> Checking if com.google.android.material:material 1.4.0 needs updating
  proxy | 2022/01/31 15:21:28 [046] GET https://jitpack.io:443/com/google/android/material/material/maven-metadata.xml
  proxy | 2022/01/31 15:21:28 [046] 404 https://jitpack.io:443/com/google/android/material/material/maven-metadata.xml
  proxy | 2022/01/31 15:21:28 [048] GET https://github.com:443/vector-im/jitsi_libre_maven/raw/main/android-sdk-3.10.0/com/google/android/material/material/maven-metadata.xml
  proxy | 2022/01/31 15:21:28 [048] * authenticating git server request (host: github.com)
  proxy | 2022/01/31 15:21:28 [048] 404 https://github.com:443/vector-im/jitsi_libre_maven/raw/main/android-sdk-3.10.0/com/google/android/material/material/maven-metadata.xml
  proxy | 2022/01/31 15:21:28 [048] * auth'd git request returned 404, retrying without auth
updater | INFO <job_273791762> Latest version is 
updater | INFO <job_273791762> Requirements to unlock update_not_possible
updater | INFO <job_273791762> Requirements update strategy 
updater | INFO <job_273791762> No update possible for com.google.android.material:material 1.4.0
```

https://github.com/vector-im/element-android/network/updates/273791762