### PR TITLE
Handling use case screen in sanity tests 

### DIFF
--- a/vector/src/main/java/im/vector/app/core/datastore/DataStoreProvider.kt
+++ b/vector/src/main/java/im/vector/app/core/datastore/DataStoreProvider.kt
@@ -28,6 +28,13 @@ import kotlin.reflect.KProperty
 /**
  * Provides a singleton datastore cache
  * allows for lazily fetching a datastore instance by key to avoid creating multiple stores for the same file
+ * Based on https://androidx.tech/artifacts/datastore/datastore-preferences/1.0.0-source/androidx/datastore/preferences/PreferenceDataStoreDelegate.kt.html
+ *
+ * Makes use of a ReadOnlyProperty in order to provide a simplified api on top of a Context
+ * ReadOnlyProperty allows us to lazily access the backing property instead of requiring it upfront as a dependency
+ * <pre>
+ * val Context.dataStoreProvider by dataStoreProvider()
+ * </pre>
  */
 fun dataStoreProvider(): ReadOnlyProperty<Context, (String) -> DataStore<Preferences>> {
     return MappedPreferenceDataStoreSingletonDelegate()

--- a/vector/src/main/java/im/vector/app/core/datastore/DataStoreProvider.kt
+++ b/vector/src/main/java/im/vector/app/core/datastore/DataStoreProvider.kt
@@ -40,7 +40,7 @@ private class MappedPreferenceDataStoreSingletonDelegate : ReadOnlyProperty<Cont
         { key ->
             dataStoreCache.getOrPut(key) {
                 PreferenceDataStoreFactory.create {
-                    context.preferencesDataStoreFile(key)
+                    context.applicationContext.preferencesDataStoreFile(key)
                 }
             }
         }

--- a/vector/src/main/java/im/vector/app/core/datastore/DataStoreProvider.kt
+++ b/vector/src/main/java/im/vector/app/core/datastore/DataStoreProvider.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Provides a singleton datastore cache
+ * allows for lazily fetching a datastore instance by key to avoid creating multiple stores for the same file
+ */
+fun dataStoreProvider(): ReadOnlyProperty<Context, (String) -> DataStore<Preferences>> {
+    return MappedPreferenceDataStoreSingletonDelegate()
+}
+
+private class MappedPreferenceDataStoreSingletonDelegate : ReadOnlyProperty<Context, (String) -> DataStore<Preferences>> {
+
+    private val dataStoreCache = ConcurrentHashMap<String, DataStore<Preferences>>()
+    private val provider: (Context) -> (String) -> DataStore<Preferences> = { context ->
+        { key ->
+            dataStoreCache.getOrPut(key) {
+                PreferenceDataStoreFactory.create {
+                    context.preferencesDataStoreFile(key)
+                }
+            }
+        }
+    }
+
+    override fun getValue(thisRef: Context, property: KProperty<*>) = provider.invoke(thisRef)
+}

--- a/vector/src/main/java/im/vector/app/core/extensions/Context.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/Context.kt
@@ -23,7 +23,10 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.FloatRange
 import androidx.core.content.ContextCompat
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import dagger.hilt.EntryPoints
+import im.vector.app.core.datastore.dataStoreProvider
 import im.vector.app.core.di.SingletonEntryPoint
 import kotlin.math.roundToInt
 
@@ -50,3 +53,5 @@ fun Context.getTintedDrawable(@DrawableRes drawableRes: Int,
 private fun Float.toAndroidAlpha(): Int {
     return (this * 255).roundToInt()
 }
+
+val Context.dataStoreProvider: (String) -> DataStore<Preferences> by dataStoreProvider()

--- a/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
@@ -179,7 +179,7 @@ class DefaultVectorAnalytics @Inject constructor(
         posthog?.identify(REUSE_EXISTING_ID, identity.getProperties().toPostHogProperties(), IGNORED_OPTIONS)
     }
 
-    private fun Map<String, Any>?.toPostHogProperties(): Properties? {
+    private fun Map<String, Any?>?.toPostHogProperties(): Properties? {
         if (this == null) return null
 
         return Properties().apply {

--- a/vector/src/main/java/im/vector/app/features/analytics/itf/VectorAnalyticsEvent.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/itf/VectorAnalyticsEvent.kt
@@ -18,5 +18,5 @@ package im.vector.app.features.analytics.itf
 
 interface VectorAnalyticsEvent {
     fun getName(): String
-    fun getProperties(): Map<String, Any>?
+    fun getProperties(): Map<String, Any?>?
 }

--- a/vector/src/main/java/im/vector/app/features/analytics/plan/Identity.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/plan/Identity.kt
@@ -55,9 +55,9 @@ data class Identity(
 
     override fun getName() = "Identity"
 
-    override fun getProperties(): Map<String, Any>? {
-        return mutableMapOf<String, Any>().apply {
-            ftueUseCaseSelection?.let { put("ftueUseCaseSelection", it.name) }
+    override fun getProperties(): Map<String, Any?>? {
+        return mutableMapOf<String, Any?>().apply {
+            put("ftueUseCaseSelection", null)
         }.takeIf { it.isNotEmpty() }
     }
 }


### PR DESCRIPTION
Whilst fixing the sanity tests after enabling the use case screen, 2 crashes were found

- Multiple `VectorSessionStore` instances were attempting to create separate dataStore instances which then throw because the same backing file was being accessed, fixed by introducing a thread safe lazy provider `(String) -> DataStore<Preferences>` to allow for dynamic created stores to be cached and reused   

- Posthog doesn't support sending empty properties and a blank analytics id when identifying a user/session. This was caused by the analytics models filtering out null properties https://github.com/matrix-org/matrix-analytics-events/pull/20, I've manually merged in the changes for the identity model.


*note 
- I haven't created a changelog entry as the feature hasn't been enabled yet, are the crash fixes worth their own separate entries? 