### PR TITLE
FTUE - Choose a display name

### DIFF
--- a/vector/src/main/java/im/vector/app/core/di/FragmentModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/FragmentModule.kt
@@ -99,6 +99,7 @@ import im.vector.app.features.matrixto.MatrixToRoomSpaceFragment
 import im.vector.app.features.matrixto.MatrixToUserFragment
 import im.vector.app.features.onboarding.ftueauth.FtueAuthAccountCreatedFragment
 import im.vector.app.features.onboarding.ftueauth.FtueAuthCaptchaFragment
+import im.vector.app.features.onboarding.ftueauth.FtueAuthChooseDisplayNameFragment
 import im.vector.app.features.onboarding.ftueauth.FtueAuthGenericTextInputFormFragment
 import im.vector.app.features.onboarding.ftueauth.FtueAuthLoginFragment
 import im.vector.app.features.onboarding.ftueauth.FtueAuthResetPasswordFragment
@@ -478,6 +479,11 @@ interface FragmentModule {
     @IntoMap
     @FragmentKey(FtueAuthAccountCreatedFragment::class)
     fun bindFtueAuthAccountCreatedFragment(fragment: FtueAuthAccountCreatedFragment): Fragment
+
+    @Binds
+    @IntoMap
+    @FragmentKey(FtueAuthChooseDisplayNameFragment::class)
+    fun bindFtueAuthChooseDisplayNameFragment(fragment: FtueAuthChooseDisplayNameFragment): Fragment
 
     @Binds
     @IntoMap

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
@@ -73,4 +73,7 @@ sealed class OnboardingAction : VectorViewModelAction {
     data class PostViewEvent(val viewEvent: OnboardingViewEvents) : OnboardingAction()
 
     data class UserAcceptCertificate(val fingerprint: Fingerprint) : OnboardingAction()
+
+    data class UpdateDisplayName(val displayName: String) : OnboardingAction()
+    object UpdateDisplayNameSkipped : OnboardingAction()
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingVariant.kt
@@ -22,4 +22,5 @@ interface OnboardingVariant {
     fun onNewIntent(intent: Intent?)
     fun initUiAndData(isFirstCreation: Boolean)
     fun setIsLoading(isLoading: Boolean)
+    fun onToolbarBack() {}
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingVariant.kt
@@ -22,5 +22,4 @@ interface OnboardingVariant {
     fun onNewIntent(intent: Intent?)
     fun initUiAndData(isFirstCreation: Boolean)
     fun setIsLoading(isLoading: Boolean)
-    fun onToolbarBack() {}
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewEvents.kt
@@ -52,4 +52,6 @@ sealed class OnboardingViewEvents : VectorViewEvents {
     object OnAccountSignedIn : OnboardingViewEvents()
     object OnTakeMeHome : OnboardingViewEvents()
     object OnPersonalizeProfile : OnboardingViewEvents()
+    object OnDisplayNameUpdated : OnboardingViewEvents()
+    object OnDisplayNameSkipped : OnboardingViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -891,11 +891,11 @@ class OnboardingViewModel @AssistedInject constructor(
             try {
                 activeSession.setDisplayName(activeSession.myUserId, displayName)
                 setState { copy(asyncDisplayName = Success(Unit)) }
+                _viewEvents.post(OnboardingViewEvents.OnDisplayNameUpdated)
             } catch (error: Throwable) {
                 setState { copy(asyncDisplayName = Fail(error)) }
                 _viewEvents.post(OnboardingViewEvents.Failure(error))
             }
-            _viewEvents.post(OnboardingViewEvents.OnDisplayNameUpdated)
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -47,6 +47,7 @@ import im.vector.app.features.login.ReAuthHelper
 import im.vector.app.features.login.ServerType
 import im.vector.app.features.login.SignMode
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.auth.AuthenticationService
@@ -146,6 +147,8 @@ class OnboardingViewModel @AssistedInject constructor(
             is OnboardingAction.UserAcceptCertificate      -> handleUserAcceptCertificate(action)
             OnboardingAction.ClearHomeServerHistory        -> handleClearHomeServerHistory()
             is OnboardingAction.PostViewEvent              -> _viewEvents.post(action.viewEvent)
+            is OnboardingAction.UpdateDisplayName          -> updateDisplayName(action.displayName)
+            OnboardingAction.UpdateDisplayNameSkipped      -> _viewEvents.post(OnboardingViewEvents.OnDisplayNameSkipped)
         }.exhaustive
     }
 
@@ -880,6 +883,17 @@ class OnboardingViewModel @AssistedInject constructor(
 
     fun getFallbackUrl(forSignIn: Boolean, deviceId: String?): String? {
         return authenticationService.getFallbackUrl(forSignIn, deviceId)
+    }
+
+    private fun updateDisplayName(displayName: String) {
+        setState { copy(asyncDisplayName = Loading()) }
+        viewModelScope.launch {
+            // TODO real upstream display name update
+            delay(2000)
+            displayName.toString()
+            setState { copy(asyncDisplayName = Success(Unit)) }
+            _viewEvents.post(OnboardingViewEvents.OnDisplayNameUpdated)
+        }
     }
 }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
@@ -32,6 +32,7 @@ data class OnboardingViewState(
         val asyncResetPassword: Async<Unit> = Uninitialized,
         val asyncResetMailConfirmed: Async<Unit> = Uninitialized,
         val asyncRegistration: Async<Unit> = Uninitialized,
+        val asyncDisplayName: Async<Unit> = Uninitialized,
 
         @PersistState
         val onboardingFlow: OnboardingFlow? = null,
@@ -70,7 +71,8 @@ data class OnboardingViewState(
                 asyncHomeServerLoginFlowRequest is Loading ||
                 asyncResetPassword is Loading ||
                 asyncResetMailConfirmed is Loading ||
-                asyncRegistration is Loading
+                asyncRegistration is Loading ||
+                asyncDisplayName is Loading
     }
 
     fun isAuthTaskCompleted(): Boolean {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
@@ -17,9 +17,11 @@
 package im.vector.app.features.onboarding.ftueauth
 
 import android.os.Bundle
+import android.text.Editable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import im.vector.app.core.platform.SimpleTextWatcher
 import im.vector.app.databinding.FragmentFtueDisplayNameBinding
 import im.vector.app.features.onboarding.OnboardingAction
 import javax.inject.Inject
@@ -36,6 +38,19 @@ class FtueAuthChooseDisplayNameFragment @Inject constructor() : AbstractFtueAuth
     }
 
     private fun setupViews() {
+        views.displayNameInput.editText?.addTextChangedListener(object : SimpleTextWatcher() {
+            override fun afterTextChanged(s: Editable) {
+                val newContent = s.toString()
+                views.displayNameSubmit.isEnabled = newContent.isNotEmpty()
+            }
+        })
+
+        views.displayNameSubmit.setOnClickListener {
+            val newDisplayName = views.displayNameInput.editText?.text.toString()
+            viewModel.handle(OnboardingAction.UpdateDisplayName(newDisplayName))
+        }
+
+        views.displayNameSkip.setOnClickListener { viewModel.handle(OnboardingAction.UpdateDisplayNameSkipped) }
     }
 
     override fun resetViewModel() {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.onboarding.ftueauth
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import im.vector.app.databinding.FragmentFtueDisplayNameBinding
+import im.vector.app.features.onboarding.OnboardingAction
+import javax.inject.Inject
+
+class FtueAuthChooseDisplayNameFragment @Inject constructor() : AbstractFtueAuthFragment<FragmentFtueDisplayNameBinding>() {
+
+    override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentFtueDisplayNameBinding {
+        return FragmentFtueDisplayNameBinding.inflate(inflater, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupViews()
+    }
+
+    private fun setupViews() {
+    }
+
+    override fun resetViewModel() {
+        // Nothing to do
+    }
+
+    override fun onBackPressed(toolbarButton: Boolean): Boolean {
+        viewModel.handle(OnboardingAction.TakeMeHome)
+        return false
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
@@ -48,12 +48,12 @@ class FtueAuthChooseDisplayNameFragment @Inject constructor() : AbstractFtueAuth
             }
         })
 
-        views.displayNameSubmit.setOnClickListener {
+        views.displayNameSubmit.debouncedClicks {
             val newDisplayName = views.displayNameInput.editText?.text.toString()
             viewModel.handle(OnboardingAction.UpdateDisplayName(newDisplayName))
         }
 
-        views.displayNameSkip.setOnClickListener { viewModel.handle(OnboardingAction.UpdateDisplayNameSkipped) }
+        views.displayNameSkip.debouncedClicks { viewModel.handle(OnboardingAction.UpdateDisplayNameSkipped) }
     }
 
     override fun resetViewModel() {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
@@ -25,6 +25,7 @@ import com.google.android.material.textfield.TextInputLayout
 import im.vector.app.core.platform.SimpleTextWatcher
 import im.vector.app.databinding.FragmentFtueDisplayNameBinding
 import im.vector.app.features.onboarding.OnboardingAction
+import im.vector.app.features.onboarding.OnboardingViewEvents
 import javax.inject.Inject
 
 class FtueAuthChooseDisplayNameFragment @Inject constructor() : AbstractFtueAuthFragment<FragmentFtueDisplayNameBinding>() {
@@ -60,7 +61,7 @@ class FtueAuthChooseDisplayNameFragment @Inject constructor() : AbstractFtueAuth
     }
 
     override fun onBackPressed(toolbarButton: Boolean): Boolean {
-        viewModel.handle(OnboardingAction.TakeMeHome)
+        viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnTakeMeHome))
         return false
     }
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
@@ -21,6 +21,7 @@ import android.text.Editable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import com.google.android.material.textfield.TextInputLayout
 import im.vector.app.core.platform.SimpleTextWatcher
 import im.vector.app.databinding.FragmentFtueDisplayNameBinding
 import im.vector.app.features.onboarding.OnboardingAction
@@ -38,6 +39,7 @@ class FtueAuthChooseDisplayNameFragment @Inject constructor() : AbstractFtueAuth
     }
 
     private fun setupViews() {
+        views.displayNameSubmit.isEnabled = views.displayNameInput.hasContentEmpty()
         views.displayNameInput.editText?.addTextChangedListener(object : SimpleTextWatcher() {
             override fun afterTextChanged(s: Editable) {
                 val newContent = s.toString()
@@ -62,3 +64,5 @@ class FtueAuthChooseDisplayNameFragment @Inject constructor() : AbstractFtueAuth
         return false
     }
 }
+
+private fun TextInputLayout.hasContentEmpty() = !editText?.text.isNullOrEmpty()

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
@@ -21,6 +21,7 @@ import android.text.Editable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import com.google.android.material.textfield.TextInputLayout
 import im.vector.app.core.platform.SimpleTextWatcher
 import im.vector.app.databinding.FragmentFtueDisplayNameBinding
@@ -47,13 +48,26 @@ class FtueAuthChooseDisplayNameFragment @Inject constructor() : AbstractFtueAuth
                 views.displayNameSubmit.isEnabled = newContent.isNotEmpty()
             }
         })
+        views.displayNameInput.editText?.setOnEditorActionListener { _, actionId, _ ->
+            when (actionId) {
+                EditorInfo.IME_ACTION_DONE -> {
+                    updateDisplayName()
+                    true
+                }
+                else                       -> false
+            }
+        }
 
         views.displayNameSubmit.debouncedClicks {
-            val newDisplayName = views.displayNameInput.editText?.text.toString()
-            viewModel.handle(OnboardingAction.UpdateDisplayName(newDisplayName))
+            updateDisplayName()
         }
 
         views.displayNameSkip.debouncedClicks { viewModel.handle(OnboardingAction.UpdateDisplayNameSkipped) }
+    }
+
+    private fun updateDisplayName() {
+        val newDisplayName = views.displayNameInput.editText?.text.toString()
+        viewModel.handle(OnboardingAction.UpdateDisplayName(newDisplayName))
     }
 
     override fun resetViewModel() {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseDisplayNameFragment.kt
@@ -62,7 +62,7 @@ class FtueAuthChooseDisplayNameFragment @Inject constructor() : AbstractFtueAuth
 
     override fun onBackPressed(toolbarButton: Boolean): Boolean {
         viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnTakeMeHome))
-        return false
+        return true
     }
 }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -403,5 +403,4 @@ class FtueAuthVariant(
         // TODO go to the real profile picture fragment
         navigateToHome(createdAccount = true)
     }
-
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -223,7 +223,7 @@ class FtueAuthVariant(
             }
             OnboardingViewEvents.OnAccountCreated                              -> onAccountCreated()
             OnboardingViewEvents.OnAccountSignedIn                             -> onAccountSignedIn()
-            OnboardingViewEvents.OnPersonalizeProfile                          -> TODO()
+            OnboardingViewEvents.OnPersonalizeProfile                          -> onPersonalizeProfile()
             OnboardingViewEvents.OnTakeMeHome                                  -> navigateToHome(createdAccount = true)
         }.exhaustive
     }
@@ -388,5 +388,16 @@ class FtueAuthVariant(
         val intent = HomeActivity.newIntent(activity, accountCreation = createdAccount)
         activity.startActivity(intent)
         activity.finish()
+    }
+
+    private fun onPersonalizeProfile() {
+        activity.addFragmentToBackstack(views.loginFragmentContainer,
+                FtueAuthChooseDisplayNameFragment::class.java,
+                option = commonOption
+        )
+    }
+
+    override fun onToolbarBack() {
+        activity.supportFragmentManager.popBackStack()
     }
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -400,11 +400,8 @@ class FtueAuthVariant(
     }
 
     private fun onDisplayNameUpdated() {
-        // TODO go to real fragment
-        activity.addFragmentToBackstack(views.loginFragmentContainer,
-                FtueAuthChooseDisplayNameFragment::class.java,
-                option = commonOption
-        )
+        // TODO go to the real profile picture fragment
+        navigateToHome(createdAccount = true)
     }
 
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -225,6 +225,8 @@ class FtueAuthVariant(
             OnboardingViewEvents.OnAccountSignedIn                             -> onAccountSignedIn()
             OnboardingViewEvents.OnPersonalizeProfile                          -> onPersonalizeProfile()
             OnboardingViewEvents.OnTakeMeHome                                  -> navigateToHome(createdAccount = true)
+            OnboardingViewEvents.OnDisplayNameUpdated                          -> onDisplayNameUpdated()
+            OnboardingViewEvents.OnDisplayNameSkipped                          -> onDisplayNameUpdated()
         }.exhaustive
     }
 
@@ -397,7 +399,12 @@ class FtueAuthVariant(
         )
     }
 
-    override fun onToolbarBack() {
-        activity.supportFragmentManager.popBackStack()
+    private fun onDisplayNameUpdated() {
+        // TODO go to real fragment
+        activity.addFragmentToBackstack(views.loginFragmentContainer,
+                FtueAuthChooseDisplayNameFragment::class.java,
+                option = commonOption
+        )
     }
+
 }

--- a/vector/src/main/res/layout/activity_login.xml
+++ b/vector/src/main/res/layout/activity_login.xml
@@ -7,13 +7,16 @@
     android:layout_height="match_parent">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/loginContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/loginFragmentContainer"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.constraintlayout.widget.Group
             android:id="@+id/loginLoading"

--- a/vector/src/main/res/layout/fragment_ftue_display_name.xml
+++ b/vector/src/main/res/layout/fragment_ftue_display_name.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/LoginFormScrollView"
+    android:layout_height="match_parent"
+    android:background="?android:colorBackground"
+    android:fillViewport="true"
+    android:paddingTop="0dp"
+    android:paddingBottom="0dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/displayNameGutterStart"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="@dimen/ftue_auth_gutter_start_percent" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/displayNameGutterEnd"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="@dimen/ftue_auth_gutter_end_percent" />
+
+        <ImageView
+            android:id="@+id/displayNameHeaderIcon"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:adjustViewBounds="true"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_user_round"
+            app:layout_constraintBottom_toTopOf="@id/displayNameHeaderTitle"
+            app:layout_constraintEnd_toEndOf="@id/displayNameGutterEnd"
+            app:layout_constraintHeight_percent="0.15"
+            app:layout_constraintStart_toStartOf="@id/displayNameGutterStart"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?colorAccent" />
+
+        <TextView
+            android:id="@+id/displayNameHeaderTitle"
+            style="@style/Widget.Vector.TextView.Title.Medium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:gravity="center"
+            android:text="@string/ftue_display_name_title"
+            android:textColor="?vctr_content_primary"
+            app:layout_constraintBottom_toTopOf="@id/displayNameHeaderSubtitle"
+            app:layout_constraintEnd_toEndOf="@id/displayNameGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/displayNameGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/displayNameHeaderIcon" />
+
+        <TextView
+            android:id="@+id/displayNameHeaderSubtitle"
+            style="@style/Widget.Vector.TextView.Subtitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:text="@string/ftue_display_name_subtitle"
+            android:textColor="?vctr_content_secondary"
+            app:layout_constraintBottom_toTopOf="@id/titleContentSpacing"
+            app:layout_constraintEnd_toEndOf="@id/displayNameGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/displayNameGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/displayNameHeaderTitle" />
+
+        <Space
+            android:id="@+id/titleContentSpacing"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/displayNameInput"
+            app:layout_constraintHeight_percent="0.03"
+            app:layout_constraintTop_toBottomOf="@id/displayNameHeaderSubtitle" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/displayNameInput"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:hint="@string/ftue_display_name_entry_title"
+            app:layout_constraintEnd_toEndOf="@id/displayNameGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/displayNameGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/titleContentSpacing">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:maxLines="1" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <TextView
+            android:id="@+id/displayNameEntryFooter"
+            style="@style/Widget.Vector.TextView.Micro"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/ftue_display_name_entry_footer"
+            app:layout_constraintEnd_toEndOf="@id/displayNameGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/displayNameGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/displayNameInput" />
+
+        <Space
+            android:id="@+id/actionsSpacing"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/displayNameSubmit"
+            app:layout_constraintHeight_percent="0.03"
+            app:layout_constraintTop_toBottomOf="@id/displayNameEntryFooter"
+            app:layout_constraintVertical_bias="0"
+            app:layout_constraintVertical_chainStyle="packed" />
+
+        <Button
+            android:id="@+id/displayNameSubmit"
+            style="@style/Widget.Vector.Button.Login"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/ftue_personalize_submit"
+            android:textAllCaps="true"
+            app:layout_constraintBottom_toTopOf="@id/displayNameSkip"
+            app:layout_constraintEnd_toEndOf="@id/displayNameGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/displayNameGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/actionsSpacing" />
+
+        <Button
+            android:id="@+id/displayNameSkip"
+            style="@style/Widget.Vector.Button.Text.Login"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/ftue_personalize_skip_this_step"
+            android:textAllCaps="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/displayNameGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/displayNameGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/displayNameSubmit" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.core.widget.NestedScrollView>
+
+

--- a/vector/src/main/res/layout/fragment_ftue_display_name.xml
+++ b/vector/src/main/res/layout/fragment_ftue_display_name.xml
@@ -45,7 +45,7 @@
             app:layout_constraintHeight_percent="0.15"
             app:layout_constraintStart_toStartOf="@id/displayNameGutterStart"
             app:layout_constraintTop_toTopOf="parent"
-            app:tint="?colorAccent" />
+            app:tint="?colorSecondary" />
 
         <TextView
             android:id="@+id/displayNameHeaderTitle"

--- a/vector/src/main/res/layout/fragment_ftue_display_name.xml
+++ b/vector/src/main/res/layout/fragment_ftue_display_name.xml
@@ -26,6 +26,13 @@
             android:orientation="vertical"
             app:layout_constraintGuide_percent="@dimen/ftue_auth_gutter_end_percent" />
 
+        <Space
+            android:id="@+id/headerSpacing"
+            android:layout_width="match_parent"
+            android:layout_height="52dp"
+            app:layout_constraintBottom_toTopOf="@id/displayNameHeaderIcon"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <ImageView
             android:id="@+id/displayNameHeaderIcon"
             android:layout_width="wrap_content"

--- a/vector/src/main/res/layout/fragment_ftue_display_name.xml
+++ b/vector/src/main/res/layout/fragment_ftue_display_name.xml
@@ -95,6 +95,7 @@
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:imeOptions="actionDone"
                 android:maxLines="1" />
 
         </com.google.android.material.textfield.TextInputLayout>

--- a/vector/src/main/res/values/donottranslate.xml
+++ b/vector/src/main/res/values/donottranslate.xml
@@ -22,4 +22,12 @@
     <string name="ftue_account_created_take_me_home" translatable="false">Take me home</string>
     <string name="ftue_account_created_congratulations_title" translatable="false">Congratulations!</string>
     <string name="ftue_account_created_subtitle" translatable="false">Your account %s has been created.</string>
+
+    <string name="ftue_display_name_title" translatable="false">Choose a display name</string>
+    <string name="ftue_display_name_subtitle" translatable="false">This will be shown when you send messages.</string>
+    <string name="ftue_display_name_entry_title" translatable="false">Display Name</string>
+    <string name="ftue_display_name_entry_footer" translatable="false">You can change this later</string>
+
+    <string name="ftue_personalize_submit" translatable="false">Save and continue</string>
+    <string name="ftue_personalize_skip_this_step" translatable="false">Skip this step</string>
 </resources>

--- a/vector/src/test/java/im/vector/app/features/crypto/quads/SharedSecureStorageViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/crypto/quads/SharedSecureStorageViewModelTest.kt
@@ -102,10 +102,16 @@ class SharedSecureStorageViewModelTest {
             viewModel.handle(SharedSecureStorageAction.UseKey)
 
             test
-                    .assertState(aViewState(
-                            hasPassphrase = true,
-                            step = SharedSecureStorageViewState.Step.EnterKey
-                    ))
+                    .assertStates(
+                            aViewState(
+                                    hasPassphrase = true,
+                                    step = SharedSecureStorageViewState.Step.EnterPassphrase
+                            ),
+                            aViewState(
+                                    hasPassphrase = true,
+                                    step = SharedSecureStorageViewState.Step.EnterKey
+                            )
+                    )
                     .finish()
         }
     }
@@ -121,10 +127,20 @@ class SharedSecureStorageViewModelTest {
             viewModel.handle(SharedSecureStorageAction.Back)
 
             test
-                    .assertState(aViewState(
-                    hasPassphrase = true,
-                    step = SharedSecureStorageViewState.Step.EnterPassphrase
-            ))
+                    .assertStates(
+                            aViewState(
+                                    hasPassphrase = true,
+                                    step = SharedSecureStorageViewState.Step.EnterPassphrase
+                            ),
+                            aViewState(
+                                    hasPassphrase = true,
+                                    step = SharedSecureStorageViewState.Step.EnterKey
+                            ),
+                            aViewState(
+                                    hasPassphrase = true,
+                                    step = SharedSecureStorageViewState.Step.EnterPassphrase
+                            )
+                    )
                     .finish()
         }
     }

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.onboarding
+
+import com.airbnb.mvrx.Fail
+import com.airbnb.mvrx.Loading
+import com.airbnb.mvrx.Success
+import com.airbnb.mvrx.test.MvRxTestRule
+import im.vector.app.features.login.ReAuthHelper
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import im.vector.app.test.fakes.FakeAnalyticsTracker
+import im.vector.app.test.fakes.FakeAuthenticationService
+import im.vector.app.test.fakes.FakeContext
+import im.vector.app.test.fakes.FakeHomeServerConnectionConfigFactory
+import im.vector.app.test.fakes.FakeHomeServerHistoryService
+import im.vector.app.test.fakes.FakeSession
+import im.vector.app.test.fakes.FakeStringProvider
+import im.vector.app.test.fakes.FakeVectorFeatures
+import im.vector.app.test.test
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+private const val A_DISPLAY_NAME = "a display name"
+
+class OnboardingViewModelTest {
+
+    @get:Rule
+    val mvrxTestRule = MvRxTestRule()
+
+    private val fakeContext = FakeContext()
+    lateinit var viewModel: OnboardingViewModel
+    private val initialState = OnboardingViewState()
+    private val fakeSession = FakeSession()
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder(fakeSession)
+
+    @Before
+    fun setUp() {
+        viewModel = createViewModel()
+    }
+
+    @Test
+    fun `when handling PostViewEvent then emits contents as view event`() = runBlockingTest {
+        val test = viewModel.test(this)
+
+        viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnTakeMeHome))
+
+        test
+                .assertEvents(OnboardingViewEvents.OnTakeMeHome)
+                .finish()
+    }
+
+    @Test
+    fun `when handling display name updates action then updates user display name and emits name updated event`() = runBlockingTest {
+        val test = viewModel.test(this)
+
+        viewModel.handle(OnboardingAction.UpdateDisplayName(A_DISPLAY_NAME))
+
+        test
+                .assertStates(
+                        initialState,
+                        initialState.copy(asyncDisplayName = Loading()),
+                        initialState.copy(asyncDisplayName = Success(Unit)),
+                )
+                .assertEvents(OnboardingViewEvents.OnDisplayNameUpdated)
+                .finish()
+    }
+
+    @Test
+    fun `given failure when handling display name updates action then emits failure event`() = runBlockingTest {
+        val test = viewModel.test(this)
+        val errorCause = RuntimeException("an error!")
+        fakeSession.fakeProfileService.givenSetDisplayNameErrors(errorCause)
+
+        viewModel.handle(OnboardingAction.UpdateDisplayName(A_DISPLAY_NAME))
+
+        test
+                .assertStates(
+                        initialState,
+                        initialState.copy(asyncDisplayName = Loading()),
+                        initialState.copy(asyncDisplayName = Fail(errorCause)),
+                )
+                .assertEvents(OnboardingViewEvents.Failure(errorCause))
+                .finish()
+    }
+
+    private fun createViewModel(): OnboardingViewModel {
+        return OnboardingViewModel(
+                initialState,
+                fakeContext.instance,
+                FakeAuthenticationService(),
+                fakeActiveSessionHolder.instance,
+                FakeHomeServerConnectionConfigFactory().instance,
+                ReAuthHelper(),
+                FakeStringProvider().instance,
+                FakeHomeServerHistoryService(),
+                FakeVectorFeatures(),
+                FakeAnalyticsTracker()
+        )
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeActiveSessionHolder.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeActiveSessionHolder.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import im.vector.app.core.di.ActiveSessionHolder
+import io.mockk.every
+import io.mockk.mockk
+
+class FakeActiveSessionHolder(
+        private val fakeSession: FakeSession = FakeSession()
+) {
+    val instance = mockk<ActiveSessionHolder> {
+        every { getActiveSession() } returns fakeSession
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeAnalyticsTracker.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeAnalyticsTracker.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import im.vector.app.features.analytics.AnalyticsTracker
+import io.mockk.mockk
+
+class FakeAnalyticsTracker : AnalyticsTracker by mockk()

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import io.mockk.mockk
+import org.matrix.android.sdk.api.auth.AuthenticationService
+
+class FakeAuthenticationService : AuthenticationService by mockk()

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeHomeServerConnectionConfigFactory.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeHomeServerConnectionConfigFactory.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import im.vector.app.features.login.HomeServerConnectionConfigFactory
+import io.mockk.mockk
+
+class FakeHomeServerConnectionConfigFactory {
+
+    val instance: HomeServerConnectionConfigFactory = mockk()
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeHomeServerHistoryService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeHomeServerHistoryService.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import io.mockk.mockk
+import org.matrix.android.sdk.api.auth.HomeServerHistoryService
+
+class FakeHomeServerHistoryService : HomeServerHistoryService by mockk() {
+    override fun getKnownServersUrls() = emptyList<String>()
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeProfileService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeProfileService.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import io.mockk.mockk
+import org.matrix.android.sdk.api.session.profile.ProfileService
+
+class FakeProfileService : ProfileService by mockk() {
+
+    private var setDisplayNameError: Throwable? = null
+
+    override suspend fun setDisplayName(userId: String, newDisplayName: String) {
+        setDisplayNameError?.let { throw it }
+    }
+
+    fun givenSetDisplayNameErrors(errorCause: RuntimeException) {
+        setDisplayNameError = errorCause
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeSession.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeSession.kt
@@ -26,6 +26,7 @@ import org.matrix.android.sdk.api.session.Session
 
 class FakeSession(
         val fakeCryptoService: FakeCryptoService = FakeCryptoService(),
+        val fakeProfileService: FakeProfileService = FakeProfileService(),
         val fakeSharedSecretStorageService: FakeSharedSecretStorageService = FakeSharedSecretStorageService()
 ) : Session by mockk(relaxed = true) {
 
@@ -36,6 +37,7 @@ class FakeSession(
     override fun cryptoService() = fakeCryptoService
     override val sharedSecretStorageService = fakeSharedSecretStorageService
     override val coroutineDispatchers = testCoroutineDispatchers
+    override suspend fun setDisplayName(userId: String, newDisplayName: String) = fakeProfileService.setDisplayName(userId, newDisplayName)
 
     fun givenVectorStore(vectorSessionStore: VectorSessionStore) {
         coEvery {

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorFeatures.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorFeatures.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import im.vector.app.features.VectorFeatures
+
+class FakeVectorFeatures : VectorFeatures {
+    override fun onboardingVariant() = VectorFeatures.OnboardingVariant.FTUE_AUTH
+    override fun isOnboardingAlreadyHaveAccountSplashEnabled() = true
+    override fun isOnboardingSplashCarouselEnabled() = true
+    override fun isOnboardingUseCaseEnabled() = true
+    override fun isOnboardingPersonalizeEnabled() = false
+}


### PR DESCRIPTION
Depends on #5158 Part of #5200

 ## Type of change

- [x] WIP Feature 
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Adds a `Choose a display name` screen to the onboarding personalisation flow, sits behind the FTUE personailzation feature flag.

## Motivation and context

To allow the user to personalise their account during the account creation process

## Screenshots / GIFs

*the gif animations are odd because the emulator has them turned off

| EMPTY | WITH CONTENT | WITH CONTENT AND KEYBOARD |
| --- | --- | --- |
![Screenshot_20220211_154053](https://user-images.githubusercontent.com/1848238/153623071-6e7d947f-9e20-46fb-9ba3-df8b0f1e9895.png)|![Screenshot_20220211_154358](https://user-images.githubusercontent.com/1848238/153623065-e3b509ee-2de3-4514-a99c-05bb6b6722bc.png)|![Screenshot_20220211_154117](https://user-images.githubusercontent.com/1848238/153623070-f476cb6f-4ef8-43bf-91a6-291744231dda.png)|

| GIF | 
| --- |
|![after-update-name](https://user-images.githubusercontent.com/1848238/153624671-2ec06f28-33d4-42fa-94db-e83c86361f00.gif)

## Tests

- Adds unit tests around the `OnboardingViewModel` (along with the fakes needed to setup the class) to ensure the display name is updated and errors are handled

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 32 / Sv2
