### PR TITLE
Tentatively fixing space menu items not being clicked on during sanity test

### DIFF
--- a/changelog.d/5269.misc
+++ b/changelog.d/5269.misc
@@ -1,0 +1,1 @@
+Tentatively fixing the UI sanity test being unable to click on the space menu items

--- a/vector/src/androidTest/java/im/vector/app/EspressoExt.kt
+++ b/vector/src/androidTest/java/im/vector/app/EspressoExt.kt
@@ -27,6 +27,9 @@ import androidx.test.espresso.IdlingResource
 import androidx.test.espresso.PerformException
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.matcher.RootMatchers
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.util.HumanReadables
 import androidx.test.espresso.util.TreeIterables
@@ -255,6 +258,10 @@ fun clickOnAndGoBack(@StringRes name: Int, block: () -> Unit) {
     BaristaClickInteractions.clickOn(name)
     block()
     Espresso.pressBack()
+}
+
+fun clickOnSheet(id: Int) {
+    Espresso.onView(ViewMatchers.withId(id)).inRoot(RootMatchers.isDialog()).perform(ViewActions.click())
 }
 
 inline fun <reified T : VectorBaseBottomSheetDialogFragment<*>> interactWithSheet(

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/space/SpaceMenuRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/space/SpaceMenuRobot.kt
@@ -24,6 +24,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.adevinta.android.barista.internal.viewaction.ClickChildAction
 import im.vector.app.R
+import im.vector.app.clickOnSheet
 import im.vector.app.espresso.tools.waitUntilActivityVisible
 import im.vector.app.espresso.tools.waitUntilDialogVisible
 import im.vector.app.espresso.tools.waitUntilViewVisible
@@ -49,7 +50,7 @@ class SpaceMenuRobot {
     }
 
     fun invitePeople() = apply {
-        clickOn(R.id.invitePeople)
+        clickOnSheet(R.id.invitePeople)
         waitUntilDialogVisible(ViewMatchers.withId(R.id.inviteByMxidButton))
         clickOn(R.id.inviteByMxidButton)
         waitUntilActivityVisible<InviteUsersToRoomActivity> {
@@ -62,7 +63,7 @@ class SpaceMenuRobot {
     }
 
     fun spaceMembers() {
-        clickOn(R.id.showMemberList)
+        clickOnSheet(R.id.showMemberList)
         waitUntilActivityVisible<RoomProfileActivity> {
             waitUntilViewVisible(ViewMatchers.withId(R.id.roomSettingsRecyclerView))
         }
@@ -70,7 +71,7 @@ class SpaceMenuRobot {
     }
 
     fun spaceSettings(block: SpaceSettingsRobot.() -> Unit) {
-        clickOn(R.id.spaceSettings)
+        clickOnSheet(R.id.spaceSettings)
         waitUntilActivityVisible<SpaceManageActivity> {
             waitUntilViewVisible(ViewMatchers.withId(R.id.roomSettingsRecyclerView))
         }
@@ -78,7 +79,7 @@ class SpaceMenuRobot {
     }
 
     fun exploreRooms() {
-        clickOn(R.id.exploreRooms)
+        clickOnSheet(R.id.exploreRooms)
         waitUntilActivityVisible<SpaceExploreActivity> {
             waitUntilViewVisible(ViewMatchers.withId(R.id.spaceDirectoryList))
         }
@@ -86,7 +87,7 @@ class SpaceMenuRobot {
     }
 
     fun addRoom() = apply {
-        clickOn(R.id.addRooms)
+        clickOnSheet(R.id.addRooms)
         waitUntilActivityVisible<SpaceManageActivity> {
             waitUntilViewVisible(ViewMatchers.withId(R.id.roomList))
         }
@@ -94,7 +95,7 @@ class SpaceMenuRobot {
     }
 
     fun addSpace() = apply {
-        clickOn(R.id.addSpaces)
+        clickOnSheet(R.id.addSpaces)
         waitUntilActivityVisible<SpaceManageActivity> {
             waitUntilViewVisible(ViewMatchers.withId(R.id.roomList))
         }
@@ -102,7 +103,7 @@ class SpaceMenuRobot {
     }
 
     fun leaveSpace() {
-        clickOn(R.id.leaveSpace)
+        clickOnSheet(R.id.leaveSpace)
         waitUntilDialogVisible(ViewMatchers.withId(R.id.leaveButton))
         clickOn(R.id.leave_selected)
         waitUntilActivityVisible<SpaceLeaveAdvancedActivity> {


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Adds a separate `clickOn` helper for interacting with dialog bottom sheets, it seems the space menu sheet lives in a separate root to the rest of the suite (could be the fast switching of activities highlighting existing issues)

## Motivation and context

To fix the UI sanity tests failing when attempting to interact with the spaces menu #5269 

## Screenshots / GIFs

| BEFORE | AFTER | 
| --- | --- |
|![before-space-test](https://user-images.githubusercontent.com/1848238/155317042-b59e8dc4-e75d-410b-a981-de6f3f5651f9.gif)|![after-spaces-test](https://user-images.githubusercontent.com/1848238/155317032-4995893a-0f70-4b5b-8852-7938a26bb577.gif)


## Tests

Run the UI sanity tests on a Pixel 5x (Sv2) emulator.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Sv2 (31)