### PR TITLE
Incrementing schema version - fixes pre-release launch crash

### DIFF
--- a/changelog.d/5243.bugfix
+++ b/changelog.d/5243.bugfix
@@ -1,0 +1,1 @@
+Increments database schema to take advantage of homeserver capabilities entity migration (fixes crash in pre-release builds)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/RealmSessionStoreMigration.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/RealmSessionStoreMigration.kt
@@ -57,7 +57,7 @@ internal class RealmSessionStoreMigration @Inject constructor(
     override fun equals(other: Any?) = other is RealmSessionStoreMigration
     override fun hashCode() = 1000
 
-    val schemaVersion = 24L
+    val schemaVersion = 25L
 
     override fun migrate(realm: DynamicRealm, oldVersion: Long, newVersion: Long) {
         Timber.d("Migrating Realm Session from $oldVersion to $newVersion")


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Increments the session store database schema version in order to take into account the `HomeServerCapabilitiesEntity` migration.

## Motivation and context

Crash on launch due to missing migration #5243, this crash isn't live and only affects the pre-release/dev users

## Screenshots / GIFs
N/A

## Tests

- Installed 1.4.0
- Installed develop on top

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 10
