### PR TITLE
Fix timber crash

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/algorithms/megolm/MXOutboundSessionInfo.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/algorithms/megolm/MXOutboundSessionInfo.kt
@@ -35,7 +35,7 @@ internal class MXOutboundSessionInfo(
         val sessionLifetime = System.currentTimeMillis() - creationTime
 
         if (useCount >= rotationPeriodMsgs || sessionLifetime >= rotationPeriodMs) {
-            Timber.v("## needsRotation() : Rotating megolm session after " + useCount + ", " + sessionLifetime + "ms")
+            Timber.v("## needsRotation() : Rotating megolm session after $useCount, ${sessionLifetime}ms")
             needsRotation = true
         }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/ThumbnailExtractor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/ThumbnailExtractor.kt
@@ -66,7 +66,7 @@ internal class ThumbnailExtractor @Inject constructor(
                 thumbnail.recycle()
                 outputStream.reset()
             } ?: run {
-                Timber.e("Cannot extract video thumbnail at %s", attachment.queryUri.toString())
+                Timber.e("Cannot extract video thumbnail at ${attachment.queryUri}")
             }
         } catch (e: Exception) {
             Timber.e(e, "Cannot extract video thumbnail")

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
@@ -36,7 +36,6 @@ import org.matrix.android.sdk.internal.database.model.ChunkEntity
 import org.matrix.android.sdk.internal.database.model.ChunkEntityFields
 import org.matrix.android.sdk.internal.database.model.TimelineEventEntity
 import org.matrix.android.sdk.internal.database.model.TimelineEventEntityFields
-import org.matrix.android.sdk.internal.database.query.where
 import org.matrix.android.sdk.internal.session.sync.handler.room.ThreadsAwarenessHandler
 import timber.log.Timber
 import java.util.Collections
@@ -198,11 +197,12 @@ internal class TimelineChunk(private val chunkEntity: ChunkEntity,
     /**
      * Simple log that displays the number and timeline of loaded events
      */
-    private fun logLoadedFromStorage(loadedFromStorage: LoadedFromStorage, direction: Timeline.Direction) =
+    private fun logLoadedFromStorage(loadedFromStorage: LoadedFromStorage, direction: Timeline.Direction) {
         Timber.v("[" +
                 "${if (timelineSettings.isThreadTimeline()) "ThreadTimeLine" else "Timeline"}] Has loaded " +
                 "${loadedFromStorage.numberOfEvents} items from storage in $direction " +
                 if (timelineSettings.isThreadTimeline() && loadedFromStorage.threadReachedEnd) "[Reached End]" else "")
+    }
 
     fun getBuiltEventIndex(eventId: String, searchInNext: Boolean, searchInPrev: Boolean): Int? {
         val builtEventIndex = builtEventsIndexes[eventId]

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
@@ -395,7 +395,7 @@ internal class TimelineChunk(private val chunkEntity: ChunkEntity,
                 paginationTask.execute(taskParams).toLoadMoreResult()
             }
         } catch (failure: Throwable) {
-            Timber.e("Failed to fetch from server: $failure", failure)
+            Timber.e(failure, "Failed to fetch from server")
             LoadMoreResult.FAILURE
         }
         return if (loadMoreResult == LoadMoreResult.SUCCESS) {

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
@@ -145,7 +145,7 @@ class ElementRobot {
             assertDisplayed(R.string.are_you_sure)
             clickOn(R.string.action_skip)
             waitUntilViewVisible(withId(R.id.bottomSheetFragmentContainer))
-        }.onFailure { Timber.w("Verification popup missing", it) }
+        }.onFailure { Timber.w(it, "Verification popup missing") }
     }
 }
 


### PR DESCRIPTION
Quick fix for a crash reported in the rageshake, I did not try to repro the issue.

I have checked that there is no other occurrence of `Timber.\w\(".*",.*\)`