### PR TITLE
Issue-4641: Show search menu item only if available

### DIFF
--- a/changelog.d/4641.misc
+++ b/changelog.d/4641.misc
@@ -1,0 +1,1 @@
+Remove Search from room options if not available

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -85,6 +85,8 @@ data class RoomDetailViewState(
 
     fun isWebRTCCallOptionAvailable() = (asyncRoomSummary.invoke()?.joinedMembersCount ?: 0) <= 2
 
+    fun isSearchAvailable() = asyncRoomSummary()?.isEncrypted == false
+
     // This checks directly on the active room widgets.
     // It can differs for a short period of time on the JitsiState as its computed async.
     fun hasActiveJitsiWidget() = activeRoomWidgets()?.any { it.type == WidgetType.Jitsi && it.isActive }.orFalse()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1141,16 +1141,12 @@ class TimelineFragment @Inject constructor(
     }
 
     private fun handleSearchAction() {
-        if (session.getRoom(timelineArgs.roomId)?.isEncrypted() == false) {
-            navigator.openSearch(
-                    context = requireContext(),
-                    roomId = timelineArgs.roomId,
-                    roomDisplayName = timelineViewModel.getRoomSummary()?.displayName,
-                    roomAvatarUrl = timelineViewModel.getRoomSummary()?.avatarUrl
-            )
-        } else {
-            showDialogWithMessage(getString(R.string.search_is_not_supported_in_e2e_room))
-        }
+        navigator.openSearch(
+                context = requireContext(),
+                roomId = timelineArgs.roomId,
+                roomDisplayName = timelineViewModel.getRoomSummary()?.displayName,
+                roomAvatarUrl = timelineViewModel.getRoomSummary()?.avatarUrl
+        )
     }
 
     private fun displayDisabledIntegrationDialog() {
@@ -1926,7 +1922,7 @@ class TimelineFragment @Inject constructor(
                 timelineViewModel.handle(action)
             }
             is EncryptedEventContent             -> {
-                    timelineViewModel.handle(RoomDetailAction.TapOnFailedToDecrypt(informationData.eventId))
+                timelineViewModel.handle(RoomDetailAction.TapOnFailedToDecrypt(informationData.eventId))
             }
             is MessageLocationContent            -> {
                 handleShowLocationPreview(messageContent, informationData.senderId)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -720,7 +720,7 @@ class TimelineViewModel @AssistedInject constructor(
                 R.id.video_call                -> state.isWebRTCCallOptionAvailable() || state.jitsiState.confId == null || state.jitsiState.hasJoined
                 // Show Join conference button only if there is an active conf id not joined. Otherwise fallback to default video disabled. ^
                 R.id.join_conference           -> !state.isWebRTCCallOptionAvailable() && state.jitsiState.confId != null && !state.jitsiState.hasJoined
-                R.id.search                    -> true
+                R.id.search                    -> state.isSearchAvailable()
                 R.id.menu_timeline_thread_list -> vectorPreferences.areThreadMessagesEnabled()
                 R.id.dev_tools                 -> vectorPreferences.developerMode()
                 else                           -> false

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1064,6 +1064,7 @@
     <string name="tab_title_search_messages">MESSAGES</string>
     <string name="tab_title_search_people">PEOPLE</string>
     <string name="tab_title_search_files">FILES</string>
+    <!-- TODO TO BE REMOVED -->
     <string name="search_is_not_supported_in_e2e_room">Searching in encrypted rooms is not supported yet.</string>
 
     <!-- Directory -->


### PR DESCRIPTION
## Type of change
 
Enhancement.
 
## Content
  
In a room timeline screen, removing the search option from the options menu when the search is not available (i.e. when the room is encrypted).
 
## Motivation and context
 
See #4641 
 
## Tests

- Go to an encrypted room screen
- Press the options menu
- Check search option is not displayed in the menu
- Go to a non encrypted room screen
- Press the options menu
- Check "Search" option is displayed in the menu
- Press "Search" option
- Check the search screen is displayed

## Checklist
 
- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)