### PR TITLE
Fixing missing identify properties 

### DIFF
--- a/changelog.d/5234.bugfix
+++ b/changelog.d/5234.bugfix
@@ -1,0 +1,1 @@
+Analytics: Fixes missing use case identity values from within the onboarding flow

--- a/vector/src/main/java/im/vector/app/core/di/NamedGlobalScope.kt
+++ b/vector/src/main/java/im/vector/app/core/di/NamedGlobalScope.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class NamedGlobalScope

--- a/vector/src/main/java/im/vector/app/core/di/SingletonModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/SingletonModule.kt
@@ -28,11 +28,13 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import im.vector.app.EmojiCompatWrapper
 import im.vector.app.EmojiSpanify
+import im.vector.app.config.analyticsConfig
 import im.vector.app.core.dispatchers.CoroutineDispatchers
 import im.vector.app.core.error.DefaultErrorFormatter
 import im.vector.app.core.error.ErrorFormatter
 import im.vector.app.core.time.Clock
 import im.vector.app.core.time.DefaultClock
+import im.vector.app.features.analytics.AnalyticsConfig
 import im.vector.app.features.analytics.AnalyticsTracker
 import im.vector.app.features.analytics.VectorAnalytics
 import im.vector.app.features.analytics.impl.DefaultVectorAnalytics
@@ -154,5 +156,10 @@ object VectorStaticModule {
     @NamedGlobalScope
     fun providesGlobalScope(): CoroutineScope {
         return GlobalScope
+    }
+
+    @Provides
+    fun providesAnalyticsConfig(): AnalyticsConfig {
+        return analyticsConfig
     }
 }

--- a/vector/src/main/java/im/vector/app/core/di/SingletonModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/SingletonModule.kt
@@ -46,6 +46,7 @@ import im.vector.app.features.ui.SharedPreferencesUiStateRepository
 import im.vector.app.features.ui.UiStateRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.SupervisorJob
 import org.matrix.android.sdk.api.Matrix
 import org.matrix.android.sdk.api.auth.AuthenticationService
@@ -146,5 +147,12 @@ object VectorStaticModule {
     @Provides
     fun providesCoroutineDispatchers(): CoroutineDispatchers {
         return CoroutineDispatchers(io = Dispatchers.IO, computation = Dispatchers.Default)
+    }
+
+    @Suppress("EXPERIMENTAL_API_USAGE")
+    @Provides
+    @NamedGlobalScope
+    fun providesGlobalScope(): CoroutineScope {
+        return GlobalScope
     }
 }

--- a/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
@@ -40,16 +40,28 @@ private val IGNORED_OPTIONS: Options? = null
 
 @Singleton
 class DefaultVectorAnalytics @Inject constructor(
-        private val postHogFactory: PostHogFactory,
+        postHogFactory: PostHogFactory,
+        analyticsConfig: AnalyticsConfig,
         private val analyticsStore: AnalyticsStore,
-        private val analyticsConfig: AnalyticsConfig,
         @NamedGlobalScope private val globalScope: CoroutineScope
 ) : VectorAnalytics {
-    private var posthog: PostHog? = null
+
+    private val posthog: PostHog? = when {
+        analyticsConfig.isEnabled -> postHogFactory.createPosthog()
+        else                      -> {
+            Timber.tag(analyticsTag.value).w("Analytics is disabled")
+            null
+        }
+    }
 
     // Cache for the store values
     private var userConsent: Boolean? = null
     private var analyticsId: String? = null
+
+    override fun init() {
+        observeUserConsent()
+        observeAnalyticsId()
+    }
 
     override fun getUserConsent(): Flow<Boolean> {
         return analyticsStore.userConsentFlow
@@ -83,12 +95,6 @@ class DefaultVectorAnalytics @Inject constructor(
         setAnalyticsId("")
     }
 
-    override fun init() {
-        createAnalyticsClient()
-        observeUserConsent()
-        observeAnalyticsId()
-    }
-
     private fun observeAnalyticsId() {
         getAnalyticsId()
                 .onEach { id ->
@@ -113,7 +119,6 @@ class DefaultVectorAnalytics @Inject constructor(
     private fun observeUserConsent() {
         getUserConsent()
                 .onEach { consent ->
-                    println("!!!, got consent: $consent")
                     Timber.tag(analyticsTag.value).d("User consent updated to $consent")
                     userConsent = consent
                     optOutPostHog()
@@ -125,20 +130,6 @@ class DefaultVectorAnalytics @Inject constructor(
         userConsent?.let { posthog?.optOut(!it) }
     }
 
-    private fun createAnalyticsClient() {
-        Timber.tag(analyticsTag.value).d("createAnalyticsClient()")
-
-        if (analyticsConfig.isEnabled.not()) {
-            Timber.tag(analyticsTag.value).w("Analytics is disabled")
-            return
-        }
-
-        posthog = postHogFactory.createPosthog()
-
-        optOutPostHog()
-        identifyPostHog()
-    }
-
     override fun capture(event: VectorAnalyticsEvent) {
         Timber.tag(analyticsTag.value).d("capture($event)")
         posthog
@@ -148,9 +139,6 @@ class DefaultVectorAnalytics @Inject constructor(
 
     override fun screen(screen: VectorAnalyticsScreen) {
         Timber.tag(analyticsTag.value).d("screen($screen)")
-
-        println("userconsnet: $userConsent")
-
         posthog
                 ?.takeIf { userConsent == true }
                 ?.screen(screen.getName(), screen.getProperties()?.toPostHogProperties())

--- a/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
@@ -113,6 +113,7 @@ class DefaultVectorAnalytics @Inject constructor(
     private fun observeUserConsent() {
         getUserConsent()
                 .onEach { consent ->
+                    println("!!!, got consent: $consent")
                     Timber.tag(analyticsTag.value).d("User consent updated to $consent")
                     userConsent = consent
                     optOutPostHog()
@@ -147,6 +148,9 @@ class DefaultVectorAnalytics @Inject constructor(
 
     override fun screen(screen: VectorAnalyticsScreen) {
         Timber.tag(analyticsTag.value).d("screen($screen)")
+
+        println("userconsnet: $userConsent")
+
         posthog
                 ?.takeIf { userConsent == true }
                 ?.screen(screen.getName(), screen.getProperties()?.toPostHogProperties())

--- a/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
@@ -43,6 +43,7 @@ class DefaultVectorAnalytics @Inject constructor(
         postHogFactory: PostHogFactory,
         analyticsConfig: AnalyticsConfig,
         private val analyticsStore: AnalyticsStore,
+        private val lateInitUserPropertiesFactory: LateInitUserPropertiesFactory,
         @NamedGlobalScope private val globalScope: CoroutineScope
 ) : VectorAnalytics {
 
@@ -105,14 +106,14 @@ class DefaultVectorAnalytics @Inject constructor(
                 .launchIn(globalScope)
     }
 
-    private fun identifyPostHog() {
+    private suspend fun identifyPostHog() {
         val id = analyticsId ?: return
         if (id.isEmpty()) {
             Timber.tag(analyticsTag.value).d("reset")
             posthog?.reset()
         } else {
             Timber.tag(analyticsTag.value).d("identify")
-            posthog?.identify(id)
+            posthog?.identify(id, lateInitUserPropertiesFactory.createUserProperties()?.getProperties()?.toPostHogUserProperties(), IGNORED_OPTIONS)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
@@ -22,13 +22,14 @@ import com.posthog.android.PostHog
 import com.posthog.android.Properties
 import im.vector.app.BuildConfig
 import im.vector.app.config.analyticsConfig
+import im.vector.app.core.di.NamedGlobalScope
 import im.vector.app.features.analytics.VectorAnalytics
 import im.vector.app.features.analytics.itf.VectorAnalyticsEvent
 import im.vector.app.features.analytics.itf.VectorAnalyticsScreen
 import im.vector.app.features.analytics.log.analyticsTag
 import im.vector.app.features.analytics.plan.UserProperties
 import im.vector.app.features.analytics.store.AnalyticsStore
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -42,7 +43,8 @@ private val IGNORED_OPTIONS: Options? = null
 @Singleton
 class DefaultVectorAnalytics @Inject constructor(
         private val context: Context,
-        private val analyticsStore: AnalyticsStore
+        private val analyticsStore: AnalyticsStore,
+        @NamedGlobalScope private val globalScope: CoroutineScope
 ) : VectorAnalytics {
     private var posthog: PostHog? = null
 
@@ -88,7 +90,6 @@ class DefaultVectorAnalytics @Inject constructor(
         createAnalyticsClient()
     }
 
-    @Suppress("EXPERIMENTAL_API_USAGE")
     private fun observeAnalyticsId() {
         getAnalyticsId()
                 .onEach { id ->
@@ -96,7 +97,7 @@ class DefaultVectorAnalytics @Inject constructor(
                     analyticsId = id
                     identifyPostHog()
                 }
-                .launchIn(GlobalScope)
+                .launchIn(globalScope)
     }
 
     private fun identifyPostHog() {
@@ -110,7 +111,6 @@ class DefaultVectorAnalytics @Inject constructor(
         }
     }
 
-    @Suppress("EXPERIMENTAL_API_USAGE")
     private fun observeUserConsent() {
         getUserConsent()
                 .onEach { consent ->
@@ -118,7 +118,7 @@ class DefaultVectorAnalytics @Inject constructor(
                     userConsent = consent
                     optOutPostHog()
                 }
-                .launchIn(GlobalScope)
+                .launchIn(globalScope)
     }
 
     private fun optOutPostHog() {

--- a/vector/src/main/java/im/vector/app/features/analytics/impl/LateInitUserPropertiesFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/impl/LateInitUserPropertiesFactory.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.analytics.impl
+
+import android.content.Context
+import im.vector.app.ActiveSessionDataSource
+import im.vector.app.core.extensions.vectorStore
+import im.vector.app.features.analytics.extensions.toTrackingValue
+import im.vector.app.features.analytics.plan.UserProperties
+import javax.inject.Inject
+
+class LateInitUserPropertiesFactory @Inject constructor(
+        private val activeSessionDataSource: ActiveSessionDataSource,
+        private val context: Context,
+) {
+    suspend fun createUserProperties(): UserProperties? {
+        val useCase = activeSessionDataSource.currentValue?.orNull()?.vectorStore(context)?.readUseCase()
+        return useCase?.let {
+            UserProperties(ftueUseCaseSelection = it.toTrackingValue())
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/analytics/impl/PostHogFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/impl/PostHogFactory.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.analytics.impl
+
+import android.content.Context
+import com.posthog.android.PostHog
+import im.vector.app.BuildConfig
+import im.vector.app.config.analyticsConfig
+import javax.inject.Inject
+
+class PostHogFactory @Inject constructor(private val context: Context) {
+
+    fun createPosthog(): PostHog {
+        return PostHog.Builder(context, analyticsConfig.postHogApiKey, analyticsConfig.postHogHost)
+                // Record certain application events automatically! (off/false by default)
+                // .captureApplicationLifecycleEvents()
+                // Record screen views automatically! (off/false by default)
+                // .recordScreenViews()
+                // Capture deep links as part of the screen call. (off by default)
+                // .captureDeepLinks()
+                // Maximum number of events to keep in queue before flushing (default 20)
+                // .flushQueueSize(20)
+                // Max delay before flushing the queue (30 seconds)
+                // .flushInterval(30, TimeUnit.SECONDS)
+                // Enable or disable collection of ANDROID_ID (true)
+                .collectDeviceId(false)
+                .logLevel(getLogLevel())
+                .build()
+    }
+
+    private fun getLogLevel(): PostHog.LogLevel {
+        return if (BuildConfig.DEBUG) {
+            PostHog.LogLevel.DEBUG
+        } else {
+            PostHog.LogLevel.INFO
+        }
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/analytics/impl/DefaultVectorAnalyticsTest.kt
+++ b/vector/src/test/java/im/vector/app/features/analytics/impl/DefaultVectorAnalyticsTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.analytics.impl
+
+import com.posthog.android.Properties
+import im.vector.app.features.analytics.itf.VectorAnalyticsEvent
+import im.vector.app.features.analytics.itf.VectorAnalyticsScreen
+import im.vector.app.test.fakes.FakeAnalyticsStore
+import im.vector.app.test.fakes.FakePostHog
+import im.vector.app.test.fakes.FakePostHogFactory
+import im.vector.app.test.fixtures.AnalyticsConfigFixture.anAnalyticsConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+
+private const val AN_ANALYTICS_ID = "analytics-id"
+private val A_SCREEN_EVENT = object : VectorAnalyticsScreen {
+    override fun getName() = "a-screen-event-name"
+    override fun getProperties() = mapOf("property-name" to "property-value")
+}
+private val AN_EVENT = object : VectorAnalyticsEvent {
+    override fun getName() = "an-event-name"
+    override fun getProperties() = mapOf("property-name" to "property-value")
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultVectorAnalyticsTest {
+
+    private val fakePostHog = FakePostHog()
+    private val fakeAnalyticsStore = FakeAnalyticsStore()
+
+    private val defaultVectorAnalytics = DefaultVectorAnalytics(
+            postHogFactory = FakePostHogFactory(fakePostHog.instance).instance,
+            analyticsStore = fakeAnalyticsStore.instance,
+            globalScope = CoroutineScope(Dispatchers.Unconfined),
+            analyticsConfig = anAnalyticsConfig(isEnabled = true)
+    )
+
+    @Before
+    fun setUp() {
+        defaultVectorAnalytics.init()
+    }
+
+    @Test
+    fun `when setting user consent then updates analytics store`() = runBlockingTest {
+        defaultVectorAnalytics.setUserConsent(true)
+
+        fakeAnalyticsStore.verifyConsentUpdated(updatedValue = true)
+    }
+
+    @Test
+    fun `when consenting to analytics then updates posthog opt out to false`() = runBlockingTest {
+        fakeAnalyticsStore.givenUserContent(consent = true)
+
+        fakePostHog.verifyOptOutStatus(optedOut = false)
+    }
+
+    @Test
+    fun `when revoking consent to analytics then updates posthog opt out to true`() = runBlockingTest {
+        fakeAnalyticsStore.givenUserContent(consent = false)
+
+        fakePostHog.verifyOptOutStatus(optedOut = true)
+    }
+
+    @Test
+    fun `when setting the analytics id then updates analytics store`() = runBlockingTest {
+        defaultVectorAnalytics.setAnalyticsId(AN_ANALYTICS_ID)
+
+        fakeAnalyticsStore.verifyAnalyticsIdUpdated(updatedValue = AN_ANALYTICS_ID)
+    }
+
+    @Test
+    fun `when valid analytics id updates then identify`() = runBlockingTest {
+        fakeAnalyticsStore.givenAnalyticsId(AN_ANALYTICS_ID)
+
+        fakePostHog.verifyIdentifies(AN_ANALYTICS_ID)
+    }
+
+    @Test
+    fun `when signing out analytics id updates then resets`() = runBlockingTest {
+        fakeAnalyticsStore.allowSettingAnalyticsIdToCallBackingFlow()
+
+        defaultVectorAnalytics.onSignOut()
+
+        fakePostHog.verifyReset()
+    }
+
+    @Test
+    fun `given user consent when tracking screen events then submits to posthog`() = runBlockingTest {
+        fakeAnalyticsStore.givenUserContent(consent = true)
+
+        defaultVectorAnalytics.screen(A_SCREEN_EVENT)
+
+        fakePostHog.verifyScreenTracked(A_SCREEN_EVENT.getName(), Properties().also {
+            it.putAll(A_SCREEN_EVENT.getProperties())
+        })
+    }
+
+    @Test
+    fun `given user has not consented when tracking screen events then does not track`() = runBlockingTest {
+        fakeAnalyticsStore.givenUserContent(consent = false)
+
+        defaultVectorAnalytics.screen(A_SCREEN_EVENT)
+
+        fakePostHog.verifyNoScreenTracking()
+    }
+
+    @Test
+    fun `given user consent when tracking events then submits to posthog`() = runBlockingTest {
+        fakeAnalyticsStore.givenUserContent(consent = true)
+
+        defaultVectorAnalytics.capture(AN_EVENT)
+
+        fakePostHog.verifyEventTracked(AN_EVENT.getName(), Properties().also {
+            it.putAll(AN_EVENT.getProperties())
+        })
+    }
+
+    @Test
+    fun `given user has not consented when tracking events then does not track`() = runBlockingTest {
+        fakeAnalyticsStore.givenUserContent(consent = false)
+
+        defaultVectorAnalytics.capture(AN_EVENT)
+
+        fakePostHog.verifyNoEventTracking()
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/analytics/impl/LateInitUserPropertiesFactoryTest.kt
+++ b/vector/src/test/java/im/vector/app/features/analytics/impl/LateInitUserPropertiesFactoryTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.analytics.impl
+
+import im.vector.app.features.analytics.plan.UserProperties
+import im.vector.app.features.onboarding.FtueUseCase
+import im.vector.app.test.fakes.FakeActiveSessionDataSource
+import im.vector.app.test.fakes.FakeContext
+import im.vector.app.test.fakes.FakeSession
+import im.vector.app.test.fakes.FakeVectorStore
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class LateInitUserPropertiesFactoryTest {
+
+    private val fakeActiveSessionDataSource = FakeActiveSessionDataSource()
+    private val fakeVectorStore = FakeVectorStore()
+    private val fakeContext = FakeContext()
+    private val fakeSession = FakeSession().also {
+        it.givenVectorStore(fakeVectorStore.instance)
+    }
+
+    private val lateInitUserProperties = LateInitUserPropertiesFactory(
+            fakeActiveSessionDataSource.instance,
+            fakeContext.instance
+    )
+
+    @Test
+    fun `given no active session when creating properties then returns null`() = runBlockingTest {
+        val result = lateInitUserProperties.createUserProperties()
+
+        result shouldBeEqualTo null
+    }
+
+    @Test
+    fun `given no use case set on an active session when creating properties then returns null`() = runBlockingTest {
+        fakeVectorStore.givenUseCase(null)
+        fakeSession.givenVectorStore(fakeVectorStore.instance)
+        fakeActiveSessionDataSource.setActiveSession(fakeSession)
+
+        val result = lateInitUserProperties.createUserProperties()
+
+        result shouldBeEqualTo null
+    }
+
+    @Test
+    fun `given use case set on an active session when creating properties then includes the use case`() = runBlockingTest {
+        fakeVectorStore.givenUseCase(FtueUseCase.TEAMS)
+        fakeActiveSessionDataSource.setActiveSession(fakeSession)
+        val result = lateInitUserProperties.createUserProperties()
+
+        result shouldBeEqualTo UserProperties(
+                ftueUseCaseSelection = UserProperties.FtueUseCaseSelection.WorkMessaging
+        )
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeActiveSessionDataSource.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeActiveSessionDataSource.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import arrow.core.Option
+import im.vector.app.ActiveSessionDataSource
+import org.matrix.android.sdk.api.session.Session
+
+class FakeActiveSessionDataSource {
+
+    val instance = ActiveSessionDataSource()
+
+    fun setActiveSession(session: Session) {
+        instance.post(Option.just(session))
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeAnalyticsStore.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeAnalyticsStore.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import im.vector.app.features.analytics.store.AnalyticsStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+
+class FakeAnalyticsStore {
+
+    private val _consentFlow = MutableSharedFlow<Boolean>()
+    private val _idFlow = MutableSharedFlow<String>()
+
+    val instance = mockk<AnalyticsStore>(relaxed = true) {
+        every { userConsentFlow } returns _consentFlow
+        every { analyticsIdFlow } returns _idFlow
+    }
+
+    fun allowSettingAnalyticsIdToCallBackingFlow() {
+        coEvery { instance.setAnalyticsId(any()) } answers {
+            runBlocking { _idFlow.emit(firstArg()) }
+        }
+    }
+
+    fun verifyConsentUpdated(updatedValue: Boolean) {
+        coVerify { instance.setUserConsent(updatedValue) }
+    }
+
+    suspend fun givenUserContent(consent: Boolean) {
+        _consentFlow.emit(consent)
+    }
+
+    fun verifyAnalyticsIdUpdated(updatedValue: String) {
+        coVerify { instance.setAnalyticsId(updatedValue) }
+    }
+
+    suspend fun givenAnalyticsId(id: String) {
+        _idFlow.emit(id)
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeLateInitUserPropertiesFactory.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeLateInitUserPropertiesFactory.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import im.vector.app.features.analytics.impl.LateInitUserPropertiesFactory
+import im.vector.app.features.analytics.plan.UserProperties
+import io.mockk.coEvery
+import io.mockk.mockk
+
+class FakeLateInitUserPropertiesFactory {
+
+    val instance = mockk<LateInitUserPropertiesFactory>()
+
+    fun givenCreatesProperties(userProperties: UserProperties?) {
+        coEvery { instance.createUserProperties() } returns userProperties
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakePostHog.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakePostHog.kt
@@ -19,6 +19,7 @@ package im.vector.app.test.fakes
 import android.os.Looper
 import com.posthog.android.PostHog
 import com.posthog.android.Properties
+import im.vector.app.features.analytics.plan.UserProperties
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -41,15 +42,20 @@ class FakePostHog {
         verify { instance.optOut(optedOut) }
     }
 
-    fun verifyIdentifies(analyticsId: String) {
-        verify { instance.identify(analyticsId) }
+    fun verifyIdentifies(analyticsId: String, userProperties: UserProperties?) {
+        verify {
+            val postHogProperties = userProperties?.getProperties()
+                    ?.let { rawProperties -> Properties().also { it.putAll(rawProperties) } }
+                    ?.takeIf { it.isNotEmpty() }
+            instance.identify(analyticsId, postHogProperties, null)
+        }
     }
 
     fun verifyReset() {
         verify { instance.reset() }
     }
 
-    fun verifyScreenTracked(name: String, properties: Properties) {
+    fun verifyScreenTracked(name: String, properties: Properties?) {
         verify { instance.screen(name, properties) }
     }
 
@@ -61,7 +67,7 @@ class FakePostHog {
         }
     }
 
-    fun verifyEventTracked(name: String, properties: Properties) {
+    fun verifyEventTracked(name: String, properties: Properties?) {
         verify { instance.capture(name, properties) }
     }
 

--- a/vector/src/test/java/im/vector/app/test/fakes/FakePostHog.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakePostHog.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import android.os.Looper
+import com.posthog.android.PostHog
+import com.posthog.android.Properties
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+
+class FakePostHog {
+
+    init {
+        // workaround to avoid PostHog.HANDLER failing
+        mockkStatic(Looper::class)
+        val looper = mockk<Looper> {
+            every { thread } returns Thread.currentThread()
+        }
+        every { Looper.getMainLooper() } returns looper
+    }
+
+    val instance = mockk<PostHog>(relaxed = true)
+
+    fun verifyOptOutStatus(optedOut: Boolean) {
+        verify { instance.optOut(optedOut) }
+    }
+
+    fun verifyIdentifies(analyticsId: String) {
+        verify { instance.identify(analyticsId) }
+    }
+
+    fun verifyReset() {
+        verify { instance.reset() }
+    }
+
+    fun verifyScreenTracked(name: String, properties: Properties) {
+        verify { instance.screen(name, properties) }
+    }
+
+    fun verifyNoScreenTracking() {
+        verify(exactly = 0) {
+            instance.screen(any())
+            instance.screen(any(), any())
+            instance.screen(any(), any(), any())
+        }
+    }
+
+    fun verifyEventTracked(name: String, properties: Properties) {
+        verify { instance.capture(name, properties) }
+    }
+
+    fun verifyNoEventTracking() {
+        verify(exactly = 0) {
+            instance.capture(any())
+            instance.capture(any(), any())
+            instance.capture(any(), any(), any())
+        }
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakePostHogFactory.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakePostHogFactory.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import com.posthog.android.PostHog
+import im.vector.app.features.analytics.impl.PostHogFactory
+import io.mockk.every
+import io.mockk.mockk
+
+class FakePostHogFactory(postHog: PostHog) {
+    val instance = mockk<PostHogFactory>().also {
+        every { it.createPosthog() } returns postHog
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeSession.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeSession.kt
@@ -16,8 +16,12 @@
 
 package im.vector.app.test.fakes
 
+import im.vector.app.core.extensions.vectorStore
+import im.vector.app.features.session.VectorSessionStore
 import im.vector.app.test.testCoroutineDispatchers
+import io.mockk.coEvery
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import org.matrix.android.sdk.api.session.Session
 
 class FakeSession(
@@ -25,7 +29,19 @@ class FakeSession(
         val fakeSharedSecretStorageService: FakeSharedSecretStorageService = FakeSharedSecretStorageService()
 ) : Session by mockk(relaxed = true) {
 
+    init {
+        mockkStatic("im.vector.app.core.extensions.SessionKt")
+    }
+
     override fun cryptoService() = fakeCryptoService
     override val sharedSecretStorageService = fakeSharedSecretStorageService
     override val coroutineDispatchers = testCoroutineDispatchers
+
+    fun givenVectorStore(vectorSessionStore: VectorSessionStore) {
+        coEvery {
+            this@FakeSession.vectorStore(any())
+        } coAnswers {
+            vectorSessionStore
+        }
+    }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorStore.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorStore.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import im.vector.app.features.onboarding.FtueUseCase
+import im.vector.app.features.session.VectorSessionStore
+import io.mockk.coEvery
+import io.mockk.mockk
+
+class FakeVectorStore {
+    val instance = mockk<VectorSessionStore>()
+
+    fun givenUseCase(useCase: FtueUseCase?) {
+        coEvery {
+            instance.readUseCase()
+        } coAnswers {
+            useCase
+        }
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fixtures/AnalyticsConfigFixture.kt
+++ b/vector/src/test/java/im/vector/app/test/fixtures/AnalyticsConfigFixture.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fixtures
+
+import im.vector.app.features.analytics.AnalyticsConfig
+
+object AnalyticsConfigFixture {
+    fun anAnalyticsConfig(
+            isEnabled: Boolean = false,
+            postHogHost: String = "http://posthog.url",
+            postHogApiKey: String = "api-key",
+            policyLink: String = "http://policy.link"
+    ) = object : AnalyticsConfig {
+        override val isEnabled: Boolean = isEnabled
+        override val postHogHost = postHogHost
+        override val postHogApiKey = postHogApiKey
+        override val policyLink = policyLink
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fixtures/UserPropertiesFixture.kt
+++ b/vector/src/test/java/im/vector/app/test/fixtures/UserPropertiesFixture.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fixtures
+
+import im.vector.app.features.analytics.plan.UserProperties
+import im.vector.app.features.analytics.plan.UserProperties.FtueUseCaseSelection
+
+fun aUserProperties(
+        ftueUseCase: FtueUseCaseSelection? = FtueUseCaseSelection.Skip
+) = UserProperties(
+        ftueUseCaseSelection = ftueUseCase
+)

--- a/vector/src/test/java/im/vector/app/test/fixtures/VectorAnalyticsFixture.kt
+++ b/vector/src/test/java/im/vector/app/test/fixtures/VectorAnalyticsFixture.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fixtures
+
+import im.vector.app.features.analytics.itf.VectorAnalyticsEvent
+import im.vector.app.features.analytics.itf.VectorAnalyticsScreen
+
+fun aVectorAnalyticsScreen(
+        name: String = "a-screen-name",
+        properties: Map<String, Any>? = null
+) = object : VectorAnalyticsScreen {
+    override fun getName() = name
+    override fun getProperties() = properties
+}
+
+fun aVectorAnalyticsEvent(
+        name: String = "an-event-name",
+        properties: Map<String, Any>? = null
+) = object : VectorAnalyticsEvent {
+    override fun getName() = name
+    override fun getProperties() = properties
+}


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Re-applies specified `UserProperties` each time the client does an initial `identify` (cold launches and on providing tracking consent)   
- Lifts the `GlobalScope` and `PostHog` creation to dagger providers for testability
- Adds unit tests around the `DefaultVectorAnalytics` and  `LateInitUserPropertiesFactory` which involves creating a bunch of fakes to enable testing

## Motivation and context

Fixes #5234 

Fixes the missing identity properties from within the onboarding flow (pre consent) specifically the onboarding use case. This was caused by `posthog.identify` being called whilst the client was opt'd out which unfortunately doesn't send the cached properties once consent is given, the fix is for us to manually send the stored properties as part of the initial identify which occurs after the user has consented for the first time or after during cold launch after consenting 

```json
"$set": {
  "ftueUseCaseSelection": "PersonalMessaging",
 ....
}
```

## Screenshots / GIFs

No UI changes

## Tests

Whilst observing https://posthog-poc.lab.element.dev/events, creating a new account and check the properties of the `identify` event

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Sv2 31