### PR TITLE
#4642 Update the top bar in a room

### DIFF
--- a/changelog.d/4642.bugfix
+++ b/changelog.d/4642.bugfix
@@ -1,0 +1,1 @@
+Update the top bar in a room

--- a/changelog.d/4642.bugfix
+++ b/changelog.d/4642.bugfix
@@ -1,1 +1,1 @@
-Update the top bar in a room
+Update the top bar in a room: remove topic and typing information

--- a/library/ui-styles/src/main/res/values/style_action_button.xml
+++ b/library/ui-styles/src/main/res/values/style_action_button.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Widget.Vector.ActionButton" parent="Widget.AppCompat.ActionButton">
+        <item name="android:paddingStart">5dp</item>
+        <item name="android:paddingEnd">5dp</item>
+        <item name="android:minWidth">0dp</item>
+    </style>
+</resources>

--- a/library/ui-styles/src/main/res/values/theme_common.xml
+++ b/library/ui-styles/src/main/res/values/theme_common.xml
@@ -25,10 +25,4 @@
         <item name="android:backgroundDimEnabled">false</item>
     </style>
 
-    <style name="Theme.Vector.ActionButton" parent="@android:style/Widget.ActionButton">
-        <item name="android:paddingStart">5dp</item>
-        <item name="android:paddingEnd">5dp</item>
-        <item name="android:minWidth">0dp</item>
-    </style>
-
 </resources>

--- a/library/ui-styles/src/main/res/values/theme_common.xml
+++ b/library/ui-styles/src/main/res/values/theme_common.xml
@@ -25,4 +25,10 @@
         <item name="android:backgroundDimEnabled">false</item>
     </style>
 
+    <style name="Theme.Vector.ActionButton" parent="@android:style/Widget.ActionButton">
+        <item name="android:paddingStart">5dp</item>
+        <item name="android:paddingEnd">5dp</item>
+        <item name="android:minWidth">0dp</item>
+    </style>
+
 </resources>

--- a/library/ui-styles/src/main/res/values/theme_dark.xml
+++ b/library/ui-styles/src/main/res/values/theme_dark.xml
@@ -141,6 +141,9 @@
         <item name="vctr_keyword_style">@style/Widget.Vector.Keyword</item>
 
         <item name="vctr_toast_background">@color/vctr_toast_background_dark</item>
+
+        <item name="android:actionButtonStyle">@style/Theme.Vector.ActionButton</item>
+
     </style>
 
     <style name="Theme.Vector.Dark" parent="Base.Theme.Vector.Dark" />

--- a/library/ui-styles/src/main/res/values/theme_dark.xml
+++ b/library/ui-styles/src/main/res/values/theme_dark.xml
@@ -142,7 +142,7 @@
 
         <item name="vctr_toast_background">@color/vctr_toast_background_dark</item>
 
-        <item name="android:actionButtonStyle">@style/Theme.Vector.ActionButton</item>
+        <item name="android:actionButtonStyle">@style/Widget.Vector.ActionButton</item>
 
     </style>
 

--- a/library/ui-styles/src/main/res/values/theme_light.xml
+++ b/library/ui-styles/src/main/res/values/theme_light.xml
@@ -142,7 +142,12 @@
         <item name="vctr_keyword_style">@style/Widget.Vector.Keyword</item>
 
         <item name="vctr_toast_background">@color/vctr_toast_background_light</item>
+
+        <item name="android:actionButtonStyle">@style/Theme.Vector.ActionButton</item>
+
     </style>
+
+
 
     <style name="Theme.Vector.Light" parent="Base.Theme.Vector.Light" />
 

--- a/library/ui-styles/src/main/res/values/theme_light.xml
+++ b/library/ui-styles/src/main/res/values/theme_light.xml
@@ -143,11 +143,9 @@
 
         <item name="vctr_toast_background">@color/vctr_toast_background_light</item>
 
-        <item name="android:actionButtonStyle">@style/Theme.Vector.ActionButton</item>
+        <item name="android:actionButtonStyle">@style/Widget.Vector.ActionButton</item>
 
     </style>
-
-
 
     <style name="Theme.Vector.Light" parent="Base.Theme.Vector.Light" />
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1615,7 +1615,6 @@ class TimelineFragment @Inject constructor(
 
     private fun renderToolbar(roomSummary: RoomSummary?) {
         if (!isThreadTimeLine()) {
-            views.includeRoomToolbar.roomToolbarSubtitleView.isVisible = false
             views.includeRoomToolbar.roomToolbarContentView.isVisible = true
             views.includeThreadToolbar.roomToolbarThreadConstraintLayout.isVisible = false
             if (roomSummary == null) {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1545,7 +1545,7 @@ class TimelineFragment @Inject constructor(
     override fun invalidate() = withState(timelineViewModel, messageComposerViewModel) { mainState, messageComposerState ->
         invalidateOptionsMenu()
         val summary = mainState.asyncRoomSummary()
-        renderToolbar(summary, mainState.formattedTypingUsers)
+        renderToolbar(summary)
         renderTypingMessageNotification(summary, mainState)
         views.removeJitsiWidgetView.render(mainState)
         if (mainState.hasFailedSending) {
@@ -1614,7 +1614,7 @@ class TimelineFragment @Inject constructor(
         }
     }
 
-    private fun renderToolbar(roomSummary: RoomSummary?, typingMessage: String?) {
+    private fun renderToolbar(roomSummary: RoomSummary?) {
         if (!isThreadTimeLine()) {
             views.includeRoomToolbar.roomToolbarContentView.isVisible = true
             views.includeThreadToolbar.roomToolbarThreadConstraintLayout.isVisible = false
@@ -1624,7 +1624,7 @@ class TimelineFragment @Inject constructor(
                 views.includeRoomToolbar.roomToolbarContentView.isClickable = roomSummary.membership == Membership.JOIN
                 views.includeRoomToolbar.roomToolbarTitleView.text = roomSummary.displayName
                 avatarRenderer.render(roomSummary.toMatrixItem(), views.includeRoomToolbar.roomToolbarAvatarImageView)
-                renderSubTitle(typingMessage, roomSummary.topic)
+                renderSubTitle(roomSummary.topic)
                 views.includeRoomToolbar.roomToolbarDecorationImageView.render(roomSummary.roomEncryptionTrustLevel)
                 views.includeRoomToolbar.roomToolbarPresenceImageView.render(roomSummary.isDirect, roomSummary.directUserPresence)
                 views.includeRoomToolbar.roomToolbarPublicImageView.isVisible = roomSummary.isPublic && !roomSummary.isDirect
@@ -1642,18 +1642,11 @@ class TimelineFragment @Inject constructor(
         }
     }
 
-    private fun renderSubTitle(typingMessage: String?, topic: String) {
-        // TODO Temporary place to put typing data
-        val subtitle = typingMessage?.takeIf { it.isNotBlank() } ?: topic
+    private fun renderSubTitle(topic: String) {
         views.includeRoomToolbar.roomToolbarSubtitleView.apply {
-            setTextOrHide(subtitle)
-            if (typingMessage.isNullOrBlank()) {
-                setTextColor(colorProvider.getColorFromAttribute(R.attr.vctr_content_secondary))
-                setTypeface(null, Typeface.NORMAL)
-            } else {
-                setTextColor(colorProvider.getColorFromAttribute(R.attr.colorPrimary))
-                setTypeface(null, Typeface.BOLD)
-            }
+            setTextOrHide(topic)
+            setTextColor(colorProvider.getColorFromAttribute(R.attr.colorPrimary))
+            setTypeface(null, Typeface.BOLD)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -21,7 +21,6 @@ import android.app.Activity
 import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.Color
-import android.graphics.Typeface
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -1616,6 +1615,7 @@ class TimelineFragment @Inject constructor(
 
     private fun renderToolbar(roomSummary: RoomSummary?) {
         if (!isThreadTimeLine()) {
+            views.includeRoomToolbar.roomToolbarSubtitleView.isVisible = false
             views.includeRoomToolbar.roomToolbarContentView.isVisible = true
             views.includeThreadToolbar.roomToolbarThreadConstraintLayout.isVisible = false
             if (roomSummary == null) {
@@ -1624,7 +1624,6 @@ class TimelineFragment @Inject constructor(
                 views.includeRoomToolbar.roomToolbarContentView.isClickable = roomSummary.membership == Membership.JOIN
                 views.includeRoomToolbar.roomToolbarTitleView.text = roomSummary.displayName
                 avatarRenderer.render(roomSummary.toMatrixItem(), views.includeRoomToolbar.roomToolbarAvatarImageView)
-                renderSubTitle(roomSummary.topic)
                 views.includeRoomToolbar.roomToolbarDecorationImageView.render(roomSummary.roomEncryptionTrustLevel)
                 views.includeRoomToolbar.roomToolbarPresenceImageView.render(roomSummary.isDirect, roomSummary.directUserPresence)
                 views.includeRoomToolbar.roomToolbarPublicImageView.isVisible = roomSummary.isPublic && !roomSummary.isDirect
@@ -1639,14 +1638,6 @@ class TimelineFragment @Inject constructor(
                 views.includeThreadToolbar.roomToolbarThreadSubtitleTextView.text = it.displayName
             }
             views.includeThreadToolbar.roomToolbarThreadTitleTextView.text = resources.getText(R.string.thread_timeline_title)
-        }
-    }
-
-    private fun renderSubTitle(topic: String) {
-        views.includeRoomToolbar.roomToolbarSubtitleView.apply {
-            setTextOrHide(topic)
-            setTextColor(colorProvider.getColorFromAttribute(R.attr.colorPrimary))
-            setTypeface(null, Typeface.BOLD)
         }
     }
 

--- a/vector/src/main/res/layout/view_room_detail_toolbar.xml
+++ b/vector/src/main/res/layout/view_room_detail_toolbar.xml
@@ -23,10 +23,10 @@
         android:id="@+id/roomToolbarDecorationImageView"
         android:layout_width="11dp"
         android:layout_height="13dp"
-        tools:ignore="MissingConstraints"
         app:layout_constraintCircle="@id/roomToolbarAvatarImageView"
         app:layout_constraintCircleAngle="120"
-        app:layout_constraintCircleRadius="18dp"/>
+        app:layout_constraintCircleRadius="18dp"
+        tools:ignore="MissingConstraints" />
 
     <im.vector.app.core.ui.views.PresenceStateImageView
         android:id="@+id/roomToolbarPresenceImageView"
@@ -69,31 +69,13 @@
         android:maxLines="1"
         android:textAlignment="viewStart"
         android:textAppearance="@style/TextAppearance.Vector.Widget.ActionBarTitle"
-        app:layout_constraintBottom_toTopOf="@id/roomToolbarSubtitleView"
+        app:layout_constraintBottom_toBottomOf="@id/roomToolbarAvatarImageView"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@id/roomToolbarDecorationImageView"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toTopOf="@id/roomToolbarAvatarImageView"
         app:layout_constraintVertical_chainStyle="packed"
         app:layout_goneMarginStart="7dp"
         tools:text="@sample/rooms.json/data/name" />
-
-    <TextView
-        android:id="@+id/roomToolbarSubtitleView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
-        android:layout_marginEnd="12dp"
-        android:ellipsize="end"
-        android:maxLines="1"
-        android:textAlignment="viewStart"
-        android:textAppearance="@style/TextAppearance.Vector.Widget.ActionBarSubTitle"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toEndOf="@id/roomToolbarAvatarImageView"
-        app:layout_constraintTop_toBottomOf="@id/roomToolbarTitleView"
-        tools:text="@sample/rooms.json/data/topic"
-        tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/main/res/layout/view_room_detail_toolbar.xml
+++ b/vector/src/main/res/layout/view_room_detail_toolbar.xml
@@ -9,8 +9,8 @@
 
     <ImageView
         android:id="@+id/roomToolbarAvatarImageView"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="34dp"
+        android:layout_height="34dp"
         android:layout_marginTop="8dp"
         android:layout_marginBottom="8dp"
         android:importantForAccessibility="no"
@@ -21,17 +21,16 @@
 
     <im.vector.app.core.ui.views.ShieldImageView
         android:id="@+id/roomToolbarDecorationImageView"
-        android:layout_width="17dp"
-        android:layout_height="17dp"
-        android:layout_marginStart="5dp"
-        android:layout_marginTop="2dp"
-        app:layout_constraintBottom_toBottomOf="@id/roomToolbarTitleView"
-        app:layout_constraintStart_toEndOf="@id/roomToolbarAvatarImageView"
-        app:layout_constraintTop_toTopOf="@id/roomToolbarTitleView" />
+        android:layout_width="11dp"
+        android:layout_height="13dp"
+        tools:ignore="MissingConstraints"
+        app:layout_constraintCircle="@id/roomToolbarAvatarImageView"
+        app:layout_constraintCircleAngle="120"
+        app:layout_constraintCircleRadius="18dp"/>
 
     <im.vector.app.core.ui.views.PresenceStateImageView
         android:id="@+id/roomToolbarPresenceImageView"
-        android:layout_width="12dp"
+        android:layout_width="11dp"
         android:layout_height="12dp"
         android:background="@drawable/background_circle"
         android:padding="2dp"
@@ -41,8 +40,10 @@
         app:layout_constraintCircleRadius="20dp"
         tools:ignore="MissingConstraints"
         tools:layout_constraintCircleRadius="8dp"
+        tools:layout_editor_absoluteX="17dp"
+        tools:layout_editor_absoluteY="365dp"
         tools:src="@drawable/ic_presence_offline"
-        tools:visibility="visible" />
+        tools:visibility="invisible" />
 
     <ImageView
         android:id="@+id/roomToolbarPublicImageView"
@@ -57,13 +58,13 @@
         app:layout_constraintCircleAngle="135"
         app:layout_constraintCircleRadius="20dp"
         tools:ignore="MissingConstraints"
-        tools:visibility="visible" />
+        tools:visibility="invisible" />
 
     <TextView
         android:id="@+id/roomToolbarTitleView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="4dp"
+        android:layout_marginStart="12dp"
         android:layout_marginEnd="8dp"
         android:ellipsize="end"
         android:maxLines="1"
@@ -82,8 +83,8 @@
         android:id="@+id/roomToolbarSubtitleView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="7dp"
-        android:layout_marginEnd="8dp"
+        android:layout_marginStart="12dp"
+        android:layout_marginEnd="12dp"
         android:ellipsize="end"
         android:maxLines="1"
         android:textAlignment="viewStart"

--- a/vector/src/main/res/layout/view_room_detail_toolbar.xml
+++ b/vector/src/main/res/layout/view_room_detail_toolbar.xml
@@ -36,14 +36,13 @@
         android:padding="2dp"
         android:visibility="gone"
         app:layout_constraintCircle="@id/roomToolbarAvatarImageView"
-        app:layout_constraintCircleAngle="135"
-        app:layout_constraintCircleRadius="20dp"
+        app:layout_constraintCircleAngle="0"
+        app:layout_constraintCircleRadius="0dp"
         tools:ignore="MissingConstraints"
-        tools:layout_constraintCircleRadius="8dp"
-        tools:layout_editor_absoluteX="17dp"
-        tools:layout_editor_absoluteY="365dp"
+        tools:layout_constraintCircleAngle="60"
+        tools:layout_constraintCircleRadius="18dp"
         tools:src="@drawable/ic_presence_offline"
-        tools:visibility="invisible" />
+        tools:visibility="visible" />
 
     <ImageView
         android:id="@+id/roomToolbarPublicImageView"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context
 - Update the Shield and the ON/OFF notification within the Room toolbar image. 
 - Remove the subtitle
 - reduce extra padding for the menu item icons. 
 
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

Dark | Light
--- | --- 
<img width="385" alt="Capture d’écran 2022-02-23 à 17 31 24" src="https://user-images.githubusercontent.com/73594434/155373832-bf53154d-3709-442f-99d9-d87e821d0689.png"> | <img width="402" alt="Capture d’écran 2022-02-23 à 17 31 30" src="https://user-images.githubusercontent.com/73594434/155373859-42d366e1-0a9a-4af9-8a9d-040b677ecf4d.png">

<!-- Only if UI have been changed -->

## Tests
 - Access to a timeline and check the toolbar. 
<!-- Explain how you tested your development -->

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
