### PR TITLE
#5225 Replace color "vctr_unread_room_badge" by "vctr_content_secondary"

### DIFF
--- a/changelog.d/5225.misc
+++ b/changelog.d/5225.misc
@@ -1,0 +1,1 @@
+Replacing color "vctr_unread_room_badge" by "vctr_content_secondary"

--- a/library/ui-styles/src/main/res/values/colors.xml
+++ b/library/ui-styles/src/main/res/values/colors.xml
@@ -57,11 +57,6 @@
     <attr name="vctr_list_separator_on_surface" format="color" />
 
     <!-- Other colors, which are not in the palette -->
-    <attr name="vctr_unread_room_badge" format="color" />
-    <color name="vctr_unread_room_badge_light">@color/palette_gray_200</color>
-    <color name="vctr_unread_room_badge_dark">@color/palette_gray_250</color>
-    <color name="vctr_unread_room_badge_black">@color/palette_gray_250</color>
-
     <attr name="vctr_fab_label_bg" format="color" />
     <color name="vctr_fab_label_bg_light">@android:color/white</color>
     <color name="vctr_fab_label_bg_dark">#FF181B21</color>

--- a/library/ui-styles/src/main/res/values/theme_black.xml
+++ b/library/ui-styles/src/main/res/values/theme_black.xml
@@ -7,7 +7,6 @@
         <!-- Only setting the items we need to override to get the background to be pure black, otherwise inheriting -->
 
         <!-- other colors -->
-        <item name="vctr_unread_room_badge">@color/vctr_unread_room_badge_black</item>
         <item name="vctr_fab_label_bg">@color/vctr_fab_label_bg_black</item>
         <item name="vctr_fab_label_stroke">@color/vctr_fab_label_stroke_black</item>
         <item name="vctr_fab_label_color">@color/vctr_fab_label_color_black</item>

--- a/library/ui-styles/src/main/res/values/theme_dark.xml
+++ b/library/ui-styles/src/main/res/values/theme_dark.xml
@@ -16,7 +16,6 @@
         <item name="vctr_system">@color/element_system_dark</item>
 
         <!-- other colors -->
-        <item name="vctr_unread_room_badge">@color/vctr_unread_room_badge_dark</item>
         <item name="vctr_fab_label_bg">@color/vctr_fab_label_bg_dark</item>
         <item name="vctr_fab_label_stroke">@color/vctr_fab_label_stroke_dark</item>
         <item name="vctr_fab_label_color">@color/vctr_fab_label_color_dark</item>

--- a/library/ui-styles/src/main/res/values/theme_light.xml
+++ b/library/ui-styles/src/main/res/values/theme_light.xml
@@ -16,7 +16,6 @@
         <item name="vctr_system">@color/element_system_light</item>
 
         <!-- other colors -->
-        <item name="vctr_unread_room_badge">@color/vctr_unread_room_badge_light</item>
         <item name="vctr_fab_label_bg">@color/vctr_fab_label_bg_light</item>
         <item name="vctr_fab_label_stroke">@color/vctr_fab_label_stroke_light</item>
         <item name="vctr_fab_label_color">@color/vctr_fab_label_color_light</item>

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
@@ -457,7 +457,7 @@ class HomeDetailFragment @Inject constructor(
         backgroundColor = if (highlight) {
             ThemeUtils.getColor(requireContext(), R.attr.colorError)
         } else {
-            ThemeUtils.getColor(requireContext(), R.attr.vctr_unread_room_badge)
+            ThemeUtils.getColor(requireContext(), R.attr.vctr_content_secondary)
         }
     }
 

--- a/vector/src/main/res/drawable/bg_unread_notification.xml
+++ b/vector/src/main/res/drawable/bg_unread_notification.xml
@@ -4,5 +4,5 @@
 
     <corners android:radius="40dp" />
 
-    <solid android:color="?vctr_unread_room_badge" />
+    <solid android:color="?vctr_content_secondary" />
 </shape>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Replacing the color attribute `vctr_unread_room_badge` by `vctr_content_secondary` since it is relying on the same color number.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
See #5225 

## Screenshots / GIFs

<!-- Only if UI have been changed -->

## Tests

<!-- Explain how you tested your development -->

- Launch the application
- Check notification badge is well displayed in home screen

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
