### PR TITLE
Changes unread marker in item_room.xml

### DIFF
--- a/changelog.d/5294.misc
+++ b/changelog.d/5294.misc
@@ -1,0 +1,1 @@
+Changes unread marker in room list from green to grey

--- a/vector/src/main/res/layout/item_room.xml
+++ b/vector/src/main/res/layout/item_room.xml
@@ -15,7 +15,7 @@
         android:id="@+id/roomUnreadIndicator"
         android:layout_width="4dp"
         android:layout_height="0dp"
-        android:background="?colorSecondary"
+        android:background="?vctr_content_secondary"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Misc

## Content

- Unread marker colour changed from colorSecondary (green) to vctr_content_secondary (grey)

## Motivation and context

iOS already uses this grey colour and we want to have parity with them

## Screenshots / GIFs

|       | Before | After |
|-------|--------|-------|
| Light | ![beforelight](https://user-images.githubusercontent.com/20701752/155114396-6d5d092f-8495-4864-9c23-271d15b8aa9f.jpg) | ![afterlight](https://user-images.githubusercontent.com/20701752/155114609-8d322543-8aa8-4512-b5b4-72e5991c6d67.jpg)|
| Dark | ![beforedark](https://user-images.githubusercontent.com/20701752/155114766-c66d1789-b3e6-4d57-a2fa-0033a100bcd9.jpg) | ![afterdark](https://user-images.githubusercontent.com/20701752/155114823-2784f490-4f4b-44ae-9308-63ecfe905340.jpg) |

## Tests

Go to Rooms tab
See that marker for rooms with unread messages is grey

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 10

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
