### PR TITLE
Fixing google play variant push notifications being skipped

### DIFF
--- a/changelog.d/5038.bugfix
+++ b/changelog.d/5038.bugfix
@@ -1,0 +1,1 @@
+Fixing missing/intermittent notifications on the google play variant when wifi is enabled


### PR DESCRIPTION
Fixes #5038 Missing google play variant push notifications

**tl;dr** The _not so ideal workaround_ is to disable wifi, as we only run the fast lane pipeline whilst the device is on a wifi connection.

The bug -

Push messages received whilst your own message is the latest in a room whilst a background sync is occurring are skipped until the background sync completes.

The conditions to encounter this bug are:

- a message from yourself is the latest local message in the room
- the device is on wifi
- the app is in the background
- receive a push notification from FCM (google play variant only)
- the fast lane `getEvent` responds faster than the scheduled `/sync`  
- any further pushes received whilst the `/sync` is running are skipped
- after the sync completes the latest message in the room is no longer yourself, breaking the cycle

The longer the sync takes, the more potential messages are skipped and each time your own message is the last in the room the bug comes back.

Further details - 

The issue is caused by us checking if the newly received message (event) has already been read and incorrectly inferring that it has been read when it may not have even been seen yet! 

Our _is already read_ rules were inferring that because the latest locally known event was from ourselves that the new event must have already been read, this is problematic because when an event comes from a FCM push it goes through a _fast lane_ pipeline which doesn't insert the new event, only the `/sync` pipeline inserts the event.

This means that whilst a push triggered `/sync` is running any pushes (including the original trigger) that goes through the fast lane pipeline end up being marked as read which in turn skips them from being displayed as notifications.

When the sync finishes and inserts the new message events the latest event in the room is no longer ourselves and future notifications will work as expected.

-----

The fix is to only check the latest room event if the new event doesn't exist

- reworks the `isEventRead` logic to always check if the new event exists locally and if not, inferring that it must not have been read
- took the opportunity to flatten all of the execution branches


*with a hardcoded delay of 5 seconds for the sync

| BEFORE | AFTER |
| --- | --- |
|![before-missed-notifications](https://user-images.githubusercontent.com/1848238/152176037-4fd29f3e-039d-4e1d-9c67-d58efbe602f7.gif)|![after-missing-notification-2](https://user-images.githubusercontent.com/1848238/152176022-1e4321db-07d6-477a-a605-e692b5a4bbdc.gif)

