### PR TITLE
Increase max heap size for build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@
 # The setting is particularly useful for tweaking memory settings.
 
 # Build Time Optimizations
-org.gradle.jvmargs=-Xmx3g -Xms512M -XX:MaxPermSize=2048m -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx4g -Xms512M -XX:MaxPermSize=2048m -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.vfs.watch=true


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

The F-Droid build ran OOM during R8 shrinking with 3GB, but worked fine with 4GB. The failure didn't seem F-Droid-specific, so I'm upstreaming this patch. Do with it what you want :)

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Tests

- Try to build Element 1.4.0 for F-Droid
- See the build fail
- [Increase the max heap size to 4GB](https://gitlab.com/fdroid/fdroiddata/-/commit/fed4824ecc6b657ca01e3250efc6f5d4ccc32eb1)
- [See the build succeed](https://monitor.f-droid.org/builds/log/im.vector.app/40104000#site-footer)

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
