### PR TITLE
#2782: Collapse server ACLs update events

### DIFF
--- a/changelog.d/2782.misc
+++ b/changelog.d/2782.misc
@@ -1,0 +1,1 @@
+Collapse ACL events

--- a/changelog.d/2782.misc
+++ b/changelog.d/2782.misc
@@ -1,1 +1,1 @@
-Collapse ACL events
+Collapse successive ACLs events in room timeline

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MergedHeaderItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MergedHeaderItemFactory.kt
@@ -27,10 +27,10 @@ import im.vector.app.features.home.room.detail.timeline.helper.TimelineEventVisi
 import im.vector.app.features.home.room.detail.timeline.helper.canBeMerged
 import im.vector.app.features.home.room.detail.timeline.helper.isRoomConfiguration
 import im.vector.app.features.home.room.detail.timeline.item.BasedMergedItem
-import im.vector.app.features.home.room.detail.timeline.item.DefaultMergedEventsItem
-import im.vector.app.features.home.room.detail.timeline.item.DefaultMergedEventsItem_
 import im.vector.app.features.home.room.detail.timeline.item.MergedRoomCreationItem
 import im.vector.app.features.home.room.detail.timeline.item.MergedRoomCreationItem_
+import im.vector.app.features.home.room.detail.timeline.item.MergedSimilarEventsItem
+import im.vector.app.features.home.room.detail.timeline.item.MergedSimilarEventsItem_
 import im.vector.app.features.home.room.detail.timeline.tools.createLinkMovementMethod
 import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.query.QueryStringValue
@@ -83,7 +83,7 @@ class MergedHeaderItemFactory @Inject constructor(private val activeSessionHolde
                                                    event: TimelineEvent,
                                                    eventIdToHighlight: String?,
                                                    requestModelBuild: () -> Unit,
-                                                   callback: TimelineEventController.Callback?): DefaultMergedEventsItem_? {
+                                                   callback: TimelineEventController.Callback?): MergedSimilarEventsItem_? {
         val mergedEvents = timelineEventVisibilityHelper.prevSameTypeEvents(
                 items,
                 currentPosition,
@@ -129,7 +129,7 @@ class MergedHeaderItemFactory @Inject constructor(private val activeSessionHolde
                 else                            -> null
             }
             summaryTitleResId?.let { summaryTitle ->
-                val attributes = DefaultMergedEventsItem.Attributes(
+                val attributes = MergedSimilarEventsItem.Attributes(
                         summaryTitleResId = summaryTitle,
                         isCollapsed = isCollapsed,
                         mergeData = mergedData,
@@ -139,7 +139,7 @@ class MergedHeaderItemFactory @Inject constructor(private val activeSessionHolde
                             requestModelBuild()
                         }
                 )
-                DefaultMergedEventsItem_()
+                MergedSimilarEventsItem_()
                         .id(mergeId)
                         .leftGuideline(avatarSizeProvider.leftGuideline)
                         .highlighted(isCollapsed && highlighted)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MergedHeaderItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MergedHeaderItemFactory.kt
@@ -123,10 +123,10 @@ class MergedHeaderItemFactory @Inject constructor(private val activeSessionHolde
                 collapsedEventIds.removeAll(mergedEventIds)
             }
             val mergeId = mergedEventIds.joinToString(separator = "_") { it.toString() }
-            val summaryTitleResId = when(event.root.getClearType()) {
-                EventType.STATE_ROOM_MEMBER -> R.plurals.membership_changes
+            val summaryTitleResId = when (event.root.getClearType()) {
+                EventType.STATE_ROOM_MEMBER     -> R.plurals.membership_changes
                 EventType.STATE_ROOM_SERVER_ACL -> R.plurals.notice_room_server_acl_changes
-                else -> null
+                else                            -> null
             }
             summaryTitleResId?.let { summaryTitle ->
                 val attributes = DefaultMergedEventsItem.Attributes(

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineDisplayableEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineDisplayableEvents.kt
@@ -56,7 +56,8 @@ object TimelineDisplayableEvents {
 }
 
 fun TimelineEvent.canBeMerged(): Boolean {
-    return root.getClearType() == EventType.STATE_ROOM_MEMBER
+    return root.getClearType() == EventType.STATE_ROOM_MEMBER ||
+            root.getClearType() == EventType.STATE_ROOM_SERVER_ACL
 }
 
 fun TimelineEvent.isRoomConfiguration(roomCreatorUserId: String?): Boolean {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/DefaultMergedEventsItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/DefaultMergedEventsItem.kt
@@ -20,6 +20,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.annotation.PluralsRes
 import androidx.core.view.children
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
@@ -27,7 +28,7 @@ import im.vector.app.R
 import im.vector.app.features.home.AvatarRenderer
 
 @EpoxyModelClass(layout = R.layout.item_timeline_event_base_noinfo)
-abstract class MergedMembershipEventsItem : BasedMergedItem<MergedMembershipEventsItem.Holder>() {
+abstract class DefaultMergedEventsItem : BasedMergedItem<DefaultMergedEventsItem.Holder>() {
 
     override fun getViewStubId() = STUB_ID
 
@@ -37,7 +38,7 @@ abstract class MergedMembershipEventsItem : BasedMergedItem<MergedMembershipEven
     override fun bind(holder: Holder) {
         super.bind(holder)
         if (attributes.isCollapsed) {
-            val summary = holder.expandView.resources.getQuantityString(R.plurals.membership_changes, attributes.mergeData.size, attributes.mergeData.size)
+            val summary = holder.expandView.resources.getQuantityString(attributes.summaryTitleResId, attributes.mergeData.size, attributes.mergeData.size)
             holder.summaryView.text = summary
             holder.summaryView.visibility = View.VISIBLE
             holder.avatarListView.visibility = View.VISIBLE
@@ -66,6 +67,7 @@ abstract class MergedMembershipEventsItem : BasedMergedItem<MergedMembershipEven
     }
 
     data class Attributes(
+            @PluralsRes val summaryTitleResId: Int,
             override val isCollapsed: Boolean,
             override val mergeData: List<Data>,
             override val avatarRenderer: AvatarRenderer,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MergedSimilarEventsItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MergedSimilarEventsItem.kt
@@ -28,7 +28,7 @@ import im.vector.app.R
 import im.vector.app.features.home.AvatarRenderer
 
 @EpoxyModelClass(layout = R.layout.item_timeline_event_base_noinfo)
-abstract class DefaultMergedEventsItem : BasedMergedItem<DefaultMergedEventsItem.Holder>() {
+abstract class MergedSimilarEventsItem : BasedMergedItem<MergedSimilarEventsItem.Holder>() {
 
     override fun getViewStubId() = STUB_ID
 

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -81,6 +81,10 @@
 
     <string name="notice_room_server_acl_updated_title">%s changed the server ACLs for this room.</string>
     <string name="notice_room_server_acl_updated_title_by_you">You changed the server ACLs for this room.</string>
+    <plurals name="notice_room_server_acl_changes">
+        <item quantity="one">%d server ACLs change</item>
+        <item quantity="other">%d server ACLs changes</item>
+    </plurals>
     <string name="notice_room_server_acl_updated_banned">• Servers matching %s are now banned.</string>
     <string name="notice_room_server_acl_updated_was_banned">• Servers matching %s were removed from the ban list.</string>
     <string name="notice_room_server_acl_updated_allowed">• Servers matching %s are now allowed.</string>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Enhancement

## Content

<!-- Describe shortly what has been changed -->
Merge of multiple successive received server ACLs updates in a room into a single collapsable/expandable item.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
See #2782 

## Screenshots / GIFs

<!-- Only if UI have been changed -->
<image src="https://user-images.githubusercontent.com/46314705/154494015-91455bbc-f160-48ab-9adf-6d2b4bfb5007.png" width=300><image src="https://user-images.githubusercontent.com/46314705/154494047-cd6a8212-fbec-4043-abfe-0bc1bf541274.png" width=300>

<image src="https://user-images.githubusercontent.com/46314705/154496905-80147a28-0bae-4e32-9755-933188d0a416.png" width=300><image src="https://user-images.githubusercontent.com/46314705/154496929-6e38d7f6-d150-44ad-bf29-4e16e1c72326.png" width=300>

## Tests

<!-- Explain how you tested your development -->

- Go to a room where there are many successive ACLs events
- Check the events are merged together
- Click on "expand" button
- Check all corresponding events are listed
- Click on "collapse" button
- Check all events are merged together

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
