### PR TITLE
#4319: Fix DM navigation in member profile screen

### DIFF
--- a/changelog.d/4319.bugfix
+++ b/changelog.d/4319.bugfix
@@ -1,0 +1,1 @@
+Open direct message screen when clicking on DM button in the space members list

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
@@ -92,7 +92,6 @@ sealed class RoomDetailAction : VectorViewModelAction {
 
     data class UpdateJoinJitsiCallStatus(val conferenceEvent: ConferenceEvent) : RoomDetailAction()
 
-    data class OpenOrCreateDm(val userId: String) : RoomDetailAction()
     data class JumpToReadReceipt(val userId: String) : RoomDetailAction()
     object QuickActionInvitePeople : RoomDetailAction()
     object QuickActionSetAvatar : RoomDetailAction()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailPendingAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailPendingAction.kt
@@ -17,7 +17,6 @@
 package im.vector.app.features.home.room.detail
 
 sealed class RoomDetailPendingAction {
-    data class OpenOrCreateDm(val userId: String) : RoomDetailPendingAction()
     data class JumpToReadReceipt(val userId: String) : RoomDetailPendingAction()
     data class MentionUser(val userId: String) : RoomDetailPendingAction()
     data class OpenRoom(val roomId: String, val closeCurrentRoom: Boolean = false) : RoomDetailPendingAction()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1234,6 +1234,7 @@ class TimelineFragment @Inject constructor(
     override fun onResume() {
         super.onResume()
         notificationDrawerManager.setCurrentRoom(timelineArgs.roomId)
+        // TODO should we handle it in HomeActivity as well? => see how we open dm from create Message button
         roomDetailPendingActionStore.data?.let { handlePendingAction(it) }
         roomDetailPendingActionStore.data = null
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1234,7 +1234,6 @@ class TimelineFragment @Inject constructor(
     override fun onResume() {
         super.onResume()
         notificationDrawerManager.setCurrentRoom(timelineArgs.roomId)
-        // TODO should we handle it in HomeActivity as well? => see how we open dm from create Message button
         roomDetailPendingActionStore.data?.let { handlePendingAction(it) }
         roomDetailPendingActionStore.data = null
 
@@ -1248,8 +1247,6 @@ class TimelineFragment @Inject constructor(
                 timelineViewModel.handle(RoomDetailAction.JumpToReadReceipt(roomDetailPendingAction.userId))
             is RoomDetailPendingAction.MentionUser       ->
                 insertUserDisplayNameInTextEditor(roomDetailPendingAction.userId)
-            is RoomDetailPendingAction.OpenOrCreateDm    ->
-                timelineViewModel.handle(RoomDetailAction.OpenOrCreateDm(roomDetailPendingAction.userId))
             is RoomDetailPendingAction.OpenRoom          ->
                 handleOpenRoom(RoomDetailViewEvents.OpenRoom(roomDetailPendingAction.roomId, roomDetailPendingAction.closeCurrentRoom))
         }.exhaustive

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -417,7 +417,6 @@ class TimelineViewModel @AssistedInject constructor(
             is RoomDetailAction.RemoveWidget                     -> handleDeleteWidget(action.widgetId)
             is RoomDetailAction.EnsureNativeWidgetAllowed        -> handleCheckWidgetAllowed(action)
             is RoomDetailAction.CancelSend                       -> handleCancel(action)
-            is RoomDetailAction.OpenOrCreateDm                   -> handleOpenOrCreateDm(action)
             is RoomDetailAction.JumpToReadReceipt                -> handleJumpToReadReceipt(action)
             RoomDetailAction.QuickActionInvitePeople             -> handleInvitePeople()
             RoomDetailAction.QuickActionSetAvatar                -> handleQuickSetAvatar()
@@ -495,20 +494,6 @@ class TimelineViewModel @AssistedInject constructor(
 
     private fun handleQuickSetAvatar() {
         _viewEvents.post(RoomDetailViewEvents.OpenSetRoomAvatarDialog)
-    }
-
-    private fun handleOpenOrCreateDm(action: RoomDetailAction.OpenOrCreateDm) {
-        viewModelScope.launch {
-            val roomId = try {
-                directRoomHelper.ensureDMExists(action.userId)
-            } catch (failure: Throwable) {
-                _viewEvents.post(RoomDetailViewEvents.ActionFailure(action, failure))
-                return@launch
-            }
-            if (roomId != initialState.roomId) {
-                _viewEvents.post(RoomDetailViewEvents.OpenRoom(roomId = roomId))
-            }
-        }
     }
 
     private fun handleJumpToReadReceipt(action: RoomDetailAction.JumpToReadReceipt) {
@@ -810,7 +795,7 @@ class TimelineViewModel @AssistedInject constructor(
         notificationDrawerManager.updateEvents { it.clearMemberShipNotificationForRoom(initialState.roomId) }
         viewModelScope.launch {
             try {
-               session.leaveRoom(room.roomId)
+                session.leaveRoom(room.roomId)
             } catch (throwable: Throwable) {
                 _viewEvents.post(RoomDetailViewEvents.Failure(throwable, showInDialog = true))
             }

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileAction.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileAction.kt
@@ -29,4 +29,5 @@ sealed class RoomMemberProfileAction : VectorViewModelAction {
     object ShareRoomMemberProfile : RoomMemberProfileAction()
     data class SetPowerLevel(val previousValue: Int, val newValue: Int, val askForValidation: Boolean) : RoomMemberProfileAction()
     data class SetUserColorOverride(val newColorSpec: String) : RoomMemberProfileAction()
+    data class OpenOrCreateDm(val userId: String) : RoomMemberProfileAction()
 }

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
@@ -127,6 +127,7 @@ class RoomMemberProfileFragment @Inject constructor(
                 is RoomMemberProfileViewEvents.ShareRoomMemberProfile      -> handleShareRoomMemberProfile(it.permalink)
                 is RoomMemberProfileViewEvents.ShowPowerLevelValidation    -> handleShowPowerLevelAdminWarning(it)
                 is RoomMemberProfileViewEvents.ShowPowerLevelDemoteWarning -> handleShowPowerLevelDemoteWarning(it)
+                is RoomMemberProfileViewEvents.OpenRoom                    -> handleOpenRoom(it)
                 is RoomMemberProfileViewEvents.OnKickActionSuccess         -> Unit
                 is RoomMemberProfileViewEvents.OnSetPowerLevelSuccess      -> Unit
                 is RoomMemberProfileViewEvents.OnBanActionSuccess          -> Unit
@@ -140,6 +141,10 @@ class RoomMemberProfileFragment @Inject constructor(
     private fun setupLongClicks() {
         headerViews.memberProfileNameView.copyOnLongClick()
         headerViews.memberProfileIdView.copyOnLongClick()
+    }
+
+    private fun handleOpenRoom(event: RoomMemberProfileViewEvents.OpenRoom) {
+        navigator.openRoom(requireContext(), event.roomId, null)
     }
 
     private fun handleShowPowerLevelDemoteWarning(event: RoomMemberProfileViewEvents.ShowPowerLevelDemoteWarning) {
@@ -297,8 +302,7 @@ class RoomMemberProfileFragment @Inject constructor(
     }
 
     override fun onOpenDmClicked() {
-        roomDetailPendingActionStore.data = RoomDetailPendingAction.OpenOrCreateDm(fragmentArgs.userId)
-        vectorBaseActivity.finish()
+        viewModel.handle(RoomMemberProfileAction.OpenOrCreateDm(fragmentArgs.userId))
     }
 
     override fun onJumpToReadReceiptClicked() {

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewEvents.kt
@@ -39,4 +39,5 @@ sealed class RoomMemberProfileViewEvents : VectorViewEvents {
     ) : RoomMemberProfileViewEvents()
 
     data class ShareRoomMemberProfile(val permalink: String) : RoomMemberProfileViewEvents()
+    data class OpenRoom(val roomId: String) : RoomMemberProfileViewEvents()
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Moving the navigation handling to open direct message from `TimelineFragment` to `RoomMemberProfileFragment`.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #4319 

## Screenshots / GIFs

<!-- Only if UI have been changed -->

## Tests

<!-- Explain how you tested your development -->

- Open drawer menu
- Click on a space menu
- Click on "List members" button
- Click on a member
- Click on "Direct message"
- Check the screen with corresponding direct message room is displayed
- Go to a room where there are different members
- Click on a member in the timeline
- Click on "Direct message"
- Check the screen with corresponding direct message room is displayed 

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
