### PR TITLE
Reduce verbosity of CleanupSession debug logs.

### DIFF
--- a/changelog.d/5209.misc
+++ b/changelog.d/5209.misc
@@ -1,0 +1,1 @@
+Reduce verbosity of debug logging,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/cleanup/CleanupSession.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/cleanup/CleanupSession.kt
@@ -94,12 +94,12 @@ internal class CleanupSession @Inject constructor(
         do {
             val sessionRealmCount = Realm.getGlobalInstanceCount(realmSessionConfiguration)
             val cryptoRealmCount = Realm.getGlobalInstanceCount(realmCryptoConfiguration)
-            Timber.d("Wait for all Realm instance to be closed ($sessionRealmCount - $cryptoRealmCount)")
             if (sessionRealmCount > 0 || cryptoRealmCount > 0) {
-                Timber.d("Waiting ${TIME_TO_WAIT_MILLIS}ms")
+                Timber.d("Waiting ${TIME_TO_WAIT_MILLIS}ms for all Realm instance to be closed ($sessionRealmCount - $cryptoRealmCount)")
                 delay(TIME_TO_WAIT_MILLIS)
                 timeToWaitMillis -= TIME_TO_WAIT_MILLIS
             } else {
+                Timber.d("Finished waiting for all Realm instance to be closed ($sessionRealmCount - $cryptoRealmCount)")
                 timeToWaitMillis = 0
             }
         } while (timeToWaitMillis > 0)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [X] Technical
- [ ] Other :

## Content

Debug logging for CleanupSession has been combined into a single log line.

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

When reading the logs from some of the integration tests, there were periods of up to 10s of these logs being generated, which was a lot to scroll through.

Currently we wait up to 10s for this operation to complete.
    
Replacing the two log lines with three, lets us halve the number of logs printed every 10ms,
but always print exactly one log line each iteration of the loop. Rather than:

```
02-10 19:58:48.880  3140  3140 D CleanupSession: Wait for all Realm instance to be closed (29 - 0)
02-10 19:58:48.880  3140  3140 D CleanupSession: Waiting 10ms
02-10 19:58:48.890  3140  3140 D CleanupSession: Wait for all Realm instance to be closed (29 - 0)
02-10 19:58:48.890  3140  3140 D CleanupSession: Waiting 10ms
02-10 19:58:48.900  3140  3140 D CleanupSession: Wait for all Realm instance to be closed (29 - 0)
02-10 19:58:48.900  3140  3140 D CleanupSession: Waiting 10ms
02-10 19:58:48.910  3140  3140 D CleanupSession: Wait for all Realm instance to be closed (29 - 0)
02-10 19:58:48.910  3140  3140 D CleanupSession: Waiting 10ms
02-10 19:58:48.920  3140  3140 D CleanupSession: Wait for all Realm instance to be closed (0 - 0)
```

We'll print:

```
02-10 19:58:48.880  3140  3140 D CleanupSession: Waiting 10ms for all Realm instance to be closed (29 - 0)
02-10 19:58:48.890  3140  3140 D CleanupSession: Waiting 10ms for all Realm instance to be closed (29 - 0)
02-10 19:58:48.900  3140  3140 D CleanupSession: Waiting 10ms for all Realm instance to be closed (29 - 0)
02-10 19:58:48.910  3140  3140 D CleanupSession: Waiting 10ms for all Realm instance to be closed (29 - 0)
02-10 19:58:48.920  3140  3140 D CleanupSession: Finished waiting for all Realm instance to be closed (0 - 0)
```
    
The above example took 40ms to finish and saved 4 log lines; you can see how it adds up to a lot of logs if you take 10000ms to finish.

## Screenshots / GIFs

N/A

## Tests

Inspected logging before/after

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
