### PR TITLE
Exclude all build output directories from git source control.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 .idea/inspectionProfiles
 .idea/*.xml
 .DS_Store
-**/build/
+**/build
 /benchmark-out
 /captures
 .externalNativeBuild

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 .idea/inspectionProfiles
 .idea/*.xml
 .DS_Store
-/build
+**/build/
 /benchmark-out
 /captures
 .externalNativeBuild

--- a/changelog.d/5273.misc
+++ b/changelog.d/5273.misc
@@ -1,0 +1,1 @@
+Exclude all build output directories from git source control.


### PR DESCRIPTION
Fixes #5273 