### PR TITLE
Call transfer with consult fails to make outgoing consultation call.

### DIFF
--- a/changelog.d/5201.bugfix
+++ b/changelog.d/5201.bugfix
@@ -1,0 +1,1 @@
+Fix for call transfer with consult failing to make outgoing consultation call.

--- a/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
@@ -165,6 +165,7 @@ class VectorCallActivity : VectorBaseActivity<ActivityCallBinding>(), CallContro
                 ?.let {
                     callViewModel.handle(VectorCallViewActions.SwitchCall(it))
                 }
+        this.intent = intent
     }
 
     override fun getMenuRes() = R.menu.vector_call

--- a/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
@@ -56,7 +56,6 @@ import im.vector.app.features.call.dialpad.CallDialPadBottomSheet
 import im.vector.app.features.call.dialpad.DialPadFragment
 import im.vector.app.features.call.transfer.CallTransferActivity
 import im.vector.app.features.call.transfer.CallTransferResult
-import im.vector.app.features.call.transfer.CallTransferViewEvents
 import im.vector.app.features.call.utils.EglUtils
 import im.vector.app.features.call.webrtc.WebRtcCall
 import im.vector.app.features.call.webrtc.WebRtcCallManager
@@ -534,7 +533,7 @@ class VectorCallActivity : VectorBaseActivity<ActivityCallBinding>(), CallContro
 
     private val callTransferActivityResultLauncher = registerStartForActivityResult { activityResult ->
 
-        when(activityResult.resultCode) {
+        when (activityResult.resultCode) {
             Activity.RESULT_CANCELED -> {
                 callViewModel.handle(VectorCallViewActions.CallTransferSelectionCancelled)
             }

--- a/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
@@ -55,7 +55,6 @@ import im.vector.app.databinding.ActivityCallBinding
 import im.vector.app.features.call.dialpad.CallDialPadBottomSheet
 import im.vector.app.features.call.dialpad.DialPadFragment
 import im.vector.app.features.call.transfer.CallTransferActivity
-import im.vector.app.features.call.transfer.CallTransferResult
 import im.vector.app.features.call.utils.EglUtils
 import im.vector.app.features.call.webrtc.WebRtcCall
 import im.vector.app.features.call.webrtc.WebRtcCallManager
@@ -525,22 +524,20 @@ class VectorCallActivity : VectorBaseActivity<ActivityCallBinding>(), CallContro
                 val callId = withState(callViewModel) { it.callId }
                 navigator.openCallTransfer(this, callTransferActivityResultLauncher, callId)
             }
-            is VectorCallViewEvents.FailToTransfer -> showSnackbar(getString(R.string.call_transfer_failure))
+            is VectorCallViewEvents.FailToTransfer         -> showSnackbar(getString(R.string.call_transfer_failure))
             null                                           -> {
             }
         }
     }
 
     private val callTransferActivityResultLauncher = registerStartForActivityResult { activityResult ->
-
         when (activityResult.resultCode) {
             Activity.RESULT_CANCELED -> {
                 callViewModel.handle(VectorCallViewActions.CallTransferSelectionCancelled)
             }
-            Activity.RESULT_OK -> {
-                activityResult.data?.extras?.getParcelable<CallTransferResult>(CallTransferActivity.EXTRA_TRANSFER_RESULT)?.also {
-                    callViewModel.handle(VectorCallViewActions.CallTransferSelectionResult(it))
-                }
+            Activity.RESULT_OK       -> {
+                CallTransferActivity.getCallTransferResult(activityResult.data)
+                        ?.let { callViewModel.handle(VectorCallViewActions.CallTransferSelectionResult(it)) }
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/call/VectorCallViewActions.kt
+++ b/vector/src/main/java/im/vector/app/features/call/VectorCallViewActions.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.call
 
 import im.vector.app.core.platform.VectorViewModelAction
 import im.vector.app.features.call.audio.CallAudioManager
+import im.vector.app.features.call.transfer.CallTransferResult
 
 sealed class VectorCallViewActions : VectorViewModelAction {
     object EndCall : VectorCallViewActions()
@@ -37,5 +38,6 @@ sealed class VectorCallViewActions : VectorViewModelAction {
     object ToggleHDSD : VectorCallViewActions()
     object InitiateCallTransfer : VectorCallViewActions()
     object CallTransferSelectionCancelled : VectorCallViewActions()
+    data class CallTransferSelectionResult(val callTransferResult: CallTransferResult) : VectorCallViewActions()
     object TransferCall : VectorCallViewActions()
 }

--- a/vector/src/main/java/im/vector/app/features/call/VectorCallViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/call/VectorCallViewEvents.kt
@@ -29,6 +29,7 @@ sealed class VectorCallViewEvents : VectorViewEvents {
     ) : VectorCallViewEvents()
     object ShowDialPad : VectorCallViewEvents()
     object ShowCallTransferScreen : VectorCallViewEvents()
+    object FailToTransfer : VectorCallViewEvents()
 //    data class CallAnswered(val content: CallAnswerContent) : VectorCallViewEvents()
 //    data class CallHangup(val content: CallHangupContent) : VectorCallViewEvents()
 //    object CallAccepted : VectorCallViewEvents()

--- a/vector/src/main/java/im/vector/app/features/call/VectorCallViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/call/VectorCallViewModel.kt
@@ -29,13 +29,17 @@ import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.extensions.exhaustive
 import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.features.call.audio.CallAudioManager
+import im.vector.app.features.call.dialpad.DialPadLookup
+import im.vector.app.features.call.transfer.CallTransferResult
 import im.vector.app.features.call.webrtc.WebRtcCall
 import im.vector.app.features.call.webrtc.WebRtcCallManager
 import im.vector.app.features.call.webrtc.getOpponentAsMatrixItem
+import im.vector.app.features.createdirect.DirectRoomHelper
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.MatrixPatterns
+import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.call.CallState
 import org.matrix.android.sdk.api.session.call.MxCall
@@ -47,7 +51,9 @@ class VectorCallViewModel @AssistedInject constructor(
         @Assisted initialState: VectorCallViewState,
         val session: Session,
         val callManager: WebRtcCallManager,
-        val proximityManager: CallProximityManager
+        val proximityManager: CallProximityManager,
+        private val dialPadLookup: DialPadLookup,
+        private val directRoomHelper: DirectRoomHelper,
 ) : VectorViewModel<VectorCallViewState, VectorCallViewActions, VectorCallViewEvents>(initialState) {
 
     private var call: WebRtcCall? = null
@@ -327,6 +333,9 @@ class VectorCallViewModel @AssistedInject constructor(
             VectorCallViewActions.CallTransferSelectionCancelled -> {
                 call?.updateRemoteOnHold(false)
             }
+            is VectorCallViewActions.CallTransferSelectionResult -> {
+                handleCallTransferSelectionResult(action.callTransferResult)
+            }
             VectorCallViewActions.TransferCall         -> {
                 handleCallTransfer()
             }
@@ -342,6 +351,53 @@ class VectorCallViewModel @AssistedInject constructor(
             val currentCall = call ?: return@launch
             val transfereeCall = callManager.getTransfereeForCallId(currentCall.callId) ?: return@launch
             currentCall.transferToCall(transfereeCall)
+        }
+    }
+
+    private fun handleCallTransferSelectionResult(result: CallTransferResult) {
+        when (result) {
+            is CallTransferResult.ConnectWithUserId      -> connectWithUserId(result)
+            is CallTransferResult.ConnectWithPhoneNumber -> connectWithPhoneNumber(result)
+        }.exhaustive
+    }
+
+    private fun connectWithUserId(result: CallTransferResult.ConnectWithUserId) {
+        viewModelScope.launch {
+            try {
+                if (result.consultFirst) {
+                    val dmRoomId = directRoomHelper.ensureDMExists(result.selectedUserId)
+                    callManager.startOutgoingCall(
+                            nativeRoomId = dmRoomId,
+                            otherUserId = result.selectedUserId,
+                            isVideoCall = call?.mxCall?.isVideoCall.orFalse(),
+                            transferee = call
+                    )
+                } else {
+                    call?.transferToUser(result.selectedUserId, null)
+                }
+            } catch (failure: Throwable) {
+                _viewEvents.post(VectorCallViewEvents.FailToTransfer)
+            }
+        }
+    }
+
+    private fun connectWithPhoneNumber(action: CallTransferResult.ConnectWithPhoneNumber) {
+        viewModelScope.launch {
+            try {
+                val result = dialPadLookup.lookupPhoneNumber(action.phoneNumber)
+                if (action.consultFirst) {
+                    callManager.startOutgoingCall(
+                            nativeRoomId = result.roomId,
+                            otherUserId = result.userId,
+                            isVideoCall = call?.mxCall?.isVideoCall.orFalse(),
+                            transferee = call
+                    )
+                } else {
+                    call?.transferToUser(result.userId, result.roomId)
+                }
+            } catch (failure: Throwable) {
+                _viewEvents.post(VectorCallViewEvents.FailToTransfer)
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferActivity.kt
@@ -16,7 +16,6 @@
 
 package im.vector.app.features.call.transfer
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle

--- a/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferActivity.kt
@@ -104,7 +104,7 @@ class CallTransferActivity : VectorBaseActivity<ActivityCallTransferBinding>() {
     }
 
     companion object {
-            const val EXTRA_TRANSFER_RESULT = "EXTRA_TRANSFER_RESULT"
+        const val EXTRA_TRANSFER_RESULT = "EXTRA_TRANSFER_RESULT"
         fun newIntent(context: Context, callId: String): Intent {
             return Intent(context, CallTransferActivity::class.java).also {
                 it.putExtra(Mavericks.KEY_ARG, CallTransferArgs(callId))

--- a/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferActivity.kt
@@ -26,6 +26,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
 import im.vector.app.core.error.ErrorFormatter
+import im.vector.app.core.extensions.exhaustive
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.databinding.ActivityCallTransferBinding
 import kotlinx.parcelize.Parcelize
@@ -55,8 +56,8 @@ class CallTransferActivity : VectorBaseActivity<ActivityCallTransferBinding>() {
 
         callTransferViewModel.observeViewEvents {
             when (it) {
-                is CallTransferViewEvents.Complete        -> handleComplete()
-            }
+                is CallTransferViewEvents.Complete -> handleComplete()
+            }.exhaustive
         }
 
         sectionsPagerAdapter = CallTransferPagerAdapter(this)
@@ -104,11 +105,16 @@ class CallTransferActivity : VectorBaseActivity<ActivityCallTransferBinding>() {
     }
 
     companion object {
-        const val EXTRA_TRANSFER_RESULT = "EXTRA_TRANSFER_RESULT"
+        private const val EXTRA_TRANSFER_RESULT = "EXTRA_TRANSFER_RESULT"
+
         fun newIntent(context: Context, callId: String): Intent {
             return Intent(context, CallTransferActivity::class.java).also {
                 it.putExtra(Mavericks.KEY_ARG, CallTransferArgs(callId))
             }
+        }
+
+        fun getCallTransferResult(intent: Intent?): CallTransferResult? {
+            return intent?.extras?.getParcelable(EXTRA_TRANSFER_RESULT)
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferResult.kt
+++ b/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferResult.kt
@@ -19,7 +19,6 @@ package im.vector.app.features.call.transfer
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
-
 sealed class CallTransferResult : Parcelable{
     @Parcelize data class ConnectWithUserId(val consultFirst: Boolean, val selectedUserId: String) : CallTransferResult()
     @Parcelize data class ConnectWithPhoneNumber(val consultFirst: Boolean, val phoneNumber: String) : CallTransferResult()

--- a/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferResult.kt
+++ b/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferResult.kt
@@ -19,7 +19,7 @@ package im.vector.app.features.call.transfer
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
-sealed class CallTransferResult : Parcelable{
+sealed class CallTransferResult : Parcelable {
     @Parcelize data class ConnectWithUserId(val consultFirst: Boolean, val selectedUserId: String) : CallTransferResult()
     @Parcelize data class ConnectWithPhoneNumber(val consultFirst: Boolean, val phoneNumber: String) : CallTransferResult()
 }

--- a/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferResult.kt
+++ b/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferResult.kt
@@ -16,9 +16,11 @@
 
 package im.vector.app.features.call.transfer
 
-import im.vector.app.core.platform.VectorViewModelAction
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
-sealed class CallTransferAction : VectorViewModelAction {
-    data class ConnectWithUserId(val consultFirst: Boolean, val selectedUserId: String) : CallTransferAction()
-    data class ConnectWithPhoneNumber(val consultFirst: Boolean, val phoneNumber: String) : CallTransferAction()
+
+sealed class CallTransferResult : Parcelable{
+    @Parcelize data class ConnectWithUserId(val consultFirst: Boolean, val selectedUserId: String) : CallTransferResult()
+    @Parcelize data class ConnectWithPhoneNumber(val consultFirst: Boolean, val phoneNumber: String) : CallTransferResult()
 }

--- a/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferViewEvents.kt
@@ -20,6 +20,4 @@ import im.vector.app.core.platform.VectorViewEvents
 
 sealed class CallTransferViewEvents : VectorViewEvents {
     object Complete : CallTransferViewEvents()
-    object Loading : CallTransferViewEvents()
-    object FailToTransfer : CallTransferViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferViewModel.kt
@@ -22,15 +22,10 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
-import im.vector.app.core.extensions.exhaustive
 import im.vector.app.core.platform.EmptyAction
 import im.vector.app.core.platform.VectorViewModel
-import im.vector.app.features.call.dialpad.DialPadLookup
 import im.vector.app.features.call.webrtc.WebRtcCall
 import im.vector.app.features.call.webrtc.WebRtcCallManager
-import im.vector.app.features.createdirect.DirectRoomHelper
-import kotlinx.coroutines.launch
-import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.call.CallState
 import org.matrix.android.sdk.api.session.call.MxCall
 
@@ -68,5 +63,4 @@ class CallTransferViewModel @AssistedInject constructor(@Assisted initialState: 
     }
 
     override fun handle(action: EmptyAction) { }
-
 }

--- a/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferViewModel.kt
@@ -23,6 +23,7 @@ import dagger.assisted.AssistedInject
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.extensions.exhaustive
+import im.vector.app.core.platform.EmptyAction
 import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.features.call.dialpad.DialPadLookup
 import im.vector.app.features.call.webrtc.WebRtcCall
@@ -34,10 +35,8 @@ import org.matrix.android.sdk.api.session.call.CallState
 import org.matrix.android.sdk.api.session.call.MxCall
 
 class CallTransferViewModel @AssistedInject constructor(@Assisted initialState: CallTransferViewState,
-                                                        private val dialPadLookup: DialPadLookup,
-                                                        private val directRoomHelper: DirectRoomHelper,
                                                         private val callManager: WebRtcCallManager) :
-    VectorViewModel<CallTransferViewState, CallTransferAction, CallTransferViewEvents>(initialState) {
+    VectorViewModel<CallTransferViewState, EmptyAction, CallTransferViewEvents>(initialState) {
 
     @AssistedFactory
     interface Factory : MavericksAssistedViewModelFactory<CallTransferViewModel, CallTransferViewState> {
@@ -68,53 +67,6 @@ class CallTransferViewModel @AssistedInject constructor(@Assisted initialState: 
         call?.removeListener(callListener)
     }
 
-    override fun handle(action: CallTransferAction) {
-        when (action) {
-            is CallTransferAction.ConnectWithUserId      -> connectWithUserId(action)
-            is CallTransferAction.ConnectWithPhoneNumber -> connectWithPhoneNumber(action)
-        }.exhaustive
-    }
+    override fun handle(action: EmptyAction) { }
 
-    private fun connectWithUserId(action: CallTransferAction.ConnectWithUserId) {
-        viewModelScope.launch {
-            try {
-                if (action.consultFirst) {
-                    val dmRoomId = directRoomHelper.ensureDMExists(action.selectedUserId)
-                    callManager.startOutgoingCall(
-                            nativeRoomId = dmRoomId,
-                            otherUserId = action.selectedUserId,
-                            isVideoCall = call?.mxCall?.isVideoCall.orFalse(),
-                            transferee = call
-                    )
-                } else {
-                    call?.transferToUser(action.selectedUserId, null)
-                }
-                _viewEvents.post(CallTransferViewEvents.Complete)
-            } catch (failure: Throwable) {
-                _viewEvents.post(CallTransferViewEvents.FailToTransfer)
-            }
-        }
-    }
-
-    private fun connectWithPhoneNumber(action: CallTransferAction.ConnectWithPhoneNumber) {
-        viewModelScope.launch {
-            try {
-                _viewEvents.post(CallTransferViewEvents.Loading)
-                val result = dialPadLookup.lookupPhoneNumber(action.phoneNumber)
-                if (action.consultFirst) {
-                    callManager.startOutgoingCall(
-                            nativeRoomId = result.roomId,
-                            otherUserId = result.userId,
-                            isVideoCall = call?.mxCall?.isVideoCall.orFalse(),
-                            transferee = call
-                    )
-                } else {
-                    call?.transferToUser(result.userId, result.roomId)
-                }
-                _viewEvents.post(CallTransferViewEvents.Complete)
-            } catch (failure: Throwable) {
-                _viewEvents.post(CallTransferViewEvents.FailToTransfer)
-            }
-        }
-    }
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-android/issues/5201

### First part of fix

Intent information(`EXTRA_MODE`) that is pass to attachViewRenderers  [here](https://github.com/vector-im/element-android/blob/11986ec9ef508b93be68860e5eb28460535592ce/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt#L505) is not present on intent when `onNewIntent` is called, so the outgoing call is never placed. Fix is to set the intent [here](https://github.com/vector-im/element-android/pull/5203/files#diff-7ccb9f5a9496cb142b284f942f64646e7e3580890854d161ab4e7bdaeca74ec2R170).


### Second part of fix

A follow on issue was related to a recent [PR](https://github.com/vector-im/element-android/pull/5083) that puts other caller on hold when going to the transfer selection and off hold [when they cancel](https://github.com/vector-im/element-android/blob/develop/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt#L532).

With consult transfers, As the consult call is started in a new task, the call transfer selection activity immediately gets returned with `RESULT_CANCELLED` (rather than `RESULT_OK` from the `Complete` view action in turn calling `setResult`). This means we do an additional unintended unhold and this places the new call in the incorrect hold state. 

### 2 options for a solution
- Start changing how the call activity stack works(changing launch options and flags etc)
- Use the transfer screen just for transfer selection, Return the selection as an activity result and do the actual transfer back on the actual call activity/view model. 

The second option seemed pretty reasonable to me and we actually already do [the second part of the consult transfer from the call view model](https://github.com/vector-im/element-android/blob/develop/vector/src/main/java/im/vector/app/features/call/VectorCallViewModel.kt#L331) already. So went with that.