### PR TITLE
Log `since` token when doing an incremental sync

### DIFF
--- a/changelog.d/5312.misc
+++ b/changelog.d/5312.misc
@@ -1,0 +1,1 @@
+Log the `since` token used when doing an incremental sync.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncTask.kt
@@ -147,7 +147,7 @@ internal class DefaultSyncTask @Inject constructor(
             }
             defaultSyncStatusService.endAll()
         } else {
-            Timber.tag(loggerTag.value).d("Start incremental sync request")
+            Timber.tag(loggerTag.value).d("Start incremental sync request with since token $token")
             defaultSyncStatusService.setStatus(SyncStatusService.Status.IncrementalSyncIdle)
             val syncResponse = try {
                 executeRequest(globalErrorReceiver) {


### PR DESCRIPTION
This aids debugging when `/sync` does something weird server side. Since we already log a line each time we do an incremental sync this shouldn't cause a problem.

---

I haven't tested this in any shape or form, nor do I know if this is *actually* where we want to add this log line. Sorry for the drive by PR, but found myself wanting this when investigating https://github.com/matrix-org/synapse/issues/11916.
