### PR TITLE
space and room card layout changed in explore rooms, space invite dia…

### DIFF
--- a/changelog.d/4304.misc
+++ b/changelog.d/4304.misc
@@ -1,0 +1,1 @@
+Changed layout for space card and room card used at "explore room" screen and space/room invite dialogs

--- a/vector/src/main/java/im/vector/app/features/matrixto/SpaceCardRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/matrixto/SpaceCardRenderer.kt
@@ -41,7 +41,8 @@ class SpaceCardRenderer @Inject constructor(
     fun render(spaceSummary: RoomSummary?,
                peopleYouKnow: List<User>,
                matrixLinkCallback: TimelineEventController.UrlClickCallback?,
-               inCard: FragmentMatrixToRoomSpaceCardBinding) {
+               inCard: FragmentMatrixToRoomSpaceCardBinding,
+               showDescription: Boolean) {
         if (spaceSummary == null) {
             inCard.matrixToCardContentVisibility.isVisible = false
             inCard.matrixToCardButtonLoading.isVisible = true
@@ -69,6 +70,8 @@ class SpaceCardRenderer @Inject constructor(
                 // hide the pill
                 inCard.matrixToMemberPills.isVisible = false
             }
+
+            inCard.matrixToCardDescText.isVisible = showDescription
 
             renderPeopleYouKnow(inCard, peopleYouKnow.map { it.toMatrixItem() })
         }

--- a/vector/src/main/java/im/vector/app/features/spaces/explore/SpaceDirectoryFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/explore/SpaceDirectoryFragment.kt
@@ -170,7 +170,7 @@ class SpaceDirectoryFragment @Inject constructor(
                     ?: getString(R.string.space_explore_activity_title)
         }
 
-        spaceCardRenderer.render(state.currentRootSummary, emptyList(), this, views.spaceCard)
+        spaceCardRenderer.render(state.currentRootSummary, emptyList(), this, views.spaceCard, showDescription = false)
         views.addOrCreateChatRoomButton.isVisible = state.canAddRooms
     }
 

--- a/vector/src/main/java/im/vector/app/features/spaces/invite/SpaceInviteBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/invite/SpaceInviteBottomSheet.kt
@@ -118,7 +118,7 @@ class SpaceInviteBottomSheet : VectorBaseBottomSheetDialogFragment<BottomSheetIn
             views.inviterMxid.isVisible = false
         }
 
-        spaceCardRenderer.render(summary, state.peopleYouKnow.invoke().orEmpty(), null, views.spaceCard)
+        spaceCardRenderer.render(summary, state.peopleYouKnow.invoke().orEmpty(), null, views.spaceCard, showDescription = true)
 
         views.spaceCard.matrixToCardMainButton.button.text = getString(R.string.action_accept)
         views.spaceCard.matrixToCardSecondaryButton.button.text = getString(R.string.action_decline)

--- a/vector/src/main/res/layout/fragment_matrix_to_room_space_card.xml
+++ b/vector/src/main/res/layout/fragment_matrix_to_room_space_card.xml
@@ -10,7 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="200dp"
-        android:padding="16dp"
+        android:padding="@dimen/layout_horizontal_margin"
         android:visibility="gone"
         tools:visibility="visible">
 
@@ -19,11 +19,9 @@
             android:layout_width="60dp"
             android:layout_height="60dp"
             android:layout_marginTop="20dp"
-            android:importantForAccessibility="no"
             android:elevation="4dp"
+            android:importantForAccessibility="no"
             android:transitionName="profile"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:src="@sample/room_round_avatars" />
@@ -31,21 +29,23 @@
         <TextView
             android:id="@+id/matrixToCardNameText"
             style="@style/Widget.Vector.TextView.Subtitle"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/layout_vertical_margin"
+            android:layout_marginStart="@dimen/layout_horizontal_margin"
             android:maxLines="1"
             android:singleLine="true"
             android:textAlignment="textStart"
             android:textColor="?vctr_content_primary"
             android:textStyle="bold"
-            app:layout_constraintTop_toBottomOf="@id/matrixToCardAvatar"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/matrixToCardAvatar"
+            app:layout_constraintTop_toTopOf="@id/matrixToCardAvatar"
             tools:text="@sample/rooms.json/data/name" />
 
         <TextView
             android:id="@+id/matrixToCardAliasText"
             style="@style/Widget.Vector.TextView.Body"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:maxLines="1"
@@ -53,6 +53,8 @@
             android:textAlignment="textStart"
             android:textColor="?vctr_content_secondary"
             android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@id/matrixToCardNameText"
             app:layout_constraintTop_toBottomOf="@id/matrixToCardNameText"
             app:layout_goneMarginTop="0dp"
             tools:text="@sample/rooms.json/data/alias"
@@ -65,7 +67,7 @@
             android:importantForAccessibility="no"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@id/matrixToAccessText"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/matrixToCardNameText"
             app:layout_constraintTop_toTopOf="@id/matrixToAccessText"
             app:tint="?vctr_content_secondary"
             tools:ignore="MissingPrefix"
@@ -75,7 +77,7 @@
         <TextView
             android:id="@+id/matrixToAccessText"
             style="@style/Widget.Vector.TextView.Body"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginTop="8dp"
@@ -88,6 +90,13 @@
             app:layout_goneMarginTop="0dp"
             tools:text="Public Space"
             tools:visibility="visible" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/header_barrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="matrixToAccessText, matrixToCardAvatar" />
 
         <LinearLayout
             android:id="@+id/matrixToMemberPills"
@@ -105,7 +114,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/matrixToAccessText">
+            app:layout_constraintTop_toBottomOf="@id/header_barrier">
 
             <ImageView
                 android:id="@+id/spaceChildMemberCountIcon"

--- a/vector/src/main/res/layout/fragment_matrix_to_room_space_card.xml
+++ b/vector/src/main/res/layout/fragment_matrix_to_room_space_card.xml
@@ -67,7 +67,7 @@
             android:importantForAccessibility="no"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@id/matrixToAccessText"
-            app:layout_constraintStart_toStartOf="@+id/matrixToCardNameText"
+            app:layout_constraintStart_toStartOf="@id/matrixToCardNameText"
             app:layout_constraintTop_toTopOf="@id/matrixToAccessText"
             app:tint="?vctr_content_secondary"
             tools:ignore="MissingPrefix"
@@ -92,7 +92,7 @@
             tools:visibility="visible" />
 
         <androidx.constraintlayout.widget.Barrier
-            android:id="@+id/header_barrier"
+            android:id="@+id/matrixToHeaderBarrier"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:barrierDirection="bottom"
@@ -114,7 +114,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/header_barrier">
+            app:layout_constraintTop_toBottomOf="@id/matrixToHeaderBarrier">
 
             <ImageView
                 android:id="@+id/spaceChildMemberCountIcon"


### PR DESCRIPTION
Changed layout for space card and room card used at "explore room" screen and space/room invite dialogs 

fixes #4304

Now it takes less vertical space

Space Invite
![space_invite_after](https://user-images.githubusercontent.com/66663241/152131185-cb9cbfdd-9697-40a0-9303-51d9ba248bad.png)

Room invite
![room_invite_after](https://user-images.githubusercontent.com/66663241/152131194-6146e4bd-7a9b-4260-ab56-8ca83c89e1e6.png)

Explore rooms
![explore_after](https://user-images.githubusercontent.com/66663241/152131198-9a399d4c-623c-48af-9a87-07375dd5a3cc.png)
