### PR TITLE
Revert "AGP 7.1.0"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ ext.versions = [
         'targetCompat'      : JavaVersion.VERSION_11,
 ]
 
-def gradle = "7.1.0"
+def gradle = "7.0.4"
 // Ref: https://kotlinlang.org/releases.html
 def kotlin = "1.5.31"
 def kotlinCoroutines = "1.5.2"
@@ -37,6 +37,7 @@ ext.libs = [
                 'gradlePlugin'            : "com.android.tools.build:gradle:$gradle",
                 'kotlinPlugin'            : "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin",
                 'hiltPlugin'              : "com.google.dagger:hilt-android-gradle-plugin:$dagger"
+
         ],
         jetbrains   : [
                 'coroutinesCore'          : "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutines",

--- a/dependencies_groups.gradle
+++ b/dependencies_groups.gradle
@@ -175,7 +175,6 @@ ext.groups = [
                         'org.sonatype.oss',
                         'org.testng',
                         'org.threeten',
-                        'org.webjars',
                         'ru.noties',
                         'xerces',
                         'xml-apis',

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -64,8 +64,8 @@ android {
         }
     }
 
-    installation {
-        installOptions '-g'
+    adbOptions {
+        installOptions "-g"
 //        timeOutInMs 350 * 1000
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncWorker.kt
@@ -27,6 +27,7 @@ import org.matrix.android.sdk.internal.di.WorkManagerProvider
 import org.matrix.android.sdk.internal.session.SessionComponent
 import org.matrix.android.sdk.internal.session.sync.SyncPresence
 import org.matrix.android.sdk.internal.session.sync.SyncTask
+import org.matrix.android.sdk.internal.task.TaskExecutor
 import org.matrix.android.sdk.internal.worker.SessionSafeCoroutineWorker
 import org.matrix.android.sdk.internal.worker.SessionWorkerParams
 import org.matrix.android.sdk.internal.worker.WorkerParamsFactory
@@ -57,6 +58,7 @@ internal class SyncWorker(context: Context, workerParameters: WorkerParameters, 
     ) : SessionWorkerParams
 
     @Inject lateinit var syncTask: SyncTask
+    @Inject lateinit var taskExecutor: TaskExecutor
     @Inject lateinit var workManagerProvider: WorkManagerProvider
 
     override fun injectWith(injector: SessionComponent) {

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -291,8 +291,9 @@ android {
         }
     }
 
-    lint {
-        lintConfig file('lint.xml')
+    lintOptions {
+        lintConfig file("lint.xml")
+
         checkDependencies true
         abortOnError true
     }

--- a/vector/lint.xml
+++ b/vector/lint.xml
@@ -6,7 +6,6 @@
     <issue id="MissingTranslation" severity="ignore" />
     <issue id="TypographyEllipsis" severity="error" />
     <issue id="ImpliedQuantity" severity="warning" />
-    <issue id="MissingQuantity" severity="warning" />
     <issue id="UnusedQuantity" severity="error" />
     <issue id="IconXmlAndPng" severity="error" />
     <issue id="IconDipSize" severity="error" />


### PR DESCRIPTION
Reverts vector-im/element-android#5082.
There are reported problems in unit tests along with hilt.
Integration tests cannot run neither in local builds nor in the CI