### PR TITLE
Fixing crash adding room by QR code

### DIFF
--- a/changelog.d/5295.bugfix
+++ b/changelog.d/5295.bugfix
@@ -1,0 +1,1 @@
+Fixing crash when adding room by QR code after accepting the camera permission for the first time

--- a/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomActivity.kt
@@ -152,7 +152,8 @@ class CreateDirectRoomActivity : SimpleFragmentActivity() {
 
     private val permissionCameraLauncher = registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
-            addFragment(views.container, QrCodeScannerFragment::class.java)
+            val args = QrScannerArgs(showExtraButtons = false, R.string.add_by_qr_code)
+            addFragment(views.container, QrCodeScannerFragment::class.java, args)
         } else if (deniedPermanently) {
             onPermissionDeniedSnackbar(R.string.permissions_denied_qr_code)
         }

--- a/vector/src/main/java/im/vector/app/features/qrcode/QrCodeScannerFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/qrcode/QrCodeScannerFragment.kt
@@ -56,7 +56,7 @@ data class QrScannerArgs(
 open class QrCodeScannerFragment @Inject constructor() : VectorBaseFragment<FragmentQrCodeScannerBinding>(), ZXingScannerView.ResultHandler {
 
     private val qrViewModel: QrCodeScannerViewModel by activityViewModel()
-    private val scannerArgs: QrScannerArgs? by args()
+    private val scannerArgs: QrScannerArgs by args()
 
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentQrCodeScannerBinding {
         return FragmentQrCodeScannerBinding.inflate(inflater, container, false)
@@ -93,13 +93,13 @@ open class QrCodeScannerFragment @Inject constructor() : VectorBaseFragment<Frag
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val title = scannerArgs?.titleRes?.let { getString(it) }
+        val title = scannerArgs.titleRes.let { getString(it) }
 
         setupToolbar(views.qrScannerToolbar)
                 .setTitle(title)
                 .allowBack(useCross = true)
 
-        scannerArgs?.showExtraButtons?.let { showButtons ->
+        scannerArgs.showExtraButtons.let { showButtons ->
             views.userCodeMyCodeButton.isVisible = showButtons
             views.userCodeOpenGalleryButton.isVisible = showButtons
 

--- a/vector/src/main/java/im/vector/app/features/qrcode/QrCodeScannerFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/qrcode/QrCodeScannerFragment.kt
@@ -53,7 +53,7 @@ data class QrScannerArgs(
         @StringRes val titleRes: Int
 ) : Parcelable
 
-open class QrCodeScannerFragment @Inject constructor() : VectorBaseFragment<FragmentQrCodeScannerBinding>(), ZXingScannerView.ResultHandler {
+class QrCodeScannerFragment @Inject constructor() : VectorBaseFragment<FragmentQrCodeScannerBinding>(), ZXingScannerView.ResultHandler {
 
     private val qrViewModel: QrCodeScannerViewModel by activityViewModel()
     private val scannerArgs: QrScannerArgs by args()


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Adds missing `QrScannerFragment` arguments when scanning a QR code accept accepting the camera permission for the first time 

## Motivation and context

Fixes #5295

## Screenshots / GIFs

| BEFORE | AFTER | 
| --- | --- |
|![before-add-room-qr](https://user-images.githubusercontent.com/1848238/155127171-efac1bf8-b1cf-4aa1-8cd4-8ea24acfe488.gif)|![after-add-room-qa](https://user-images.githubusercontent.com/1848238/155127169-f64dc3df-fb97-4aa3-a4a9-a2422ec482ed.gif)


## Tests

- With a fresh install
- Attempt to add a room by qr code

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 10
