### PR TITLE
join and leave methods moved from MembershipService to RoomService an…

### DIFF
--- a/changelog.d/5183.sdk
+++ b/changelog.d/5183.sdk
@@ -1,0 +1,1 @@
+`join` and `leave` methods moved from MembershipService to RoomService and SpaceService to split logic for rooms and spaces

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/space/SpaceHierarchyTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/space/SpaceHierarchyTest.kt
@@ -344,7 +344,6 @@ class SpaceHierarchyTest : InstrumentedTest {
         // Test part one of the rooms
 
         val bRoomId = spaceBInfo.roomIds.first()
-        val bRoom = session.getRoom(bRoomId)
 
         commonTestHelper.waitWithLatch { latch ->
             val flatAChildren = session.getFlattenRoomSummaryChildrenOfLive(spaceAInfo.spaceId)
@@ -360,7 +359,7 @@ class SpaceHierarchyTest : InstrumentedTest {
             }
 
             // part from b room
-            bRoom!!.leave(null)
+            session.leaveRoom(bRoomId)
             // The room should have disapear from flat children
             flatAChildren.observeForever(childObserver)
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomService.kt
@@ -77,6 +77,13 @@ interface RoomService {
     )
 
     /**
+     * Leave the room, or reject an invitation.
+     * @param roomId the roomId of the room to leave
+     * @param reason optional reason for leaving the room
+     */
+    suspend fun leaveRoom(roomId: String, reason: String? = null)
+
+    /**
      * Get a room from a roomId
      * @param roomId the roomId to look for.
      * @return a room with roomId or null

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/members/MembershipService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/members/MembershipService.kt
@@ -81,14 +81,4 @@ interface MembershipService {
 
     @Deprecated("Use remove instead", ReplaceWith("remove(userId, reason)"))
     suspend fun kick(userId: String, reason: String? = null) = remove(userId, reason)
-
-    /**
-     * Join the room, or accept an invitation.
-     */
-    suspend fun join(reason: String? = null, viaServers: List<String> = emptyList())
-
-    /**
-     * Leave the room, or reject an invitation.
-     */
-    suspend fun leave(reason: String? = null)
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/Space.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/Space.kt
@@ -26,8 +26,6 @@ interface Space {
 
     val spaceId: String
 
-    suspend fun leave(reason: String? = null)
-
     /**
      * A current snapshot of [RoomSummary] associated with the space
      */

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/SpaceService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/SpaceService.kt
@@ -89,10 +89,10 @@ interface SpaceService {
 
     /**
      * Leave the space, or reject an invitation.
-     * @param roomId the roomId of the space to leave
+     * @param spaceId the spaceId of the space to leave
      * @param reason optional reason for leaving the space
      */
-    suspend fun leaveSpace(roomId: String, reason: String? = null)
+    suspend fun leaveSpace(spaceId: String, reason: String? = null)
 
 //    fun getSpaceParentsOfRoom(roomId: String) : List<SpaceSummary>
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/SpaceService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/SpaceService.kt
@@ -87,6 +87,13 @@ interface SpaceService {
 
     suspend fun rejectInvite(spaceId: String, reason: String?)
 
+    /**
+     * Leave the space, or reject an invitation.
+     * @param roomId the roomId of the space to leave
+     * @param reason optional reason for leaving the space
+     */
+    suspend fun leaveSpace(roomId: String, reason: String? = null)
+
 //    fun getSpaceParentsOfRoom(roomId: String) : List<SpaceSummary>
 
     /**

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoomService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoomService.kt
@@ -46,6 +46,7 @@ import org.matrix.android.sdk.internal.session.room.create.CreateRoomTask
 import org.matrix.android.sdk.internal.session.room.membership.RoomChangeMembershipStateDataSource
 import org.matrix.android.sdk.internal.session.room.membership.RoomMemberHelper
 import org.matrix.android.sdk.internal.session.room.membership.joining.JoinRoomTask
+import org.matrix.android.sdk.internal.session.room.membership.leaving.LeaveRoomTask
 import org.matrix.android.sdk.internal.session.room.peeking.PeekRoomTask
 import org.matrix.android.sdk.internal.session.room.peeking.ResolveRoomStateTask
 import org.matrix.android.sdk.internal.session.room.read.MarkAllRoomsReadTask
@@ -66,7 +67,8 @@ internal class DefaultRoomService @Inject constructor(
         private val peekRoomTask: PeekRoomTask,
         private val roomGetter: RoomGetter,
         private val roomSummaryDataSource: RoomSummaryDataSource,
-        private val roomChangeMembershipStateDataSource: RoomChangeMembershipStateDataSource
+        private val roomChangeMembershipStateDataSource: RoomChangeMembershipStateDataSource,
+        private val leaveRoomTask: LeaveRoomTask,
 ) : RoomService {
 
     override suspend fun createRoom(createRoomParams: CreateRoomParams): String {
@@ -131,6 +133,10 @@ internal class DefaultRoomService @Inject constructor(
                                   reason: String?,
                                   thirdPartySigned: SignInvitationResult) {
         joinRoomTask.execute(JoinRoomTask.Params(roomId, reason, thirdPartySigned = thirdPartySigned))
+    }
+
+    override suspend fun leaveRoom(roomId: String, reason: String?) {
+        leaveRoomTask.execute(LeaveRoomTask.Params(roomId, reason))
     }
 
     override suspend fun markAllAsRead(roomIds: List<String>) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/DefaultMembershipService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/DefaultMembershipService.kt
@@ -37,8 +37,6 @@ import org.matrix.android.sdk.internal.query.QueryStringValueProcessor
 import org.matrix.android.sdk.internal.query.process
 import org.matrix.android.sdk.internal.session.room.membership.admin.MembershipAdminTask
 import org.matrix.android.sdk.internal.session.room.membership.joining.InviteTask
-import org.matrix.android.sdk.internal.session.room.membership.joining.JoinRoomTask
-import org.matrix.android.sdk.internal.session.room.membership.leaving.LeaveRoomTask
 import org.matrix.android.sdk.internal.session.room.membership.threepid.InviteThreePidTask
 import org.matrix.android.sdk.internal.util.fetchCopied
 
@@ -48,8 +46,6 @@ internal class DefaultMembershipService @AssistedInject constructor(
         private val loadRoomMembersTask: LoadRoomMembersTask,
         private val inviteTask: InviteTask,
         private val inviteThreePidTask: InviteThreePidTask,
-        private val joinTask: JoinRoomTask,
-        private val leaveRoomTask: LeaveRoomTask,
         private val membershipAdminTask: MembershipAdminTask,
         @UserId
         private val userId: String,
@@ -138,15 +134,5 @@ internal class DefaultMembershipService @AssistedInject constructor(
     override suspend fun invite3pid(threePid: ThreePid) {
         val params = InviteThreePidTask.Params(roomId, threePid)
         return inviteThreePidTask.execute(params)
-    }
-
-    override suspend fun join(reason: String?, viaServers: List<String>) {
-        val params = JoinRoomTask.Params(roomId, reason, viaServers)
-        joinTask.execute(params)
-    }
-
-    override suspend fun leave(reason: String?) {
-        val params = LeaveRoomTask.Params(roomId, reason)
-        leaveRoomTask.execute(params)
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpace.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpace.kt
@@ -40,10 +40,6 @@ internal class DefaultSpace(
 
     override val spaceId = room.roomId
 
-    override suspend fun leave(reason: String?) {
-        return room.leave(reason)
-    }
-
     override fun spaceSummary(): RoomSummary? {
         return spaceSummaryDataSource.getSpaceSummary(room.roomId)
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpaceService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpaceService.kt
@@ -184,8 +184,8 @@ internal class DefaultSpaceService @Inject constructor(
         return joinSpaceTask.execute(JoinSpaceTask.Params(spaceIdOrAlias, reason, viaServers))
     }
 
-    override suspend fun leaveSpace(roomId: String, reason: String?) {
-        leaveRoomTask.execute(LeaveRoomTask.Params(roomId, reason))
+    override suspend fun leaveSpace(spaceId: String, reason: String?) {
+        leaveRoomTask.execute(LeaveRoomTask.Params(spaceId, reason))
     }
 
     override suspend fun rejectInvite(spaceId: String, reason: String?) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpaceService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpaceService.kt
@@ -184,6 +184,10 @@ internal class DefaultSpaceService @Inject constructor(
         return joinSpaceTask.execute(JoinSpaceTask.Params(spaceIdOrAlias, reason, viaServers))
     }
 
+    override suspend fun leaveSpace(roomId: String, reason: String?) {
+        leaveRoomTask.execute(LeaveRoomTask.Params(roomId, reason))
+    }
+
     override suspend fun rejectInvite(spaceId: String, reason: String?) {
         leaveRoomTask.execute(LeaveRoomTask.Params(spaceId, reason))
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -801,14 +801,14 @@ class TimelineViewModel @AssistedInject constructor(
 
     private fun handleRejectInvite() {
         viewModelScope.launch {
-            tryOrNull { room.leave(null) }
+            tryOrNull { session.leaveRoom(room.roomId) }
         }
     }
 
     private fun handleAcceptInvite() {
         viewModelScope.launch {
             tryOrNull {
-                room.join()
+                session.joinRoom(room.roomId)
                 analyticsTracker.capture(room.roomSummary().toAnalyticsJoinedRoom())
             }
         }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
@@ -440,7 +440,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                         is ParsedCommand.LeaveRoom                         -> {
                             viewModelScope.launch(Dispatchers.IO) {
                                 try {
-                                    session.getRoom(slashCommandResult.roomId)?.leave(null)
+                                    session.leaveRoom(slashCommandResult.roomId)
                                     popDraft()
                                     _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
                                 } catch (failure: Throwable) {
@@ -683,7 +683,9 @@ class MessageComposerViewModel @AssistedInject constructor(
                         ?.roomId
                         ?.let { session.getRoom(it) }
             }
-                    ?.leave(reason = null)
+                    ?.let {
+                        session.leaveRoom(it.roomId)
+                    }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
@@ -225,7 +225,7 @@ class RoomListViewModel @AssistedInject constructor(
         val room = session.getRoom(roomId) ?: return@withState
         viewModelScope.launch {
             try {
-                room.join()
+                session.joinRoom(room.roomId)
                 analyticsTracker.capture(action.roomSummary.toAnalyticsJoinedRoom())
                 // We do not update the joiningRoomsIds here, because, the room is not joined yet regarding the sync data.
                 // Instead, we wait for the room to be joined
@@ -245,10 +245,9 @@ class RoomListViewModel @AssistedInject constructor(
             return@withState
         }
 
-        val room = session.getRoom(roomId) ?: return@withState
         viewModelScope.launch {
             try {
-                room.leave(null)
+                session.leaveRoom(roomId)
                 // We do not update the rejectingRoomsIds here, because, the room is not rejected yet regarding the sync data.
                 // Instead, we wait for the room to be rejected
                 // Known bug: if the user is invited again (after rejecting the first invitation), the loading will be displayed instead of the buttons.
@@ -333,9 +332,8 @@ class RoomListViewModel @AssistedInject constructor(
 
     private fun handleLeaveRoom(action: RoomListAction.LeaveRoom) {
         _viewEvents.post(RoomListViewEvents.Loading(null))
-        val room = session.getRoom(action.roomId) ?: return
         viewModelScope.launch {
-            val value = runCatching { room.leave(null) }
+            val value = runCatching { session.leaveRoom(action.roomId) }
                     .fold({ RoomListViewEvents.Done }, { RoomListViewEvents.Failure(it) })
             _viewEvents.post(value)
         }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
@@ -222,10 +222,9 @@ class RoomListViewModel @AssistedInject constructor(
             )
         }
 
-        val room = session.getRoom(roomId) ?: return@withState
         viewModelScope.launch {
             try {
-                session.joinRoom(room.roomId)
+                session.joinRoom(roomId)
                 analyticsTracker.capture(action.roomSummary.toAnalyticsJoinedRoom())
                 // We do not update the joiningRoomsIds here, because, the room is not joined yet regarding the sync data.
                 // Instead, we wait for the room to be joined

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationBroadcastReceiver.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationBroadcastReceiver.kt
@@ -83,7 +83,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
             if (room != null) {
                 session.coroutineScope.launch {
                     tryOrNull {
-                        room.join()
+                        session.joinRoom(room.roomId)
                         analyticsTracker.capture(room.roomSummary().toAnalyticsJoinedRoom())
                     }
                 }
@@ -93,11 +93,8 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
 
     private fun handleRejectRoom(roomId: String) {
         activeSessionHolder.getSafeActiveSession()?.let { session ->
-            val room = session.getRoom(roomId)
-            if (room != null) {
-                session.coroutineScope.launch {
-                    tryOrNull { room.leave() }
-                }
+            session.coroutineScope.launch {
+                tryOrNull { session.leaveRoom(roomId) }
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileViewModel.kt
@@ -186,7 +186,7 @@ class RoomProfileViewModel @AssistedInject constructor(
         _viewEvents.post(RoomProfileViewEvents.Loading(stringProvider.getString(R.string.room_profile_leaving_room)))
         viewModelScope.launch {
             try {
-                room.leave(null)
+                session.leaveRoom(room.roomId)
                 // Do nothing, we will be closing the room automatically when it will get back from sync
             } catch (failure: Throwable) {
                 _viewEvents.post(RoomProfileViewEvents.Failure(failure))

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceListViewModel.kt
@@ -256,7 +256,7 @@ class SpaceListViewModel @AssistedInject constructor(@Assisted initialState: Spa
     private fun handleLeaveSpace(action: SpaceListAction.LeaveSpace) {
         viewModelScope.launch {
             tryOrNull("Failed to leave space ${action.spaceSummary.roomId}") {
-                session.spaceService().getSpace(action.spaceSummary.roomId)?.leave(null)
+                session.spaceService().leaveSpace(action.spaceSummary.roomId)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceMenuViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceMenuViewModel.kt
@@ -131,7 +131,7 @@ class SpaceMenuViewModel @AssistedInject constructor(
         session.coroutineScope.launch {
             try {
                 if (state.leaveMode == SpaceMenuState.LeaveMode.LEAVE_NONE) {
-                    session.getRoom(initialState.spaceId)?.leave(null)
+                    session.spaceService().leaveSpace(initialState.spaceId)
                 } else if (state.leaveMode == SpaceMenuState.LeaveMode.LEAVE_ALL) {
                     // need to find all child rooms that i have joined
 
@@ -143,13 +143,13 @@ class SpaceMenuViewModel @AssistedInject constructor(
                             }
                     ).forEach {
                         try {
-                            session.getRoom(it.roomId)?.leave(null)
+                            session.spaceService().leaveSpace(it.roomId)
                         } catch (failure: Throwable) {
                             // silently ignore?
                             Timber.e(failure, "Fail to leave sub rooms/spaces")
                         }
                     }
-                    session.getRoom(initialState.spaceId)?.leave(null)
+                    session.spaceService().leaveSpace(initialState.spaceId)
                 }
 
                 // We observe the membership and to dismiss when we have remote echo of leaving

--- a/vector/src/main/java/im/vector/app/features/spaces/invite/SpaceInviteBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/invite/SpaceInviteBottomSheetViewModel.kt
@@ -104,7 +104,7 @@ class SpaceInviteBottomSheetViewModel @AssistedInject constructor(
                 setState { copy(joinActionState = Loading()) }
                 session.coroutineScope.launch(Dispatchers.IO) {
                     try {
-                        session.getRoom(initialState.spaceId)?.join()
+                        session.spaceService().joinSpace(initialState.spaceId)
                         setState { copy(joinActionState = Success(Unit)) }
                     } catch (failure: Throwable) {
                         setState { copy(joinActionState = Fail(failure)) }
@@ -116,7 +116,7 @@ class SpaceInviteBottomSheetViewModel @AssistedInject constructor(
                 setState { copy(rejectActionState = Loading()) }
                 session.coroutineScope.launch(Dispatchers.IO) {
                     try {
-                        session.getRoom(initialState.spaceId)?.leave()
+                        session.spaceService().leaveSpace(initialState.spaceId)
                         setState { copy(rejectActionState = Success(Unit)) }
                     } catch (failure: Throwable) {
                         setState { copy(rejectActionState = Fail(failure)) }

--- a/vector/src/main/java/im/vector/app/features/spaces/leave/SpaceLeaveAdvancedViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/leave/SpaceLeaveAdvancedViewModel.kt
@@ -72,14 +72,14 @@ class SpaceLeaveAdvancedViewModel @AssistedInject constructor(
                     try {
                         state.selectedRooms.forEach {
                             try {
-                                session.getRoom(it)?.leave(null)
+                                session.leaveRoom(it)
                             } catch (failure: Throwable) {
                                 // silently ignore?
                                 Timber.e(failure, "Fail to leave sub rooms/spaces")
                             }
                         }
 
-                        session.getRoom(initialState.spaceId)?.leave(null)
+                        session.spaceService().leaveSpace(initialState.spaceId)
                         // We observe the membership and to dismiss when we have remote echo of leaving
                     } catch (failure: Throwable) {
                         setState { copy(leaveState = Fail(failure)) }


### PR DESCRIPTION
There are methods to join and leave room/space in `MembershipService` but in context of this service (as part of `Room`) it's not always possible to validate if current instance is `Room` or `Space` and `JoinRoomTask` is always used, even though for spaces we should use `JoinSpaceTask`. This PR removes `join` and `leave` methods from `MembershipService` and replaces it with a separate implementation in `RoomService` and `SpaceService` according to context. This will allow us to properly track events for analytics and also will prevent possible bugs when Space is treated as Room 