### PR TITLE
Aligning use case tracking with iOS

### DIFF
--- a/changelog.d/5142.bugfix
+++ b/changelog.d/5142.bugfix
@@ -1,1 +1,1 @@
-Aligns use case identifying with iOS implementation
+Analytics: aligns use case identifying with iOS implementation

--- a/changelog.d/5142.bugfix
+++ b/changelog.d/5142.bugfix
@@ -1,0 +1,1 @@
+Aligns use case identifying with iOS implementation

--- a/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
@@ -176,7 +176,7 @@ class DefaultVectorAnalytics @Inject constructor(
     }
 
     override fun updateUserProperties(identity: Identity) {
-        posthog?.identify(REUSE_EXISTING_ID, identity.getProperties().toPostHogProperties(), IGNORED_OPTIONS)
+        posthog?.identify(REUSE_EXISTING_ID, identity.getProperties()?.toPostHogUserProperties(), IGNORED_OPTIONS)
     }
 
     private fun Map<String, Any?>?.toPostHogProperties(): Properties? {
@@ -184,6 +184,16 @@ class DefaultVectorAnalytics @Inject constructor(
 
         return Properties().apply {
             putAll(this@toPostHogProperties)
+        }
+    }
+
+    /**
+     * We avoid sending nulls as part of the UserProperties as this will reset the values across all devices
+     * The Identify event has nullable properties to allow for clients to opt in
+     */
+    private fun Map<String, Any?>.toPostHogUserProperties(): Properties {
+        return Properties().apply {
+            putAll(this@toPostHogUserProperties.filter { it.value != null })
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -465,13 +465,11 @@ class OnboardingViewModel @AssistedInject constructor(
 
     private fun handleUpdateUseCase(action: OnboardingAction.UpdateUseCase) {
         setState { copy(useCase = action.useCase) }
-        analyticsTracker.updateUserProperties(Identity(ftueUseCaseSelection = action.useCase.toTrackingValue()))
         _viewEvents.post(OnboardingViewEvents.OpenServerSelection)
     }
 
     private fun resetUseCase() {
         setState { copy(useCase = null) }
-        analyticsTracker.updateUserProperties(Identity(ftueUseCaseSelection = null))
     }
 
     private fun handleUpdateServerType(action: OnboardingAction.UpdateServerType) {
@@ -754,6 +752,7 @@ class OnboardingViewModel @AssistedInject constructor(
     private suspend fun onSessionCreated(session: Session) {
         awaitState().useCase?.let { useCase ->
             session.vectorStore(applicationContext).setUseCase(useCase)
+            analyticsTracker.updateUserProperties(Identity(ftueUseCaseSelection = useCase.toTrackingValue()))
         }
         activeSessionHolder.setActiveSession(session)
 


### PR DESCRIPTION
Aligning use case user property tracking with iOS

- Filters out null user properties as we want to avoid 1 device resetting values for others, we allow new non absent values to be set
- Delays applying the use case property until the point of account creation to avoid needing to reset the value.