### PR TITLE
Draft : When accepting an invite, expecting to see the room

### DIFF
--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1578,12 +1578,21 @@ class TimelineFragment @Inject constructor(
                 views.hideComposerViews()
                 views.notificationAreaView.render(NotificationAreaView.State.Tombstone(mainState.tombstoneEvent))
             }
-        } else if (summary?.membership == Membership.INVITE && inviter != null) {
+        } else if (summary?.membership == Membership.INVITE && inviter != null && !timelineArgs.isInviteAlreadyAccepted ) {
             views.hideComposerViews()
             lazyLoadedViews.inviteView(true)?.apply {
                 callback = this@TimelineFragment
                 isVisible = true
-                render(inviter, VectorInviteView.Mode.LARGE, mainState.changeMembershipState)
+                render(inviter, VectorInviteView.Mode.LARGE, mainState.changeMembershipState, false)
+                setOnClickListener(null)
+            }
+            Unit
+        } else if (summary?.membership == Membership.INVITE && inviter != null && timelineArgs.isInviteAlreadyAccepted) {
+            views.hideComposerViews()
+            lazyLoadedViews.inviteView(true)?.apply {
+                callback = this@TimelineFragment
+                isVisible = true
+                render(inviter, VectorInviteView.Mode.LARGE, mainState.changeMembershipState, true)
                 setOnClickListener(null)
             }
             Unit

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/arguments/TimelineArgs.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/arguments/TimelineArgs.kt
@@ -28,5 +28,6 @@ data class TimelineArgs(
         val sharedData: SharedData? = null,
         val openShareSpaceForId: String? = null,
         val threadTimelineArgs: ThreadTimelineArgs? = null,
-        val switchToParentSpace: Boolean = false
+        val switchToParentSpace: Boolean = false,
+        val isInviteAlreadyAccepted: Boolean = false
 ) : Parcelable

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -121,7 +121,7 @@ class RoomListFragment @Inject constructor(
             when (it) {
                 is RoomListViewEvents.Loading                   -> showLoading(it.message)
                 is RoomListViewEvents.Failure                   -> showFailure(it.throwable)
-                is RoomListViewEvents.SelectRoom                -> handleSelectRoom(it)
+                is RoomListViewEvents.SelectRoom                -> handleSelectRoom(it, it.isInviteAlreadyAccepted)
                 is RoomListViewEvents.Done                      -> Unit
                 is RoomListViewEvents.NavigateToMxToBottomSheet -> handleShowMxToLink(it.link)
             }.exhaustive
@@ -184,8 +184,8 @@ class RoomListFragment @Inject constructor(
         super.onDestroyView()
     }
 
-    private fun handleSelectRoom(event: RoomListViewEvents.SelectRoom) {
-        navigator.openRoom(requireActivity(), event.roomSummary.roomId)
+    private fun handleSelectRoom(event: RoomListViewEvents.SelectRoom, isInviteAlreadyAccepted: Boolean?) {
+        navigator.openRoom(requireActivity(), event.roomSummary.roomId, isInviteAlreadyAccepted = isInviteAlreadyAccepted)
     }
 
     private fun setupCreateRoomButton() {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewEvents.kt
@@ -27,7 +27,7 @@ sealed class RoomListViewEvents : VectorViewEvents {
     data class Loading(val message: CharSequence? = null) : RoomListViewEvents()
     data class Failure(val throwable: Throwable) : RoomListViewEvents()
 
-    data class SelectRoom(val roomSummary: RoomSummary) : RoomListViewEvents()
+    data class SelectRoom(val roomSummary: RoomSummary, val isInviteAlreadyAccepted: Boolean?) : RoomListViewEvents()
     object Done : RoomListViewEvents()
     data class NavigateToMxToBottomSheet(val link: String) : RoomListViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/invite/VectorInviteView.kt
+++ b/vector/src/main/java/im/vector/app/features/invite/VectorInviteView.kt
@@ -56,7 +56,10 @@ class VectorInviteView @JvmOverloads constructor(context: Context, attrs: Attrib
         views.inviteRejectView.commonClicked = { callback?.onRejectInvite() }
     }
 
-    fun render(sender: RoomMemberSummary, mode: Mode = Mode.LARGE, changeMembershipState: ChangeMembershipState) {
+    fun render(sender: RoomMemberSummary, mode: Mode = Mode.LARGE, changeMembershipState: ChangeMembershipState, alreadyAccepted: Boolean) {
+        if (alreadyAccepted) {
+            callback?.onAcceptInvite()
+        }
         if (mode == Mode.LARGE) {
             updateLayoutParams { height = LayoutParams.MATCH_CONSTRAINT }
             avatarRenderer.render(sender.toMatrixItem(), views.inviteAvatarView)

--- a/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
@@ -147,13 +147,14 @@ class DefaultNavigator @Inject constructor(
             context: Context,
             roomId: String,
             eventId: String?,
-            buildTask: Boolean
+            buildTask: Boolean,
+            isInviteAlreadyAccepted: Boolean?
     ) {
         if (sessionHolder.getSafeActiveSession()?.getRoom(roomId) == null) {
             fatalError("Trying to open an unknown room $roomId", vectorPreferences.failFast())
             return
         }
-        val args = TimelineArgs(roomId, eventId)
+        val args = TimelineArgs(roomId = roomId, eventId = eventId, isInviteAlreadyAccepted = isInviteAlreadyAccepted ?: false)
         val intent = RoomDetailActivity.newIntent(context, args)
         startActivity(context, intent, buildTask)
     }

--- a/vector/src/main/java/im/vector/app/features/navigation/Navigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/Navigator.kt
@@ -50,7 +50,7 @@ interface Navigator {
 
     fun softLogout(context: Context)
 
-    fun openRoom(context: Context, roomId: String, eventId: String? = null, buildTask: Boolean = false)
+    fun openRoom(context: Context, roomId: String, eventId: String? = null, buildTask: Boolean = false, isInviteAlreadyAccepted: Boolean? = false)
 
     sealed class PostSwitchSpaceAction {
         object None : PostSwitchSpaceAction()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
