### PR TITLE
Notify channel on sanity test result

### DIFF
--- a/.github/workflows/sanity_test.yml
+++ b/.github/workflows/sanity_test.yml
@@ -78,3 +78,17 @@ jobs:
           path: |
             emulator.log
             failure_screenshots/
+
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: integration-tests
+    if: always()
+    steps:
+    - uses: michaelkaye/matrix-hookshot-action@v0.2.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        matrix_access_token: ${{ secrets.ELEMENT_ANDROID_NOTIFICATION_ACCESS_TOKEN }}
+        matrix_room_id: ${{ secrets.ELEMENT_ANDROID_INTERNAL_ROOM_ID }}
+        text_template: "Sanity test run: {{#each job_statuses }}{{#with this }}{{#if completed }}  {{name}} {{conclusion}} at {{completed_at}} {{html_url}}{{/if}}{{/with}}{{/each}}"
+        html_template: "CI Sanity test run results: {{#each job_statuses }}{{#with this }}{{#if completed }}  {{name}} {{conclusion}} at {{completed_at}} <a href=\"{{html_url}}\">[details]</a>{{/if}}{{/with}}{{/each}}"

--- a/changelog.d/5314.misc
+++ b/changelog.d/5314.misc
@@ -1,0 +1,1 @@
+Notify element-android channel each time a nightly build completes.


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [X] Technical
- [ ] Other :

## Content

Github workflow has been enhanced with a notification to the correct matrix channel.

Configuration is via secrets for channel, matrix token, but the message body is templatable in the workflow file if required.

## Motivation and context

Fixes #5314

## Screenshots / GIFs

![Screenshot from 2022-02-23 10-23-33](https://user-images.githubusercontent.com/1917473/155301856-5a9c973f-a528-4aab-8e5a-5a5c5451e2a7.png)


## Tests

michaelk/gha_experiment branch has been running this code on push and the notification worked.

## Tested devices

N/A

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
