### PR TITLE
Fix back pagination conduit

### DIFF
--- a/changelog.d/5166.bugfix
+++ b/changelog.d/5166.bugfix
@@ -1,0 +1,1 @@
+Back pagination not working on conduit

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEvent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEvent.kt
@@ -24,5 +24,5 @@ internal interface TokenChunkEvent {
     val events: List<Event>
     val stateEvents: List<Event>?
 
-    fun hasMore() = start != end
+    fun hasMore() = end != null && start != end
 }


### PR DESCRIPTION
Fixes #5166
@ganfra Could you have a look at it? and check for any side effects?
Basically EA is relying on the`end` field of /messages call, but as per spec it should be omitted if no events .
Conduit is doing as per spec, and it's breaking EA back pagination.

