### PR TITLE
#5218: Fix crash at registration when redirecting to Web View

### DIFF
--- a/changelog.d/5218.bugfix
+++ b/changelog.d/5218.bugfix
@@ -1,0 +1,1 @@
+Fix crash during registration when redirecting to Web Browser

--- a/changelog.d/5218.bugfix
+++ b/changelog.d/5218.bugfix
@@ -1,1 +1,1 @@
-Fix crash during registration when redirecting to Web Browser
+Fix crash during account registration when redirecting to Web View

--- a/vector/src/main/java/im/vector/app/features/login/LoginWebFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginWebFragment.kt
@@ -51,8 +51,6 @@ class LoginWebFragment @Inject constructor(
         private val assetReader: AssetReader
 ) : AbstractLoginFragment<FragmentLoginWebBinding>() {
 
-    // TODO I noticed in the Git history this variable was a local variable inside notifyViewModel method
-    // TODO was there any reason ? To be able to create this ViewModel we must be sure we will have a valid session
     private val softLogoutViewModel: SoftLogoutViewModel by activityViewModel()
 
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentLoginWebBinding {

--- a/vector/src/main/java/im/vector/app/features/login/LoginWebFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginWebFragment.kt
@@ -51,6 +51,7 @@ class LoginWebFragment @Inject constructor(
         private val assetReader: AssetReader
 ) : AbstractLoginFragment<FragmentLoginWebBinding>() {
 
+    // TODO confirm the need of this viewModel
     val softLogoutViewModel: SoftLogoutViewModel by activityViewModel()
 
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentLoginWebBinding {

--- a/vector/src/main/java/im/vector/app/features/login/LoginWebFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginWebFragment.kt
@@ -72,7 +72,6 @@ class LoginWebFragment @Inject constructor(
     override fun updateWithState(state: LoginViewState) {
         setupTitle(state)
 
-        // TODO check how it is possible to arrive in this case
         isForSessionRecovery = state.deviceId?.isNotBlank() == true
 
         if (!isWebViewLoaded) {

--- a/vector/src/main/java/im/vector/app/features/login/LoginWebFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginWebFragment.kt
@@ -51,8 +51,9 @@ class LoginWebFragment @Inject constructor(
         private val assetReader: AssetReader
 ) : AbstractLoginFragment<FragmentLoginWebBinding>() {
 
-    // TODO confirm the need of this viewModel
-    val softLogoutViewModel: SoftLogoutViewModel by activityViewModel()
+    // TODO I noticed in the Git history this variable was a local variable inside notifyViewModel method
+    // TODO was there any reason ? To be able to create this ViewModel we must be sure we will have a valid session
+    private val softLogoutViewModel: SoftLogoutViewModel by activityViewModel()
 
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentLoginWebBinding {
         return FragmentLoginWebBinding.inflate(inflater, container, false)
@@ -71,6 +72,7 @@ class LoginWebFragment @Inject constructor(
     override fun updateWithState(state: LoginViewState) {
         setupTitle(state)
 
+        // TODO check how it is possible to arrive in this case
         isForSessionRecovery = state.deviceId?.isNotBlank() == true
 
         if (!isWebViewLoaded) {

--- a/vector/src/main/java/im/vector/app/features/login2/LoginWebFragment2.kt
+++ b/vector/src/main/java/im/vector/app/features/login2/LoginWebFragment2.kt
@@ -56,6 +56,7 @@ class LoginWebFragment2 @Inject constructor(
         return FragmentLoginWebBinding.inflate(inflater, container, false)
     }
 
+    // TODO confirm the need of this viewModel
     val softLogoutViewModel: SoftLogoutViewModel by activityViewModel()
 
     private var isWebViewLoaded = false

--- a/vector/src/main/java/im/vector/app/features/login2/LoginWebFragment2.kt
+++ b/vector/src/main/java/im/vector/app/features/login2/LoginWebFragment2.kt
@@ -56,8 +56,9 @@ class LoginWebFragment2 @Inject constructor(
         return FragmentLoginWebBinding.inflate(inflater, container, false)
     }
 
-    // TODO confirm the need of this viewModel
-    val softLogoutViewModel: SoftLogoutViewModel by activityViewModel()
+    // TODO I noticed in the Git history this variable was a local variable inside notifyViewModel method
+    // TODO was there any reason ? To be able to create this ViewModel we must be sure we will have a valid session
+    private val softLogoutViewModel: SoftLogoutViewModel by activityViewModel()
 
     private var isWebViewLoaded = false
     private var isForSessionRecovery = false
@@ -72,6 +73,7 @@ class LoginWebFragment2 @Inject constructor(
     override fun updateWithState(state: LoginViewState2) {
         setupTitle(state)
 
+        // TODO check how it is possible to arrive in this case
         isForSessionRecovery = state.deviceId?.isNotBlank() == true
 
         if (!isWebViewLoaded) {

--- a/vector/src/main/java/im/vector/app/features/login2/LoginWebFragment2.kt
+++ b/vector/src/main/java/im/vector/app/features/login2/LoginWebFragment2.kt
@@ -56,8 +56,6 @@ class LoginWebFragment2 @Inject constructor(
         return FragmentLoginWebBinding.inflate(inflater, container, false)
     }
 
-    // TODO I noticed in the Git history this variable was a local variable inside notifyViewModel method
-    // TODO was there any reason ? To be able to create this ViewModel we must be sure we will have a valid session
     private val softLogoutViewModel: SoftLogoutViewModel by activityViewModel()
 
     private var isWebViewLoaded = false
@@ -84,7 +82,7 @@ class LoginWebFragment2 @Inject constructor(
     private fun setupTitle(state: LoginViewState2) {
         toolbar?.title = when (state.signMode) {
             SignMode2.SignIn -> getString(R.string.login_signin)
-            else            -> getString(R.string.login_signup)
+            else             -> getString(R.string.login_signup)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/login2/LoginWebFragment2.kt
+++ b/vector/src/main/java/im/vector/app/features/login2/LoginWebFragment2.kt
@@ -73,7 +73,6 @@ class LoginWebFragment2 @Inject constructor(
     override fun updateWithState(state: LoginViewState2) {
         setupTitle(state)
 
-        // TODO check how it is possible to arrive in this case
         isForSessionRecovery = state.deviceId?.isNotBlank() == true
 
         if (!isWebViewLoaded) {

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
@@ -21,7 +21,6 @@ import im.vector.app.features.login.LoginConfig
 import im.vector.app.features.login.ServerType
 import im.vector.app.features.login.SignMode
 import org.matrix.android.sdk.api.auth.data.Credentials
-import org.matrix.android.sdk.api.auth.data.SsoIdentityProvider
 import org.matrix.android.sdk.api.auth.registration.RegisterThreePid
 import org.matrix.android.sdk.internal.network.ssl.Fingerprint
 
@@ -70,11 +69,6 @@ sealed class OnboardingAction : VectorViewModelAction {
 
     // Homeserver history
     object ClearHomeServerHistory : OnboardingAction()
-
-    // For the soft logout case
-    data class SetupSsoForSessionRecovery(val homeServerUrl: String,
-                                          val deviceId: String,
-                                          val ssoIdentityProviders: List<SsoIdentityProvider>?) : OnboardingAction()
 
     data class PostViewEvent(val viewEvent: OnboardingViewEvents) : OnboardingAction()
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -143,7 +143,6 @@ class OnboardingViewModel @AssistedInject constructor(
             is OnboardingAction.ResetPasswordMailConfirmed -> handleResetPasswordMailConfirmed()
             is OnboardingAction.RegisterAction             -> handleRegisterAction(action)
             is OnboardingAction.ResetAction                -> handleResetAction(action)
-            is OnboardingAction.SetupSsoForSessionRecovery -> handleSetupSsoForSessionRecovery(action)
             is OnboardingAction.UserAcceptCertificate      -> handleUserAcceptCertificate(action)
             OnboardingAction.ClearHomeServerHistory        -> handleClearHomeServerHistory()
             is OnboardingAction.PostViewEvent              -> _viewEvents.post(action.viewEvent)
@@ -246,18 +245,6 @@ class OnboardingViewModel @AssistedInject constructor(
                 }
                         ?.let { onSessionCreated(it) }
             }
-        }
-    }
-
-    private fun handleSetupSsoForSessionRecovery(action: OnboardingAction.SetupSsoForSessionRecovery) {
-        setState {
-            copy(
-                    signMode = SignMode.SignIn,
-                    loginMode = LoginMode.Sso(action.ssoIdentityProviders),
-                    homeServerUrlFromUser = action.homeServerUrl,
-                    homeServerUrl = action.homeServerUrl,
-                    deviceId = action.deviceId
-            )
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthWebFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthWebFragment.kt
@@ -30,7 +30,6 @@ import android.view.ViewGroup
 import android.webkit.SslErrorHandler
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import com.airbnb.mvrx.activityViewModel
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import im.vector.app.R
 import im.vector.app.core.utils.AssetReader
@@ -40,8 +39,6 @@ import im.vector.app.features.login.SignMode
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewEvents
 import im.vector.app.features.onboarding.OnboardingViewState
-import im.vector.app.features.signout.soft.SoftLogoutAction
-import im.vector.app.features.signout.soft.SoftLogoutViewModel
 import org.matrix.android.sdk.api.auth.data.Credentials
 import org.matrix.android.sdk.internal.di.MoshiProvider
 import timber.log.Timber
@@ -56,15 +53,11 @@ class FtueAuthWebFragment @Inject constructor(
         private val assetReader: AssetReader
 ) : AbstractFtueAuthFragment<FragmentLoginWebBinding>() {
 
-    // TODO confirm the need of this viewModel
-    val softLogoutViewModel: SoftLogoutViewModel by activityViewModel()
-
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentLoginWebBinding {
         return FragmentLoginWebBinding.inflate(inflater, container, false)
     }
 
     private var isWebViewLoaded = false
-    private var isForSessionRecovery = false
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -75,8 +68,6 @@ class FtueAuthWebFragment @Inject constructor(
 
     override fun updateWithState(state: OnboardingViewState) {
         setupTitle(state)
-
-        isForSessionRecovery = state.deviceId?.isNotBlank() == true
 
         if (!isWebViewLoaded) {
             setupWebView(state)
@@ -240,11 +231,7 @@ class FtueAuthWebFragment @Inject constructor(
     }
 
     private fun notifyViewModel(credentials: Credentials) {
-        if (isForSessionRecovery) {
-            softLogoutViewModel.handle(SoftLogoutAction.WebLoginSuccess(credentials))
-        } else {
-            viewModel.handle(OnboardingAction.WebLoginSuccess(credentials))
-        }
+        viewModel.handle(OnboardingAction.WebLoginSuccess(credentials))
     }
 
     override fun resetViewModel() {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthWebFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthWebFragment.kt
@@ -56,6 +56,7 @@ class FtueAuthWebFragment @Inject constructor(
         private val assetReader: AssetReader
 ) : AbstractFtueAuthFragment<FragmentLoginWebBinding>() {
 
+    // TODO confirm the need of this viewModel
     val softLogoutViewModel: SoftLogoutViewModel by activityViewModel()
 
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentLoginWebBinding {

--- a/vector/src/main/java/im/vector/app/features/signout/soft/SoftLogoutViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/signout/soft/SoftLogoutViewModel.kt
@@ -16,7 +16,6 @@
 
 package im.vector.app.features.signout.soft
 
-import com.airbnb.mvrx.ActivityViewModelContext
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.MavericksViewModelFactory
@@ -26,8 +25,10 @@ import com.airbnb.mvrx.ViewModelContext
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import dagger.hilt.EntryPoints
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
+import im.vector.app.core.di.SingletonEntryPoint
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.extensions.hasUnsavedKeys
 import im.vector.app.core.platform.VectorViewModel
@@ -56,15 +57,23 @@ class SoftLogoutViewModel @AssistedInject constructor(
     companion object : MavericksViewModelFactory<SoftLogoutViewModel, SoftLogoutViewState> by hiltMavericksViewModelFactory() {
 
         override fun initialState(viewModelContext: ViewModelContext): SoftLogoutViewState? {
-            val activity: SoftLogoutActivity = (viewModelContext as ActivityViewModelContext).activity()
-            val userId = activity.session.myUserId
-            return SoftLogoutViewState(
-                    homeServerUrl = activity.session.sessionParams.homeServerUrl,
-                    userId = userId,
-                    deviceId = activity.session.sessionParams.deviceId ?: "",
-                    userDisplayName = activity.session.getUser(userId)?.displayName ?: userId,
-                    hasUnsavedKeys = activity.session.hasUnsavedKeys()
-            )
+            val sessionHolder = EntryPoints.get(viewModelContext.app(), SingletonEntryPoint::class.java)
+                    .activeSessionHolder()
+
+            return if (sessionHolder.hasActiveSession()) {
+                val session = sessionHolder.getActiveSession()
+                val userId = session.myUserId
+
+                SoftLogoutViewState(
+                        homeServerUrl = session.sessionParams.homeServerUrl,
+                        userId = userId,
+                        deviceId = session.sessionParams.deviceId.orEmpty(),
+                        userDisplayName = session.getUser(userId)?.displayName ?: userId,
+                        hasUnsavedKeys = session.hasUnsavedKeys()
+                )
+            } else {
+                null
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/signout/soft/SoftLogoutViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/signout/soft/SoftLogoutViewModel.kt
@@ -56,7 +56,7 @@ class SoftLogoutViewModel @AssistedInject constructor(
 
     companion object : MavericksViewModelFactory<SoftLogoutViewModel, SoftLogoutViewState> by hiltMavericksViewModelFactory() {
 
-        override fun initialState(viewModelContext: ViewModelContext): SoftLogoutViewState? {
+        override fun initialState(viewModelContext: ViewModelContext): SoftLogoutViewState {
             val sessionHolder = EntryPoints.get(viewModelContext.app(), SingletonEntryPoint::class.java)
                     .activeSessionHolder()
 
@@ -72,7 +72,13 @@ class SoftLogoutViewModel @AssistedInject constructor(
                         hasUnsavedKeys = session.hasUnsavedKeys()
                 )
             } else {
-                null
+                SoftLogoutViewState(
+                        homeServerUrl = "",
+                        userId = "",
+                        deviceId = "",
+                        userDisplayName = "",
+                        hasUnsavedKeys = false
+                )
             }
         }
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
- Removing usage of `SoftLogoutViewModel` in `FtueAuthWebFragment` since it seems the code which is using it cannot be reached.
- Changing the way we retrieve the current active `Session` to initialize the `ViewState` used in `SoftLogoutViewModel`: there is no more reference to the `Activity` using the `ViewModel` which caused the crash (ClassCastException).

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
See #5218.

## Screenshots / GIFs

<!-- Only if UI have been changed -->

## Tests

<!-- Explain how you tested your development -->

- Edit temporarily the code to reproduce the flow leading to web view redirection as explained in [this comment](https://github.com/vector-im/element-android/issues/5218#issuecomment-1042746067).
- Start onboarding
- Choose to create a new account on "Matrix.org" server for example
- Wait to see the redirection dialog
- Choose "yes" to be redirected to web view
- Check the app does not crash and displays the registration web view

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
