### PR TITLE
Rooms with virtual rooms do not render the merged timeline with call events.

### DIFF
--- a/changelog.d/5198.buxfix
+++ b/changelog.d/5198.buxfix
@@ -1,0 +1,1 @@
+Fix for rooms with virtual rooms not showing call status events in the timeline.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/accountdata/RoomAccountDataDataSource.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/accountdata/RoomAccountDataDataSource.kt
@@ -54,8 +54,7 @@ internal class RoomAccountDataDataSource @Inject constructor(@SessionDatabase pr
      */
     fun getAccountDataEvents(roomId: String?, types: Set<String>): List<RoomAccountDataEvent> {
         return realmSessionProvider.withRealm { realm ->
-            val roomEntity = buildRoomQuery(realm, roomId, types).findFirst() ?: return@withRealm emptyList()
-            roomEntity.accountDataEvents(types)
+            buildRoomQuery(realm, roomId, types).findAll().flatMap { it.accountDataEvents(types) }
         }
     }
 


### PR DESCRIPTION
Updates getAccountDataEvents function to match its description.

Fixes https://github.com/vector-im/element-android/issues/5198