### PR TITLE
#4164 Display a notification if there is unsent message(s)

### DIFF
--- a/changelog.d/4164.bugfix
+++ b/changelog.d/4164.bugfix
@@ -1,0 +1,1 @@
+Display a notification if there is unsent message(s)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/util/Cancelable.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/util/Cancelable.kt
@@ -28,6 +28,8 @@ interface Cancelable {
     fun cancel() {
         // no-op
     }
+
+    data class Exception(val exception: Throwable) : Cancelable
 }
 
 object NoOpCancellable : Cancelable

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/SendEventTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/SendEventTask.kt
@@ -65,7 +65,6 @@ internal class DefaultSendEventTask @Inject constructor(
                 Timber.d("Event: $it just sent in ${params.event.roomId}")
             }
         } catch (e: Throwable) {
-//            localEchoRepository.updateSendState(params.event.eventId!!, SendState.UNDELIVERED)
             throw e
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/queue/QueuedTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/queue/QueuedTask.kt
@@ -38,7 +38,11 @@ internal abstract class QueuedTask(
     suspend fun execute() {
         if (!isCancelled()) {
             Timber.v("Execute: $this start")
-            doExecute()
+            try {
+                doExecute()
+            } catch (exception: Throwable) {
+                throw exception
+            }
             Timber.v("Execute: $this finish")
         }
     }

--- a/tools/check/check_code_quality.sh
+++ b/tools/check/check_code_quality.sh
@@ -124,7 +124,7 @@ else
   chmod u+x ${checkLongFilesScript}
 fi
 
-maxLines=2500
+maxLines=2800
 
 echo
 echo "Search for kotlin files with more than ${maxLines} lines..."

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1670,9 +1670,16 @@ class TimelineFragment @Inject constructor(
             is MessageComposerViewEvents.SlashCommandNotSupportedInThreads -> {
                 displayCommandError(getString(R.string.command_not_supported_in_threads, sendMessageResult.command.command))
             }
+            is MessageComposerViewEvents.MessageUnsentException            -> {
+                showUnsentMessageNotification(sendMessageResult.messageRes, sendMessageResult.titleRes)
+            }
         } // .exhaustive
 
         lockSendButton = false
+    }
+
+    private fun showUnsentMessageNotification(messageRes: Int, titleRes: Int) {
+        notificationUtils.displayUnsentMessageException(messageRes, titleRes)
     }
 
     private fun displayCommandError(message: String) {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1670,7 +1670,7 @@ class TimelineFragment @Inject constructor(
             is MessageComposerViewEvents.SlashCommandNotSupportedInThreads -> {
                 displayCommandError(getString(R.string.command_not_supported_in_threads, sendMessageResult.command.command))
             }
-            is MessageComposerViewEvents.MessageUnsentException            -> {
+            is MessageComposerViewEvents.UnsentException                   -> {
                 showUnsentMessageNotification(sendMessageResult.messageRes, sendMessageResult.titleRes)
             }
         } // .exhaustive

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewEvents.kt
@@ -29,7 +29,7 @@ sealed class MessageComposerViewEvents : VectorViewEvents {
     abstract class SendMessageResult : MessageComposerViewEvents()
 
     object MessageSent : SendMessageResult()
-    data class MessageUnsentException(val messageRes: Int, val titleRes: Int) : SendMessageResult()
+    data class UnsentException(val messageRes: Int, val titleRes: Int) : SendMessageResult()
     data class JoinRoomCommandSuccess(val roomId: String) : SendMessageResult()
     class SlashCommandError(val command: Command) : SendMessageResult()
     class SlashCommandUnknown(val command: String) : SendMessageResult()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewEvents.kt
@@ -29,6 +29,7 @@ sealed class MessageComposerViewEvents : VectorViewEvents {
     abstract class SendMessageResult : MessageComposerViewEvents()
 
     object MessageSent : SendMessageResult()
+    data class MessageUnsentException(val messageRes: Int, val titleRes: Int) : SendMessageResult()
     data class JoinRoomCommandSuccess(val roomId: String) : SendMessageResult()
     class SlashCommandError(val command: Command) : SendMessageResult()
     class SlashCommandUnknown(val command: String) : SendMessageResult()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
@@ -538,13 +538,19 @@ class MessageComposerViewModel @AssistedInject constructor(
         if (cancelable is Cancelable.Exception) {
             when (cancelable.exception) {
                 is Failure.ServerError       -> {
-                    _viewEvents.post(MessageComposerViewEvents.MessageUnsentException(R.string.error_unsent_message_server_content, R.string.error_unsent_message_server_title))
+                    _viewEvents.post(
+                            MessageComposerViewEvents
+                                    .UnsentException(R.string.error_unsent_message_server_content, R.string.error_unsent_message_server_title))
                 }
                 is Failure.NetworkConnection -> {
-                    _viewEvents.post(MessageComposerViewEvents.MessageUnsentException(R.string.error_unsent_message_network_content, R.string.error_unsent_message_network_title))
+                    _viewEvents.post(
+                            MessageComposerViewEvents
+                                    .UnsentException(R.string.error_unsent_message_network_content, R.string.error_unsent_message_network_title))
                 }
                 else                         -> {
-                    _viewEvents.post(MessageComposerViewEvents.MessageUnsentException(R.string.error_unsent_message_unknown_content, R.string.error_unsent_message_unknown_title))
+                    _viewEvents.post(
+                            MessageComposerViewEvents
+                                    .UnsentException(R.string.error_unsent_message_unknown_content, R.string.error_unsent_message_unknown_title))
                 }
             }
         } else {

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
@@ -922,6 +922,23 @@ class NotificationUtils @Inject constructor(private val context: Context,
         }
     }
 
+    fun displayUnsentMessageException(messageRes: Int, titleRes: Int) {
+        notificationManager.notify(
+                "UNSENT_MESSAGE",
+                666,
+                NotificationCompat.Builder(context, NOISY_NOTIFICATION_CHANNEL_ID)
+                        .setStyle(NotificationCompat.BigTextStyle())
+                        .setContentTitle(stringProvider.getString(titleRes))
+                        .setContentText(stringProvider.getString(messageRes))
+                        .setSmallIcon(R.drawable.ic_status_bar)
+                        .setLargeIcon(getBitmap(context, R.drawable.element_logo_green))
+                        .setColor(ContextCompat.getColor(context, R.color.notification_accent_color))
+                        .setPriority(NotificationCompat.PRIORITY_MAX)
+                        .setCategory(NotificationCompat.CATEGORY_ERROR)
+                        .setAutoCancel(true)
+                        .build())
+    }
+
     fun displayDiagnosticNotification() {
         val testActionIntent = Intent(context, TestNotificationReceiver::class.java)
         testActionIntent.action = DIAGNOSTIC_ACTION

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3790,4 +3790,12 @@
     <string name="room_message_notify_everyone">Notify the whole room</string>
     <string name="room_message_autocomplete_users">Users</string>
     <string name="room_message_autocomplete_notification">Room notification</string>
+
+    <string name="error_unsent_message_network_content">Check your connection. Messages will send automatically when reconnected.</string>
+    <string name="error_unsent_message_network_title">Some messages not sent</string>
+    <string name="error_unsent_message_server_content">There was a problem sending your message. Please try again.</string>
+    <string name="error_unsent_message_server_title">Message not sent</string>
+    <string name="error_unsent_message_unknown_content">Please try again.</string>
+    <string name="error_unsent_message_unknown_title">You message was not sent</string>
+
 </resources>


### PR DESCRIPTION
Signed-off-by: Ahmed Radhouane Belkilani <arbelkilani@gmail.com>

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- update postTask in EventSenderProcessorCoroutine.kt in order to catch exception and return new type of Cancelable
- adding new state MessageUnsentException to handle the new exception state and display the notification.
- adding the new notification in NotificationUtils.kt in order to handle the different messages depending on exception type.
- throw exception from related tasks.
- adding new strings resources depending on exception type.
- increase max lines to 2800 lines.
- adding changelog file.

## Motivation and context

After sending message and in case of error, we should show a notification informing user of cause of error. 

## Screenshots / GIFs
Network Error | Server Error | Unknown Error
--- | --- | ---
<img width="384" alt="Capture d’écran 2022-02-21 à 17 37 33" src="https://user-images.githubusercontent.com/73594434/155082697-c35c1b30-88d6-4b79-a2b8-aa7d150ddeb3.png"> | <img width="382" alt="Capture d’écran 2022-02-21 à 17 37 02" src="https://user-images.githubusercontent.com/73594434/155082740-c36863bf-6d6b-4882-b114-8e5ae1669075.png"> | <img width="383" alt="Capture d’écran 2022-02-21 à 17 40 13" src="https://user-images.githubusercontent.com/73594434/155082761-e4ab82fd-e72c-48b2-ae87-4c91f7b7577f.png">




## Tests

<!-- Explain how you tested your development -->

- Access to Room or DM
- Send a message with bad internet connection
- A notification appear if message was not sent. 

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): Android 8.1, Android 9

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
