### PR TITLE
Fixing ignored font weights 

### DIFF
--- a/changelog.d/3907.bugfix
+++ b/changelog.d/3907.bugfix
@@ -1,0 +1,1 @@
+Fixes non sans-serif font weights being ignored

--- a/library/ui-styles/src/main/res/values/theme_dark.xml
+++ b/library/ui-styles/src/main/res/values/theme_dark.xml
@@ -105,9 +105,6 @@
         <!-- disable the overscroll because setOverscrollHeader/Footer don't always work -->
         <item name="android:overScrollMode">never</item>
 
-        <!-- fonts -->
-        <item name="android:typeface">sans</item>
-
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
 
         <item name="pf_lock_screen">@style/PinCodeScreenStyle</item>

--- a/library/ui-styles/src/main/res/values/theme_light.xml
+++ b/library/ui-styles/src/main/res/values/theme_light.xml
@@ -105,9 +105,6 @@
         <!-- disable the overscroll because setOverscrollHeader/Footer don't always work -->
         <item name="android:overScrollMode">never</item>
 
-        <!-- fonts -->
-        <item name="android:typeface">sans</item>
-
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
 
         <item name="pf_lock_screen">@style/PinCodeScreenStyle</item>


### PR DESCRIPTION
Fixes #3907 Ignored font weights

We're setting a global typeface in our application theme which is overriding our manually set `fontFamily` styles  

| BEFORE | AFTER | 
| --- | --- |
|![before-font-weights](https://user-images.githubusercontent.com/1848238/152200870-6428880b-1ba7-447a-a3a2-4d7b617a2142.png)|![after-without-font-limit](https://user-images.githubusercontent.com/1848238/152200873-19f0dabe-3744-4724-b825-b5f22e8cdfc7.png)
