### PR TITLE
Upgrade to Android stem 2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.3.10'
         classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3'
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.4'
-        classpath "com.likethesalad.android:string-reference:1.2.2"
+        classpath "com.likethesalad.android:stem-plugin:2.0.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/changelog.d/5348.misc
+++ b/changelog.d/5348.misc
@@ -1,0 +1,1 @@
+Upgrade the plugin which generate strings with template from 1.2.2 to 2.0.0

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'placeholder-resolver'
+apply plugin: 'com.likethesalad.stem'
 apply plugin: 'dagger.hilt.android.plugin'
 
 kapt {

--- a/vector/lint.xml
+++ b/vector/lint.xml
@@ -75,14 +75,6 @@
     <issue id="Typos" severity="error" />
     <issue id="TypographyDashes" severity="error" />
 
-    <!-- Ignore lint issue in generated resource file from templates.
-     https://github.com/LikeTheSalad/android-string-reference generates string from the default language
-     if the translation is missing, and it can lead to typos. Lint should only check the string from the
-     original file, so with id starting by `template_`. -->
-    <issue id="all">
-        <ignore path="**/generated/resolved/**/resolved.xml" />
-    </issue>
-
     <!-- DI -->
     <issue id="JvmStaticProvidesInObjectDetector" severity="error" />
 </lint>

--- a/vector/src/main/res/values-ar/strings.xml
+++ b/vector/src/main/res/values-ar/strings.xml
@@ -269,7 +269,7 @@
     <string name="local_address_book_header">دفتر العناوين المحلي</string>
     <string name="matrix_only_filter">متراسلو «ماترِكس» فقط</string>
     <string name="no_conversation_placeholder">لا محادثات</string>
-    <string name="template_no_contact_access_placeholder">لم تسمح لِ‍ Element بمطالعة متراسليك المحليين</string>
+    <string name="no_contact_access_placeholder">لم تسمح لِ‍ Element بمطالعة متراسليك المحليين</string>
     <string name="no_result_placeholder">لا نتائج</string>
     <string name="rooms_header">الغرف</string>
     <string name="rooms_directory_header">دليل الغرف</string>
@@ -671,18 +671,18 @@
     <string name="compression_options">"أرسِل كَ‍ "</string>
     <string name="call_error_ice_failed">فشل اتصال الوسائط</string>
     <string name="call_error_answered_elsewhere">رُدّ على المكالة في مكان آخر</string>
-    <string name="template_permissions_rationale_msg_storage">يحتاج Element تصريحا منك للوصول إلى مكتبتي الصور والفديو لإرسال المرفقات وحفظها.
+    <string name="permissions_rationale_msg_storage">يحتاج Element تصريحا منك للوصول إلى مكتبتي الصور والفديو لإرسال المرفقات وحفظها.
 
 رجاءً اسمح بالوصول في المنبثقة التالية لتقدر على إرسال الملفات من هاتفك.</string>
-    <string name="template_permissions_rationale_msg_camera">يحتاج Element تصريحا منك للوصول إلى الكمرة لأخذ الصور وللمكالمات الصورية.</string>
-    <string name="template_permissions_rationale_msg_record_audio">يحتاج Element تصريحا منك للوصول إلى المِكرفون لإجراء المكالمات الصوتية.</string>
+    <string name="permissions_rationale_msg_camera">يحتاج Element تصريحا منك للوصول إلى الكمرة لأخذ الصور وللمكالمات الصورية.</string>
+    <string name="permissions_rationale_msg_record_audio">يحتاج Element تصريحا منك للوصول إلى المِكرفون لإجراء المكالمات الصوتية.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">
 
 رجاءً اسمح بالنفاذ في المنبثقة الآتية لتتمكن من إجراء محادثة.</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">يحتاج Element تصريحا منك للوصول إلى الكمرة والمِكرفون لإجراء المكالمات الصورية.
+    <string name="permissions_rationale_msg_camera_and_audio">يحتاج Element تصريحا منك للوصول إلى الكمرة والمِكرفون لإجراء المكالمات الصورية.
 
 رجاءً اسمح بالوصول في المنبثقة التالية لتقدر على إرسال إجراء المكالمات الصورية.</string>
-    <string name="template_permissions_rationale_msg_contacts">يحتاج Element تصريحا منك للوصول إلى دفتر العناوين للعثور على مستخدمي ماترِكس الآخرين وذلك حسب البريد الإلكتروني ورقم الهاتف.
+    <string name="permissions_rationale_msg_contacts">يحتاج Element تصريحا منك للوصول إلى دفتر العناوين للعثور على مستخدمي ماترِكس الآخرين وذلك حسب البريد الإلكتروني ورقم الهاتف.
 
 رجاءً اسمح بالوصول في المنبثقة التالية لتستكشف مستخدميك في دفتر العناوين من Element.</string>
     <string name="media_slider_saved">حُفظت</string>
@@ -699,7 +699,7 @@
     <string name="read_receipts_list">قائمة علامات القراءة</string>
     <string name="compression_opt_list_original">الأصلي</string>
     <string name="call_error_user_not_responding">لم يُجب الطرف البعيد.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">يحتاج Element تصريحا منك للوصول إلى دفتر العناوين للعثور على مستخدمي ماترِكس الآخرين وذلك حسب البريد الإلكتروني ورقم الهاتف.
+    <string name="permissions_msg_contacts_warning_other_androids">يحتاج Element تصريحا منك للوصول إلى دفتر العناوين للعثور على مستخدمي ماترِكس الآخرين وذلك حسب البريد الإلكتروني ورقم الهاتف.
 
 أتسمح بأن يصل Element إلى متراسليك؟</string>
     <string name="room_participants_header_direct_chats">الدردشات المباشرة</string>
@@ -914,7 +914,7 @@
     <string name="e2e_re_request_encryption_key"><u>أعِد طلب مفاتيح التعمية</u>من أجهزتك الأخرى.</string>
     <string name="e2e_re_request_encryption_key_sent">أُرسل طلب المفتاح.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">أُرسل الطلب</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">رجاءً أطلِق Element في جهاز آخر يقدر على فك تعمية الرسالة ليُرسل المفاتيح إلى هذا الجهاز.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">رجاءً أطلِق Element في جهاز آخر يقدر على فك تعمية الرسالة ليُرسل المفاتيح إلى هذا الجهاز.</string>
     <string name="action_speak">انطِق</string>
     <string name="action_clear">امسح</string>
     <string name="room_participants_online">متّصل</string>
@@ -936,8 +936,8 @@
     <string name="startup_notification_privacy_button_grant">امنح التصريح</string>
     <string name="startup_notification_privacy_button_other">اختر خيارا آخر</string>
     <string name="settings_opt_in_of_analytics">أرسِل بيانات التحاليل</string>
-    <string name="template_settings_opt_in_of_analytics_summary">يجمع Element التحاليل بشكل مجهّل فيتيح لنا ذلك تحسين التطبيق.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">رجاءً فعّل التحاليل لمساعدتنا في تحسين Element.</string>
+    <string name="settings_opt_in_of_analytics_summary">يجمع Element التحاليل بشكل مجهّل فيتيح لنا ذلك تحسين التطبيق.</string>
+    <string name="settings_opt_in_of_analytics_prompt">رجاءً فعّل التحاليل لمساعدتنا في تحسين Element.</string>
     <string name="settings_opt_in_of_analytics_ok">نعم أريد المساعدة!</string>
     <string name="lock_screen_hint">اكتب هنا…</string>
     <string name="widget_integration_missing_parameter">ثمة معامل مطلوب ناقص.</string>
@@ -999,7 +999,7 @@
         <item quantity="other">%d محدّدة</item>
     </plurals>
     <string name="settings_preview_media_before_sending">عايِن الوسيط قبل إرساله</string>
-    <string name="template_startup_notification_privacy_message">يمكن أن يعمل Element في الخلفية ليُدير الإخطارات بأمان وخصوصية (قد يؤثّر هذا على استهلاك البطارية).</string>
+    <string name="startup_notification_privacy_message">يمكن أن يعمل Element في الخلفية ليُدير الإخطارات بأمان وخصوصية (قد يؤثّر هذا على استهلاك البطارية).</string>
     <string name="settings_without_flair">لست عضوًا في أي مجتمع حاليًا.</string>
     <plurals name="notification_unread_notified_messages">
         <item quantity="zero">لا رسائل إخطار غير مقروءة</item>

--- a/vector/src/main/res/values-b+sr+Latn/strings.xml
+++ b/vector/src/main/res/values-b+sr+Latn/strings.xml
@@ -178,7 +178,7 @@
     <string name="room_info_room_topic">Tema sobe</string>
 
     <string name="settings_call_category">Pozivi</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Koristi podrazumevani ${app_name} zvuk zvona za dolazeće pozive</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Koristi podrazumevani ${app_name} zvuk zvona za dolazeće pozive</string>
     <string name="settings_call_ringtone_title">Zvuk zvona dolazećeg poziva</string>
     <string name="settings_call_ringtone_dialog_title">Izaberite zvuk zvona za pozive:</string>
 
@@ -202,7 +202,7 @@
 
     <string name="settings_troubleshoot_test_service_boot_success">Servis će se početi sa radom prilikom ponovnog pokretanja uređaja.</string>
     <string name="settings_troubleshoot_test_battery_title">Optimizacija potrošnje baterije</string>
-    <string name="template_settings_troubleshoot_test_battery_success">Optimizacija potrošnje baterije ne utiče na ${app_name}.</string>
+    <string name="settings_troubleshoot_test_battery_success">Optimizacija potrošnje baterije ne utiče na ${app_name}.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignoriši optimizacije</string>
 
     <string name="settings_notification_privacy_normal">Normalno</string>
@@ -257,7 +257,7 @@
     <string name="settings_discovery_category">Pronalaženje</string>
     <string name="settings_discovery_manage">Upravljajte vašim podešavanjima za pronalaženje.</string>
     <string name="startup_notification_privacy_title">Privatnost obaveštenja</string>
-    <string name="template_startup_notification_privacy_message">${app_name} može da radi u pozadini kako bi upravljao vašim obaveštenjima sigurno i privatno. Ovo može da utiče na potrošnju baterije.</string>
+    <string name="startup_notification_privacy_message">${app_name} može da radi u pozadini kako bi upravljao vašim obaveštenjima sigurno i privatno. Ovo može da utiče na potrošnju baterije.</string>
     <string name="startup_notification_privacy_button_grant">Dozvoli</string>
     <string name="startup_notification_privacy_button_other">Izaberi drugu opciju</string>
 

--- a/vector/src/main/res/values-bg/strings.xml
+++ b/vector/src/main/res/values-bg/strings.xml
@@ -337,7 +337,7 @@
     <string name="user_directory_header">Директория с потребители</string>
     <string name="matrix_only_filter">Само потребители на Matrix</string>
     <string name="no_conversation_placeholder">Няма разговори</string>
-    <string name="template_no_contact_access_placeholder">Не сте дали достъп на ${app_name} до локалните ви контакти</string>
+    <string name="no_contact_access_placeholder">Не сте дали достъп на ${app_name} до локалните ви контакти</string>
     <string name="no_result_placeholder">Няма резултати</string>
     <string name="rooms_header">Стаи</string>
     <string name="rooms_directory_header">Директория със стаи</string>
@@ -756,22 +756,22 @@
     <string name="widget_integration_missing_user_id">Липсва user_id в заявката.</string>
     <string name="widget_integration_room_not_visible">Стая %s не е видима.</string>
     <string name="room_add_matrix_apps">Добави Matrix приложения</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} иска разрешение за достъп до Вашата галерия със снимки и видеа, за да изпраща и запазва прикачени файлове.
+    <string name="permissions_rationale_msg_storage">${app_name} иска разрешение за достъп до Вашата галерия със снимки и видеа, за да изпраща и запазва прикачени файлове.
 \n
 \nМоля, разрешете достъпа от следващия прозорец, който се покаже, за да можете да изпращате файлове от телефона си.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} иска разшерение за достъп до Вашата камера, за да прави снимки или да осъществи видео разговори.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} иска разшерение за достъп до Вашата камера, за да прави снимки или да осъществи видео разговори.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nМоля, разрешете достъпа от следващия прозорец, който ще се покаже, за да можете да се обадите."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} иска разшерение за достъп до Вашия микрофон, за да се извърши звуков разговор.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} иска разшерение за достъп до Вашия микрофон, за да се извърши звуков разговор.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nМоля, разрешете достъпа от следващия прозорец, който ще се покаже, за да можете да се обадите."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} иска разширение за достъп до микрофона и камерата Ви, за да извърши видео разговор.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} иска разширение за достъп до микрофона и камерата Ви, за да извърши видео разговор.
 \n
 \nМоля, разрешете достъпа от следващия прозорец, който ще се покаже, за да можете да се обадите.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} може да провери контактите ви, за да намери други Matrix потребители по имейл или телефонен номер. Ако сте съгласни да споделите списъка с контактите си за тази цел, моля разрешете достъп при предстоящото запитване.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} може да провери контактите ви, за да намери други Matrix потребители по имейл и телефонен номер.
+    <string name="permissions_rationale_msg_contacts">${app_name} може да провери контактите ви, за да намери други Matrix потребители по имейл или телефонен номер. Ако сте съгласни да споделите списъка с контактите си за тази цел, моля разрешете достъп при предстоящото запитване.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} може да провери контактите ви, за да намери други Matrix потребители по имейл и телефонен номер.
 \n
 \nРазрешавате ли да се сподели списъка с контакти за тази цел\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Извинете. Операцията не е извършена поради липсващи разрешения за достъп</string>
@@ -887,7 +887,7 @@
     <string name="settings_notification_privacy_nosecure_message_content">• Уведомленията съдържат <b>метаданни и съдържания на съобщения</b></string>
     <string name="settings_notification_privacy_message_content_not_shown">• Уведомленията <b>няма да показват съдържания на съобщения</b></string>
     <string name="startup_notification_privacy_title">Конфиденциалност на известията</string>
-    <string name="template_startup_notification_privacy_message">${app_name} може да работи във фонов режим за да получава известия по защитен начин. Може да повлияе на консумацията на енергия.</string>
+    <string name="startup_notification_privacy_message">${app_name} може да работи във фонов режим за да получава известия по защитен начин. Може да повлияе на консумацията на енергия.</string>
     <string name="startup_notification_privacy_button_grant">Разреши достъп</string>
     <string name="startup_notification_privacy_button_other">Избери друг вариант</string>
     <string name="settings_notification_privacy">Конфиденциалност на известията</string>
@@ -900,8 +900,8 @@
     <string name="settings_deactivate_account_section">Деактивиране на акаунт</string>
     <string name="settings_deactivate_my_account">Деактивирай акаунта ми</string>
     <string name="settings_opt_in_of_analytics">Изпращане на статистически данни</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} събира анонимни статистики за да ни помогне да подобрим приложението.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Моля, включете изпращането на статистики за да ни помогнете да подобрим ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} събира анонимни статистики за да ни помогне да подобрим приложението.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Моля, включете изпращането на статистики за да ни помогнете да подобрим ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Да, искам да помогна!</string>
     <string name="widget_integration_missing_parameter">Липсва задължителен параметър.</string>
     <string name="widget_integration_invalid_parameter">Невалиден параметър.</string>
@@ -923,7 +923,7 @@
     <string name="e2e_re_request_encryption_key"><u>Изисквай повторно ключове за шифроване</u> от другите ми устройства.</string>
     <string name="e2e_re_request_encryption_key_sent">Заявката за ключове беше изпратена.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Изпратена заявка</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Моля стартирайте ${app_name} на друго устройство можещо да разшифрова съобщението, за да може то да изпрати ключовете до това устройство.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Моля стартирайте ${app_name} на друго устройство можещо да разшифрова съобщението, за да може то да изпрати ключовете до това устройство.</string>
     <string name="lock_screen_hint">Пишете тук…</string>
     <string name="option_send_voice">Изпрати гласово съобщение</string>
     <string name="go_on_with">продължете с…</string>
@@ -1020,7 +1020,7 @@
     <string name="action_accept">Приемам</string>
     <string name="auth_accept_policies">Моля прегледайте и приемете политиките на сървъра:</string>
     <string name="settings_call_category">Обаждания</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Използвай мелодията по подразбиране на ${app_name} за входящи повиквания</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Използвай мелодията по подразбиране на ${app_name} за входящи повиквания</string>
     <string name="settings_call_ringtone_title">Мелодия за входящо повикване</string>
     <string name="settings_call_ringtone_dialog_title">Избор на мелодия за обаждания:</string>
     <string name="room_participants_action_remove">Изгони</string>
@@ -1061,12 +1061,12 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Разреши</string>
     <string name="settings_troubleshoot_test_device_settings_title">Настройки на устройството.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Уведомленията са разрешени за това устройство.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Уведомленията са забранени за тази сесия.
+    <string name="settings_troubleshoot_test_device_settings_failed">Уведомленията са забранени за тази сесия.
 \nМоля, проверете настройките на ${app_name}.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Разреши</string>
     <string name="settings_troubleshoot_test_play_services_title">Проверка на Google Play услугите</string>
     <string name="settings_troubleshoot_test_play_services_success">APK пакет за Google Play услугите е наличен и с актуална версия.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} използва Google Play услугите за да доставя известия за съобщения, но изглежда те не са конфигурирани правилно:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} използва Google Play услугите за да доставя известия за съобщения, но изглежда те не са конфигурирани правилно:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Поправи Google Play услугите</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase токен</string>
@@ -1083,21 +1083,21 @@
     <string name="settings_troubleshoot_test_service_restart_failed">Услугата не успя да се рестартира</string>
     <string name="settings_troubleshoot_test_service_boot_title">Стартирай при старт на системата</string>
     <string name="settings_troubleshoot_test_service_boot_success">Услугата ще стартира когато устройството се рестартира.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Услугата няма да стартира когато устройството се рестартира. Няма да получавате известия докато ${app_name} не бъде отворен поне веднъж.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Услугата няма да стартира когато устройството се рестартира. Няма да получавате известия докато ${app_name} не бъде отворен поне веднъж.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Стартирай при старт на системата</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Проверка на фоновите ограничения</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Ограниченията във фонов режим са изключени за ${app_name}. Тази проверка трябва да се изпълни използвайки мобилни данни (не на Wi-Fi).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Ограниченията във фонов режим са изключени за ${app_name}. Тази проверка трябва да се изпълни използвайки мобилни данни (не на Wi-Fi).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Активирани са ограничения във фонов режим за ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Активирани са ограничения във фонов режим за ${app_name}.
 \nРаботата, която приложението се опитва да извършва във фонов режим бива агресивно ограничена. Това може да повлияе на известяването.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Премахни ограниченията</string>
     <string name="settings_troubleshoot_test_battery_title">Оптимизация на батерията</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} не се влияе от Оптимизация на батерията.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} не се влияе от Оптимизация на батерията.</string>
     <string name="settings_troubleshoot_test_battery_failed">Ако потребител остави устройството неподвижно с изключен екран за известно време, то влиза в режим на заспиване. Това предотвратява приложенията да достъпват мрежата и отлага техните задачи, синхронизации и стандартни аларми.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Игнорирай оптимизацията</string>
     <string name="startup_notification_fdroid_battery_optim_title">Връзка във фонов режим</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} трябва да поддържа ниско-натоварваща връзка във фонов режим, за да може известията да пристигат надеждно.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} трябва да поддържа ниско-натоварваща връзка във фонов режим, за да може известията да пристигат надеждно.
 \nНа следващия екран, ще бъдете попитани дали да позволите на ${app_name} винаги да работи във фонов режим. Моля, приемете.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Разреши</string>
     <string name="account_email_error">Възникна грешка при проверката на имейл адреса Ви.</string>
@@ -1117,11 +1117,11 @@
     <string name="settings_troubleshoot_test_bing_settings_failed">Някои известия са изключени в собствените Ви настройки.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">Неуспешно зареждане на собствените правила. Опитайте пак.</string>
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Провери настройките</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nТази грешка е извън контрола на ${app_name}. Според Google, грешката показва, че устройството има прекалено много приложения регистрирани към системата за известия FCM. Проблема се случва само в случай на огромен брой приложения, така че не би трябвало да повлияе средно-статистическия потребител.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nТази грешка е извън контрола на ${app_name}. Може да се случи поради няколко причини. Възможно е проблема да изчезне, ако опитате по-късно. Също така, може да проверите дали Google Play услугите не са ограничени откъм мобилни данни (вижте системните настройки), или че часовникът на устройството е правилен. Възможно е грешката да възникне и ако използвате модифицирана операционна система (custom ROM).</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nТази грешка е извън контрола на ${app_name}. Няма Google акаунт на телефонът. Отворете системата за управления на акаунти и добавете Google акаунт.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Добави акаунт</string>
     <string name="settings_noisy_notifications_preferences">Настройка на шумни известия</string>
@@ -1133,7 +1133,7 @@
     <string name="notification_silent">Безшумно</string>
     <string name="passphrase_empty_error_message">Моля, въведете парола</string>
     <string name="passphrase_passphrase_too_weak">Паролата е прекалено слаба</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Моля, изтрийте паролата, ако искате ${app_name} да генерира ключ за възстановяване.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Моля, изтрийте паролата, ако искате ${app_name} да генерира ключ за възстановяване.</string>
     <string name="keys_backup_no_session_error">Не беше открита Matrix сесия</string>
     <string name="keys_backup_setup_step1_title">Никога не губете шифровани съобщения</string>
     <string name="keys_backup_setup_step1_description">Съобщения в шифровани стаи са защитени с шифроване от край до край. Само Вие и получателят (получателите) имате ключовете за прочитането им.
@@ -1262,7 +1262,7 @@
     <string name="passwords_do_not_match">Паролите не съвпадат</string>
     <string name="autodiscover_invalid_response">Невалиден отговор при опит за откриване на адреса на сървъра</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Опции за откриване на сървър</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} откри конфигурация за собствен сървър за домейна от потребителското Ви име \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} откри конфигурация за собствен сървър за домейна от потребителското Ви име \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Използвай конфигурацията</string>
     <string name="notification_sync_init">Инициализиране на услугата</string>
@@ -1378,7 +1378,7 @@
     <string name="please_wait">Изчакайте…</string>
     <string name="group_all_communities">Всички общности</string>
     <string name="room_preview_no_preview">Тази стая не може да бъде прегледана</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Прегледа на стаи четими от цял свят все още не се поддържа от ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Прегледа на стаи четими от цял свят все още не се поддържа от ${app_name}</string>
     <string name="fab_menu_create_room">Стаи</string>
     <string name="fab_menu_create_chat">Директни съобщения</string>
     <string name="create_room_title">Нова стая</string>
@@ -1473,10 +1473,10 @@
     <string name="invite_no_identity_server_error">Добавете сървър за самоличност в настройки за да извършите това действие.</string>
     <string name="settings_background_fdroid_sync_mode">Режим на фонова синхронизация</string>
     <string name="settings_background_fdroid_sync_mode_battery">Пестящ батерия</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} ще синхронизира във фонов режим по начин, който пести ограничените ресурси на устройството (батерия).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} ще синхронизира във фонов режим по начин, който пести ограничените ресурси на устройството (батерия).
 \nВ зависимост от състоянието на ресурсите, синхронизацията може да бъде отложена от операционната система.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Целящ висока интерактивност</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} ще синхронизира във фонов режим на определен интервал (конфигурируемо).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} ще синхронизира във фонов режим на определен интервал (конфигурируемо).
 \nТова ще повлияе на използването на антената и батерията. Ще се показва перманентна нотификация, че ${app_name} слуша за събития.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Без фонова синхронизация</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Няма да бъдете уведомени за входящи съобщения, когато приложението е във фонов режим.</string>
@@ -1561,13 +1561,13 @@
     <string name="content_reported_as_inappropriate_content">Съдържанието беше докладвано като неподходящо. 
 \n 
 \nАко не искате да виждате повече съдържание от този потребител, може да ги игнорирате за да скриете съобщенията им.</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} се нуждае от привилегии за да запази E2E ключовете върху диска.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} се нуждае от привилегии за да запази E2E ключовете върху диска.
 \n
 \nПозволете достъп на следващия екран, за да може в бъдеще да експортирате ключовете си ръчно.</string>
     <string name="no_network_indicator">В момента няма връзка с мрежата</string>
     <string name="login_error_no_homeserver_found">Това не е валиден адрес на Matrix сървър</string>
     <string name="settings_add_3pid_confirm_password_title">Потвърдете паролата</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Не може да направите това от мобилно приложение на ${app_name}</string>
+    <string name="settings_add_3pid_flow_not_supported">Не може да направите това от мобилно приложение на ${app_name}</string>
     <string name="settings_add_3pid_authentication_needed">Нужна е автентикация</string>
     <string name="settings_integrations">Интеграции</string>
     <string name="settings_integrations_summary">Използвайте мениджър на интеграции за да управлявате ботове, връзки с други мрежи, приспособления и стикери.
@@ -1733,7 +1733,7 @@
 \nВлезте отново за да достъпите профила и съобщенията си.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Ще загубите достъпа до защитените съобщения, освен ако не влезете за да възстановите ключовете за шифроване.</string>
     <string name="soft_logout_clear_data_dialog_submit">Изчисти данните</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Текущата сесия е за потребител %1$s, а вие сте въвели данни за вход за %2$s. ${app_name} не поддържа това.
+    <string name="soft_logout_sso_not_same_user_error">Текущата сесия е за потребител %1$s, а вие сте въвели данни за вход за %2$s. ${app_name} не поддържа това.
 \nПърво изчистете данните, след това влезте отново с друг профил.</string>
     <string name="permalink_malformed">matrix.to връзката ви беше невалидна</string>
     <string name="bug_report_error_too_short">Описанието е прекалено кратко</string>
@@ -1751,7 +1751,7 @@
     <string name="devices_other_devices">Други устройства</string>
     <string name="autocomplete_limited_results">Показване само на първите резултати. Въведете още букви…</string>
     <string name="settings_developer_mode_fail_fast_title">Бърз-провал</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} може да забива по-често когато възникне неочаквана грешка</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} може да забива по-често когато възникне неочаквана грешка</string>
     <string name="notification_ticker_text_dm">%1$s: %2$s</string>
     <string name="notification_ticker_text_group">%1$s: %2$s %3$s</string>
     <string name="event_redacted">Съобщението беше изтрито</string>
@@ -1792,7 +1792,7 @@
     <string name="call_select_sound_device">Избор на звуково устройство</string>
     <string name="call_failed_no_connection_description">Неуспешно установяване на връзка в реално време.
 \nПомолете администратора на сървъра да конфигурира TURN сървър, за да може разговорите да работят надеждно.</string>
-    <string name="template_call_failed_no_connection">Свързването е неуспешно</string>
+    <string name="call_failed_no_connection">Свързването е неуспешно</string>
     <string name="bottom_action_notification">Уведомления</string>
     <string name="dialog_title_success">Успешно</string>
     <string name="action_copy">Копирай</string>
@@ -1834,9 +1834,9 @@
     <string name="verify_cannot_cross_sign">Тази сесия не може да сподели потвърждението с другите ви сесии.
 \nПотвърждението ще се съхрани локално и ще може да бъде споделено в бъдеща версия на приложението.</string>
     <string name="unignore">Махни игнорирането</string>
-    <string name="template_rendering_event_error_exception">${app_name} срещна проблем опитвайки се да визуализира съдържанието на събитие с идентификатор \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} не може да обработи събитие от тип \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} не може да обработва събития от тип \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} срещна проблем опитвайки се да визуализира съдържанието на събитие с идентификатор \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} не може да обработи събитие от тип \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} не може да обработва събития от тип \'%1$s\'</string>
     <string name="room_member_jump_to_read_receipt">Отиди на последното прочетено съобщение</string>
     <string name="room_member_power_level_custom_in">Собствено ниво (%1$d) в %2$s</string>
     <string name="room_member_power_level_default_in">По подразбиране в %1$s</string>
@@ -2086,7 +2086,7 @@
     <string name="encryption_information_dg_xsigning_complete">Кръстосаното-подписване е включено.
 \nЧастните ключове са на устройството.</string>
     <string name="identity_server_error_outdated_home_server">Операцията е невъзможна. Сървърът е стар.</string>
-    <string name="template_identity_server_error_outdated_identity_server">Този сървър за идентичност е стар. ${app_name} поддържа само API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Този сървър за идентичност е стар. ${app_name} поддържа само API V2.</string>
     <string name="disconnect_identity_server_dialog_content">Прекъснете връзката със сървъра за идентичност %s\?</string>
     <string name="open_terms_of">Отворете условията за %s</string>
     <string name="choose_locale_loading_locales">Зареждане на наличните езици…</string>
@@ -2137,13 +2137,13 @@
     <string name="enter_secret_storage_passphrase_or_key">За да продължите, използвайте %1$s или %2$s.</string>
     <string name="command_description_discard_session_not_handled">Поддържа се само в шифровани стаи</string>
     <string name="command_description_discard_session">Принудително премахва текущата изходяща групова сесия от шифрованата стая</string>
-    <string name="template_use_latest_app">Използвайте последната версия на ${app_name} за устройствата си:</string>
+    <string name="use_latest_app">Използвайте последната версия на ${app_name} за устройствата си:</string>
     <string name="or_other_mx_capable_client">или друг Matrix клиент поддържаш кръстосано-подписване</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
-    <string name="template_use_other_session_content_description">Използвайте последната версия на ${app_name} за устройствата си (${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} за Android) или друг Matrix клиент поддържаш кръстосано-подписване</string>
+    <string name="use_other_session_content_description">Използвайте последната версия на ${app_name} за устройствата си (${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} за Android) или друг Matrix клиент поддържаш кръстосано-подписване</string>
     <string name="change_password_summary">Промяна на паролата за профила…</string>
     <string name="error_saving_media_file">Неуспешно съхраняване на медиен файл</string>
     <string name="error_adding_media_file_to_gallery">Неуспешно добавяне на медиен файл в галерията</string>
@@ -2255,19 +2255,19 @@
     <string name="refresh">Обнови</string>
     <string name="e2e_use_keybackup">Разблокирай шифрованата история на съобщенията</string>
     <string name="settings_key_requests">Заявки за ключове</string>
-    <string name="template_login_default_session_public_name">${app_name} за Android</string>
+    <string name="login_default_session_public_name">${app_name} за Android</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Ключовете вече са обновени!</string>
     <string name="universal_link_malformed">Връзката беше с грешен формат</string>
     <string name="room_error_not_found">Неуспешно откриване на стаята. Потвърдете, че съществува.</string>
     <string name="error_opening_banned_room">Не можете да отворите стаи, от които сте били блокирани.</string>
     <string name="auth_pin_confirm_to_disable_title">Потвърждение на PIN код, за да изключване на PIN кода</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">PIN код се изисква всеки път когато отворите ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Изисква се PIN код след 2 минути неизползване на ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">PIN код се изисква всеки път когато отворите ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Изисква се PIN код след 2 минути неизползване на ${app_name}.</string>
     <string name="settings_security_pin_code_grace_period_title">Изисквай PIN код след 2 минути</string>
     <string name="settings_security_pin_code_notifications_summary_off">Показвай само броя непрочетени съобщения в опростено уведомление.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Показвай подробности, като имена на стаи и съдържание на съобщенията.</string>
     <string name="settings_security_pin_code_notifications_title">Показвай съдържанието в уведомленията</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">PIN кодът е единственият начин да отключите ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">PIN кодът е единственият начин да отключите ${app_name}.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Включване на биометрични данни поддържани от устройството, като пръстов отпечатък и разпознаване на лица.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Включване на биометрични данни</string>
     <string name="settings_security_pin_code_summary">Ако искате да нулирате PIN кода си, натиснете Забравен PIN код, за да излезете от профила и да го нулирате.</string>
@@ -2348,7 +2348,7 @@
     <string name="identity_server_set_default_notice">Сървърът ви (%1$s) предлага използването на %2$s за сървър за идентичност</string>
     <string name="identity_server_error_no_current_binding_error">Няма асоциация с текущия идентификатор.</string>
     <string name="identity_server_error_binding_error">Асоциацията беше неуспешна.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">За вашата поверителност, ${app_name} поддържа изпращането на адреси и телефонни номера на потребители само в хеширан вид.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">За вашата поверителност, ${app_name} поддържа изпращането на адреси и телефонни номера на потребители само в хеширан вид.</string>
     <string name="identity_server_error_terms_not_signed">Първо приемете условията за сървъра за идентичност от Настройки.</string>
     <string name="identity_server_error_no_identity_server_configured">Конфигурирайте сървъра си за идентичност.</string>
     <string name="warning_unsaved_change_discard">Отхвърляне на промените</string>

--- a/vector/src/main/res/values-bn-rBD/strings.xml
+++ b/vector/src/main/res/values-bn-rBD/strings.xml
@@ -55,7 +55,7 @@
 \n আপনার কীগুলি এড়াতে নিরাপদে ব্যাক আপ দিন।</string>
     <string name="keys_backup_setup_step1_title">এনক্রিপ্ট করা বার্তাগুলি কখনই হারাবেন না</string>
     <string name="keys_backup_no_session_error">কোনও ম্যাট্রিক্স সেশন উপলব্ধ নেই</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">আপনি যদি এলিমেন্টটি পুনরুদ্ধার কী তৈরি করতে চান তবে দয়া করে পাসফ্রেজটি মুছুন।</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">আপনি যদি এলিমেন্টটি পুনরুদ্ধার কী তৈরি করতে চান তবে দয়া করে পাসফ্রেজটি মুছুন।</string>
     <string name="passphrase_passphrase_too_weak">পাসফ্রেজটি খুব দুর্বল</string>
     <string name="passphrase_empty_error_message">দয়া করে একটি পাসফ্রেজ লিখুন</string>
     <string name="passphrase_passphrase_does_not_match">পাসফ্রেজ মেলে নি</string>
@@ -285,17 +285,17 @@
     <string name="settings_notification_privacy_normal">সাধারণ</string>
     <string name="settings_troubleshoot_test_battery_quickfix">অপ্টিমাইজেশান অবহেলা</string>
     <string name="settings_troubleshoot_test_battery_failed">যদি কোনও ব্যবহারকারী কোনও ডিভাইসটিকে নির্দিষ্ট সময়ের জন্য আনপ্লাগ এবং স্থিতিশীল রাখে তবে স্ক্রীন বন্ধের সাথে ডিভাইসটি ডোজ মোডে প্রবেশ করে। এটি অ্যাপ্লিকেশানগুলিকে নেটওয়ার্ক অ্যাক্সেস করতে বাধা দেয় এবং তাদের কাজ, সিঙ্ক এবং মান অ্যালার্মগুলি স্থগিত করে।</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} ব্যাটারি অপ্টিমাইজেশান দ্বারা প্রভাবিত হয় না।</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} ব্যাটারি অপ্টিমাইজেশান দ্বারা প্রভাবিত হয় না।</string>
     <string name="settings_troubleshoot_test_battery_title">ব্যাটারি অপ্টিমাইজেশান</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">সীমাবদ্ধগুলি নিষ্ক্রিয়</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">ব্যাকগ্রউন্ডের সীমাবদ্ধতা রিমোট এর জন্য সক্রিয় করা হয়েছে।
+    <string name="settings_troubleshoot_test_bg_restricted_failed">ব্যাকগ্রউন্ডের সীমাবদ্ধতা রিমোট এর জন্য সক্রিয় করা হয়েছে।
 \nঅ্যাপ্লিকেশন যেটি করার চেষ্টা করে সেটি ব্যাকগ্রাউন্ডে থাকা অবস্থায় আক্রমনাত্মকভাবে সীমিত হবে এবং এটি বিজ্ঞপ্তিগুলিতে প্রভাবিত হতে পারে।
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">ব্যাকগ্রউন্ডের সীমাবদ্ধতা ${app_name} এর জন্য নিষ্ক্রিয় করা হয়েছে। এই পরীক্ষা মোবাইল ডেটা ব্যবহার করে চালানো উচিত (ওয়াইফাই না)।
+    <string name="settings_troubleshoot_test_bg_restricted_success">ব্যাকগ্রউন্ডের সীমাবদ্ধতা ${app_name} এর জন্য নিষ্ক্রিয় করা হয়েছে। এই পরীক্ষা মোবাইল ডেটা ব্যবহার করে চালানো উচিত (ওয়াইফাই না)।
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">ব্যাকগ্রাউন্ড এর সীমাবদ্ধতা চেক করুন</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">বুট থেকে শুরু করা সক্রিয় করুন</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">ডিভাইসটি পুনরায় চালু হওয়ার সময় পরিষেবাটি শুরু হবে না, আপনি একবার ${app_name} টি খোলা না হওয়া পর্যন্ত বিজ্ঞপ্তি পাবেন না।</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">ডিভাইসটি পুনরায় চালু হওয়ার সময় পরিষেবাটি শুরু হবে না, আপনি একবার ${app_name} টি খোলা না হওয়া পর্যন্ত বিজ্ঞপ্তি পাবেন না।</string>
     <string name="settings_troubleshoot_test_service_boot_success">ডিভাইসটি পুনরায় চালু হলে পরিষেবা শুরু হবে।</string>
     <string name="settings_troubleshoot_test_service_boot_title">বুট করার সময় শুরু</string>
     <string name="settings_troubleshoot_test_service_restart_failed">পরিষেবা পুনরায় আরম্ভ করতে ব্যর্থ হয়েছে</string>
@@ -306,11 +306,11 @@
     <string name="settings_troubleshoot_test_token_registration_success">FCM টোকেন সফলভাবে হোম সার্ভারে নিবন্ধিত।</string>
     <string name="settings_troubleshoot_test_token_registration_title">টোকেন নিবন্ধন</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">একাউন্ট যোগ করুন</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nএই ত্রুটি ${app_name} এর নিয়ন্ত্রণের বাইরে। ফোনে কোন গুগল একাউন্ট নেই। অ্যাকাউন্ট ম্যানেজার খুলুন এবং একটি গুগল একাউন্ট যোগ করুন।</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nএই ত্রুটি ${app_name} এর নিয়ন্ত্রণের বাইরে। এটা বিভিন্ন কারণে ঘটতে পারে। আপনি পরে পুনরায় চেষ্টা করলে হয়তো এটি কাজ করবে, আপনি এটিও পরীক্ষা করতে পারেন যে Google Play পরিষেবাটি সিস্টেম সেটিংসে ডেটা ব্যবহারের ক্ষেত্রে সীমাবদ্ধ নয়, অথবা আপনার ডিভাইসের ঘড়ি সঠিক, বা এটি কাস্টম রমতে ঘটতে পারে।</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nএই ত্রুটিটি ${app_name} এর নিয়ন্ত্রণের বাইরে এবং Google এর মতে, এই ত্রুটিটি ইঙ্গিত করে যে ডিভাইসটিতে FCM এর সাথে নিবন্ধিত অনেকগুলি অ্যাপ্লিকেশন রয়েছে। ত্রুটিগুলি কেবলমাত্র অ্যাপ্লিকেশনের চরম সংখ্যাগুলিতে ঘটে থাকে, তাই এটি গড় ব্যবহারকারীকে প্রভাবিত করবে না।</string>
     <string name="settings_troubleshoot_test_fcm_failed">FCM টোকেন উদ্ধার করতে ব্যর্থ হয়েছে:
 \n%1$s</string>
@@ -318,7 +318,7 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase এর টোকেন</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Play Services ঠিক করুন</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} পুশ বার্তার প্রদানের জন্য Google Play পরিষেবাদি ব্যবহার করে কিন্তু এটি সঠিকভাবে কনফিগার করা বলে মনে হচ্ছে না:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} পুশ বার্তার প্রদানের জন্য Google Play পরিষেবাদি ব্যবহার করে কিন্তু এটি সঠিকভাবে কনফিগার করা বলে মনে হচ্ছে না:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_success">গুগল প্লে সার্ভিসেস APK পাওয়া গেছে এবং আপ টু ডেট রয়েছে।</string>
     <string name="settings_troubleshoot_test_play_services_title">Play Services পরীক্ষা</string>
@@ -328,7 +328,7 @@
     <string name="settings_troubleshoot_test_bing_settings_success_with_warn">লক্ষ্য করুন যে কিছু বার্তা টাইপ নীরব করা হয়েছে (কোন শব্দ ছাড়াই একটি বিজ্ঞপ্তি তৈরি করবে)।</string>
     <string name="settings_troubleshoot_test_bing_settings_title">কাস্টম সেটিংস।</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">সক্ষম</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">বিজ্ঞপ্তি এই সেশানের জন্য অনুমতি দেওয়া হয় নি।
+    <string name="settings_troubleshoot_test_device_settings_failed">বিজ্ঞপ্তি এই সেশানের জন্য অনুমতি দেওয়া হয় নি।
 \n${app_name} এর সেটিংস যাচাই করুন।</string>
     <string name="settings_troubleshoot_test_device_settings_success">বিজ্ঞপ্তি এই সেশানের জন্য সক্রিয় করা হয়েছে।</string>
     <string name="settings_troubleshoot_test_device_settings_title">সেশান সেটিংস।</string>
@@ -496,7 +496,7 @@
     </plurals>
     <string name="groups_list">গোষ্ঠীগুলি সারি</string>
     <string name="read_receipts_list">পড়ো প্রাপ্তিগুলি সারি</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">দয়া করে শুরু করুন ${app_name} অন্য সেশান যেটা পারে বর্ণনা করতে বার্তা কে সুতরাং এটা পারে পাঠাতে চাবিগুলো কে যন্ত্র তে.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">দয়া করে শুরু করুন ${app_name} অন্য সেশান যেটা পারে বর্ণনা করতে বার্তা কে সুতরাং এটা পারে পাঠাতে চাবিগুলো কে যন্ত্র তে.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">অনুরোধ পাঠানো</string>
     <string name="e2e_re_request_encryption_key_sent">চাবির অনুরোধ পাঠানো।</string>
     <string name="e2e_re_request_encryption_key"><u>পুনরায় অনুরোধ এনক্রিপশন চাবিগুলি</u>আপনার অন্য সেশানগুলি থেকে।</string>
@@ -595,7 +595,7 @@
     <string name="call_select_sound_device">সাউন্ড ডিভাইস নির্বাচন করুন</string>
     <string name="call_failed_no_connection_description">রিয়েল টাইম সংযোগ স্থাপন করতে ব্যর্থ।
 \nকলগুলি নির্ভরযোগ্যতার সাথে কাজ করার জন্য দয়া করে আপনার হোমসার্ভারের প্রশাসককে একটি টার্ন সার্ভার কনফিগার করতে বলুন।</string>
-    <string name="template_call_failed_no_connection">এলিমেন্ট কল ব্যর্থ</string>
+    <string name="call_failed_no_connection">এলিমেন্ট কল ব্যর্থ</string>
     <string name="call_failed_dont_ask_again">আবার আমাকে জিজ্ঞাসা করবেন না</string>
     <string name="call_failed_no_ice_use_alt">%s ব্যবহার করার চেষ্টা করুন</string>
     <string name="call_failed_no_ice_description">কলগুলি নির্ভরযোগ্যভাবে কাজ করার জন্য দয়া করে আপনার হোমসার্ভার (%1$s) এর প্রশাসককে একটি টার্ন সার্ভার কনফিগার করতে বলুন।
@@ -646,7 +646,7 @@
     <string name="rooms_header">রুমগুলি</string>
     <string name="people_no_identity_server">কোনও পরিচয় সার্ভার কনফিগার করা নেই।</string>
     <string name="no_result_placeholder">কোন ফলাফল নেই</string>
-    <string name="template_no_contact_access_placeholder">আপনি রায়টকে আপনার স্থানীয় পরিচিতি অ্যাক্সেস করার অনুমতি দেয় নি</string>
+    <string name="no_contact_access_placeholder">আপনি রায়টকে আপনার স্থানীয় পরিচিতি অ্যাক্সেস করার অনুমতি দেয় নি</string>
     <string name="no_conversation_placeholder">কথাবার্তা নেই</string>
     <string name="matrix_only_filter">শুধুমাত্র ম্যাট্রিক্সের যোগাযোগগুলি</string>
     <string name="user_directory_header">ব্যবহারকারী ডিরেক্টরি</string>
@@ -810,17 +810,17 @@
     <string name="settings_data_save_mode_summary">ডেটা সংরক্ষণ মোড একটি নির্দিষ্ট ফিল্টার প্রয়োগ করে যাতে উপস্থিতি আপডেট এবং টাইপিং বিজ্ঞপ্তি ফিল্টার করা হয়।</string>
     <string name="settings_data_save_mode">ডেটা সংরক্ষণ মোড</string>
     <string name="settings_opt_in_of_analytics_ok">হ্যাঁ, আমি সাহায্য করতে চাই!</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">আমাদের ${app_name} উন্নত করতে সাহায্য করার জন্য বিশ্লেষণ সক্রিয় করুন।</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} আমাদের অ্যাপ্লিকেশন উন্নত করার অনুমতি দেওয়ার জন্য বেনামী বিশ্লেষণ সংগ্রহ করে।</string>
+    <string name="settings_opt_in_of_analytics_prompt">আমাদের ${app_name} উন্নত করতে সাহায্য করার জন্য বিশ্লেষণ সক্রিয় করুন।</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} আমাদের অ্যাপ্লিকেশন উন্নত করার অনুমতি দেওয়ার জন্য বেনামী বিশ্লেষণ সংগ্রহ করে।</string>
     <string name="settings_opt_in_of_analytics">বিশ্লেষণ তথ্য পাঠান</string>
     <string name="settings_analytics">বৈশ্লেষিক ন্যায়</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">অনুমতি প্রদান করুন</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">নির্ভরযোগ্য বিজ্ঞপ্তি পেতে ${app_name} কম প্রভাব ব্যাকগ্রাউন্ড সংযোগ রাখা প্রয়োজন।
+    <string name="startup_notification_fdroid_battery_optim_message">নির্ভরযোগ্য বিজ্ঞপ্তি পেতে ${app_name} কম প্রভাব ব্যাকগ্রাউন্ড সংযোগ রাখা প্রয়োজন।
 \nপরবর্তী স্ক্রিনে আপনাকে দাঙ্গাটি সর্বদা ব্যাকগ্রাউন্ডে চালানোর অনুমতি দেওয়া হবে, দয়া করে স্বীকার করুন।</string>
     <string name="startup_notification_fdroid_battery_optim_title">পটভূমি সংযোগ</string>
     <string name="startup_notification_privacy_button_other">অন্য বিকল্প চয়ন করুন</string>
     <string name="startup_notification_privacy_button_grant">অনুমতি প্রদান করুন</string>
-    <string name="template_startup_notification_privacy_message">সুরক্ষিতভাবে এবং ব্যক্তিগতভাবে আপনার বিজ্ঞপ্তি পরিচালনা করতে ${app_name} পটভূমিতে চালাতে পারে। এই ব্যাটারি ব্যবহার প্রভাবিত হতে পারে।</string>
+    <string name="startup_notification_privacy_message">সুরক্ষিতভাবে এবং ব্যক্তিগতভাবে আপনার বিজ্ঞপ্তি পরিচালনা করতে ${app_name} পটভূমিতে চালাতে পারে। এই ব্যাটারি ব্যবহার প্রভাবিত হতে পারে।</string>
     <string name="startup_notification_privacy_title">বিজ্ঞপ্তি\'র গোপনীয়তা</string>
     <string name="settings_discovery_manage">আপনার আবিষ্কারের সেটিংস পরিচালনা করুন।</string>
     <string name="settings_discovery_category">আবিষ্কার</string>
@@ -889,10 +889,10 @@
     <string name="settings_background_sync_update_error">সেটিংস আপডেট করতে ব্যর্থ।</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">অ্যাপটি ব্যাকগ্রাউন্ডে থাকা অবস্থায় আপনাকে আগত বার্তাগুলি সম্পর্কে অবহিত করা হবে না।</string>
     <string name="settings_background_fdroid_sync_mode_disabled">কোনও পটভূমি সিঙ্ক না</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">রায়ট নির্দিষ্ট সময়ে সময়ে পটভূমিতে সিঙ্ক হবে (কনফিগারযোগ্য)।
+    <string name="settings_background_fdroid_sync_mode_real_time_description">রায়ট নির্দিষ্ট সময়ে সময়ে পটভূমিতে সিঙ্ক হবে (কনফিগারযোগ্য)।
 \nএটি রেডিও এবং ব্যাটারির ব্যবহারকে প্রভাবিত করবে, রায়ট ইভেন্টগুলি শুনছে বলে জানিয়ে একটি স্থায়ী বিজ্ঞপ্তি প্রদর্শিত হবে।</string>
     <string name="settings_background_fdroid_sync_mode_real_time">রিয়েল টাইম জন্য অনুকূলিত</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">রায়ট এমনভাবে পটভূমিতে সিঙ্ক হবে যা ডিভাইসের সীমিত সংস্থান (ব্যাটারি) সংরক্ষণ করে।
+    <string name="settings_background_fdroid_sync_mode_battery_description">রায়ট এমনভাবে পটভূমিতে সিঙ্ক হবে যা ডিভাইসের সীমিত সংস্থান (ব্যাটারি) সংরক্ষণ করে।
 \nআপনার ডিভাইস রিসোর্স স্থিতির উপর নির্ভর করে সিঙ্কটি অপারেটিং সিস্টেম দ্বারা পিছিয়ে যেতে পারে।</string>
     <string name="settings_background_fdroid_sync_mode_battery">ব্যাটারির জন্য অনুকূলিত</string>
     <string name="action_skip">বাদ</string>
@@ -1282,22 +1282,22 @@
     <string name="media_slider_saved_message">ডাউনলোডে সংরক্ষণ করবেন\?</string>
     <string name="media_slider_saved">সংরক্ষিত</string>
     <string name="permissions_action_not_performed_missing_permissions">দুঃখিত। কর্ম সঞ্চালিত না, অনুপস্থিত অনুমতির জন্য</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">রায়ট অন্যান্য ম্যাট্রিক্স ব্যবহারকারীদের তাদের ইমেল এবং ফোন নম্বরগুলির উপর ভিত্তি করে আপনার ঠিকানা বইটি চেক করতে পারে।
+    <string name="permissions_msg_contacts_warning_other_androids">রায়ট অন্যান্য ম্যাট্রিক্স ব্যবহারকারীদের তাদের ইমেল এবং ফোন নম্বরগুলির উপর ভিত্তি করে আপনার ঠিকানা বইটি চেক করতে পারে।
 \n
 \nআপনি এই উদ্দেশ্যে আপনার ঠিকানা বই ভাগ করতে সম্মত হন\?</string>
-    <string name="template_permissions_rationale_msg_contacts">রায়ট অন্যান্য ম্যাট্রিক্স ব্যবহারকারীদের তাদের ইমেল এবং ফোন নম্বরগুলির উপর ভিত্তি করে আপনার ঠিকানা বইটি চেক করতে পারে। আপনি যদি এই উদ্দেশ্যে আপনার ঠিকানা বইটি ভাগ করে নিতে সম্মত হন তবে দয়া করে পরবর্তী পপ-আপটিতে অ্যাক্সেসের অনুমতি দিন।</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">ভিডিও কল সম্পাদনের জন্য ${app_name} আপনার ক্যামেরা এবং আপনার মাইক্রোফোন অ্যাক্সেস করার অনুমতির প্রয়োজন।
+    <string name="permissions_rationale_msg_contacts">রায়ট অন্যান্য ম্যাট্রিক্স ব্যবহারকারীদের তাদের ইমেল এবং ফোন নম্বরগুলির উপর ভিত্তি করে আপনার ঠিকানা বইটি চেক করতে পারে। আপনি যদি এই উদ্দেশ্যে আপনার ঠিকানা বইটি ভাগ করে নিতে সম্মত হন তবে দয়া করে পরবর্তী পপ-আপটিতে অ্যাক্সেসের অনুমতি দিন।</string>
+    <string name="permissions_rationale_msg_camera_and_audio">ভিডিও কল সম্পাদনের জন্য ${app_name} আপনার ক্যামেরা এবং আপনার মাইক্রোফোন অ্যাক্সেস করার অনুমতির প্রয়োজন।
 \n
 \nকল করতে সক্ষম হতে পরবর্তী পপ আপ অ্যাক্সেস অনুমতি দিন।</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nদেয়া করে অনুমতিদিন প্রবেশ করতে পরের pop-up এ যেটা কল করতে সক্ষম।"</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} এর প্রয়োজন অনুমতি নিয়ে প্রবেশ করতে আপনার মাইক্রোফোন আর মাধ্যমে শোনার কালএর সঞ্চালনা করতে।</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} এর প্রয়োজন অনুমতি নিয়ে প্রবেশ করতে আপনার মাইক্রোফোন আর মাধ্যমে শোনার কালএর সঞ্চালনা করতে।</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nদয়াকরে অনুমতি দিন প্রবেশ করাতে পরের পপ -আপ কে যেটা ডাকতে সক্ষম।"</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} এর প্রয়োজন অনুমতি নিয়ে প্রবেশে করতে আপনার ছবি তোলার যন্ত্র থেকে ছবি নিতে এবং দৃষ্টি রেকর্ড ডাকতে।</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} এর প্রয়াজন অনুমতি নিতে আপনার ছবি এবং দৃশ্য রেকর্ড কে গ্রন্থাগার থেকে পাঠিয়ে জমার জায়গায় সংযুক্ত করতে।
+    <string name="permissions_rationale_msg_camera">${app_name} এর প্রয়োজন অনুমতি নিয়ে প্রবেশে করতে আপনার ছবি তোলার যন্ত্র থেকে ছবি নিতে এবং দৃষ্টি রেকর্ড ডাকতে।</string>
+    <string name="permissions_rationale_msg_storage">${app_name} এর প্রয়াজন অনুমতি নিতে আপনার ছবি এবং দৃশ্য রেকর্ড কে গ্রন্থাগার থেকে পাঠিয়ে জমার জায়গায় সংযুক্ত করতে।
 \nদেয়া করে অনুমতি দিন প্রবেশ করতে পরের pop-up কে যেটা সক্ষম আপনার নথি কে আপনার ফোন থেকে পাঠাতে।</string>
     <string name="permissions_rationale_popup_title">তথা</string>
     <string name="media_picker_cannot_record_video">পারছেন না দৃশ্য নথি করতে</string>
@@ -1322,7 +1322,7 @@
     <string name="settings_call_ringtone_title">আসা কল এর রিংটোন</string>
     <string name="settings_call_ringtone_use_default_stun_sum">আপনার হোমসার্ভার একটি প্রস্তাব না দিলে সহায়তা হিসাবে %s ব্যবহার করবে (আপনার আইপি ঠিকানা কল করার সময় ভাগ করা হবে)</string>
     <string name="settings_call_ringtone_use_default_stun">ফ্যালব্যাক কল সহায়তা সার্ভারকে অনুমতি দিন</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">ব্যবহার করছেন অনুপস্থিত ${app_name} রিংটোন আগামী ডাক এর জন্য</string>
+    <string name="settings_call_ringtone_use_app_ringtone">ব্যবহার করছেন অনুপস্থিত ${app_name} রিংটোন আগামী ডাক এর জন্য</string>
     <string name="settings_call_category">ডাকা</string>
     <string name="room_info_room_topic">ঘরএর বিষয়</string>
     <string name="room_info_room_name">ঘরএর নাম</string>

--- a/vector/src/main/res/values-bn-rIN/strings.xml
+++ b/vector/src/main/res/values-bn-rIN/strings.xml
@@ -309,7 +309,7 @@
     <string name="user_directory_header">ব্যবহারকারী ডিরেক্টরি</string>
     <string name="matrix_only_filter">শুধুমাত্র ম্যাট্রিক্সের যোগাযোগগুলি</string>
     <string name="no_conversation_placeholder">"কথাবার্তা নেই "</string>
-    <string name="template_no_contact_access_placeholder">আপনি রায়টকে আপনার স্থানীয় পরিচিতি অ্যাক্সেস করার অনুমতি দেয় নি</string>
+    <string name="no_contact_access_placeholder">আপনি রায়টকে আপনার স্থানীয় পরিচিতি অ্যাক্সেস করার অনুমতি দেয় নি</string>
     <string name="no_result_placeholder">কোন ফলাফল নেই</string>
 
     <string name="rooms_header">রুমগুলি</string>
@@ -449,7 +449,7 @@
     <string name="e2e_re_request_encryption_key_sent">চাবির অনুরোধ পাঠানো।</string>
 
     <string name="e2e_re_request_encryption_key_dialog_title">অনুরোধ পাঠানো</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">দয়া করে শুরু করুন ${app_name} অন্য সেশান যেটা পারে বর্ণনা করতে বার্তা কে সুতরাং এটা পারে পাঠাতে চাবিগুলো কে যন্ত্র তে.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">দয়া করে শুরু করুন ${app_name} অন্য সেশান যেটা পারে বর্ণনা করতে বার্তা কে সুতরাং এটা পারে পাঠাতে চাবিগুলো কে যন্ত্র তে.</string>
 
     <string name="read_receipts_list">পড়ো প্রাপ্তিগুলি সারি</string>
 
@@ -478,7 +478,7 @@
     <string name="room_info_room_topic">ঘরএর বিষয়</string>
 
     <string name="settings_call_category">ডাকা</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">ব্যবহার করছেন অনুপস্থিত ${app_name} রিংটোন আগামী ডাক এর জন্য</string>
+    <string name="settings_call_ringtone_use_app_ringtone">ব্যবহার করছেন অনুপস্থিত ${app_name} রিংটোন আগামী ডাক এর জন্য</string>
     <string name="settings_call_ringtone_title">আসা কল এর রিংটোন</string>
     <string name="settings_call_ringtone_dialog_title">নির্বাচন করুন রিংটোন কল আর জন্য:</string>
 
@@ -502,22 +502,22 @@
     <string name="media_picker_cannot_record_video">পারছেন না দৃশ্য নথি করতে</string>
 
     <string name="permissions_rationale_popup_title">তথা</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} এর প্রয়াজন অনুমতি নিতে আপনার ছবি এবং দৃশ্য রেকর্ড কে গ্রন্থাগার থেকে পাঠিয়ে জমার জায়গায় সংযুক্ত করতে।
+    <string name="permissions_rationale_msg_storage">${app_name} এর প্রয়াজন অনুমতি নিতে আপনার ছবি এবং দৃশ্য রেকর্ড কে গ্রন্থাগার থেকে পাঠিয়ে জমার জায়গায় সংযুক্ত করতে।
 \nদেয়া করে অনুমতি দিন প্রবেশ করতে পরের pop-up কে যেটা সক্ষম আপনার নথি কে আপনার ফোন থেকে পাঠাতে।</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} এর প্রয়োজন অনুমতি নিয়ে প্রবেশে করতে আপনার ছবি তোলার যন্ত্র থেকে ছবি নিতে এবং দৃষ্টি রেকর্ড ডাকতে।</string>
+    <string name="permissions_rationale_msg_camera">${app_name} এর প্রয়োজন অনুমতি নিয়ে প্রবেশে করতে আপনার ছবি তোলার যন্ত্র থেকে ছবি নিতে এবং দৃষ্টি রেকর্ড ডাকতে।</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nদয়াকরে অনুমতি দিন প্রবেশ করাতে পরের পপ -আপ কে যেটা ডাকতে সক্ষম।"</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} এর প্রয়োজন অনুমতি নিয়ে প্রবেশ করতে আপনার মাইক্রোফোন আর মাধ্যমে শোনার কালএর সঞ্চালনা করতে।</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} এর প্রয়োজন অনুমতি নিয়ে প্রবেশ করতে আপনার মাইক্রোফোন আর মাধ্যমে শোনার কালএর সঞ্চালনা করতে।</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nদেয়া করে অনুমতিদিন প্রবেশ করতে পরের pop-up এ যেটা কল করতে সক্ষম।"</string>
     <string name="notification_sync_init">সেবা আরম্ভ করা হচ্ছে</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">ভিডিও কল সম্পাদনের জন্য ${app_name} আপনার ক্যামেরা এবং আপনার মাইক্রোফোন অ্যাক্সেস করার অনুমতির প্রয়োজন।
+    <string name="permissions_rationale_msg_camera_and_audio">ভিডিও কল সম্পাদনের জন্য ${app_name} আপনার ক্যামেরা এবং আপনার মাইক্রোফোন অ্যাক্সেস করার অনুমতির প্রয়োজন।
 \n
 \nকল করতে সক্ষম হতে পরবর্তী পপ আপ অ্যাক্সেস অনুমতি দিন।</string>
-    <string name="template_permissions_rationale_msg_contacts">রায়ট অন্যান্য ম্যাট্রিক্স ব্যবহারকারীদের তাদের ইমেল এবং ফোন নম্বরগুলির উপর ভিত্তি করে আপনার ঠিকানা বইটি চেক করতে পারে। আপনি যদি এই উদ্দেশ্যে আপনার ঠিকানা বইটি ভাগ করে নিতে সম্মত হন তবে দয়া করে পরবর্তী পপ-আপটিতে অ্যাক্সেসের অনুমতি দিন।</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">রায়ট অন্যান্য ম্যাট্রিক্স ব্যবহারকারীদের তাদের ইমেল এবং ফোন নম্বরগুলির উপর ভিত্তি করে আপনার ঠিকানা বইটি চেক করতে পারে।
+    <string name="permissions_rationale_msg_contacts">রায়ট অন্যান্য ম্যাট্রিক্স ব্যবহারকারীদের তাদের ইমেল এবং ফোন নম্বরগুলির উপর ভিত্তি করে আপনার ঠিকানা বইটি চেক করতে পারে। আপনি যদি এই উদ্দেশ্যে আপনার ঠিকানা বইটি ভাগ করে নিতে সম্মত হন তবে দয়া করে পরবর্তী পপ-আপটিতে অ্যাক্সেসের অনুমতি দিন।</string>
+    <string name="permissions_msg_contacts_warning_other_androids">রায়ট অন্যান্য ম্যাট্রিক্স ব্যবহারকারীদের তাদের ইমেল এবং ফোন নম্বরগুলির উপর ভিত্তি করে আপনার ঠিকানা বইটি চেক করতে পারে।
 \n
 \nআপনি এই উদ্দেশ্যে আপনার ঠিকানা বই ভাগ করতে সম্মত হন\?</string>
 
@@ -737,7 +737,7 @@
 
     <string name="settings_troubleshoot_test_device_settings_title">সেশান সেটিংস।</string>
     <string name="settings_troubleshoot_test_device_settings_success">বিজ্ঞপ্তি এই সেশানের জন্য সক্রিয় করা হয়েছে।</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">বিজ্ঞপ্তি এই সেশানের জন্য অনুমতি দেওয়া হয় নি।
+    <string name="settings_troubleshoot_test_device_settings_failed">বিজ্ঞপ্তি এই সেশানের জন্য অনুমতি দেওয়া হয় নি।
 \n${app_name} এর সেটিংস যাচাই করুন।</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">সক্ষম</string>
 
@@ -749,7 +749,7 @@
 
     <string name="settings_troubleshoot_test_play_services_title">Play Services পরীক্ষা</string>
     <string name="settings_troubleshoot_test_play_services_success">গুগল প্লে সার্ভিসেস APK পাওয়া গেছে এবং আপ টু ডেট রয়েছে।</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} পুশ বার্তার প্রদানের জন্য Google Play পরিষেবাদি ব্যবহার করে কিন্তু এটি সঠিকভাবে কনফিগার করা বলে মনে হচ্ছে না:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} পুশ বার্তার প্রদানের জন্য Google Play পরিষেবাদি ব্যবহার করে কিন্তু এটি সঠিকভাবে কনফিগার করা বলে মনে হচ্ছে না:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Play Services ঠিক করুন</string>
 
@@ -758,11 +758,11 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">FCM টোকেন উদ্ধার করতে ব্যর্থ হয়েছে:
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nএই ত্রুটিটি ${app_name} এর নিয়ন্ত্রণের বাইরে এবং Google এর মতে, এই ত্রুটিটি ইঙ্গিত করে যে ডিভাইসটিতে FCM এর সাথে নিবন্ধিত অনেকগুলি অ্যাপ্লিকেশন রয়েছে। ত্রুটিগুলি কেবলমাত্র অ্যাপ্লিকেশনের চরম সংখ্যাগুলিতে ঘটে থাকে, তাই এটি গড় ব্যবহারকারীকে প্রভাবিত করবে না।</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nএই ত্রুটি ${app_name} এর নিয়ন্ত্রণের বাইরে। এটা বিভিন্ন কারণে ঘটতে পারে। আপনি পরে পুনরায় চেষ্টা করলে হয়তো এটি কাজ করবে, আপনি এটিও পরীক্ষা করতে পারেন যে Google Play পরিষেবাটি সিস্টেম সেটিংসে ডেটা ব্যবহারের ক্ষেত্রে সীমাবদ্ধ নয়, অথবা আপনার ডিভাইসের ঘড়ি সঠিক, বা এটি কাস্টম রমতে ঘটতে পারে।</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nএই ত্রুটি ${app_name} এর নিয়ন্ত্রণের বাইরে। ফোনে কোন গুগল একাউন্ট নেই। অ্যাকাউন্ট ম্যানেজার খুলুন এবং একটি গুগল একাউন্ট যোগ করুন।</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">একাউন্ট যোগ করুন</string>
 
@@ -777,19 +777,19 @@
 
     <string name="settings_troubleshoot_test_service_boot_title">বুট করার সময় শুরু</string>
     <string name="settings_troubleshoot_test_service_boot_success">ডিভাইসটি পুনরায় চালু হলে পরিষেবা শুরু হবে।</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">ডিভাইসটি পুনরায় চালু হওয়ার সময় পরিষেবাটি শুরু হবে না, আপনি একবার ${app_name} টি খোলা না হওয়া পর্যন্ত বিজ্ঞপ্তি পাবেন না।</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">ডিভাইসটি পুনরায় চালু হওয়ার সময় পরিষেবাটি শুরু হবে না, আপনি একবার ${app_name} টি খোলা না হওয়া পর্যন্ত বিজ্ঞপ্তি পাবেন না।</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">বুট থেকে শুরু করা সক্রিয় করুন</string>
 
     <string name="settings_troubleshoot_test_bg_restricted_title">ব্যাকগ্রাউন্ড এর সীমাবদ্ধতা চেক করুন</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">ব্যাকগ্রউন্ডের সীমাবদ্ধতা ${app_name} এর জন্য নিষ্ক্রিয় করা হয়েছে। এই পরীক্ষা মোবাইল ডেটা ব্যবহার করে চালানো উচিত (ওয়াইফাই না)।
+    <string name="settings_troubleshoot_test_bg_restricted_success">ব্যাকগ্রউন্ডের সীমাবদ্ধতা ${app_name} এর জন্য নিষ্ক্রিয় করা হয়েছে। এই পরীক্ষা মোবাইল ডেটা ব্যবহার করে চালানো উচিত (ওয়াইফাই না)।
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">ব্যাকগ্রউন্ডের সীমাবদ্ধতা রিমোট এর জন্য সক্রিয় করা হয়েছে।
+    <string name="settings_troubleshoot_test_bg_restricted_failed">ব্যাকগ্রউন্ডের সীমাবদ্ধতা রিমোট এর জন্য সক্রিয় করা হয়েছে।
 \nঅ্যাপ্লিকেশন যেটি করার চেষ্টা করে সেটি ব্যাকগ্রাউন্ডে থাকা অবস্থায় আক্রমনাত্মকভাবে সীমিত হবে এবং এটি বিজ্ঞপ্তিগুলিতে প্রভাবিত হতে পারে।
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">সীমাবদ্ধগুলি নিষ্ক্রিয়</string>
 
     <string name="settings_troubleshoot_test_battery_title">ব্যাটারি অপ্টিমাইজেশান</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} ব্যাটারি অপ্টিমাইজেশান দ্বারা প্রভাবিত হয় না।</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} ব্যাটারি অপ্টিমাইজেশান দ্বারা প্রভাবিত হয় না।</string>
     <string name="settings_troubleshoot_test_battery_failed">যদি কোনও ব্যবহারকারী কোনও ডিভাইসটিকে নির্দিষ্ট সময়ের জন্য আনপ্লাগ এবং স্থিতিশীল রাখে তবে স্ক্রীন বন্ধের সাথে ডিভাইসটি ডোজ মোডে প্রবেশ করে। এটি অ্যাপ্লিকেশানগুলিকে নেটওয়ার্ক অ্যাক্সেস করতে বাধা দেয় এবং তাদের কাজ, সিঙ্ক এবং মান অ্যালার্মগুলি স্থগিত করে।</string>
     <string name="settings_troubleshoot_test_battery_quickfix">"অপ্টিমাইজেশান অবহেলা "</string>
 
@@ -917,19 +917,19 @@
     <string name="settings_deactivate_my_account">আমার একাউন্ট নিষ্ক্রিয় করুন</string>
 
     <string name="startup_notification_privacy_title">বিজ্ঞপ্তি\'র গোপনীয়তা</string>
-    <string name="template_startup_notification_privacy_message">সুরক্ষিতভাবে এবং ব্যক্তিগতভাবে আপনার বিজ্ঞপ্তি পরিচালনা করতে ${app_name} পটভূমিতে চালাতে পারে। এই ব্যাটারি ব্যবহার প্রভাবিত হতে পারে।</string>
+    <string name="startup_notification_privacy_message">সুরক্ষিতভাবে এবং ব্যক্তিগতভাবে আপনার বিজ্ঞপ্তি পরিচালনা করতে ${app_name} পটভূমিতে চালাতে পারে। এই ব্যাটারি ব্যবহার প্রভাবিত হতে পারে।</string>
     <string name="startup_notification_privacy_button_grant">অনুমতি প্রদান করুন</string>
     <string name="startup_notification_privacy_button_other">অন্য বিকল্প চয়ন করুন</string>
 
     <string name="startup_notification_fdroid_battery_optim_title">পটভূমি সংযোগ</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">নির্ভরযোগ্য বিজ্ঞপ্তি পেতে ${app_name} কম প্রভাব ব্যাকগ্রাউন্ড সংযোগ রাখা প্রয়োজন।
+    <string name="startup_notification_fdroid_battery_optim_message">নির্ভরযোগ্য বিজ্ঞপ্তি পেতে ${app_name} কম প্রভাব ব্যাকগ্রাউন্ড সংযোগ রাখা প্রয়োজন।
 \nপরবর্তী স্ক্রিনে আপনাকে দাঙ্গাটি সর্বদা ব্যাকগ্রাউন্ডে চালানোর অনুমতি দেওয়া হবে, দয়া করে স্বীকার করুন।</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">অনুমতি প্রদান করুন</string>
 
     <string name="settings_analytics">বৈশ্লেষিক ন্যায়</string>
     <string name="settings_opt_in_of_analytics">বিশ্লেষণ তথ্য পাঠান</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} আমাদের অ্যাপ্লিকেশন উন্নত করার অনুমতি দেওয়ার জন্য বেনামী বিশ্লেষণ সংগ্রহ করে।</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">আমাদের ${app_name} উন্নত করতে সাহায্য করার জন্য বিশ্লেষণ সক্রিয় করুন।</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} আমাদের অ্যাপ্লিকেশন উন্নত করার অনুমতি দেওয়ার জন্য বেনামী বিশ্লেষণ সংগ্রহ করে।</string>
+    <string name="settings_opt_in_of_analytics_prompt">আমাদের ${app_name} উন্নত করতে সাহায্য করার জন্য বিশ্লেষণ সক্রিয় করুন।</string>
     <string name="settings_opt_in_of_analytics_ok">হ্যাঁ, আমি সাহায্য করতে চাই!</string>
 
     <string name="settings_data_save_mode">ডেটা সংরক্ষণ মোড</string>
@@ -1269,10 +1269,10 @@
 
     <string name="settings_background_fdroid_sync_mode">পটভূমি সিঙ্ক মোড (পরীক্ষামূলক)</string>
     <string name="settings_background_fdroid_sync_mode_battery">ব্যাটারির জন্য অনুকূলিত</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">রায়ট এমনভাবে পটভূমিতে সিঙ্ক হবে যা ডিভাইসের সীমিত সংস্থান (ব্যাটারি) সংরক্ষণ করে।
+    <string name="settings_background_fdroid_sync_mode_battery_description">রায়ট এমনভাবে পটভূমিতে সিঙ্ক হবে যা ডিভাইসের সীমিত সংস্থান (ব্যাটারি) সংরক্ষণ করে।
 \nআপনার ডিভাইস রিসোর্স স্থিতির উপর নির্ভর করে সিঙ্কটি অপারেটিং সিস্টেম দ্বারা পিছিয়ে যেতে পারে।</string>
     <string name="settings_background_fdroid_sync_mode_real_time">রিয়েল টাইম জন্য অনুকূলিত</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">রায়ট নির্দিষ্ট সময়ে সময়ে পটভূমিতে সিঙ্ক হবে (কনফিগারযোগ্য)।
+    <string name="settings_background_fdroid_sync_mode_real_time_description">রায়ট নির্দিষ্ট সময়ে সময়ে পটভূমিতে সিঙ্ক হবে (কনফিগারযোগ্য)।
 \nএটি রেডিও এবং ব্যাটারির ব্যবহারকে প্রভাবিত করবে, রায়ট ইভেন্টগুলি শুনছে বলে জানিয়ে একটি স্থায়ী বিজ্ঞপ্তি প্রদর্শিত হবে।</string>
     <string name="settings_background_fdroid_sync_mode_disabled">কোনও পটভূমি সিঙ্ক না</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">অ্যাপটি ব্যাকগ্রাউন্ডে থাকা অবস্থায় আপনাকে আগত বার্তাগুলি সম্পর্কে অবহিত করা হবে না।</string>
@@ -1416,7 +1416,7 @@
     <string name="dialog_title_success">সাফল্য</string>
 
     <string name="bottom_action_notification">বিজ্ঞপ্তিগুলি</string>
-    <string name="template_call_failed_no_connection">এলিমেন্ট কল ব্যর্থ</string>
+    <string name="call_failed_no_connection">এলিমেন্ট কল ব্যর্থ</string>
     <string name="call_failed_no_connection_description">রিয়েল টাইম সংযোগ স্থাপন করতে ব্যর্থ।
 \nকলগুলি নির্ভরযোগ্যতার সাথে কাজ করার জন্য দয়া করে আপনার হোমসার্ভারের প্রশাসককে একটি টার্ন সার্ভার কনফিগার করতে বলুন।</string>
 
@@ -1513,7 +1513,7 @@
     <string name="passphrase_empty_error_message">দয়া করে একটি পাসফ্রেজ লিখুন</string>
     <string name="passphrase_passphrase_too_weak">পাসফ্রেজটি খুব দুর্বল</string>
 
-    <string name="template_keys_backup_passphrase_not_empty_error_message">আপনি যদি এলিমেন্টটি পুনরুদ্ধার কী তৈরি করতে চান তবে দয়া করে পাসফ্রেজটি মুছুন।</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">আপনি যদি এলিমেন্টটি পুনরুদ্ধার কী তৈরি করতে চান তবে দয়া করে পাসফ্রেজটি মুছুন।</string>
     <string name="keys_backup_no_session_error">কোনও ম্যাট্রিক্স সেশন উপলব্ধ নেই</string>
 
     <string name="keys_backup_setup_step1_title">এনক্রিপ্ট করা বার্তাগুলি কখনই হারাবেন না</string>

--- a/vector/src/main/res/values-bs/strings.xml
+++ b/vector/src/main/res/values-bs/strings.xml
@@ -76,7 +76,7 @@
     <string name="user_directory_header">Imenik korisnika</string>
     <string name="matrix_only_filter">Samo matriks kontakti</string>
     <string name="no_conversation_placeholder">Nema razgovora</string>
-    <string name="template_no_contact_access_placeholder">Niste omogućili ${app_name}u pristup vašim lokalnim kontaktima</string>
+    <string name="no_contact_access_placeholder">Niste omogućili ${app_name}u pristup vašim lokalnim kontaktima</string>
     <string name="no_result_placeholder">Nema rezultata</string>
     <string name="rooms_header">Sobe</string>
     <string name="rooms_directory_header">Imenik soba</string>
@@ -200,24 +200,24 @@ Odjavljeni ste sa svih uređaja i više nećete primati obavijesti. Da biste pon
     <string name="media_picker_both_capture_title">Snimi fotografiju ili video</string>
     <string name="media_picker_cannot_record_video">Nije moguće snimiti video</string>
     <string name="permissions_rationale_popup_title">Informacije</string>
-    <string name="template_permissions_rationale_msg_storage">Hepek treba dopuštenje za pristup vašoj biblioteci fotografija i videozapisa za slanje i spremanje privitaka.
+    <string name="permissions_rationale_msg_storage">Hepek treba dopuštenje za pristup vašoj biblioteci fotografija i videozapisa za slanje i spremanje privitaka.
 
 Omogućite pristup sljedećem skočnom prozoru da biste mogli slati datoteke sa telefona.</string>
-    <string name="template_permissions_rationale_msg_camera">Hepek treba dopuštenje za pristup vašoj kameri za snimanje fotografija i videopoziva.</string>
+    <string name="permissions_rationale_msg_camera">Hepek treba dopuštenje za pristup vašoj kameri za snimanje fotografija i videopoziva.</string>
     <string name="permissions_rationale_msg_camera_explanation">
 
 Omogućite pristup sljedećem pop-upu kako biste mogli uputiti poziv.</string>
-    <string name="template_permissions_rationale_msg_record_audio">Hepek traži dopuštenje za pristup mikrofonu za obavljanje audio poziva.</string>
+    <string name="permissions_rationale_msg_record_audio">Hepek traži dopuštenje za pristup mikrofonu za obavljanje audio poziva.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">
 
 Omogućite pristup sljedećem pop-upu kako biste mogli uputiti poziv.</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">Hepek treba dopuštenje za pristup vašoj kemeri i mikrofonu za obavljanje video poziva.
+    <string name="permissions_rationale_msg_camera_and_audio">Hepek treba dopuštenje za pristup vašoj kemeri i mikrofonu za obavljanje video poziva.
 
 Omogućite pristup sljedećim skočnim prozorima da biste mogli uspostaviti poziv.</string>
-    <string name="template_permissions_rationale_msg_contacts">Hepek treba dopuštenje za pristup kontaktima kako bi pronašao druge Matrix korisnike na temelju njihove email adrese i telefonskih brojeva.
+    <string name="permissions_rationale_msg_contacts">Hepek treba dopuštenje za pristup kontaktima kako bi pronašao druge Matrix korisnike na temelju njihove email adrese i telefonskih brojeva.
 
 Dopustite pristup sljedećem skočnom prozoru da biste otkrili kontakte koji koriste Hepek.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">Hepek treba dopuštenje za pristup kontaktima kako bi pronašao druge Matrix korisnike na temelju njihove email adrese i telefonskih brojeva.
+    <string name="permissions_msg_contacts_warning_other_androids">Hepek treba dopuštenje za pristup kontaktima kako bi pronašao druge Matrix korisnike na temelju njihove email adrese i telefonskih brojeva.
 
 Želite li dopustiti da Hepek pristupi vašim kontaktima?</string>
     <string name="permissions_action_not_performed_missing_permissions">Nažalost, akcija nije izvršena zbog nedostatka dozvola</string>

--- a/vector/src/main/res/values-ca/strings.xml
+++ b/vector/src/main/res/values-ca/strings.xml
@@ -337,7 +337,7 @@
     <string name="user_directory_header">Directori d\'usuari</string>
     <string name="matrix_only_filter">Només contactes de Matrix</string>
     <string name="no_conversation_placeholder">No hi ha xats</string>
-    <string name="template_no_contact_access_placeholder">No has donat permís a ${app_name} perquè pugui accedir als teus contactes locals</string>
+    <string name="no_contact_access_placeholder">No has donat permís a ${app_name} perquè pugui accedir als teus contactes locals</string>
     <string name="no_result_placeholder">Sense resultats</string>
     <string name="rooms_header">Sales</string>
     <string name="rooms_directory_header">Directori de sala</string>
@@ -473,22 +473,22 @@
     <string name="media_picker_both_capture_title">Fes una foto o un vídeo"</string>
     <string name="media_picker_cannot_record_video">No es poden gravar vídeos"</string>
     <string name="permissions_rationale_popup_title">Informació</string>
-    <string name="template_permissions_rationale_msg_storage">Per poder enviar i desar fitxers adjunts, ${app_name} necessita permís per accedir a la galeria de fotos i vídeos.
+    <string name="permissions_rationale_msg_storage">Per poder enviar i desar fitxers adjunts, ${app_name} necessita permís per accedir a la galeria de fotos i vídeos.
 \n
 \nPermet-li l\'accés en la següent finestra emergent per poder enviar fitxers des del mòbil.</string>
-    <string name="template_permissions_rationale_msg_camera">Per poder fer fotos i videotrucades, ${app_name} necessita permís per accedir a la càmera.</string>
+    <string name="permissions_rationale_msg_camera">Per poder fer fotos i videotrucades, ${app_name} necessita permís per accedir a la càmera.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nPermet-li l\'accés en la següent finestra emergent per tal de poder fer la trucada."</string>
-    <string name="template_permissions_rationale_msg_record_audio">Per tal de fer trucades de veu, ${app_name} necessita permís per accedir al micròfon.</string>
+    <string name="permissions_rationale_msg_record_audio">Per tal de fer trucades de veu, ${app_name} necessita permís per accedir al micròfon.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nPermet-li l\'accés en la següent finestra emergent per tal de poder fer la trucada."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">Per tal de fer videotrucades, ${app_name} necessita permís per accedir a la càmera i al micròfon.
+    <string name="permissions_rationale_msg_camera_and_audio">Per tal de fer videotrucades, ${app_name} necessita permís per accedir a la càmera i al micròfon.
 \n
 \nPermet-li l\'accés en la següent finestra emergent per tal de poder fer la trucada.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} pot revisar la teva llista de contactes per tal de trobar altres usuaris de Matrix basant-se en les seves adreces de correu i números de telèfon. Si acceptes compartir la teva llista de contactes amb aquesta finalitat, permet l\'accés en la següent finestra emergent.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">Per tal de trobar altres usuaris de Matrix a partir dels seus correus o dels seus números de telèfon, ${app_name} necessita permís d\'accés a la llista de contactes.
+    <string name="permissions_rationale_msg_contacts">${app_name} pot revisar la teva llista de contactes per tal de trobar altres usuaris de Matrix basant-se en les seves adreces de correu i números de telèfon. Si acceptes compartir la teva llista de contactes amb aquesta finalitat, permet l\'accés en la següent finestra emergent.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">Per tal de trobar altres usuaris de Matrix a partir dels seus correus o dels seus números de telèfon, ${app_name} necessita permís d\'accés a la llista de contactes.
 \n
 \nPermets que ${app_name} accedeixi als teus contactes amb aquesta finalitat\?</string>
     <string name="permissions_action_not_performed_missing_permissions">No s\'ha realitzat l\'acció per falta de permisos</string>
@@ -938,7 +938,7 @@
     <string name="e2e_re_request_encryption_key">Tornar a demanar les claus de xifrat de les teves altres sessions.</string>
     <string name="e2e_re_request_encryption_key_sent">Petició de clau enviada.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Sol·licitud enviada</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Si us plau, obre ${app_name} a un altre dispositiu que pugui desxifrar el missatge de manera que pugui enviar les claus a aquesta sessió.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Si us plau, obre ${app_name} a un altre dispositiu que pugui desxifrar el missatge de manera que pugui enviar les claus a aquesta sessió.</string>
     <string name="settings_notification_privacy_normal">Normal</string>
     <string name="missing_permissions_error">No es pot dur a terme aquesta acció per falta de permisos.</string>
     <string name="dialog_title_error">Error</string>
@@ -987,12 +987,12 @@
     <string name="settings_deactivate_account_section">Desactivar el compte</string>
     <string name="settings_deactivate_my_account">Desactivar el meu compte</string>
     <string name="startup_notification_privacy_title">Notificació de privacitat</string>
-    <string name="template_startup_notification_privacy_message">El ${app_name} pot funcionar en segon pla per gestionar les vostres notificacions de forma segura i privada. Això podria afectar el consum de bateria.</string>
+    <string name="startup_notification_privacy_message">El ${app_name} pot funcionar en segon pla per gestionar les vostres notificacions de forma segura i privada. Això podria afectar el consum de bateria.</string>
     <string name="startup_notification_privacy_button_grant">Concedir permís</string>
     <string name="startup_notification_privacy_button_other">Escolliu una altra opció</string>
     <string name="settings_opt_in_of_analytics">Envia dades d\'anàlisi</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} recopila dades d\'anàlisi anònimes per tal de permetre millorar l\'aplicació.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Si us plau, activa les dades d\'anàlisi per ajudar-nos a millorar ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} recopila dades d\'anàlisi anònimes per tal de permetre millorar l\'aplicació.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Si us plau, activa les dades d\'anàlisi per ajudar-nos a millorar ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Sí, vull ajudar!</string>
     <string name="settings_without_flair">Ara mateix no ets membre de cap comunitat.</string>
     <string name="encryption_export_notice">Crea una frase per xifrar les claus exportades. Hauràs d\'introduir la mateixa frase per poder importar les claus.</string>
@@ -1058,7 +1058,7 @@
     <string name="merged_events_collapse">plega</string>
     <string name="action_accept">Accepta</string>
     <string name="settings_call_category">Trucada</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Utilitza el to de trucada d\'${app_name} predeterminat per trucades entrants</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Utilitza el to de trucada d\'${app_name} predeterminat per trucades entrants</string>
     <string name="settings_call_ringtone_title">To de trucada entrant</string>
     <string name="settings_call_ringtone_dialog_title">Tria el to per les trucades:</string>
     <string name="room_participants_action_remove">Expulsa</string>
@@ -1094,11 +1094,11 @@
     <string name="settings_troubleshoot_test_service_boot_title">Inicia\'l a l\'arrencada</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Inhabilita les restriccions</string>
     <string name="settings_troubleshoot_test_battery_title">Optimització de bateria</string>
-    <string name="template_settings_troubleshoot_test_battery_success">El ${app_name} no està afectat per l\'optimització de bateria.</string>
+    <string name="settings_troubleshoot_test_battery_success">El ${app_name} no està afectat per l\'optimització de bateria.</string>
     <string name="settings_show_join_leave_messages">Mostra els esdeveniments d\'unió i sortida</string>
     <string name="settings_show_avatar_display_name_changes_messages_summary">Inclou els canvis d\'icona i d\'àlies.</string>
     <string name="startup_notification_fdroid_battery_optim_title">Connexió al rerefons</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">Per poder obtenir notificacions fiables, ${app_name} necessita mantenir una connexió en segon pla de baixa incidència.
+    <string name="startup_notification_fdroid_battery_optim_message">Per poder obtenir notificacions fiables, ${app_name} necessita mantenir una connexió en segon pla de baixa incidència.
 \nA la pantalla següent se\'t demanarà que permetis a ${app_name} executar-se sempre en segon pla, si us plau, accepta-ho.</string>
     <string name="settings_password">Contrasenya</string>
     <string name="account_additional_info">Informació addicional: %s</string>
@@ -1124,7 +1124,7 @@
     <string name="settings_notification_troubleshoot">Diagnostica les notificacions</string>
     <string name="settings_troubleshoot_diagnostic">Diagnòstic de la resolució de problemes</string>
     <string name="settings_troubleshoot_diagnostic_failure_status_no_quickfix">Ha fallat una o més proves, envia un informe d\'errors per ajudar-nos a investigar-ho.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Les notificacions per aquesta sessió no estan activades.
+    <string name="settings_troubleshoot_test_device_settings_failed">Les notificacions per aquesta sessió no estan activades.
 \nComprova la configuració d\'${app_name}.</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Configuració personalitzada.</string>
     <string name="settings_troubleshoot_test_bing_settings_success_with_warn">Tingues en compte que alguns tipus de missatge estan configurats per ser silenciosos (es produirà una notificació sense so).</string>
@@ -1133,14 +1133,14 @@
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Comprova la configuració</string>
     <string name="settings_troubleshoot_test_play_services_title">Comprovació dels serveis de Play</string>
     <string name="settings_troubleshoot_test_play_services_success">L\'APK dels Serveis de Google Play està disponible i està actualitzada.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} utilitza els serveis de Google Play per lliurar missatges però sembla que no està configurat correctament:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} utilitza els serveis de Google Play per lliurar missatges però sembla que no està configurat correctament:
 \n %1$s</string>
     <string name="settings_troubleshoot_test_fcm_title">Token de Firebase</string>
     <string name="settings_troubleshoot_test_fcm_success">Token FCM obtingut correctament:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">No s\'ha pogut obtenir el token FCM:
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nAquest error està fora del control d\'${app_name} i, segons Google, aquest error indica que aquest dispositiu té massa aplicacions registrades amb FCM. L\'error només ocorre en casos en què hi ha un nombre extrem d\'aplicacions i, per tant, no hauria d\'afectar els usuari normals.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Afegeix un compte</string>
     <string name="settings_troubleshoot_test_token_registration_title">Registre de token</string>
@@ -1151,7 +1151,7 @@
     <string name="settings_troubleshoot_test_service_restart_success">El servei s\'ha parat i tornat a iniciar automàticament.</string>
     <string name="settings_troubleshoot_test_service_restart_failed">No s\'ha pogut iniciar el servei</string>
     <string name="settings_troubleshoot_test_service_boot_success">El servei s\'iniciarà quan es reiniciï el dispositiu.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">El servei no s\'iniciarà quan el dispositiu es reiniciï, per tant, no rebràs notificacions fins que ${app_name} no s\'hagi obert per primera vegada.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">El servei no s\'iniciarà quan el dispositiu es reiniciï, per tant, no rebràs notificacions fins que ${app_name} no s\'hagi obert per primera vegada.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Habilita l\'inici durant l\'arrencada</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Comprova les restriccions del rerefons</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignora l\'optimització</string>
@@ -1172,7 +1172,7 @@
     <string name="notification_silent">Silenciós</string>
     <string name="passphrase_empty_error_message">Introduïu una frase de pas</string>
     <string name="passphrase_passphrase_too_weak">La frase de pas és massa feble</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Suprimiu la frase si vols que ${app_name} generi una clau de recuperació.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Suprimiu la frase si vols que ${app_name} generi una clau de recuperació.</string>
     <string name="keys_backup_no_session_error">No hi ha cap sessió de Matrix disponible</string>
     <string name="keys_backup_setup_step1_title">No perdeu mai els missatges xifrats</string>
     <string name="keys_backup_setup_step1_description">Els missatges en sales xifrades estan protegits amb xifrat d\'extrem a extrem. Només tu i el/s destinatari/s teniu les claus per poder llegir aquests missatges.
@@ -1200,13 +1200,13 @@
     <string name="keys_backup_restore_key_enter_hint">Introdueix la clau de recuperació</string>
     <string name="keys_backup_restore_setup_recovery_key">Recuperació de missatges</string>
     <string name="keys_backup_restore_with_key_helper">Has perdut la clau de recuperació\? Pots configurar-ne una de nova a la configuració.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nAquest error està fora del control d\'${app_name}. Pot ser causat per diferents motius. És possible que torni a funcionar més endavant. També pots comprovar, a la configuració del sistema, que els Serveis de Google Play no tinguin cap restricció de dades o que l\'hora del dispositiu sigui la correcta. També pot passar si tens una ROM personalitzada.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nAquest error està fora del control d\'${app_name}. No hi ha cap compte de Google al telèfon. Vés a la configuració de comptes i afegeix un compte de Google.</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Les restriccions en segon pla per a ${app_name} estan desactivades. Aquesta prova s\'hauria de fer emprant dades mòbils (sense WiFi).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Les restriccions en segon pla per a ${app_name} estan desactivades. Aquesta prova s\'hauria de fer emprant dades mòbils (sense WiFi).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Les restriccions en segon pla per a ${app_name} estan activades.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Les restriccions en segon pla per a ${app_name} estan activades.
 \nLes tasques que l\'aplicació intenta fer en segon pla estaran força restringides, això pot afectar a les notificacions.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_battery_failed">Si un usuari deixa un dispositiu amb la pantalla apagada, desendollat i quiet durant un període de temps, el dispositiu entra en el mode repòs. Això impedeix que les aplicacions accedeixin a la xarxa i n\'ajorna les seves tasques, sincronitzacions i alarmes estàndard.</string>
@@ -1359,7 +1359,7 @@
     <string name="keys_backup_setup_override_stop">Aturar</string>
     <string name="keys_backup_settings_checking_backup_state">Comprovant l\'estat de la còpia de seguretat</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Opcions de compleció automàtica del servidor</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} ha detectat una configuració de servidor personalitzada pel teu domini d\'ID d\'usuari \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} ha detectat una configuració de servidor personalitzada pel teu domini d\'ID d\'usuari \"%1$s\":
 \n%2$s</string>
     <string name="invalid_or_expired_credentials">Se t\'ha desconnectat a causa de credencials incorrectes o caducades.</string>
     <string name="sas_verify_title">Verificar comparant una cadena de text curta.</string>
@@ -1430,7 +1430,7 @@
     <string name="please_wait">Espereu, si us plau…</string>
     <string name="group_all_communities">Totes les comunitats</string>
     <string name="room_preview_no_preview">Aquesta sala no es pot pre-visualitzar</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">${app_name} encara no admet la pre-visualització de les sales llegibles per tothom</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">${app_name} encara no admet la pre-visualització de les sales llegibles per tothom</string>
     <string name="fab_menu_create_room">Sales</string>
     <string name="fab_menu_create_chat">Xats personals</string>
     <string name="create_room_title">Sala nova</string>
@@ -1453,7 +1453,7 @@
     <string name="room_participants_remove_reason">Motiu de l\'expulsió</string>
     <string name="room_participants_remove_title">Expulsa usuari</string>
     <string name="login_signin_sso">Continua amb SSO</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Per a la teva pròpia privadesa, ${app_name} només admet l\'enviament del \"hash\" de correus electrònics i números de telèfon.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Per a la teva pròpia privadesa, ${app_name} només admet l\'enviament del \"hash\" de correus electrònics i números de telèfon.</string>
     <string name="command_description_discard_session_not_handled">Només admès en sales xifrades</string>
     <string name="encryption_unknown_algorithm_tile_description">El xifrat que utilitza aquesta sala no és compatible</string>
     <string name="auth_flow_not_supported">No pots fer això des del mòbil</string>
@@ -1463,7 +1463,7 @@
     <string name="login_mode_not_supported">L\'aplicació no ha pogut iniciar sessió en aquest servidor. El servidor és compatible amb el/s següent/s tipus d\'inici de sessió: %1$s.
 \n
 \nVols iniciar sessió utilitzant un client web\?</string>
-    <string name="template_settings_add_3pid_flow_not_supported">No pots fer això des d\'${app_name} per a mòbils</string>
+    <string name="settings_add_3pid_flow_not_supported">No pots fer això des d\'${app_name} per a mòbils</string>
     <string name="warning_room_not_created_yet">La sala encara no s\'ha acabat de crear. Vols cancel·lar la seva creació\?</string>
     <string name="room_error_not_found">No s\'ha trobat aquesta sala. Assegura\'t que existeixi.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Mostra detalls com per exemple noms de sala i contingut dels missatges.</string>
@@ -1552,7 +1552,7 @@
     <string name="room_participants_action_cancel_invite">Cancel·la invitació</string>
     <string name="return_to_call">Torna a la trucada</string>
     <string name="login_error_ssl_other">Error SSL.</string>
-    <string name="template_call_failed_no_connection">La trucada d\'${app_name} ha fallat</string>
+    <string name="call_failed_no_connection">La trucada d\'${app_name} ha fallat</string>
     <string name="login_reset_password_on">Restableix la contrasenya a %1$s</string>
     <string name="login_login_with_email_error">Aquest correu electrònic no està associat amb cap compte.</string>
     <string name="login_registration_disabled">Ho sentim, aquest servidor no accepta comptes nous.</string>
@@ -1732,10 +1732,10 @@
     <string name="settings_background_sync_update_error">No s\'ha pogut actualitzar la configuració.</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">No se\'t notificarà de missatges entrants quan l\'aplicació es trobi en segon pla.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Sense sincronització en segon pla</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} farà la sincronització en segon pla periòdicament en instants de temps precisos (configurable).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} farà la sincronització en segon pla periòdicament en instants de temps precisos (configurable).
 \nAixò tindrà un impacte en l\'ús de la ràdio i la bateria, es mostrarà una notificació permanent informant de que ${app_name} està a l\'espera d\'esdeveniments.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimitzat per a temps real</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} farà la sincronització en segon pla de manera que es preservin els recursos limitats del dispositiu (bateria).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} farà la sincronització en segon pla de manera que es preservin els recursos limitats del dispositiu (bateria).
 \nEn funció de l\'estat dels recursos del dispositiu, pot ser que el sistema operatiu endarrereixi la sincronització.</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimitzat per a la bateria</string>
     <string name="settings_background_fdroid_sync_mode">Mode de sincronització en segon pla</string>
@@ -1922,9 +1922,9 @@
     <string name="auth_invalid_login_param_space_in_password">Usuari i/o contrasenya incorrectes. La contrasenya introduïda comença o acaba amb espais, comprova-la.</string>
     <string name="auth_invalid_login_deactivated_account">Aquest compte ha estat desactivat.</string>
     <string name="attachment_viewer_item_x_of_y">%1$d de %2$d</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} per a escriptori</string>
     <string name="add_people">Afegeix gent</string>
     <string name="add_members_to_room">Afegeix membres</string>
@@ -1936,7 +1936,7 @@
     <string name="a11y_qr_code_for_verification">Codi QR</string>
     <string name="a11y_open_chat">Obre el xat</string>
     <string name="a11y_mute_microphone">Silencia el micròfon</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">El codi PIN és l\'única manera de desbloquejar ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">El codi PIN és l\'única manera de desbloquejar ${app_name}.</string>
     <string name="or_other_mx_capable_client">o un altre client Matrix compatible amb la signatura creuada</string>
     <string name="encryption_information_dg_xsigning_disabled">La signatura creuada no està activada</string>
     <string name="encryption_information_dg_xsigning_not_trusted">La signatura creuada està activada
@@ -1952,7 +1952,7 @@
     <string name="room_permissions_send_m_room_server_acl_events">Enviar esdeveniments m.room.server_acl</string>
     <string name="room_permissions_change_permissions">Canviar els permisos</string>
     <string name="room_permissions_change_room_name">Canviar el nom de la sala</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} necessita permís per poder desar les claus E2E al disc.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} necessita permís per poder desar les claus E2E al disc.
 \n
 \nPermet-li l\'accés en la següent finestra emergent per poder exportar les claus manualment.</string>
     <string name="no_network_indicator">Ara mateix no hi ha cap connexió</string>
@@ -1996,8 +1996,8 @@
     <string name="auth_pin_confirm_to_disable_title">Confirma el PIN per poder desactivar el PIN</string>
     <string name="settings_security_pin_code_change_pin_summary">Canvia el teu PIN actual</string>
     <string name="settings_security_pin_code_change_pin_title">Canvia el PIN</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Codi PIN necessari cada vegada que obres ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Codi PIN necessari al cap de 2 minuts sense utilitzar ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Codi PIN necessari cada vegada que obres ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Codi PIN necessari al cap de 2 minuts sense utilitzar ${app_name}.</string>
     <string name="settings_security_pin_code_grace_period_title">Demana el PIN al cap de 2 minuts</string>
     <string name="settings_security_pin_code_notifications_summary_off">Mostra, només, el nombre de missatges no llegits en les notificacions simples.</string>
     <string name="settings_security_pin_code_notifications_title">Mostra el contingut de les notificacions</string>
@@ -2078,7 +2078,7 @@
     <string name="start_chatting">Comença a xatejar</string>
     <string name="system_theme">Predeterminat pel sistema</string>
     <string name="enter_secret_storage_passphrase_or_key">Utilitza la %1$s o la %2$s per a continuar.</string>
-    <string name="template_use_latest_app">Utilitza l\'última versió d\'${app_name} als teus altres dispositius:</string>
+    <string name="use_latest_app">Utilitza l\'última versió d\'${app_name} als teus altres dispositius:</string>
     <string name="soft_logout_signin_notice">L\'administrador del servidor local (%1$s) ha tancat la teva sessió del compte %2$s (%3$s).</string>
     <plurals name="fallback_users_read">
         <item quantity="one">%d usuari ho ha llegit</item>
@@ -2146,7 +2146,7 @@
     <string name="new_session_review">Clica per revisar i verificar</string>
     <string name="new_session">Nou inici de sessió. Has estat tu\?</string>
     <string name="refresh">Actualitza</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Les claus ja estan actualitzades!</string>
     <string name="event_redacted_by_user_reason_with_reason">Esdeveniment eliminat per un usuari, motiu: %1$s</string>
     <string name="event_redacted_by_admin_reason_with_reason">Esdeveniment moderat per un administrador de sala, motiu: %1$s</string>
@@ -2180,7 +2180,7 @@
     <string name="create_room_alias_hint">Adreça de la sala</string>
     <string name="create_room_encryption_title">Activa el xifrat</string>
     <string name="command_description_shrug">Afegeix ¯\\_(ツ)_/¯ a l\'inici d\'un missatge de text pla</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">Pot ser que ${app_name} falli més sovint quan es produeixi un error inesperat</string>
+    <string name="settings_developer_mode_fail_fast_summary">Pot ser que ${app_name} falli més sovint quan es produeixi un error inesperat</string>
     <string name="devices_other_devices">Altres sessions</string>
     <string name="devices_current_device">Sessió actual</string>
     <string name="settings">Configuració</string>
@@ -2268,8 +2268,8 @@
     <string name="settings_troubleshoot_test_notification_title">Visualització de notificació</string>
     <string name="this_is_the_beginning_of_room">Inici de %s.</string>
     <string name="invite_friends">Convida amics</string>
-    <string name="template_invite_friends_text">Ei, parla amb mi des d\'${app_name}: %s</string>
-    <string name="template_invite_friends_rich_title">🔐️ Uneix-te a ${app_name}</string>
+    <string name="invite_friends_text">Ei, parla amb mi des d\'${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Uneix-te a ${app_name}</string>
     <string name="user_code_info_text">Comparteix aquest codi amb la gent perquè puguin escanejar-lo, afegir-te i començar a xatejar amb tu.</string>
     <string name="identity_server_user_consent_not_provided">L\'usuari no s\'ha acceptat el consentiment.</string>
     <string name="command_confetti">Envia el missatge proporcionat amb confetis</string>
@@ -2307,7 +2307,7 @@
     <string name="login_server_text">Com els correus electrònics, els comptes pertanyen a una entitat però els pots fer servir per parlar amb tothom</string>
     <string name="create_room_disable_federation_description">Potser ho hauries d\'activar si la sala només s\'utilitzarà per la interacció de grups interns dins el teu servidor local. Això no es podrà canviar més tard.</string>
     <string name="create_room_disable_federation_title">Bloqueja qualsevol persona que no formi part de %s perquè mai pugui unir-se a la sala</string>
-    <string name="template_soft_logout_sso_not_same_user_error">La sessió actual és de l\'usuari %1$s i has introduït les credencials de l\'usuari %2$s. Això no es pot fer amb ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">La sessió actual és de l\'usuari %1$s i has introduït les credencials de l\'usuari %2$s. Això no es pot fer amb ${app_name}.
 \nPrimer esborra les dades i després torna a iniciar sessió amb l\'altre compte.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Perdràs l\'accés als missatges protegits tret de que iniciïs sessió i obtinguis les teves claus de xifrat.</string>
     <string name="soft_logout_clear_data_notice">Atenció: les teves dades personals (incloses les claus de xifrat) encara estan desades en aquest dispositiu.
@@ -2392,9 +2392,9 @@
     <string name="complete_security">Completa la seguretat</string>
     <string name="crosssigning_other_user_not_trust">Pot ser que altres usuaris no hi confiïn</string>
     <string name="unignore">Deixa d\'ignorar</string>
-    <string name="template_rendering_event_error_exception">${app_name} ha trobat un problema al renderitzar el contingut de l\'esdeveniment amb ID \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} no gestiona els missatges de tipus \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} no gestiona els esdeveniments de tipus \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} ha trobat un problema al renderitzar el contingut de l\'esdeveniment amb ID \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} no gestiona els missatges de tipus \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} no gestiona els esdeveniments de tipus \'%1$s\'</string>
     <string name="room_profile_leaving_room">Marxant de la sala…</string>
     <string name="direct_room_profile_section_more_leave">Marxa</string>
     <string name="room_profile_section_more_leave">Marxa de la sala</string>
@@ -2469,7 +2469,7 @@
 \nSegur que vols continuar\?</string>
     <string name="external_link_confirmation_title">Comprova aquest enllaç</string>
     <string name="mark_as_verified">Marca-ho com a segur</string>
-    <string name="template_use_other_session_content_description">Utilitza l\'última versió d\'${app_name} als teus altres dispositius, ${app_name} Web, ${app_name} per escriptori, ${app_name} iOS, ${app_name} per Android, o algun altre client de Matrix que admeti signatura creuada</string>
+    <string name="use_other_session_content_description">Utilitza l\'última versió d\'${app_name} als teus altres dispositius, ${app_name} Web, ${app_name} per escriptori, ${app_name} iOS, ${app_name} per Android, o algun altre client de Matrix que admeti signatura creuada</string>
     <string name="bootstrap_progress_storing_in_sss">Desant secret de clau de còpia de seguretat a SSSS</string>
     <string name="security_prompt_text">Verifica\'t a tu i als altres per mantenir els teus xats segurs</string>
     <string name="command_description_plain">Envia un missatge com a text pla, sense tenir en compte la formatació markdown</string>
@@ -2497,7 +2497,7 @@
     </plurals>
     <string name="secure_backup_reset_if_you_reset_all">Si ho restableixes tot</string>
     <string name="secure_backup_reset_all_no_other_devices">Fes això només si no tens cap altre dispositiu per poder verificar-ne aquest.</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} necessita que introdueixis les teves credencials per poder realitzar aquesta acció.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} necessita que introdueixis les teves credencials per poder realitzar aquesta acció.</string>
     <string name="re_authentication_activity_title">Re-autenticació necessària</string>
     <string name="contacts_book_title">Llista de contactes</string>
     <string name="empty_phone_book">La teva agenda està buida</string>
@@ -2518,7 +2518,7 @@
     <string name="identity_server_error_binding_error">L\'associació ha fallat.</string>
     <string name="identity_server_error_no_identity_server_configured">Primer configura un servidor d\'identitat.</string>
     <string name="identity_server_error_outdated_home_server">No es pot realitzar aquesta operació. El servidor local no està actualitzat.</string>
-    <string name="template_identity_server_error_outdated_identity_server">Aquest servidor d\'identitat no està actualitzat. ${app_name} només és compatible amb l\'API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Aquest servidor d\'identitat no està actualitzat. ${app_name} només és compatible amb l\'API V2.</string>
     <string name="disconnect_identity_server_dialog_content">Vols desconnectar-te del servidor d\'identitat %s\?</string>
     <string name="choose_locale_loading_locales">Carregant idiomes disponibles…</string>
     <string name="choose_locale_other_locales_title">Altres idiomes disponibles</string>

--- a/vector/src/main/res/values-cs/strings.xml
+++ b/vector/src/main/res/values-cs/strings.xml
@@ -353,7 +353,7 @@
     <string name="user_directory_header">Uživatelský adresář</string>
     <string name="matrix_only_filter">Pouze kontakty Matrix</string>
     <string name="no_conversation_placeholder">Žádné konverzace</string>
-    <string name="template_no_contact_access_placeholder">Nepovolil jste aplikaci ${app_name} přístup k místním kontaktům</string>
+    <string name="no_contact_access_placeholder">Nepovolil jste aplikaci ${app_name} přístup k místním kontaktům</string>
     <string name="no_result_placeholder">Žádné výsledky</string>
     <string name="rooms_header">Místnosti</string>
     <string name="rooms_directory_header">Adresář místností</string>
@@ -502,7 +502,7 @@
     <string name="room_info_room_name">Název místnosti</string>
     <string name="room_info_room_topic">Téma místnosti</string>
     <string name="settings_call_category">Hovory</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Použít původní vyzvánění ${app_name}u pro příchozí hovory</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Použít původní vyzvánění ${app_name}u pro příchozí hovory</string>
     <string name="settings_call_ringtone_title">Vyzvánění příchozího hovoru</string>
     <string name="settings_call_ringtone_dialog_title">Vybrat vyzvánění pro hovory:</string>
     <string name="call">Hovor</string>
@@ -521,14 +521,14 @@
     <string name="media_picker_both_capture_title">Pořídit fotografii nebo video</string>
     <string name="media_picker_cannot_record_video">Nemohu natáčet video</string>
     <string name="permissions_rationale_popup_title">Informace</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} potřebuje oprávnění pro přístup do Vaší knihovny fotografií a videí, aby mohl odesílat a ukládat přílohy.
+    <string name="permissions_rationale_msg_storage">${app_name} potřebuje oprávnění pro přístup do Vaší knihovny fotografií a videí, aby mohl odesílat a ukládat přílohy.
 \n
 \nProsím, povolte přístup na následující hlášce pro možnost odesílání souborů z Vašeho telefonu.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} potřebuje oprávnění pro přístup k Vašemu fotoaparátu pro pořizování fotografií a uskutečňování video hovorů.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} potřebuje oprávnění pro přístup k Vašemu fotoaparátu pro pořizování fotografií a uskutečňování video hovorů.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nProsím, povolte přístup na následující hlášce, abyste mohli uskutečnit hovor."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} potřebuje oprávnění pro přístup k Vašemu mikrofonu pro uskutečnění hlasových hovorů.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} potřebuje oprávnění pro přístup k Vašemu mikrofonu pro uskutečnění hlasových hovorů.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nProsím, povolte přístup na následující hlášce, abyste mohli uskutečnit hovor."</string>
@@ -542,7 +542,7 @@
     <string name="action_preview">Náhled</string>
     <string name="room_preview_invitation_format">Byli jste pozváni od %s ke vstupu do místnosti</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Žádost odeslána</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Prosím, spusťte ${app_name} na jiném zařízení, které může dešifrovat zprávu, aby poslalo klíče této relaci.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Prosím, spusťte ${app_name} na jiném zařízení, které může dešifrovat zprávu, aby poslalo klíče této relaci.</string>
     <string name="read_receipts_list">Seznam doručenek</string>
     <string name="groups_list">Seznam skupin</string>
     <string name="permissions_action_not_performed_missing_permissions">Omlouváme se, ale akce nebyla provedena z důvodu chybějících oprávnění</string>
@@ -677,11 +677,11 @@
     <string name="action_abort">Zrušit</string>
     <string name="action_sign_out_confirmation_simple">Opravdu se chcete odhlásit\?</string>
     <string name="video_call_in_progress">Video hovor probíhá…</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} potřebuje oprávnění pro přístup k Vaší kameře a mikrofonu pro uskutečnění video hovoru.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} potřebuje oprávnění pro přístup k Vaší kameře a mikrofonu pro uskutečnění video hovoru.
 \n
 \nProsím, povolte přístup na následující hlášce abyste mohli uskutečnit hovor.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} může nahlédnout do vašeho adresáře, aby nalezl ostatní uživatele Matrixu na základě jejich e-mailu a telefonního čísla. Pokud souhlasíte se sdílením svého adresáře za tímto účelem, prosím, povolte přístup v příští hlášce.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} může nahlédnout do vašeho adresáře, aby nalezl ostatní uživatele Matrixu na základě jejich e-mailu a telefonního čísla.
+    <string name="permissions_rationale_msg_contacts">${app_name} může nahlédnout do vašeho adresáře, aby nalezl ostatní uživatele Matrixu na základě jejich e-mailu a telefonního čísla. Pokud souhlasíte se sdílením svého adresáře za tímto účelem, prosím, povolte přístup v příští hlášce.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} může nahlédnout do vašeho adresáře, aby nalezl ostatní uživatele Matrixu na základě jejich e-mailu a telefonního čísla.
 \n 
 \nSouhlasíte se sdílením svého adresáře za tímto účelem\?</string>
     <string name="room_preview_unlinked_email_warning">Pozvánka byla odeslána na %s, což není spárováno s tímto účtem. 
@@ -781,7 +781,7 @@
     <string name="settings_call_ringtone_use_default_stun_sum">Použiiji %s jako nápomoc, pokud Váš domovský server žádnou nenabízí (Vaše IP adresa bude sdělena během hovoru)</string>
     <string name="invite_no_identity_server_error">Pro provedení této akce přidat server identit v nastavení.</string>
     <string name="settings_add_3pid_confirm_password_title">Potvrďte své heslo</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Nelze provést z ${app_name} mobile</string>
+    <string name="settings_add_3pid_flow_not_supported">Nelze provést z ${app_name} mobile</string>
     <string name="settings_add_3pid_authentication_needed">Ověření je nutné</string>
     <string name="settings_notification_privacy">Soukromí oznámení</string>
     <string name="settings_notification_troubleshoot">Odstraňování problémů s oznámeními</string>
@@ -803,7 +803,7 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Zapnout</string>
     <string name="settings_troubleshoot_test_device_settings_title">Nastavení relací.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Pro tuto relaci jsou oznámení zapnuta.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Oznámení nejsou zapnuta pro tuto relaci.
+    <string name="settings_troubleshoot_test_device_settings_failed">Oznámení nejsou zapnuta pro tuto relaci.
 \nProsím, prověřte nastavení ${app_name}u.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Zapnout</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Vlastní nastavení.</string>
@@ -813,7 +813,7 @@
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Kontrola nastavení</string>
     <string name="settings_troubleshoot_test_play_services_title">Kontrola služeb Play</string>
     <string name="settings_troubleshoot_test_play_services_success">Google Play Services APK je k dispozici a aktuální.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} používá Google Play Services pro doručení zpráv push, ale patrně nejsou správně nastaveny:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} používá Google Play Services pro doručení zpráv push, ale patrně nejsou správně nastaveny:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Opravit Play Services</string>
     <string name="settings_troubleshoot_test_fcm_title">Token Firebase</string>
@@ -821,11 +821,11 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">Načtení FCM tokenu selhalo:
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nTato chyba je mimo kontrolu ${app_name}u a podle Googlu indikuje, že zařízení má příliš mnoho aplikací registrovaných s FCM. Tato chyba se ukáže jen v případech extrémního množství aplikací, a proto by neměla mít vliv na normálního uživatele.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nTato chyba je mimo kontrolu ${app_name}u. Múže k ní dojít z několika důvodů. Snad bude fungovat, když zkusíte znovu později, můžete též zkontrolovat, zda Google Play Service nejsou omezeny v množství dat v systémových nastavení nebo zda hodiny zařízení jdou správné nebo k chybě může dojít na zvláštní ROM.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nTato chyba je mimo kontrolu ${app_name}u. V telefonu není žádný účet Google. Prosím, spusťte správce účtů a doplňte účet Google.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Přidat účet</string>
     <string name="settings_troubleshoot_test_token_registration_title">Registrace tokenu</string>
@@ -837,17 +837,17 @@
     <string name="settings_troubleshoot_test_service_restart_failed">Restart služby se nezdařil</string>
     <string name="settings_troubleshoot_test_service_boot_title">Spustit při zavádění</string>
     <string name="settings_troubleshoot_test_service_boot_success">Služba se spustí při restartu zařízení.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Služba se nespustí při startu zařízení, neobdržíte oznámení, dokud jednou neotevřete ${app_name}.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Služba se nespustí při startu zařízení, neobdržíte oznámení, dokud jednou neotevřete ${app_name}.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Zapnout Spustit při zavádění</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Zkontrolovat omezení na pozadí</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Omezení na pozadí jsou pro ${app_name} vypnuta. Tento test by měl běžet s mobilními daty (ne WIFI).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Omezení na pozadí jsou pro ${app_name} vypnuta. Tento test by měl běžet s mobilními daty (ne WIFI).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Omezení na pozadí jsou pro ${app_name} zapnuta.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Omezení na pozadí jsou pro ${app_name} zapnuta.
 \nČinnosti prováděné aplikací budou agresivně omezeny, bude-li v pozadí, a to může mít vliv na oznámení.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Vypnout omezení</string>
     <string name="settings_troubleshoot_test_battery_title">Optimalizace baterie</string>
-    <string name="template_settings_troubleshoot_test_battery_success">Optimalizace baterie nemá na ${app_name} vliv.</string>
+    <string name="settings_troubleshoot_test_battery_success">Optimalizace baterie nemá na ${app_name} vliv.</string>
     <string name="settings_troubleshoot_test_battery_failed">Nechá-li uživatel zařízení vytažený ze zásuvky a v klidu po nějakou dobu a s obrazovkou vypnutou, zařízení vstoupí do stavu spánku. Ten zamezí aplikacím přístup k síti a odloží jejich úlohy, synchronizaci a běžná upozornění.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignorovat optimalizaci</string>
     <string name="settings_notification_privacy_normal">Normální</string>
@@ -877,10 +877,10 @@
     <string name="settings_background_sync">Synchronizace na pozadí</string>
     <string name="settings_background_fdroid_sync_mode">Režim synchronizace na pozadí</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimalizován pro baterii</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} bude synchronizovat na pozadí způsobem, který šetří omezené zdroje zařízení (baterii).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} bude synchronizovat na pozadí způsobem, který šetří omezené zdroje zařízení (baterii).
 \nV závislosti na stavu zdrojů zařízení může být sync operačním systémem odložen.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimalizováno pro reálný čas</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} bude synchronizovat na pozadí periodicky v přesný čas (nastavitelné).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} bude synchronizovat na pozadí periodicky v přesný čas (nastavitelné).
 \nTo bude mít vliv na využití rádia a baterie, stálé oznámení o tom, že ${app_name} čeká na události, bude zobrazeno.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Žádný sync na pozadí</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Neobdržíte oznámení o příchozích zprávách, je-li aplikace na pozadí.</string>
@@ -942,17 +942,17 @@
     <string name="settings_discovery_category">Objevování</string>
     <string name="settings_discovery_manage">Správa Vašich nastavení pro objevování.</string>
     <string name="startup_notification_privacy_title">Soukromí ohledně oznámení</string>
-    <string name="template_startup_notification_privacy_message">${app_name} může běžet na pozadí, aby spravoval Vaše oznámení bezpečně a v soukromí. To může mít vliv na baterii.</string>
+    <string name="startup_notification_privacy_message">${app_name} může běžet na pozadí, aby spravoval Vaše oznámení bezpečně a v soukromí. To může mít vliv na baterii.</string>
     <string name="startup_notification_privacy_button_grant">Udělit oprávnění</string>
     <string name="startup_notification_privacy_button_other">Vybrat jinou volbu</string>
     <string name="startup_notification_fdroid_battery_optim_title">Spojení na pozadí</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} potřebuje udržovat spojení na pozadí se slabým vlivem, abyste obdrželi spolehlivá oznámení.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} potřebuje udržovat spojení na pozadí se slabým vlivem, abyste obdrželi spolehlivá oznámení.
 \nNa příští obrazovce budete dotázáni o svolení nechat ${app_name} vždy v chodu na pozadí, prosím, souhlaste.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Udělit oprávění</string>
     <string name="settings_analytics">Analýza</string>
     <string name="settings_opt_in_of_analytics">Odeslat analytická data</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} sbírá anonymní analytická data pro vylepšení aplikace.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Prosím, zapněte analýzu pro vylepšení ${app_name}u.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} sbírá anonymní analytická data pro vylepšení aplikace.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Prosím, zapněte analýzu pro vylepšení ${app_name}u.</string>
     <string name="settings_opt_in_of_analytics_ok">Ano, chci pomoci!</string>
     <string name="settings_data_save_mode">Režim úsporných dat</string>
     <string name="settings_data_save_mode_summary">Režim úsporných data zavádí specifický filtr, takže aktualizace přítomnosti a oznámení o psaní jsou fitrovány.</string>
@@ -1373,7 +1373,7 @@
     <string name="passphrase_passphrase_does_not_match">Přistupová fráze se neshoduje</string>
     <string name="passphrase_empty_error_message">Prosím, zadejte přístupovou frázi</string>
     <string name="passphrase_passphrase_too_weak">Přístupová fráze je příliš slabá</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Prosím, smažte přístupovou frázi, přejete-li si, aby ${app_name} generoval klíč pro obnovu.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Prosím, smažte přístupovou frázi, přejete-li si, aby ${app_name} generoval klíč pro obnovu.</string>
     <string name="keys_backup_no_session_error">Žádná relace Matrix není dostupná</string>
     <string name="keys_backup_setup_step1_title">Nikdy neztraťte šifrované zprávy</string>
     <string name="keys_backup_setup_step1_description">Zprávy v šifrovaných místnostech jsou zabezpečeny pomocí koncového šifrování. Pouze Vy a adresát(i) máte klíče ke čtení těchto zpráv.
@@ -1465,7 +1465,7 @@
     <string name="keys_backup_info_title_signature">Podpis</string>
     <string name="autodiscover_invalid_response">Neplatná odpověď z hledání domovských serverů</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Volby serveru automaticky</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} nalezl vlastní konfiguraci serveru pro doménu Vašeho uživatelského Id \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} nalezl vlastní konfiguraci serveru pro doménu Vašeho uživatelského Id \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Použít konfiguraci</string>
     <string name="invalid_or_expired_credentials">Byli jste odhlášení kvůli chybným či neplatným ověřovacím údajům.</string>
@@ -1540,7 +1540,7 @@
     <string name="please_wait">Prosím, čekejte…</string>
     <string name="group_all_communities">Všechny komunity</string>
     <string name="room_preview_no_preview">Nelze provést náhled této místnosti</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Náhled místnosti čitelné pro všechny zatím ${app_name} nepodporuje</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Náhled místnosti čitelné pro všechny zatím ${app_name} nepodporuje</string>
     <string name="fab_menu_create_room">Místnosti</string>
     <string name="fab_menu_create_chat">Přímé zprávy</string>
     <string name="create_room_title">Nová místnost</string>
@@ -1680,7 +1680,7 @@
     <string name="content_reported_as_inappropriate_content">Obsah byl nahlášen jako nepatřičný.
 \n
 \nPokud si dále nepřejete vidět obsah tohoto uživatele, můžete jej ignorovat a tím skrýt jejich zprávy.</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} potřebuje práva k uložení Vašich E2E klíčů na disk.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} potřebuje práva k uložení Vašich E2E klíčů na disk.
 \n
 \nProsím, povolte přístup v příštím dialogu, abyste mohli exportovat své klíče manuálně.</string>
     <string name="no_network_indicator">Právě nyní není k dispozici žádné síťové spojení</string>
@@ -1821,7 +1821,7 @@
 \nPro přístup k účtu a zprávám se znovu se přihlaste.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Ztratíte přístup k šifrovaným zprávám, pokud se nepřihlásíte za účelem obnovy šifrovacích klíčů.</string>
     <string name="soft_logout_clear_data_dialog_submit">Vyčistit data</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Tato relace je pro uživatele %1$s a Vy jste zadali údaje pro uživatele %2$s. ${app_name} toto nepodporuje.
+    <string name="soft_logout_sso_not_same_user_error">Tato relace je pro uživatele %1$s a Vy jste zadali údaje pro uživatele %2$s. ${app_name} toto nepodporuje.
 \nProsím, nejdříve vyčistěte data a pak se přihlaste k jinému účtu.</string>
     <string name="permalink_malformed">Váš odkaz matrix.to byl chybný</string>
     <string name="bug_report_error_too_short">Popis je příliš krátký</string>
@@ -1839,7 +1839,7 @@
     <string name="devices_other_devices">Jiné relace</string>
     <string name="autocomplete_limited_results">Ukazuji jen první výsledky, zadejte více znaků…</string>
     <string name="settings_developer_mode_fail_fast_title">Fail-fast</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} může spadnout častěji, když se objeví neočekávané chyby</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} může spadnout častěji, když se objeví neočekávané chyby</string>
     <string name="command_description_shrug">Předsune ¯\\_(ツ)_/¯ do textové zprávy</string>
     <string name="create_room_encryption_title">Zapnout šifrování</string>
     <string name="create_room_encryption_description">Jakmile zapnuto, šifrování nelze vypnout.</string>
@@ -1911,9 +1911,9 @@
     <string name="room_member_power_level_moderator_in">Moderátor v %1$s</string>
     <string name="room_member_power_level_custom_in">Vlastní (%1$d) in %2$s</string>
     <string name="room_member_jump_to_read_receipt">Přeskočit k potvrzení přečtení</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} neobstarává události typu \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} neobstarává zprávy typu \'%1$s\'</string>
-    <string name="template_rendering_event_error_exception">${app_name} narazil na chybu při převádění obsahu události s id \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} neobstarává události typu \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} neobstarává zprávy typu \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} narazil na chybu při převádění obsahu události s id \'%1$s\'</string>
     <string name="unignore">Odignorovat</string>
     <string name="verify_cannot_cross_sign">Tato relace nemůže sdílet toto ověření s jinými z Vašich relací.
 \nToto ověření bude uloženo místně a sdíleno v budoucí verzi aplikace.</string>
@@ -2000,7 +2000,7 @@
     <string name="event_redacted_by_user_reason_with_reason">Událost smazána uživatelem, důvod: %1$s</string>
     <string name="event_redacted_by_admin_reason_with_reason">Událost moderována správcem místnosti, důvod: %1$s</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Klíče jsou již aktuální!</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">Požadavky na klíče</string>
     <string name="e2e_use_keybackup">Odemknout zašifrovanou historii zpráv</string>
     <string name="refresh">Obnovit</string>
@@ -2121,13 +2121,13 @@
     <string name="login_signin_matrix_id_error_invalid_matrix_id">To není platný identifikátor uživatele. Platný formát: \'@uživatel:homeserver.org\'</string>
     <string name="autodiscover_well_known_error">Nemohu najít platný domovský server. Prosím, zkontrolujte svůj identifikátor</string>
     <string name="no_connectivity_to_the_server_indicator_airplane">Režim letadlo je zapnut</string>
-    <string name="template_use_other_session_content_description">Použijte na svých zařízeních nejnovější ${app_name}, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} pro Android nebo jiný Matrix klient schopný křížového podepisování</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="use_other_session_content_description">Použijte na svých zařízeních nejnovější ${app_name}, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} pro Android nebo jiný Matrix klient schopný křížového podepisování</string>
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
     <string name="or_other_mx_capable_client">nebo jiný Matrix klient schopný křížového podepisování</string>
-    <string name="template_use_latest_app">Použijte na svých zařízeních nejnovější ${app_name}:</string>
+    <string name="use_latest_app">Použijte na svých zařízeních nejnovější ${app_name}:</string>
     <string name="command_description_discard_session">Vynutí zahození probíhající skupinové relace v šifrované místnosti</string>
     <string name="command_description_discard_session_not_handled">Podporováno jen v šifrovaných místnostech</string>
     <string name="enter_secret_storage_passphrase_or_key">Použijte své %1$s nebo použijte svůj %2$s a pokračujte.</string>
@@ -2169,11 +2169,11 @@
     <string name="choose_locale_loading_locales">Načítám dostupné jayzky…</string>
     <string name="open_terms_of">Otevřít všeobecné podmínky %s</string>
     <string name="disconnect_identity_server_dialog_content">Odpojit se od serveru identit %s\?</string>
-    <string name="template_identity_server_error_outdated_identity_server">Tento server identit je zastaralý. ${app_name} podporuje jen API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Tento server identit je zastaralý. ${app_name} podporuje jen API V2.</string>
     <string name="identity_server_error_outdated_home_server">Tato operace není možná. Domovský server je zastaralý.</string>
     <string name="identity_server_error_no_identity_server_configured">Prosím, nejdříve nastavit server identit.</string>
     <string name="identity_server_error_terms_not_signed">Prosím, přijměte nejdříve všeobecné podmínky serveru identit v nastavení.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Pro Vaše soukromí, ${app_name} podporuje jen odesílání hašovaných emailových adress a telefonních čísel.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Pro Vaše soukromí, ${app_name} podporuje jen odesílání hašovaných emailových adress a telefonních čísel.</string>
     <string name="identity_server_error_binding_error">Propojení selhalo.</string>
     <string name="identity_server_error_no_current_binding_error">S tímto identifikátorem neexistuje žádné propojení.</string>
     <string name="identity_server_set_default_notice">Váš domovský server (%1$s) navrhuje použít %2$s za Váš domovský server</string>
@@ -2199,7 +2199,7 @@
     <string name="action_copy">Kopírovat</string>
     <string name="dialog_title_success">Podařilo se</string>
     <string name="bottom_action_notification">Oznámení</string>
-    <string name="template_call_failed_no_connection">Volání ${app_name}u se nezdařilo</string>
+    <string name="call_failed_no_connection">Volání ${app_name}u se nezdařilo</string>
     <string name="call_failed_no_connection_description">Nezdařilo se navázat spojení v reálném čase.
 \nProsím, požádejte správce svého domovského serveru o konfiguraci TURN serveru, aby volání fungovala spolehlivě.</string>
     <string name="call_select_sound_device">Vybrat zvukové zařízení</string>
@@ -2398,13 +2398,13 @@
     <string name="warning_unsaved_change_discard">Zahodit změny</string>
     <string name="warning_unsaved_change">Zahodit neuložené změny\?</string>
     <string name="warning_room_not_created_yet">Místnost nebyla ještě založena. Zrušit založení místnosti\?</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Kód PIN se vyžaduje při každém otevření ${app_name}u.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Kód PIN se vyžaduje, pokud se ${app_name} nepoužil 2 minuty.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Kód PIN se vyžaduje při každém otevření ${app_name}u.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Kód PIN se vyžaduje, pokud se ${app_name} nepoužil 2 minuty.</string>
     <string name="settings_security_pin_code_grace_period_title">Žádat PIN po 2 minutách</string>
     <string name="settings_security_pin_code_notifications_summary_off">Zobrazit pouze počet nepřečtených zpráv v jednoduchém oznámení.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Zobrazit podrobnosti např. názvy místností a obsah zpráv.</string>
     <string name="settings_security_pin_code_notifications_title">Zobrazit obsah v oznámení</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">Kód PIN je jediný způsob, jak odemknout ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">Kód PIN je jediný způsob, jak odemknout ${app_name}.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Zapnout biometriku specifickou pro zařízení, např. otisk prstu nebo rozpoznání obličeje.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Zapnout biometriku</string>
     <string name="settings_security_application_protection_screen_title">Nastavit ochranu</string>
@@ -2473,8 +2473,8 @@
     <string name="user_code_share">Sdílet můj kód</string>
     <string name="user_code_scan">Skenovat QR kód</string>
     <string name="not_a_valid_qr_code">To není platný matrixový QR kód</string>
-    <string name="template_invite_friends_rich_title">🔐️ Přidej se ke mně v ${app_name}u</string>
-    <string name="template_invite_friends_text">Ahoj, pojď si povídat v ${app_name}u: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Přidej se ke mně v ${app_name}u</string>
+    <string name="invite_friends_text">Ahoj, pojď si povídat v ${app_name}u: %s</string>
     <string name="invite_friends">Pozvat přátele</string>
     <string name="add_people">Přidat lidi</string>
     <string name="topic_prefix">"Téma: "</string>
@@ -2591,7 +2591,7 @@
     <string name="action_add">Přidat</string>
     <string name="system_theme">Výchozí téma</string>
     <string name="authentication_error">Ověření se nezdařilo</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} vyžaduje zadání přihlašovacích údajů k provedení této akce.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} vyžaduje zadání přihlašovacích údajů k provedení této akce.</string>
     <string name="re_authentication_activity_title">Je nutné opětovné ověření</string>
     <string name="failed_to_initialize_cross_signing">Nastavení křížového podepisování se nezdařilo</string>
     <string name="error_unauthorized">Neautorizováno, chybí platné ověřovací údaje</string>
@@ -2912,7 +2912,7 @@
     <string name="settings_notification_other">Další</string>
     <string name="settings_notification_mentions_and_keywords">Zmínky a klíčová slova</string>
     <string name="settings_notification_default">Výchozí oznámení</string>
-    <string name="template_link_this_email_with_your_account">%s v Nastavení pro příjem pozvánek přímo v ${app_name}u.</string>
+    <string name="link_this_email_with_your_account">%s v Nastavení pro příjem pozvánek přímo v ${app_name}u.</string>
     <string name="link_this_email_settings_link">Propojte tento e-mail se svým účtem</string>
     <string name="this_invite_to_this_room_was_sent">Pozvánka do této místnosti byla odeslána na adresu %s, která není spojena s vaším účtem</string>
     <string name="this_invite_to_this_space_was_sent">Pozvánka do tohoto prostoru byla odeslána na adresu %s, která není spojena s vaším účtem</string>
@@ -3081,7 +3081,7 @@
     </plurals>
     <string name="preference_system_settings">Systémová nastavení</string>
     <string name="preference_versions">Verze</string>
-    <string name="template_preference_help_summary">Získejte pomoc při používání ${app_name}u</string>
+    <string name="preference_help_summary">Získejte pomoc při používání ${app_name}u</string>
     <string name="preference_help_title">Nápověda a podpora</string>
     <string name="preference_help">Nápověda</string>
     <string name="preference_root_legals">Právní dokumenty</string>
@@ -3089,15 +3089,15 @@
     <string name="legals_third_party_notices">Knihovny třetích stran</string>
     <string name="legals_identity_server_title">Zásady vašeho serveru identit</string>
     <string name="legals_home_server_title">Zásady vašeho domovského serveru</string>
-    <string name="template_legals_application_title">Zásady aplikace ${app_name}</string>
+    <string name="legals_application_title">Zásady aplikace ${app_name}</string>
     <string name="analytics_opt_in_list_item_3">Tuto funkci můžete kdykoli vypnout v nastavení</string>
     <string name="analytics_opt_in_list_item_2"><b>Nesdílíme</b> informace s třetími stranami</string>
     <string name="analytics_opt_in_list_item_1"><b>Nezaznamenáváme ani neprofilujeme</b> žádné údaje o účtu</string>
     <string name="analytics_opt_in_content_link">zde</string>
-    <string name="template_analytics_opt_in_content">Pomozte nám identifikovat problémy a vylepšit ${app_name} sdílením anonymních údajů o používání. Abychom pochopili, jak lidé používají více zařízení, vygenerujeme náhodný identifikátor sdílený vašimi zařízeními.
+    <string name="analytics_opt_in_content">Pomozte nám identifikovat problémy a vylepšit ${app_name} sdílením anonymních údajů o používání. Abychom pochopili, jak lidé používají více zařízení, vygenerujeme náhodný identifikátor sdílený vašimi zařízeními.
 \n
 \nMůžete si přečíst všechny naše podmínky %s.</string>
-    <string name="template_analytics_opt_in_title">Pomozte vylepšit ${app_name}</string>
+    <string name="analytics_opt_in_title">Pomozte vylepšit ${app_name}</string>
     <string name="action_enable">Povolit</string>
     <string name="restart_the_application_to_apply_changes">Restartujte aplikaci, aby se změna projevila.</string>
     <string name="labs_enable_latex_maths">Povolit matematické výrazy LaTeXu</string>
@@ -3120,8 +3120,8 @@
     <string name="settings_enable_location_sharing_summary">Po zapnutí budete moci odeslat svou polohu do libovolné místnosti</string>
     <string name="settings_enable_location_sharing">Povolit sdílení polohy</string>
     <string name="location_share_external">Otevřít v</string>
-    <string name="template_location_not_available_dialog_content">${app_name} nemohl získat přístup k vaší poloze. Zkuste to prosím později.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} nemohl získat přístup k vaší poloze</string>
+    <string name="location_not_available_dialog_content">${app_name} nemohl získat přístup k vaší poloze. Zkuste to prosím později.</string>
+    <string name="location_not_available_dialog_title">${app_name} nemohl získat přístup k vaší poloze</string>
     <string name="location_share">Sdílet polohu</string>
     <string name="a11y_location_share_icon">Sdílet polohu</string>
     <string name="location_activity_title_preview">Poloha</string>

--- a/vector/src/main/res/values-da/strings.xml
+++ b/vector/src/main/res/values-da/strings.xml
@@ -126,7 +126,7 @@
     <string name="user_directory_header">Bruger katalog</string>
     <string name="matrix_only_filter">Kun Matrix kontakter</string>
     <string name="no_conversation_placeholder">Ingen samtaler</string>
-    <string name="template_no_contact_access_placeholder">Du gav ikke ${app_name} tilladelse til at se dine lokale kontakter</string>
+    <string name="no_contact_access_placeholder">Du gav ikke ${app_name} tilladelse til at se dine lokale kontakter</string>
     <string name="no_result_placeholder">Ingen resultater</string>
     <string name="rooms_header">Rum</string>
     <string name="rooms_directory_header">Rum katalog</string>
@@ -257,23 +257,23 @@ Du er blevet logget ud af alle enheder og vil ikke længere modtage pushnotifika
     <string name="media_picker_both_capture_title">Tag et billede eller optag en video</string>
     <string name="media_picker_cannot_record_video">Kan ikke optage video</string>
     <string name="permissions_rationale_popup_title">Information</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} skal bruge tilladelse til at tilgå dit billed- og videoarkiv for at sende og gemme vedhæftninger.
+    <string name="permissions_rationale_msg_storage">${app_name} skal bruge tilladelse til at tilgå dit billed- og videoarkiv for at sende og gemme vedhæftninger.
 Giv venligst tilladelse ved næste pop-up for at kunne sende filer fra din telefon.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} skal bruge tilladelse til at bruge dit kamera for at billeder og lave videoopkald.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} skal bruge tilladelse til at bruge dit kamera for at billeder og lave videoopkald.</string>
     <string name="permissions_rationale_msg_camera_explanation">
 
 Giv venligst tilladelse ved næste pop-up for at kunne lave opkald.</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} skal bruge tilladelse til at bruge din mikrofon for at lave lydopkald.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} skal bruge tilladelse til at bruge din mikrofon for at lave lydopkald.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">
 
 Giv venligst tilladelse ved næste pop-up for at kunne lave opkaldet.</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} skal bruge tilladelse til at bruge dit kamera og din mikrofon for at lave videoopkald.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} skal bruge tilladelse til at bruge dit kamera og din mikrofon for at lave videoopkald.
 
 Giv venligst tilladelse ved næste pop-up for at lave opkaldet.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} skal bruge adgang til dine kontakter for at finde andre Matrix brugere ud fra deres email og telefonnumre.
+    <string name="permissions_rationale_msg_contacts">${app_name} skal bruge adgang til dine kontakter for at finde andre Matrix brugere ud fra deres email og telefonnumre.
 
 Giv venligst tilladelse ved næste pop-up for at finde kontakter der er på ${app_name}.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} skal bruge adgang til dine kontakter for at finde andre Matrix brugere ud fra deres email og telefonnumre.
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} skal bruge adgang til dine kontakter for at finde andre Matrix brugere ud fra deres email og telefonnumre.
 
 Vil du give ${app_name} adgang til dine kontakter?</string>
     <string name="permissions_action_not_performed_missing_permissions">Beklager… Handlingen blev ikke udført fordi der mangler tilladelser</string>

--- a/vector/src/main/res/values-de/strings.xml
+++ b/vector/src/main/res/values-de/strings.xml
@@ -329,7 +329,7 @@
     <string name="local_address_book_header">Lokales Adressbuch</string>
     <string name="matrix_only_filter">Nur Matrix-Kontakte</string>
     <string name="no_conversation_placeholder">Keine Konversationen</string>
-    <string name="template_no_contact_access_placeholder">${app_name} wurde nicht erlaubt, auf lokale Kontakte zuzugreifen</string>
+    <string name="no_contact_access_placeholder">${app_name} wurde nicht erlaubt, auf lokale Kontakte zuzugreifen</string>
     <string name="no_result_placeholder">Keine Ergebnisse</string>
     <string name="rooms_header">Räume</string>
     <string name="rooms_directory_header">Raumverzeichnis</string>
@@ -454,20 +454,20 @@
     <string name="media_picker_both_capture_title">Foto oder Video aufnehmen</string>
     <string name="media_picker_cannot_record_video">Video kann nicht aufgenommen werden</string>
     <string name="permissions_rationale_popup_title">Information</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} benötigt die Berechtigung, auf deine Fotos und Videos zugreifen zu können, um Anhänge zu senden und zu speichern.\n\nBitte erlaube den Zugriff im nächsten Dialog, um Dateien von deinem Gerät zu versenden.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} benötigt die Berechtigung, auf deine Kamera zugreifen zu können, um Bilder aufzunehmen und Video-Anrufe durchzuführen.</string>
+    <string name="permissions_rationale_msg_storage">${app_name} benötigt die Berechtigung, auf deine Fotos und Videos zugreifen zu können, um Anhänge zu senden und zu speichern.\n\nBitte erlaube den Zugriff im nächsten Dialog, um Dateien von deinem Gerät zu versenden.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} benötigt die Berechtigung, auf deine Kamera zugreifen zu können, um Bilder aufzunehmen und Video-Anrufe durchzuführen.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nBitte erlaube den Zugriff im nächsten Dialog, um den Anruf durchzuführen."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} benötigt die Berechtigung, auf dein Mikrofon zugreifen zu können, um (Sprach-)Anrufe tätigen zu können.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} benötigt die Berechtigung, auf dein Mikrofon zugreifen zu können, um (Sprach-)Anrufe tätigen zu können.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nBitte erlaube den Zugriff im nächsten Dialog, um den Anruf durchzuführen."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} benötigt die Berechtigung, auf Kamera und Mikrofon zu zugreifen, um Video-Anrufe durchzuführen.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} benötigt die Berechtigung, auf Kamera und Mikrofon zu zugreifen, um Video-Anrufe durchzuführen.
 \n
 \nBitte erlaube den Zugriff im nächsten Dialog, um den Anruf durchzuführen.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} kann dein Adressbuch durchsuchen, um andere Matrix-Nutzer anhand ihrer E-Mail-Adresse und Telefonnummer zu finden. Wenn du der Nutzung deines Adressbuchs zu diesem Zweck zustimmst, erlaube den Zugriff im nächsten Pop-up-Fenster.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} kann dein Adressbuch durchsuchen, um andere Matrix-Nutzer anhand ihrer E-Mail-Adresse und Telefonnummer zu finden.
+    <string name="permissions_rationale_msg_contacts">${app_name} kann dein Adressbuch durchsuchen, um andere Matrix-Nutzer anhand ihrer E-Mail-Adresse und Telefonnummer zu finden. Wenn du der Nutzung deines Adressbuchs zu diesem Zweck zustimmst, erlaube den Zugriff im nächsten Pop-up-Fenster.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} kann dein Adressbuch durchsuchen, um andere Matrix-Nutzer anhand ihrer E-Mail-Adresse und Telefonnummer zu finden.
 \n
 \nStimmst du der Nutzung deines Adressbuchs zu diesem Zweck zu\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Entschuldige. Die Aktion wurde aufgrund fehlender Berechtigungen nicht ausgeführt</string>
@@ -939,7 +939,7 @@
     <string name="settings_notification_privacy_nosecure_message_content">• Benachrichtigungen enthalten <b>Metadaten und Nachrichteninhalte</b></string>
     <string name="settings_notification_privacy_message_content_not_shown">• Benachrichtigungen werden <b>den Nachrichteninhalt nicht anzeigen</b></string>
     <string name="startup_notification_privacy_title">Benachrichtungs-Datenschutz</string>
-    <string name="template_startup_notification_privacy_message">${app_name} kann im Hintergrund laufen um deine Benachrichtigungen sicher und privat zu verwalten. Dies kann den Energieverbrauch beeinflussen.</string>
+    <string name="startup_notification_privacy_message">${app_name} kann im Hintergrund laufen um deine Benachrichtigungen sicher und privat zu verwalten. Dies kann den Energieverbrauch beeinflussen.</string>
     <string name="startup_notification_privacy_button_grant">Berechtigung gewähren</string>
     <string name="startup_notification_privacy_button_other">Wähle eine andere Option</string>
     <string name="title_activity_choose_sticker">Sticker senden</string>
@@ -950,8 +950,8 @@
     <string name="settings_deactivate_account_section">Account deaktivieren</string>
     <string name="settings_deactivate_my_account">Meinen Account deaktivieren</string>
     <string name="settings_opt_in_of_analytics">Sende Analysedaten</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} sammelt anonyme Analysedaten um uns zu helfen, die App zu verbessern.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Bitte aktive Analysedaten um uns zu helfen ${app_name} zu verbessern.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} sammelt anonyme Analysedaten um uns zu helfen, die App zu verbessern.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Bitte aktive Analysedaten um uns zu helfen ${app_name} zu verbessern.</string>
     <string name="settings_opt_in_of_analytics_ok">Ja, ich möchte helfen!</string>
     <string name="widget_integration_missing_parameter">Ein benötigter Parameter fehlt.</string>
     <string name="widget_integration_invalid_parameter">Ein Parameter ist nicht valide.</string>
@@ -973,7 +973,7 @@
     <string name="e2e_re_request_encryption_key">Schlüssel von deinen anderen Sitzungen erneut anfordern.</string>
     <string name="e2e_re_request_encryption_key_sent">Schlüsselanfrage gesendet.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Anfrage gesendet</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Bitte öffne ${app_name} auf einem anderen Gerät, das die Nachricht entschlüsseln kann, damit es die Schlüssel an diese Sitzung senden kann.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Bitte öffne ${app_name} auf einem anderen Gerät, das die Nachricht entschlüsseln kann, damit es die Schlüssel an diese Sitzung senden kann.</string>
     <string name="lock_screen_hint">Hier tippen…</string>
     <string name="option_send_voice">Sprachnachricht senden</string>
     <string name="go_on_with">Fortfahren mit…</string>
@@ -1087,7 +1087,7 @@
     <string name="settings_show_avatar_display_name_changes_messages">Kontoänderungen zeigen</string>
     <string name="settings_show_avatar_display_name_changes_messages_summary">Enthält Änderungen des Profilbilds und des Anzeigenamens.</string>
     <string name="settings_call_category">Anrufe</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Nutze den Standard-Klingelton von ${app_name} für eingehende Anrufe</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Nutze den Standard-Klingelton von ${app_name} für eingehende Anrufe</string>
     <string name="settings_call_ringtone_title">Klingelton für eingehende Anrufe</string>
     <string name="settings_call_ringtone_dialog_title">Wähle Klingelton für Anrufe:</string>
     <string name="action_accept">Akzeptieren</string>
@@ -1108,10 +1108,10 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Aktiviere</string>
     <string name="settings_troubleshoot_test_device_settings_title">Sitzungseinstellungen.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Benachrichtigungen sind für diese Sitzung aktiviert.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Benachrichtigungen sind für diese Sitzung nicht aktiviert.
+    <string name="settings_troubleshoot_test_device_settings_failed">Benachrichtigungen sind für diese Sitzung nicht aktiviert.
 \nBitte überprüfe die Einstellungen für ${app_name}.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Aktiviere</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} benutzt Google-Play-Dienste um Push-Nachrichten zu übermitteln, doch scheinen sie nicht korrekt konfiguriert zu sein:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} benutzt Google-Play-Dienste um Push-Nachrichten zu übermitteln, doch scheinen sie nicht korrekt konfiguriert zu sein:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Repariere Play-Dienste</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase-Token</string>
@@ -1127,17 +1127,17 @@
     <string name="settings_troubleshoot_test_service_restart_failed">Dienst konnte nicht neu gestartet werden</string>
     <string name="settings_troubleshoot_test_service_boot_title">Starte beim Hochfahren</string>
     <string name="settings_troubleshoot_test_service_boot_success">Dienst wird starten, wenn das Gerät neu gestartet wird.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Dieser Dienst wird nicht starten, wenn das Gerät neu gestartet wird. Du wirst keine Benachrichtigungen bekommen bis ${app_name} einmal geöffnet wurde.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Dieser Dienst wird nicht starten, wenn das Gerät neu gestartet wird. Du wirst keine Benachrichtigungen bekommen bis ${app_name} einmal geöffnet wurde.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Aktiviere das Starten beim Hochfahren</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Überprüfe Hintergrund-Einschränkungen</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Hintergrund-Einschränkungen sind für ${app_name} deaktiviert. Dieser Test sollte über mobile Daten ausgeführt werden (kein WLAN).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Hintergrund-Einschränkungen sind für ${app_name} deaktiviert. Dieser Test sollte über mobile Daten ausgeführt werden (kein WLAN).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Hintergrund-Einschränkungen sind für ${app_name} aktiviert.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Hintergrund-Einschränkungen sind für ${app_name} aktiviert.
 \nDie App wird aggressiv eingeschränkt, während sie im Hintergrund arbeiten möchte. Dies könnte Benachrichtigungen beeinflussen.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Einschränkungen deaktivieren</string>
     <string name="settings_troubleshoot_test_battery_title">Batterieoptimierung</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} wird nicht von Batterieoptimierungen beeinflusst.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} wird nicht von Batterieoptimierungen beeinflusst.</string>
     <string name="settings_notification_troubleshoot">Benachrichtigungsprobleme finden</string>
     <string name="settings_troubleshoot_diagnostic">Diagnose von Fehlern</string>
     <string name="settings_troubleshoot_diagnostic_success_status">Basisdiagnose ist OK. Wenn du immer noch keine Benachrichtigungen bekommst, sende bitte einen Fehlerbericht, um uns beim Nachforschen zu helfen.</string>
@@ -1147,7 +1147,7 @@
     <string name="settings_troubleshoot_test_battery_failed">Wenn ein Benutzer ein abgestecktes Gerät mit ausgeschaltetem Bildschirm eine Weile nicht bewegt, wechselt es in den Bereitschaftsmodus. Dies hindert Apps daran, auf das Netzwerk zuzugreifen und verzögert die Ausführung von Aufgaben, Synchronisierungen und Standard-Alarmen.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignoriere Optimierungen</string>
     <string name="startup_notification_fdroid_battery_optim_title">Hintergrundverbindung</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} muss eine Hintergrundverbindung (nur geringe Belastung) aufrechterhalten, um verlässliche Benachrichtigungen zu erhalten.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} muss eine Hintergrundverbindung (nur geringe Belastung) aufrechterhalten, um verlässliche Benachrichtigungen zu erhalten.
 \nAuf dem nächsten Bildschirm wirst du gefragt, ob du ${app_name} erlauben möchtest im Hintergrund zu laufen. Bitte akzeptieren.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Berechtigung gewähren</string>
     <string name="account_email_error">Beim Verifizieren deiner E-Mail-Adresse trat ein Fehler auf.</string>
@@ -1174,7 +1174,7 @@
     <string name="notification_silent">Stumm</string>
     <string name="passphrase_empty_error_message">Bitte eine Passphrase eingeben</string>
     <string name="passphrase_passphrase_too_weak">Passphrase ist zu schwach</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Bitte lösche die Passphrase, wenn ${app_name} einen Wiederherstellungs-Schlüssel erzeugen soll.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Bitte lösche die Passphrase, wenn ${app_name} einen Wiederherstellungs-Schlüssel erzeugen soll.</string>
     <string name="keys_backup_no_session_error">Keine Matrix-Sitzung verfügbar</string>
     <string name="keys_backup_setup_step1_title">Verliere nie wieder verschlüsselte Nachrichten</string>
     <string name="keys_backup_setup_step2_button_title">Setze Passphrase</string>
@@ -1197,11 +1197,11 @@
     <string name="keys_backup_settings_delete_backup_error">Konnte Sicherung nicht löschen (%s)</string>
     <string name="keys_backup_settings_delete_confirm_title">Lösche Sicherung</string>
     <string name="settings_notification_by_event">Präferenz der Benachrichtigungen nach Ereignis</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nDieser Fehler ist außerhalb von ${app_name} passiert. Google sagt, dass dieses Gerät zu viele Apps registriert hat um FCM zu nutzen. Der Fehler taucht nur auf, wenn sehr viele Apps installiert sind. Er sollte also den Durchschnittsnutzer nicht betreffen.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nDieser Fehler liegt nicht unter der Kontrolle von ${app_name}. Er kann aus verschiedenen Gründen auftreten. Vielleicht wird es funktionieren, wenn du es später noch einmal probierst. Außerdem kannst Du prüfen, ob die Datennutzung der Google-Play-Dienste unbeschränkt ist und die Geräteuhr richtig eingestellt ist. Der Fehler kann aber auch unter Custom-ROMs auftreten.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nDieser Fehler ist außerhalb von ${app_name} passiert. Es gibt kein Google-Konto auf dem Gerät. Bitte füge ein Google-Konto hinzu.</string>
     <string name="settings_cryptography_manage_keys">Verwaltung der Kryptoschlüssel</string>
     <string name="encryption_settings_manage_message_recovery_summary">Schlüssel-Sicherung verwalten</string>
@@ -1313,7 +1313,7 @@
     <string name="passwords_do_not_match">Passwörter stimmen nicht überein</string>
     <string name="autodiscover_invalid_response">Ungültige Antwort beim Verbinden mit dem Homeserver</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Serveroptionen vervollständigen</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} hat eine benutzerdefinierte Serverkonfiguration für die Domäne deines Benutzernamens gefunden \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} hat eine benutzerdefinierte Serverkonfiguration für die Domäne deines Benutzernamens gefunden \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Nutze Konfiguration</string>
     <string name="notification_sync_init">Initialisiere Dienst</string>
@@ -1408,7 +1408,7 @@
     <string name="please_wait">Bitte warten…</string>
     <string name="group_all_communities">Alle Communities</string>
     <string name="room_preview_no_preview">Für diesen Raum kann keine Vorschau angezeigt werden</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Die Vorschau von öffentlichen Räumen wird von ${app_name} noch nicht unterstützt</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Die Vorschau von öffentlichen Räumen wird von ${app_name} noch nicht unterstützt</string>
     <string name="fab_menu_create_room">Räume</string>
     <string name="fab_menu_create_chat">Direktnachrichten</string>
     <string name="create_room_title">Neuer Raum</string>
@@ -1541,12 +1541,12 @@
     <string name="settings_call_ringtone_use_default_stun_sum">Wir nutzen %s als Ersatz, wenn dein Heimserver keinen anbietet (Deine IP-Adresse wird während des Anrufs geteilt)</string>
     <string name="invite_no_identity_server_error">Füge einen Identitätsserver in deinen Einstellungen hinzu, um diese Aktion auszuführen.</string>
     <string name="settings_add_3pid_confirm_password_title">Passwort bestätigen</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Du kannst dies nicht auf einem mobilen ${app_name} tun</string>
+    <string name="settings_add_3pid_flow_not_supported">Du kannst dies nicht auf einem mobilen ${app_name} tun</string>
     <string name="settings_add_3pid_authentication_needed">Authentifizierung benötigt</string>
     <string name="settings_background_fdroid_sync_mode">Hintergrund-Synchronisierungsmodus</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} wird sich im Hintergrund auf eine Art synchronisieren, die Ressourcen des Geräts (Akku) schont.
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} wird sich im Hintergrund auf eine Art synchronisieren, die Ressourcen des Geräts (Akku) schont.
 \nAbhängig vom Ressourcen-Status deines Geräts kann dein System die Synchronisierung verschieben.</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} wird sich im Hintergrund periodisch zu einem bestimmten Zeitpunkt synchronisieren (konfigurierbar).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} wird sich im Hintergrund periodisch zu einem bestimmten Zeitpunkt synchronisieren (konfigurierbar).
 \nDies wird Funk- und Akkunutzung beeinflussen. Es wird eine permanente Benachrichtigung geben, die sagt, dass ${app_name} auf Ereignisse lauscht.</string>
     <string name="settings_set_workmanager_delay_summary">%s
 \nDie Synchronisierung kann aufgrund deiner Ressourcen (Akku) oder Gerätezustands (schlafend) verschoben werden.</string>
@@ -1637,7 +1637,7 @@
     <string name="content_reported_as_inappropriate_content">Dieser Inhalt wurde als unangebracht gemeldet.
 \n
 \nWenn du keine weiteren Inhalte dieses Nutzers sehen möchtest, kannst ihn ignorieren, um jene Nachrichten auszublenden.</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} benötigt Berechtigungen, um deine E2E Schlüssel zu speichern.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} benötigt Berechtigungen, um deine E2E Schlüssel zu speichern.
 \n
 \nBitte erlaube den Zugriff im nächsten Pop-up sodass du deine Schlüssel manuell exportieren kannst.</string>
     <string name="no_network_indicator">Aktuell besteht keine Netzwerkverbindung</string>
@@ -1783,7 +1783,7 @@
 \nMelde dich erneut an, um auf deine Kontodaten und Nachrichten zuzugreifen.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Du verlierst den Zugriff auf verschlüsselte Nachrichten, außer, du meldest dich an, um den Schlüssel wiederherzustellen.</string>
     <string name="soft_logout_clear_data_dialog_submit">Daten löschen</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Die aktuelle Sitzung gehört dem Benutzer %1$s. Die angegebenen Anmeldeinformationen sind vom Benutzer %2$s. Dies wird nicht von ${app_name} unterstützt.
+    <string name="soft_logout_sso_not_same_user_error">Die aktuelle Sitzung gehört dem Benutzer %1$s. Die angegebenen Anmeldeinformationen sind vom Benutzer %2$s. Dies wird nicht von ${app_name} unterstützt.
 \nBitte zuerst die Daten löschen und dann erneut anmelden.</string>
     <string name="permalink_malformed">matrix.to-Link fehlerhaft</string>
     <string name="bug_report_error_too_short">Die Beschreibung ist zu kurz</string>
@@ -1801,7 +1801,7 @@
     <string name="devices_other_devices">Andere Sitzungen</string>
     <string name="autocomplete_limited_results">Zeigt nur die ersten Ergebnisse, gib mehr Buchstaben ein…</string>
     <string name="settings_developer_mode_fail_fast_title">Ausfallsicher</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} kann häufiger abstürzen, wenn ein unerwarteter Fehler auftritt</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} kann häufiger abstürzen, wenn ein unerwarteter Fehler auftritt</string>
     <string name="command_description_shrug">Stellt einer Klartextnachricht ¯\\_(ツ)_/¯ voran</string>
     <string name="create_room_encryption_title">Aktiviere Verschlüsselung</string>
     <string name="create_room_encryption_description">Nach der Aktivierung kann die Verschlüsselung nicht deaktiviert werden.</string>
@@ -1871,9 +1871,9 @@
     <string name="room_member_power_level_admin_in">Admin in %1$s</string>
     <string name="room_member_power_level_moderator_in">Moderation in %1$s</string>
     <string name="room_member_jump_to_read_receipt">Springen &amp; als gelesen markieren</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} kann keine Ereignisse vom Typ \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} beherrscht keine Nachrichten vom Typ \'%1$s\'</string>
-    <string name="template_rendering_event_error_exception">${app_name} ist beim Verarbeiten des Ereignisinhalts mit der ID \'%1$s\' auf ein Problem gestoßen</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} kann keine Ereignisse vom Typ \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} beherrscht keine Nachrichten vom Typ \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} ist beim Verarbeiten des Ereignisinhalts mit der ID \'%1$s\' auf ein Problem gestoßen</string>
     <string name="unignore">Nicht ignorieren</string>
     <string name="verify_cannot_cross_sign">Diese Sitzung kann diese Verifizierung nicht mit deinen anderen Sitzungen teilen.
 \nDie Überprüfung wird lokal gespeichert und in einer zukünftigen Version der App freigegeben.</string>
@@ -1960,7 +1960,7 @@
     <string name="keys_backup_restore_success_title_already_up_to_date">Schlüssel sind bereits aktuell!</string>
     <string name="spoiler">Spoiler</string>
     <string name="room_member_power_level_custom_in">Benutzerdefiniert (%1$d) in %2$s</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">Schlüsselanforderungen</string>
     <string name="e2e_use_keybackup">Schalte den verschlüsselten Nachrichtenverlauf frei</string>
     <string name="refresh">Neu laden</string>
@@ -2061,13 +2061,13 @@
     <string name="media_file_added_to_gallery">Datei wurde der Galerie hinzugefügt</string>
     <string name="error_adding_media_file_to_gallery">Datei konnte nicht zur Galerie hinzugefügt werden</string>
     <string name="change_password_summary">Neues Benutzerpasswort festlegen…</string>
-    <string name="template_use_other_session_content_description">Nutze die neueste Version von ${app_name} auf deinen anderen Geräten, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} für Android oder einen anderen cross-signing-fähigen Matrix-Client</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="use_other_session_content_description">Nutze die neueste Version von ${app_name} auf deinen anderen Geräten, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} für Android oder einen anderen cross-signing-fähigen Matrix-Client</string>
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
     <string name="or_other_mx_capable_client">oder einen anderen cross-signing-fähigen Matrix Client</string>
-    <string name="template_use_latest_app">Nutze die neueste Version von ${app_name} auf deinen anderen Geräten:</string>
+    <string name="use_latest_app">Nutze die neueste Version von ${app_name} auf deinen anderen Geräten:</string>
     <string name="command_description_discard_session">Erzwingt das Verwerfen der aktuell ausgehende Gruppensitzung in einem verschlüsseltem Raum</string>
     <string name="command_description_discard_session_not_handled">Wird nur in verschlüsselten Räumen unterstützt</string>
     <string name="enter_secret_storage_passphrase_or_key">Benutze deine %1$s oder deinen %2$s um fortzufahren.</string>
@@ -2108,7 +2108,7 @@
     <string name="action_pause">Pause</string>
     <string name="action_copy">Kopieren</string>
     <string name="bottom_action_notification">Benachrichtigungen</string>
-    <string name="template_call_failed_no_connection">${app_name}-Anruf fehlgeschlagen</string>
+    <string name="call_failed_no_connection">${app_name}-Anruf fehlgeschlagen</string>
     <string name="action_play">Abspielen</string>
     <string name="action_dismiss">Ablehnen</string>
     <string name="dialog_title_success">Erfolg</string>
@@ -2213,11 +2213,11 @@
     <string name="choose_locale_loading_locales">Lade verfügbare Sprachen…</string>
     <string name="open_terms_of">Öffne AGBs von %s</string>
     <string name="disconnect_identity_server_dialog_content">Trenne Verbindung zu Identitätsserver %s\?</string>
-    <string name="template_identity_server_error_outdated_identity_server">Dieser Identitätsserver ist veraltet. ${app_name} unterstützt nur API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Dieser Identitätsserver ist veraltet. ${app_name} unterstützt nur API V2.</string>
     <string name="identity_server_error_outdated_home_server">Diese Operation ist nicht möglich. Der Homeserver ist veraltet.</string>
     <string name="identity_server_error_no_identity_server_configured">Bitte konfiguriere zuerst einen Identitätsserver.</string>
     <string name="identity_server_error_terms_not_signed">Bitte akzeptiere zuerst die AGB des Identitätsservers in den Einstellungen.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Deiner Privatsphäre wegen unterstützt ${app_name} nur das Senden gehashter E-Mail-Adressen und Telefonnummern.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Deiner Privatsphäre wegen unterstützt ${app_name} nur das Senden gehashter E-Mail-Adressen und Telefonnummern.</string>
     <string name="identity_server_error_binding_error">Die Assoziierung ist fehlgeschlagen.</string>
     <string name="identity_server_error_no_current_binding_error">Für diese Kennung gibt es aktuell keine Zuordnung.</string>
     <string name="identity_server_set_default_notice">Dein Homeserver (%1$s) schlägt %2$s als Identitätsserver vor</string>
@@ -2356,7 +2356,7 @@
     <string name="no_permissions_to_start_conf_call_in_direct_room">Du hast keine Berechtigung ein Konferenzgespräch zu starten</string>
     <string name="settings_security_pin_code_notifications_summary_on">Details wie Raumnamen und Nachrichteninhalt zeigen.</string>
     <string name="settings_security_pin_code_notifications_title">Inhalt in Benachrichtigungen anzeigen</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">PIN-Code ist die einzige Möglichkeit ${app_name} zu entsperren.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">PIN-Code ist die einzige Möglichkeit ${app_name} zu entsperren.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Aktiviere Gerät-spezifische Biometrie wie Fingerabdrücke und Gesichtserkennung.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Biometrie aktivieren</string>
     <string name="settings_security_application_protection_screen_title">Schutz konfigurieren</string>
@@ -2394,8 +2394,8 @@
     <string name="settings_troubleshoot_test_notification_notice">Bitte klicke auf die Benachrichtigung. Wenn die Benachrichtigung nicht angezeigt wird, überprüfe die Systemeinstellungen.</string>
     <string name="settings_troubleshoot_test_push_notification_content">Du siehst die Benachrichtigung! Klick mich!</string>
     <string name="settings_troubleshoot_test_notification_title">Benachrichtigungsanzeige</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Bei jedem Öffnen von ${app_name} ist der PIN-Code erforderlich.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">PIN-Code ist erforderlich, nachdem ${app_name} 2 Minuten lang nicht verwendet wurde.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Bei jedem Öffnen von ${app_name} ist der PIN-Code erforderlich.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">PIN-Code ist erforderlich, nachdem ${app_name} 2 Minuten lang nicht verwendet wurde.</string>
     <string name="settings_security_pin_code_grace_period_title">Fordere PIN nach 2 Minuten an</string>
     <string name="settings_security_pin_code_notifications_summary_off">Nur die Anzahl ungelesener Nachrichten in der Benachrichtigung zeigen.</string>
     <string name="attachment_type_dialog_title">Bild hinzufügen mit</string>
@@ -2455,8 +2455,8 @@
     <string name="user_code_my_code">Mein Code</string>
     <string name="user_code_scan">Scanne einen QR-Code</string>
     <string name="not_a_valid_qr_code">Das ist kein korrekter QR-Code von Matrix</string>
-    <string name="template_invite_friends_rich_title">🔐️ Komm mit zu ${app_name}</string>
-    <string name="template_invite_friends_text">Hey, schreibe mit mir auf ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Komm mit zu ${app_name}</string>
+    <string name="invite_friends_text">Hey, schreibe mit mir auf ${app_name}: %s</string>
     <string name="invite_friends">Freunde einladen</string>
     <string name="add_people">Leute hinzufügen</string>
     <string name="topic_prefix">"Thema: "</string>
@@ -2540,7 +2540,7 @@
     <string name="room_permissions_send_m_room_server_acl_events">m.room.server_acl-Ereignisse senden</string>
     <string name="room_permissions_change_permissions">Berechtigungen ändern</string>
     <string name="authentication_error">Authentifizierung fehlgeschlagen</string>
-    <string name="template_re_authentication_default_confirm_text">Deine Anmeldeinformationen müssen für ${app_name} eingegeben werden, um diese Aktion auszuführen.</string>
+    <string name="re_authentication_default_confirm_text">Deine Anmeldeinformationen müssen für ${app_name} eingegeben werden, um diese Aktion auszuführen.</string>
     <string name="re_authentication_activity_title">Erneute Authentifizierung erforderlich</string>
     <string name="failed_to_initialize_cross_signing">Cross-Signing konnte nicht eingerichtet werden</string>
     <string name="error_unauthorized">Nicht autorisierte, fehlende gültige Authentifizierungsdaten</string>
@@ -2975,7 +2975,7 @@
     <string name="analytics_opt_in_list_item_3">Du kannst dies jederzeit in den Einstellungen deaktivieren</string>
     <string name="analytics_opt_in_list_item_2">Wir teilen <b>keine</b> Informationen mit Drittpersonen</string>
     <string name="analytics_opt_in_list_item_1">Wir erfassen und analysieren <b>keine</b> Accountdaten</string>
-    <string name="template_analytics_opt_in_content">Hilf uns dabei Probleme zu identifizieren und ${app_name} zu verbessern, indem du anonyme Nutzungsdaten teilst. Um zu verstehen, wie Personen mehrere Geräte benutzen, werden wir eine zufällige Kennung generieren, die zwischen deinen Geräten geteilt wird.
+    <string name="analytics_opt_in_content">Hilf uns dabei Probleme zu identifizieren und ${app_name} zu verbessern, indem du anonyme Nutzungsdaten teilst. Um zu verstehen, wie Personen mehrere Geräte benutzen, werden wir eine zufällige Kennung generieren, die zwischen deinen Geräten geteilt wird.
 \n
 \n%s kannst du alle unsere Bedingungen lesen.</string>
     <string name="create_spaces_invite_public_header_desc">Stelle sicher, dass die richtigen Personen Zugriff auf %s haben. Du kannst jederzeit weitere Personen einladen.</string>
@@ -2985,13 +2985,13 @@
     <string name="settings_discovery_show_identity_server_policy_title">Bedingungen des Identitätsservers anzeigen</string>
     <string name="preference_system_settings">Systemeinstellungen</string>
     <string name="preference_versions">Versionen</string>
-    <string name="template_preference_help_summary">Erhalte Hilfe bei der Bedienung von ${app_name}</string>
+    <string name="preference_help_summary">Erhalte Hilfe bei der Bedienung von ${app_name}</string>
     <string name="preference_help_title">Hilfe und Unterstützung</string>
     <string name="preference_help">Hilfe</string>
     <string name="preference_root_legals">Rechtliches</string>
     <string name="decide_which_spaces_can_access">Entscheide, welche Spaces Zugriff auf den Raum haben sollen. Die Mitglieder der Spaces können diesen Räumen beitreten.</string>
     <string name="analytics_opt_in_content_link">hier</string>
-    <string name="template_analytics_opt_in_title">Hilf mit, ${app_name} zu verbessern</string>
+    <string name="analytics_opt_in_title">Hilf mit, ${app_name} zu verbessern</string>
     <string name="action_enable">Aktivieren</string>
     <string name="room_member_override_nick_color">Farbe des Nicknamens ändern</string>
     <string name="ftue_auth_carousel_control_title">Du hast die volle Kontrolle.</string>
@@ -3010,7 +3010,7 @@
     </plurals>
     <string name="restart_the_application_to_apply_changes">Starte die Anwendung neu, damit die Änderung wirksam wird.</string>
     <string name="labs_enable_latex_maths">LaTeX-Mathematik aktivieren</string>
-    <string name="template_link_this_email_with_your_account">%s in den Einstellungen, um Einladungen direkt in ${app_name} zu erhalten.</string>
+    <string name="link_this_email_with_your_account">%s in den Einstellungen, um Einladungen direkt in ${app_name} zu erhalten.</string>
     <string name="this_invite_to_this_space_was_sent">Diese Einladung zu diesem Raum wurde an %s gesendet, der nicht mit deinem Konto verbunden ist</string>
     <string name="labs_auto_report_uisi_desc">Das System sendet automatisch Protokolle, wenn ein Fehler bei der Entschlüsselung auftritt</string>
     <string name="labs_auto_report_uisi">Entschlüsselungsfehler automatisch melden.</string>
@@ -3030,7 +3030,7 @@
     <string name="legals_no_policy_provided">Dieser Server stellt keine Richtlinie bereit.</string>
     <string name="legals_identity_server_title">Deine Identitätsserver-Richtlinie</string>
     <string name="legals_home_server_title">Deine Heimserver Richtlinie</string>
-    <string name="template_legals_application_title">${app_name} Richtlinie</string>
+    <string name="legals_application_title">${app_name} Richtlinie</string>
     <string name="tooltip_attachment_poll">Abstimmung erstellen</string>
     <string name="tooltip_attachment_contact">Kontakte öffnen</string>
     <string name="tooltip_attachment_sticker">Sticker verschicken</string>
@@ -3057,8 +3057,8 @@
     <string name="location_activity_title_static_sharing">Standort freigeben</string>
     <string name="settings_enable_location_sharing">Standortfreigabe aktivieren</string>
     <string name="location_share_external">Öffnen mit</string>
-    <string name="template_location_not_available_dialog_content">${app_name} konnte nicht auf deinen Standort zugreifen. Bitte versuche es später noch einmal.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} konnte nicht auf deinen Standort zugreifen</string>
+    <string name="location_not_available_dialog_content">${app_name} konnte nicht auf deinen Standort zugreifen. Bitte versuche es später noch einmal.</string>
+    <string name="location_not_available_dialog_title">${app_name} konnte nicht auf deinen Standort zugreifen</string>
     <string name="location_activity_title_preview">Standort</string>
     <string name="closed_poll_option_description">Ergebnisse werden erst angezeigt, wenn du die Umfrage beendest</string>
     <string name="closed_poll_option_title">Geschlossene Umfrage</string>

--- a/vector/src/main/res/values-el/strings.xml
+++ b/vector/src/main/res/values-el/strings.xml
@@ -206,7 +206,7 @@
     <string name="room_info_room_name">Όνομα δωματίου</string>
     <string name="room_info_room_topic">Θέμα δωματίου</string>
     <string name="settings_call_category">Κλήσεις</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Χρήση του προεπιλεγμένου ήχου κλήσης του ${app_name} για τις εισερχόμενες κλήσεις</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Χρήση του προεπιλεγμένου ήχου κλήσης του ${app_name} για τις εισερχόμενες κλήσεις</string>
     <string name="settings_call_ringtone_title">Ήχος εισερχομένων κλήσεων</string>
     <string name="settings_call_ringtone_dialog_title">Επιλέξτε ήχο κλήσης:</string>
     <string name="call">Κλήση</string>
@@ -232,7 +232,7 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Ενεργοποίηση</string>
     <string name="settings_troubleshoot_test_device_settings_title">Ρυθμίσεις συσκευής.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Οι ειδοποιήσεις είναι ενεργοποιημένες για αυτή την συσκευή.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Οι ειδοποιήσεις δεν επιτρέπονται για αυτή την συσκευή.
+    <string name="settings_troubleshoot_test_device_settings_failed">Οι ειδοποιήσεις δεν επιτρέπονται για αυτή την συσκευή.
 \nΠαρακαλώ ελέγξτε τις ρυθμίσεις του ${app_name}.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Ενεργοποίηση</string>
     <string name="settings_devices_list">Συσκευές</string>
@@ -513,7 +513,7 @@
     <string name="call_select_sound_device">Αλλαγή Συσκευής Ήχου</string>
     <string name="call_failed_no_connection_description">Αποτυχία σύνδεσης σε πραγματικό χρόνο.
 \nΖητήστε από τον διαχειριστή του οικιακού σας διακομιστή να διαμορφώσει έναν διακομιστή TURN ώστε οι κλήσεις να λειτουργούν αξιόπιστα.</string>
-    <string name="template_call_failed_no_connection">Η Κλήση ${app_name} Aπέτυχε</string>
+    <string name="call_failed_no_connection">Η Κλήση ${app_name} Aπέτυχε</string>
     <string name="call_failed_dont_ask_again">Να μην ερωτηθώ ξανά</string>
     <string name="call_failed_no_ice_use_alt">Προσπαθήστε να χρησιμοποιήσετε το %s</string>
     <string name="call_failed_no_ice_description">Παρακαλώ ζητήστε απο τον διαχειριστή του ιδιέταιρου διακομιστή (%1$s) να ρυθμίσει ένα διακομιστή TURN ώστε οι κλήσεις να δουλέυουν αξιόπιστα.
@@ -544,7 +544,7 @@
     <string name="call_notification_hangup">Τέλος κλήσης</string>
     <string name="ongoing_conference_call">Τρέχουσα κλήση συνδιάσκεψης.
 \nΣυνδεθείτε με %1$s ή %2$s</string>
-    <string name="template_no_contact_access_placeholder">Δεν επιτρέψατε στο ${app_name} την πρόσβαση στις επαφές σας</string>
+    <string name="no_contact_access_placeholder">Δεν επιτρέψατε στο ${app_name} την πρόσβαση στις επαφές σας</string>
     <string name="bottom_action_notification">Ειδοποιήσεις</string>
     <string name="copied_to_clipboard">Αντιγράφηκε στο πρόχειρο</string>
     <string name="action_add">Πρόσθεση</string>

--- a/vector/src/main/res/values-en-rGB/strings.xml
+++ b/vector/src/main/res/values-en-rGB/strings.xml
@@ -14,7 +14,7 @@
     <string name="settings_background_fdroid_sync_mode_battery">Optimised for battery</string>
     <string name="settings_background_sync">Background synchronisation</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignore Optimisation</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} is not affected by Battery Optimisation.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} is not affected by Battery Optimisation.</string>
     <string name="settings_troubleshoot_test_battery_title">Battery Optimisation</string>
     <string name="room_settings_de_prioritize">De-prioritise</string>
     <string name="call_error_camera_init_failed">Cannot initialise the camera</string>

--- a/vector/src/main/res/values-eo/strings.xml
+++ b/vector/src/main/res/values-eo/strings.xml
@@ -337,7 +337,7 @@
     <string name="direct_chats_header">Interparoloj</string>
     <string name="local_address_book_header">Loka adresaro</string>
     <string name="no_conversation_placeholder">Neniuj interparoloj</string>
-    <string name="template_no_contact_access_placeholder">Vi ne permesis al ${app_name} aliron al viaj lokaj kontaktoj</string>
+    <string name="no_contact_access_placeholder">Vi ne permesis al ${app_name} aliron al viaj lokaj kontaktoj</string>
     <string name="no_result_placeholder">Neniuj rezultoj</string>
     <string name="people_no_identity_server">Neniu identiga servilo estas agordita.</string>
     <string name="rooms_header">Ĉambroj</string>
@@ -500,10 +500,10 @@
     <string name="settings_background_sync">Fona spegulado</string>
     <string name="settings_background_fdroid_sync_mode">Reĝimo de fona spegulado</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimumigita por baterio</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} spegulos fone, per maniero konservanta la limigitajn rimedojn de la aparato (ĉefe la baterion).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} spegulos fone, per maniero konservanta la limigitajn rimedojn de la aparato (ĉefe la baterion).
 \nDepende de la stato de la rimedoj de via aparato, la spegulado povus esti prokrastita de la operaciumo.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimumigita por tujeco</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} spegulos fone, ripete, je preciza tempo (agordebla).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} spegulos fone, ripete, je preciza tempo (agordebla).
 \nĈi tio influos uzadon de baterio kaj radiilo, kaj aperigos ĉiaman sciigon pri tio, ke ${app_name} aŭskultas okazojn.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Neniu fona spegulado</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Vi ne sciiĝos pri envenaj mesaĝoj dum la aplikaĵo estas fone.</string>
@@ -596,7 +596,7 @@
     <string name="e2e_re_request_encryption_key">Repeti ĉifrajn ŝlosilojn de aliaj viaj salutaĵoj.</string>
     <string name="e2e_re_request_encryption_key_sent">Peto de ŝlosilo sendiĝis.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Peto sendiĝis</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Bonvolu ruli ${app_name} sur alia aparato kiu scipovas malĉifri la mesaĝon, por ke ĝi povu sendi la ŝlosilojn al ĉi tiu salutaĵo.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Bonvolu ruli ${app_name} sur alia aparato kiu scipovas malĉifri la mesaĝon, por ke ĝi povu sendi la ŝlosilojn al ĉi tiu salutaĵo.</string>
     <string name="incoming_call">Envena voko</string>
     <string name="incoming_video_call">Envena vidvoko</string>
     <string name="incoming_voice_call">Envena voĉvoko</string>
@@ -606,22 +606,22 @@
     <string name="media_picker_both_capture_title">Foti aŭ filmi</string>
     <string name="media_picker_cannot_record_video">Ne povas filmi</string>
     <string name="permissions_rationale_popup_title">Informoj</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} bezonas permeson aliri viajn fotojn kaj filmojn, por sendi kaj konservi kunsendaĵojn.
+    <string name="permissions_rationale_msg_storage">${app_name} bezonas permeson aliri viajn fotojn kaj filmojn, por sendi kaj konservi kunsendaĵojn.
 \n
 \nBonvolu permesi aliron per la sekva ŝprucpeto, por povi sendi dosierojn el via telefono.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} bezonas permeson aliri vian filmilon por foti kaj vidvoki.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} bezonas permeson aliri vian filmilon por foti kaj vidvoki.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nBonvolu permesi aliron per la sekva ŝprucpeto, por ebligi la vokon."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} bezonas permeson aliri vian mikrofonon por fari voĉvokojn.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} bezonas permeson aliri vian mikrofonon por fari voĉvokojn.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nBonvolu permesi aliron per la sekva ŝprucpeto, por ebligi la vokon."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} bezonas premeson aliri viajn filmilon kaj mikrofonon por fari vidvokojn.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} bezonas premeson aliri viajn filmilon kaj mikrofonon por fari vidvokojn.
 \n 
 \nBonvolu permesi aliron per la sekva ŝprucpeto, por ebligi la vokon.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} povas kontroli vian adresaron por trovi aliajn uzantojn de Matrix per iliaj retpoŝtadresoj kaj telefonnumeroj. Se vi konsentas kunhavi vian adresaron por tiu celo, bonvolu permesi aliron per la sekva ŝprucpeto.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} povas kontroli vian adresaron por trovi aliajn uzantojn de Matrix per iliaj retpoŝtadresoj kaj telefonnumeroj.
+    <string name="permissions_rationale_msg_contacts">${app_name} povas kontroli vian adresaron por trovi aliajn uzantojn de Matrix per iliaj retpoŝtadresoj kaj telefonnumeroj. Se vi konsentas kunhavi vian adresaron por tiu celo, bonvolu permesi aliron per la sekva ŝprucpeto.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} povas kontroli vian adresaron por trovi aliajn uzantojn de Matrix per iliaj retpoŝtadresoj kaj telefonnumeroj.
 \n
 \nĈu vi konsentas kunhavi vian adresaron por tiu celo\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Pardonu. Ago ne efektiviĝis, pro mankantaj permesoj</string>
@@ -731,9 +731,9 @@
     <string name="verify_cannot_cross_sign">Tiu ĉi salutaĵo ne povas konigi ĉi tiun kontrolon al aliaj viaj salutaĵoj.
 \nLa kontrolo konserviĝos loke kaj estos konigota de venonta versio de la aplikaĵo.</string>
     <string name="unignore">Reatenti</string>
-    <string name="template_rendering_event_error_exception">${app_name} renkontis problemon bildigante enhavon de okazo kun la identigilo «%1$s»</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} ne traktas mesaĝojn de speco «%1$s»</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} ne traktas okazojn de speco «%1$s»</string>
+    <string name="rendering_event_error_exception">${app_name} renkontis problemon bildigante enhavon de okazo kun la identigilo «%1$s»</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} ne traktas mesaĝojn de speco «%1$s»</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} ne traktas okazojn de speco «%1$s»</string>
     <string name="room_member_jump_to_read_receipt">Salti al legokonfirmo</string>
     <string name="room_member_power_level_custom_in">Propra (%1$d) en %2$s</string>
     <string name="room_member_power_level_default_in">Ordinara en %1$s</string>
@@ -816,7 +816,7 @@
     <string name="create_room_encryption_description">Post ŝalto, ne eblas ĉifradon malŝalti.</string>
     <string name="create_room_encryption_title">Ŝalti ĉifradon</string>
     <string name="command_description_shrug">Antaŭmetas ¯\\_(ツ)_/¯ al platteksta mesaĝo</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} povas fiaski pli ofte kiam okazas neatendita eraro</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} povas fiaski pli ofte kiam okazas neatendita eraro</string>
     <string name="autocomplete_limited_results">Montras nur la unuajn rezultojn; tajpu pliajn literojn…</string>
     <string name="devices_other_devices">Aliaj salutaĵoj</string>
     <string name="devices_current_device">Nuna salutaĵo</string>
@@ -831,7 +831,7 @@
     <string name="notification_initial_sync">Komenca spegulado…</string>
     <string name="bug_report_error_too_short">La priskribo estas tro mallonga</string>
     <string name="permalink_malformed">Via ligilo al matrix.to estis misformita</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Ĉi tiu salutaĵo estas por uzanto %1$s kaj vi donas salutilojn por uzanto %2$s. ${app_name} ne subtenas tion.
+    <string name="soft_logout_sso_not_same_user_error">Ĉi tiu salutaĵo estas por uzanto %1$s kaj vi donas salutilojn por uzanto %2$s. ${app_name} ne subtenas tion.
 \nBonvolu unue vakigi datumojn, kaj poste saluti alian konton.</string>
     <string name="soft_logout_clear_data_dialog_submit">Vakigi datumojn</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Vi perdos aliron al sekuraj mesaĝoj, se vi ne salutos por rehavi viajn ĉifrajn ŝlosilojn.</string>
@@ -968,7 +968,7 @@
     <string name="room_list_quick_actions_notifications_all_noisy">Ĉiuj mesaĝoj (laŭte)</string>
     <string name="message_ignore_user">Malatenti uzanton</string>
     <string name="no_network_indicator">Estas neniu retkonekto nun</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} bezonas rajton konservi viajn tutvoje ĉifrajn ŝlosilojn surdiske.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} bezonas rajton konservi viajn tutvoje ĉifrajn ŝlosilojn surdiske.
 \n
 \nBonvolu permesi aliron per la venonta ŝprucpeto, por povi elporti viajn ŝlosilojn permane.</string>
     <string name="content_reported_as_inappropriate_content">Ĉi tiu enhavo estis raportita kiel maltaŭga.
@@ -1110,7 +1110,7 @@
     <string name="create_room_title">Nova ĉambro</string>
     <string name="fab_menu_create_chat">Individuaj ĉambroj</string>
     <string name="fab_menu_create_room">Ĉambroj</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Antaŭrigardo al ĉambro legebla de ĉiuj ankoraŭ ne estas subtenata de ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Antaŭrigardo al ĉambro legebla de ĉiuj ankoraŭ ne estas subtenata de ${app_name}</string>
     <string name="room_preview_no_preview">Ne eblas antaŭrigardi ĉi tiun ĉambron</string>
     <string name="group_all_communities">Ĉiuj komunumoj</string>
     <string name="please_wait">Bonvolu atendi…</string>
@@ -1306,7 +1306,7 @@
 \nSekure savkopiu viajn ŝlosilojn por eviti ilian perdon.</string>
     <string name="keys_backup_setup_step1_title">Neniam perdu ĉifritajn mesaĝojn</string>
     <string name="keys_backup_no_session_error">Neniu salutaĵo de Matrix estas disponebla</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Bonvolu forigi la pasfrazon se vi volas, ke ${app_name} estigu novan rehavan ŝlosilon.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Bonvolu forigi la pasfrazon se vi volas, ke ${app_name} estigu novan rehavan ŝlosilon.</string>
     <string name="passphrase_passphrase_too_weak">Pasfrazo estas tro malforta</string>
     <string name="passphrase_empty_error_message">Bonvolu enigi pasfrazon</string>
     <string name="passphrase_passphrase_does_not_match">Pasfrazo ne akordas</string>
@@ -1673,17 +1673,17 @@
     <string name="settings_data_save_mode_summary">Datumkonserva reĝimo aplikas sepecialan filtron al sciigoj pri ĉeesto kaj tajpado.</string>
     <string name="settings_data_save_mode">Datumkonserva reĝimo</string>
     <string name="settings_opt_in_of_analytics_ok">Jes, mi volas helpi!</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Bonvolu ŝalti analizon por helpi la ni plibonigi ${app_name}.</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} kolektas sennomajn analizojn por helpi al ni plibonigi la aplikaĵon.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Bonvolu ŝalti analizon por helpi la ni plibonigi ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} kolektas sennomajn analizojn por helpi al ni plibonigi la aplikaĵon.</string>
     <string name="settings_opt_in_of_analytics">Sendi datumojn de analizo</string>
     <string name="settings_analytics">Analizo</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Doni permeson</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} bezonas malpezan fonan konekton por havi dependeblajn sciigojn.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} bezonas malpezan fonan konekton por havi dependeblajn sciigojn.
 \nLa sekva ekrano petos ĉiam ruli ${app_name} fone; bonvolu akcepti.</string>
     <string name="startup_notification_fdroid_battery_optim_title">Fona konekto</string>
     <string name="startup_notification_privacy_button_other">Elekti alian elekteblon</string>
     <string name="startup_notification_privacy_button_grant">Doni permeson</string>
-    <string name="template_startup_notification_privacy_message">${app_name} povas ruliĝi fone por mastrumi viajn sciigojn sekure kaj private. Tio povas influi uzadon de la baterio.</string>
+    <string name="startup_notification_privacy_message">${app_name} povas ruliĝi fone por mastrumi viajn sciigojn sekure kaj private. Tio povas influi uzadon de la baterio.</string>
     <string name="startup_notification_privacy_title">Privateco de sciigoj</string>
     <string name="settings_discovery_manage">Administri viajn agordojn de trovado.</string>
     <string name="settings_discovery_category">Trovado</string>
@@ -1746,17 +1746,17 @@
     <string name="settings_notification_privacy_reduced">Malplia privateco</string>
     <string name="settings_notification_privacy_normal">Normala</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Malatenti optimumigon</string>
-    <string name="template_settings_troubleshoot_test_battery_success">Optimumigo de baterio ne influas sur ${app_name}.</string>
+    <string name="settings_troubleshoot_test_battery_success">Optimumigo de baterio ne influas sur ${app_name}.</string>
     <string name="settings_troubleshoot_test_battery_title">Optimumigo de baterio</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Malŝalti limigojn</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Fonaj limigoj estas ŝaltitaj por ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Fonaj limigoj estas ŝaltitaj por ${app_name}.
 \nAgado de la aplikaĵo estos akre limigita dum ĝi estas fone, kaj tio povus influi sciigojn.
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Fonaj limigoj estas malŝaltitaj por ${app_name}. Ĉi tiu testo devus esti rulata kun telefonaj datumoj (ne kun Vifio).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Fonaj limigoj estas malŝaltitaj por ${app_name}. Ĉi tiu testo devus esti rulata kun telefonaj datumoj (ne kun Vifio).
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Kontroli fonajn limigojn</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Ŝalti ekadon kune kun aparato</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">La servo ne ekos kiam la aparato reekos, kaj vi ne ricevos sciigojn ĝis vi mem ${app_name} malfermos.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">La servo ne ekos kiam la aparato reekos, kaj vi ne ricevos sciigojn ĝis vi mem ${app_name} malfermos.</string>
     <string name="settings_troubleshoot_test_service_boot_success">La servo ekos kiam la aparato reekos.</string>
     <string name="settings_troubleshoot_test_service_boot_title">Eki kune kun aparato</string>
     <string name="settings_troubleshoot_test_service_restart_failed">Servo malsukcesis reeki</string>
@@ -1790,11 +1790,11 @@
     <string name="settings_troubleshoot_test_token_registration_success">Ĵetono de FCM sukcese registriĝis ĉe la hejmservilo.</string>
     <string name="settings_troubleshoot_test_token_registration_title">Registrado de ĵetono</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Aldoni konton</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nTiu ĉi eraro ne dependas de ${app_name}. La telefono ne havas konton de Google. Bonvolu malfermi la administrilon de kontoj kaj aldoni konton de Google.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nTiu ĉi eraro ne dependas de ${app_name}. Ĝi povas okazi pro kelkaj kialoj. Eble ĝi funkcios se vi reprovos poste. Vi ankaŭ povas kontroli, ĉu la servo de Google Play ne estas datume limigita en la sistemaj agordoj, aŭ ĉu la horloĝo de via aparato ĝuste funkcias, aŭ ĉu ĝi ne okazas sur propra ROM.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nTiu ĉi eraro ne dependas de ${app_name}, kaj laŭ Google ĝi indikas, ke la aparato havas tro multajn aplikaĵojn registritajn je FCM. La eraro nur okazas kiam multegaj aplikaĵoj estas samtempe instalitaj, kaj ne devus koncerni ordinaran uzanton.</string>
     <string name="settings_troubleshoot_test_fcm_failed">Malsukcesis akiri ĵetonon de FCM:
 \n%1$s</string>
@@ -1802,7 +1802,7 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_title">Ĵetono de Firebase</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Ripari servojn de Google Play</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} uzas la servojn de Google Play por liveri pasivajn mesaĝojn, sed ili ne ŝajnas ĝuste agorditaj:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} uzas la servojn de Google Play por liveri pasivajn mesaĝojn, sed ili ne ŝajnas ĝuste agorditaj:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_success">APK de servoj de Google Play estas ĝisdata kaj disponebla.</string>
     <string name="settings_troubleshoot_test_play_services_title">Kontrolo de servoj de Google Play</string>
@@ -1812,7 +1812,7 @@
     <string name="settings_troubleshoot_test_bing_settings_success_with_warn">Rimarku, ke iuj specoj de mesaĝoj estas silentaj (sciigas sensone).</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Propraj agordoj.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Ŝalti</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Sciigoj ne estas ŝaltitaj por ĉi tiu salutaĵo.
+    <string name="settings_troubleshoot_test_device_settings_failed">Sciigoj ne estas ŝaltitaj por ĉi tiu salutaĵo.
 \nBonvolu kontroli la agordojn de ${app_name}.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Sciigoj estas ŝaltitaj por ĉi tiu salutaĵo.</string>
     <string name="settings_troubleshoot_test_device_settings_title">Agordoj de salutaĵo.</string>
@@ -1839,7 +1839,7 @@
     <string name="settings_emails_empty">Neniu retpoŝtadreso aldoniĝis al via konto</string>
     <string name="settings_emails">Retpoŝtadresoj</string>
     <string name="settings_add_3pid_authentication_needed">Necesas aŭtentikigo</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Vi ne povas fari tion per ${app_name} por poŝtelefonoj</string>
+    <string name="settings_add_3pid_flow_not_supported">Vi ne povas fari tion per ${app_name} por poŝtelefonoj</string>
     <string name="settings_add_3pid_confirm_password_title">Konfirmu vian pasvorton</string>
     <string name="settings_app_info_link_summary">Montri informojn pri aplikaĵo en sistemaj agordoj.</string>
     <string name="settings_app_info_link_title">Informoj pri aplikaĵo</string>
@@ -1954,7 +1954,7 @@
     <string name="call_select_sound_device">Elekti sonaparaton</string>
     <string name="call_failed_no_connection_description">Malsukcesis fari realtempan konekton.
 \nBonvolu peti la administranton de via hejmservilo agordi TURN-servilon, por ke vokoj funkciu dependeble.</string>
-    <string name="template_call_failed_no_connection">Malsukcesis voko de ${app_name}</string>
+    <string name="call_failed_no_connection">Malsukcesis voko de ${app_name}</string>
     <string name="matrix_only_filter">Nur kontaktoj de Matrix</string>
     <string name="bottom_action_notification">Sciigoj</string>
     <string name="dialog_title_success">Sukceso</string>
@@ -1987,20 +1987,20 @@
     <string name="settings_home_display">Hejmekrano</string>
     <string name="settings_troubleshoot_test_battery_failed">Se uzanto lasas aparaton neŝargata kaj senmova por ioma tempo, kun ekrano malaktiva, la aparato eniras dorman reĝimon. Tio malhelpas aplikaĵojn aliri la reton kaj fortenas iliajn taskojn, speguladon, kaj normalajn avertojn.</string>
     <string name="room_settings_add_homescreen_shortcut">Aldoni al hejmekrano</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Uzi implicitan sonoron de ${app_name} por envenaj vokoj</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Uzi implicitan sonoron de ${app_name} por envenaj vokoj</string>
     <string name="call_switch_camera">Baskuli filmilon</string>
     <string name="auth_pin_forgot">Forgesita numero\?</string>
     <string name="universal_link_malformed">La ligilo estis misformita</string>
     <string name="room_error_not_found">Ne povas trovi ĉi tiun ĉambron. Certiĝu, ke ĝi ekzistas.</string>
     <string name="error_opening_banned_room">Ne povas malfermi ĉambron, de kiu vi forbariĝis.</string>
     <string name="auth_pin_confirm_to_disable_title">Konfirmu personan identigan numeron por malŝalti ĝin</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Persona identiga numero estas postulata je ĉiu malfermo de ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Persona identiga numero estas postulata post 2 minutoj de neuzado de ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Persona identiga numero estas postulata je ĉiu malfermo de ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Persona identiga numero estas postulata post 2 minutoj de neuzado de ${app_name}.</string>
     <string name="settings_security_pin_code_grace_period_title">Postuli personan identigan numeron post 2 minutoj</string>
     <string name="settings_security_pin_code_notifications_summary_off">Montri nur la nombron de nelegitaj mesaĝoj en simpla sciigo.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Montri detalojn kiel nomojn de ĉambroj kaj enhavon de mesaĝoj.</string>
     <string name="settings_security_pin_code_notifications_title">Montri enhavon en sciigoj</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">La persona identiga numero estas la sola maniero malŝlosi ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">La persona identiga numero estas la sola maniero malŝlosi ${app_name}.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Ŝalti vivaĵanalizojn de la aparato, kiel ekzemple rekonadon de fingrospuroj aŭ vizaĝo.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Ŝalti vivaĵanalizojn</string>
     <string name="settings_security_pin_code_summary">Se vi volas restarigi vian personan identigan numeron, tuŝetu je «Forgesita numero» por adiaŭi kaj restarigi.</string>
@@ -2080,11 +2080,11 @@
     <string name="identity_server_set_default_submit">Uzi %1$s</string>
     <string name="identity_server_error_no_current_binding_error">Nun efektivas neniu ligo kun ĉi tiu identigilo.</string>
     <string name="identity_server_error_binding_error">Malsukcesis la ligo.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Pro via privateco, ${app_name} nur subtenas sendadon de haketitaj retpoŝtadresoj kaj telefonnumeroj.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Pro via privateco, ${app_name} nur subtenas sendadon de haketitaj retpoŝtadresoj kaj telefonnumeroj.</string>
     <string name="identity_server_error_terms_not_signed">Bonvolu unue akcepti la uzokondiĉojn de la identiga servilo per la agordoj.</string>
     <string name="identity_server_error_no_identity_server_configured">Bonvolu unue agordi identigan servilon.</string>
     <string name="identity_server_error_outdated_home_server">Ĉi tiu ago ne eblas. La hejmservilo estas eksdata.</string>
-    <string name="template_identity_server_error_outdated_identity_server">Ĉi tiu identiga servilo estas eksdata. ${app_name} suportas nur version 2 de la API.</string>
+    <string name="identity_server_error_outdated_identity_server">Ĉi tiu identiga servilo estas eksdata. ${app_name} suportas nur version 2 de la API.</string>
     <string name="disconnect_identity_server_dialog_content">Ĉu malkonektiĝi de la identiga servilo %s\?</string>
     <string name="open_terms_of">Malfermi uzokondiĉojn de %s</string>
     <string name="choose_locale_loading_locales">Enlegante disponeblajn lingvojn…</string>
@@ -2120,13 +2120,13 @@
     <string name="use_recovery_key">Uzi rehavan ŝlosilon</string>
     <string name="enter_secret_storage_passphrase_or_key">Por daŭrigi, necesas via %1$s aŭ via %2$s.</string>
     <string name="command_description_discard_session_not_handled">Subtenata nur en ĉifritaj ĉambroj</string>
-    <string name="template_use_latest_app">Uzu la plej freŝan version de ${app_name} per aliaj viaj aparatoj:</string>
+    <string name="use_latest_app">Uzu la plej freŝan version de ${app_name} per aliaj viaj aparatoj:</string>
     <string name="or_other_mx_capable_client">aŭ alian klienton de Matrix kapablan je delegaj subskriboj</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
-    <string name="template_app_desktop_web">${app_name} Web (por TTT)
+    <string name="app_desktop_web">${app_name} Web (por TTT)
 \n${app_name} Desktop (por labortablo)</string>
-    <string name="template_use_other_session_content_description">Uzu la plej freŝan ${app_name} per aliaj viaj aparatoj: ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} por Android, aŭ alian klienton de Matrix kapablan je delegaj subskriboj</string>
+    <string name="use_other_session_content_description">Uzu la plej freŝan ${app_name} per aliaj viaj aparatoj: ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} por Android, aŭ alian klienton de Matrix kapablan je delegaj subskriboj</string>
     <string name="change_password_summary">Agordi novan pasvorton de konto…</string>
     <string name="error_saving_media_file">Ne povis konservi dosieron de vidaŭdaĵo</string>
     <string name="error_adding_media_file_to_gallery">Ne povis aldoni dosieron de vidaŭdaĵo al bildaro</string>
@@ -2191,7 +2191,7 @@
     <string name="refresh">Aktualigi</string>
     <string name="e2e_use_keybackup">Malŝlosi historion de ĉifritaj mesĝoj</string>
     <string name="settings_key_requests">Ŝlosilpetoj</string>
-    <string name="template_login_default_session_public_name">${app_name} por Android</string>
+    <string name="login_default_session_public_name">${app_name} por Android</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Ŝlosiloj jam estas ĝisdataj!</string>
     <string name="event_redacted_by_admin_reason_with_reason">Okazo foriĝis de administranto de la ĉambro, kialo: %1$s</string>
     <string name="event_redacted_by_user_reason_with_reason">Okazo foriĝis de uzanto, kialo: %1$s</string>
@@ -2344,7 +2344,7 @@
     <string name="create_room_topic_hint">Temo</string>
     <string name="create_room_topic_section">Temo de ĉambro (malnepra)</string>
     <string name="create_room_name_section">Nomo de ĉambro</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} trovis propran servilan agordaron per la retnomo «%1$s» el via identigilo de uzanto:
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} trovis propran servilan agordaron per la retnomo «%1$s» el via identigilo de uzanto:
 \n%2$s</string>
     <string name="autodiscover_invalid_response">Nevalidas hejmservil-serĉanta respondo</string>
     <string name="room_permissions_notice">Elektu la rolojn bezonatajn por ŝanĝi diversajn partojn de la ĉambro</string>
@@ -2495,8 +2495,8 @@
     <string name="user_code_share">Havigi mian kodon</string>
     <string name="user_code_scan">Skani rapidrespondan kodon (QR)</string>
     <string name="not_a_valid_qr_code">Tio ne estas valida rapidresponda kodo (QR) de Matrix</string>
-    <string name="template_invite_friends_rich_title">🔐️ Aliĝu al mi per ${app_name}</string>
-    <string name="template_invite_friends_text">Saluton, parolu kun mi per ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Aliĝu al mi per ${app_name}</string>
+    <string name="invite_friends_text">Saluton, parolu kun mi per ${app_name}: %s</string>
     <string name="invite_friends">Inviti amikojn</string>
     <string name="add_people">Aldoni personojn</string>
     <string name="failed_to_initialize_cross_signing">Malsukcesis agordi delegajn subskribojn</string>
@@ -2616,7 +2616,7 @@
     <string name="a11y_open_widget">Malfermi fenestraĵojn</string>
     <string name="a11y_screenshot">Ekrankopio</string>
     <string name="authentication_error">Malsukcesis aŭtentikigi</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} postulas enigon de viaj salutiloj por tiu ĉi ago.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} postulas enigon de viaj salutiloj por tiu ĉi ago.</string>
     <string name="error_jitsi_join_conf">Pardonu, eraris via aliĝo al la grupa voko</string>
     <string name="this_space_has_no_rooms_admin">Iuj ĉambroj povas esti kaŝitaj ĉar ili estas privataj kaj vi bezonas inviton.</string>
     <string name="this_space_has_no_rooms_not_admin">Iuj ĉambroj povas esti kaŝitaj, ĉar ili estas privataj kaj vi bezonas inviton.

--- a/vector/src/main/res/values-es-rMX/strings.xml
+++ b/vector/src/main/res/values-es-rMX/strings.xml
@@ -140,7 +140,7 @@
     <string name="local_address_book_header">Libreta local de direcciones</string>
     <string name="matrix_only_filter">Solamente contactos Matrix</string>
     <string name="no_conversation_placeholder">Sin conversaciones</string>
-    <string name="template_no_contact_access_placeholder">No ha permitido a ${app_name} acceder a sus contactos locales</string>
+    <string name="no_contact_access_placeholder">No ha permitido a ${app_name} acceder a sus contactos locales</string>
     <string name="no_result_placeholder">Sin resultados</string>
     <string name="rooms_header">Salas</string>
     <string name="rooms_directory_header">Directorio de salas</string>
@@ -263,14 +263,14 @@
     <string name="media_picker_both_capture_title">Tomar una foto o grabar un video"</string>
     <string name="media_picker_cannot_record_video">No pudo grabar video"</string>
     <string name="permissions_rationale_popup_title">Información</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} necesita tu permiso para entrar en tu almacenaje de fotos y videos para enviar y guardar archivos.\n\nPor favor permite el acceso en el siguiente mensaje para poder enviar archivos desde su dispostivo.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} necesita tu permiso para usar tu cámara para tomar fotos y hacer llamadas de video.</string>
+    <string name="permissions_rationale_msg_storage">${app_name} necesita tu permiso para entrar en tu almacenaje de fotos y videos para enviar y guardar archivos.\n\nPor favor permite el acceso en el siguiente mensaje para poder enviar archivos desde su dispostivo.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} necesita tu permiso para usar tu cámara para tomar fotos y hacer llamadas de video.</string>
     <string name="permissions_rationale_msg_camera_explanation">\n\nPor favor permite el acceso en el siguiente mensaje para poder hacer la llamada.</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} necesita tu permiso para usar tu micrófono para hacer llamadas de voz.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} necesita tu permiso para usar tu micrófono para hacer llamadas de voz.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">\n\nPor favor permite el acceso en el siguiente mensaje para poder hacer la llamada.</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} necesita tu permiso para usar su cámara y micrófono para hacer llamadas de video.\n\nPor favor permite el acceso en el siguiente mensaje para poder hacer la llamada.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} necesita tu permiso para leer tus contactos y directorio para encontrar a otros usuarios por sus correos electrónicos y números telefónicos.\n\nPor favor permite el acceso en el siguiente mensaje para encontrar usuarios de ${app_name} en su directorio.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} necesita tu permiso para leer los contactos de tu directorio para encontrar otros usuarios de Matrix por sus correos electrónicos y números telefónicos.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} necesita tu permiso para usar su cámara y micrófono para hacer llamadas de video.\n\nPor favor permite el acceso en el siguiente mensaje para poder hacer la llamada.</string>
+    <string name="permissions_rationale_msg_contacts">${app_name} necesita tu permiso para leer tus contactos y directorio para encontrar a otros usuarios por sus correos electrónicos y números telefónicos.\n\nPor favor permite el acceso en el siguiente mensaje para encontrar usuarios de ${app_name} en su directorio.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} necesita tu permiso para leer los contactos de tu directorio para encontrar otros usuarios de Matrix por sus correos electrónicos y números telefónicos.
 
 ¿Permitir el acceso a ${app_name} para leer tus contactos ?</string>
     <string name="permissions_action_not_performed_missing_permissions">Perdón. Operación no realizada debido a permisos faltantes</string>
@@ -650,7 +650,7 @@ Dispositivos desconocidos:</string>
     <string name="call_anyway">Llamar de todos modos</string>
     <string name="title_activity_verify_device">Verificar dispositivo</string>
     <string name="settings_call_category">Llamadas</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Usar el tono de llamada normal de ${app_name} para llamadas entrantes</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Usar el tono de llamada normal de ${app_name} para llamadas entrantes</string>
     <string name="settings_call_ringtone_title">Tono para llamadas entrantes</string>
     <string name="settings_call_ringtone_dialog_title">Elegir sonido de llamadas:</string>
     <string name="reason_hint">Razón</string>

--- a/vector/src/main/res/values-es/strings.xml
+++ b/vector/src/main/res/values-es/strings.xml
@@ -326,7 +326,7 @@
     <string name="local_address_book_header">Agenda de contactos local</string>
     <string name="matrix_only_filter">Solo contactos de Matrix</string>
     <string name="no_conversation_placeholder">No hay conversaciones</string>
-    <string name="template_no_contact_access_placeholder">No permitiste que ${app_name} acceda a tus contactos locales</string>
+    <string name="no_contact_access_placeholder">No permitiste que ${app_name} acceda a tus contactos locales</string>
     <string name="no_result_placeholder">No hay resultados</string>
     <string name="rooms_header">Salas</string>
     <string name="rooms_directory_header">Directorio de salas</string>
@@ -453,24 +453,24 @@
     <string name="media_picker_both_capture_title">Tomar una foto o un vídeo</string>
     <string name="media_picker_cannot_record_video">No se puede grabar vídeo</string>
     <string name="permissions_rationale_popup_title">Información</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} necesita permiso para acceder a tu biblioteca de fotos y vídeos para enviar y guardar archivos adjuntos.
+    <string name="permissions_rationale_msg_storage">${app_name} necesita permiso para acceder a tu biblioteca de fotos y vídeos para enviar y guardar archivos adjuntos.
 \n
 \nPor favor permite el acceso en la próxima ventana emergente para poder enviar archivos desde tu teléfono.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} necesita permiso para acceder a tu cámara para tomar fotos y realizar llamadas de vídeo.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} necesita permiso para acceder a tu cámara para tomar fotos y realizar llamadas de vídeo.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nPor favor permite el acceso en la próxima ventana emergente para poder realizar la llamada."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} necesita permiso para acceder a tu micrófono para realizar llamadas de voz.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} necesita permiso para acceder a tu micrófono para realizar llamadas de voz.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nPor favor permite el acceso en la próxima ventana emergente para poder realizar la llamada."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} necesita permiso para acceder a tu cámara y micrófono para realizar llamadas de vídeo.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} necesita permiso para acceder a tu cámara y micrófono para realizar llamadas de vídeo.
 \n
 \nPor favor permite el acceso en las próximas ventanas emergentes para poder realizar la llamada.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} necesita permiso para acceder a tu agenda de contactos para encontrar otros usuarios de Matrix por sus correos electrónicos y números telefónicos.
+    <string name="permissions_rationale_msg_contacts">${app_name} necesita permiso para acceder a tu agenda de contactos para encontrar otros usuarios de Matrix por sus correos electrónicos y números telefónicos.
 
 Por favor permite el acceso en la próxima ventana emergente para descubrir usuarios accesibles desde ${app_name} en tu agenda de contactos.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} necesita permiso para acceder a tu agenda de contactos para encontrar otros usuarios de Matrix por sus correos electrónicos y números telefónicos.
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} necesita permiso para acceder a tu agenda de contactos para encontrar otros usuarios de Matrix por sus correos electrónicos y números telefónicos.
 \n
 \n¿Permitir que ${app_name} acceda a tus contactos \?</string>
     <string name="permissions_action_not_performed_missing_permissions">Lo sentimos. Acción no realizada, debido a que faltan permisos</string>
@@ -971,7 +971,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="widget_integration_missing_parameter">Falta un parámetro requerido.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Solicitud enviada</string>
     <string name="action_speak">Conversar</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Por favor, inicia ${app_name} en otro dispositivo que pueda descifrar el mensaje para que pueda enviar las claves a esta sesión.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Por favor, inicia ${app_name} en otro dispositivo que pueda descifrar el mensaje para que pueda enviar las claves a esta sesión.</string>
     <string name="dialog_title_third_party_licences">Licencias de terceros</string>
     <string name="action_clear">Borrar</string>
     <string name="go_on_with">continuar con…</string>
@@ -979,10 +979,10 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="e2e_re_request_encryption_key">Volver a solicitar las claves de cifrado de tus otras sesiones.</string>
     <string name="e2e_re_request_encryption_key_sent">Solicitud de clave enviada.</string>
     <string name="startup_notification_privacy_title">Privacidad de Notificaciones</string>
-    <string name="template_startup_notification_privacy_message">${app_name} puede ejecutarse en segundo plano para gestionar tus notificaciones de forma segura y privada. Esto podría afectar la duración de la batería.</string>
+    <string name="startup_notification_privacy_message">${app_name} puede ejecutarse en segundo plano para gestionar tus notificaciones de forma segura y privada. Esto podría afectar la duración de la batería.</string>
     <string name="settings_opt_in_of_analytics">Enviar datos de análisis de estadísticas</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} recopila análisis de estadísticas anónimas para permitirnos mejorar la aplicación.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Por favor, habilita los análisis de estadísticas para ayudarnos a mejorar ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} recopila análisis de estadísticas anónimas para permitirnos mejorar la aplicación.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Por favor, habilita los análisis de estadísticas para ayudarnos a mejorar ${app_name}.</string>
     <string name="lock_screen_hint">Escribe aquí…</string>
     <string name="send_bug_report_description_in_english">Si es posible, por favor escribe la descripción en inglés.</string>
     <string name="room_message_placeholder_reply_to_encrypted">Enviar una respuesta cifrada…</string>
@@ -1066,7 +1066,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="action_accept">Aceptar</string>
     <string name="auth_accept_policies">Por favor revisa y acepta las reglas de este servidor doméstico:</string>
     <string name="settings_call_category">Llamadas</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Usar el tono de llamada normal de ${app_name} para llamadas entrantes</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Usar el tono de llamada normal de ${app_name} para llamadas entrantes</string>
     <string name="settings_call_ringtone_title">Tono para llamadas entrantes</string>
     <string name="settings_call_ringtone_dialog_title">Elegir sonido de llamadas:</string>
     <string name="video_call_in_progress">Llamada de video en proceso…</string>
@@ -1108,7 +1108,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="settings_troubleshoot_test_account_settings_quickfix">Activar</string>
     <string name="settings_troubleshoot_test_device_settings_title">Ajustes de sesión.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Las notificaciones están activadas para esta sesión.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Las notificaciones no están habilitadas para esta sesión.
+    <string name="settings_troubleshoot_test_device_settings_failed">Las notificaciones no están habilitadas para esta sesión.
 \nPor favor comprueba los ajustes ${app_name}.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Activar</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Ajustes personalizados.</string>
@@ -1126,15 +1126,15 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="settings_troubleshoot_diagnostic_failure_status_no_quickfix">Una o más pruebas han fallado, por favor mándanos un informe de error para que podamos investigar.</string>
     <string name="sign_out_bottom_sheet_warning_backing_up">Copia de seguridad en progreso. Si cierras sesión ahora perderás el acceso a tus mensajes cifrados.</string>
     <string name="sign_out_bottom_sheet_warning_backup_not_active">La copia de seguridad debería estar activa ahora en todas tus sesiones para evitar la pérdida de acceso a tus mensajes cifrados.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} usa los servicios de Google Play para entregar mensajes Push pero no parece estar configurado correctamente:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} usa los servicios de Google Play para entregar mensajes Push pero no parece estar configurado correctamente:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">solucionar error con los Servicios de Google Play</string>
     <string name="settings_troubleshoot_test_fcm_title">Token Base</string>
     <string name="settings_troubleshoot_test_fcm_success">Token FCM recuperada correctamente:\n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">Error al recuperar token FCM:\n%1$s</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]\nEste error esta fuera del control de ${app_name} y de acuerdo con Google, este error indica que el dispositivo tiene demasiadas apps registradas con FCM. Este error solo ocurre cuando existe un numero demasiado alto de apps por lo que no deberia afectar a un usuario promedio.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]\nEste error esta fuera del control de ${app_name}. Puede ocurrir por numerosas razones. Probablemente funcione si vuelve a intentarlo mas tarde. También puede comprobar si los Servicios de Google Play están limitados por los ajustes del sistema o si la hora del dispositivo es correcta o si puede pasar en ROM personalizada.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]\nEste error esta fuera del control de ${app_name} y de acuerdo con Google, este error indica que el dispositivo tiene demasiadas apps registradas con FCM. Este error solo ocurre cuando existe un numero demasiado alto de apps por lo que no deberia afectar a un usuario promedio.</string>
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]\nEste error esta fuera del control de ${app_name}. Puede ocurrir por numerosas razones. Probablemente funcione si vuelve a intentarlo mas tarde. También puede comprobar si los Servicios de Google Play están limitados por los ajustes del sistema o si la hora del dispositivo es correcta o si puede pasar en ROM personalizada.</string>
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nEste error esta fuera del control de ${app_name}. No hay cuenta de googled registrada en este dispositivo. Por favor abre el gestor dde cuentas y añade una cuenta de Google.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Añadir cuenta</string>
     <string name="settings_troubleshoot_test_token_registration_title">Token de registro</string>
@@ -1159,17 +1159,17 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="settings_troubleshoot_test_service_restart_failed">Error al reiniciar el servicio</string>
     <string name="settings_troubleshoot_test_service_boot_title">Inicio automático</string>
     <string name="settings_troubleshoot_test_service_boot_success">El servicio funcionará cuando reinicie el dispositivo.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">El servicio no se iniciará al reiniciar el dispositivo, no recibirá notificaciones hasta que ${app_name} haya sido abierto al menos 1 vez.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">El servicio no se iniciará al reiniciar el dispositivo, no recibirá notificaciones hasta que ${app_name} haya sido abierto al menos 1 vez.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Activar Inicio automático</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Comprobar restricciones en segundo plano</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Las restricciones de segundo plano están desactivadas para ${app_name}. Este debería funcionar con datos móviles (sin WIFI).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Las restricciones de segundo plano están desactivadas para ${app_name}. Este debería funcionar con datos móviles (sin WIFI).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Las restricciones de segundo plano están activadas para ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Las restricciones de segundo plano están activadas para ${app_name}.
 \nLa app estará completamente restringida mientras esté en segundo plano y esto podría afectar a las notificaciones.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Desactivar restricciones</string>
     <string name="settings_troubleshoot_test_battery_title">Optimización de la bateria</string>
-    <string name="template_settings_troubleshoot_test_battery_success">A ${app_name} no le afecta la Optimización de la bateria.</string>
+    <string name="settings_troubleshoot_test_battery_success">A ${app_name} no le afecta la Optimización de la bateria.</string>
     <string name="settings_troubleshoot_test_battery_failed">Si un usuario deja el dispositivo desenchufado e inmóvil durante cierto periodo de tiempo con la pantalla apagada, el dispositivo entrará en modo hibernación. Esto evita que las apps accedan a la red y postpone sus tareas, sincronizaciones y alarmas.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">ignorar optimización</string>
     <string name="settings_notification_privacy_no_background_sync">Las apps <b>no</b> necesita conectarse al servidor doméstico en segundo plano, esto debería reducir el uso de la batería</string>
@@ -1192,7 +1192,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="settings_send_message_with_enter">Enviar mensaje con intro</string>
     <string name="settings_send_message_with_enter_summary">La tecla Intro enviará el mensaje en vez de añadir un salto de línea</string>
     <string name="startup_notification_fdroid_battery_optim_title">Conexión en segundo plano</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} necesita mantener una leve conexión en segundo plano para poder ofrecer notificaciones de confianza.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} necesita mantener una leve conexión en segundo plano para poder ofrecer notificaciones de confianza.
 \nEn la siguiente pantalla se le pedirá permisos para que ${app_name} siempre funcione en segundo plano, por favor acepte.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Conceder permiso</string>
     <string name="settings_data_save_mode_summary">El modo de guardado de datos aplica un filtro específico para que las actualizaciones de presencia y las notificaciones de escritura sean eliminadas.</string>
@@ -1242,7 +1242,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="no_valid_google_play_services_apk">No se ha encontrado ningún APK válido de Servicios de Google Play. Las notificaciones podrían no funcionar correctamente.</string>
     <string name="passphrase_empty_error_message">Por favor introduzca una contraseña</string>
     <string name="passphrase_passphrase_too_weak">La contraseña que has introducido es muy débil</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Por favor borra la contraseña si quieres que ${app_name} genere una clave de recuperación.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Por favor borra la contraseña si quieres que ${app_name} genere una clave de recuperación.</string>
     <string name="keys_backup_no_session_error">No hay ninguna sesión de Matrix disponible</string>
     <string name="keys_backup_setup_step1_title">Nunca perder los mensajes cifrados</string>
     <string name="keys_backup_setup_step1_description">Los mensajes en salas cifradas están asegurados con cifrado Extremo-a-Extremo. Solo los integrantes de la sala y tu podéis leer estos mensajes.
@@ -1323,7 +1323,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     </plurals>
     <string name="keys_backup_info_title_signature">Firma</string>
     <string name="autodiscover_well_known_autofill_dialog_title">autocompletar opciones del servidor</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} ha detectado una configuración personalizada del servidor para el dominio de su ID de usuario \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} ha detectado una configuración personalizada del servidor para el dominio de su ID de usuario \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Configuración de uso</string>
     <string name="settings_default_media_source">Origen predeterminado de medios</string>
@@ -1422,7 +1422,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="please_wait">Espere por favor…</string>
     <string name="group_all_communities">Todas la comunidades</string>
     <string name="room_preview_no_preview">Esta sala no se puede previsualizar</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">La previsualización de salas públicas no es posible todavía con ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">La previsualización de salas públicas no es posible todavía con ${app_name}</string>
     <string name="fab_menu_create_room">Salas</string>
     <string name="fab_menu_create_chat">Chats</string>
     <string name="create_room_title">Nueva sala</string>
@@ -1474,9 +1474,9 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="auth_add_phone_message_2">Pon un número de teléfono para que las personas que conoces te puedan encontrar.</string>
     <string name="settings_call_ringtone_use_default_stun_sum">Se usará %s como asistencia cuando el servidor doméstico no la ofrezca (su dirección IP se compartirá durante una llamada)</string>
     <string name="settings_background_fdroid_sync_mode">Modo Sincronización en segundo plano</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} se sincronizará en segundo plano de manera que se preserven los recursos del dispositivo (batería).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} se sincronizará en segundo plano de manera que se preserven los recursos del dispositivo (batería).
 \nDependiendo del estado de los recursos del dispositivo, la sincronización puede ser aplazada por el sistema operativo.</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} se sincronizará en segundo plano periódicamente en un momento preciso (configurable).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} se sincronizará en segundo plano periódicamente en un momento preciso (configurable).
 \nEsto afectará al uso de la radio y la batería, se mostrará una notificación permanente que indica que ${app_name} está escuchando a nuevos acontecimientos.</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">No se le notificará de los mensajes entrantes cuando la aplicación esté en segundo plano.</string>
     <string name="settings_set_workmanager_delay">Intervalo de sincronización preferido</string>
@@ -1639,7 +1639,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="content_reported_as_inappropriate_content">Este contenido fue reportado como inapropiado.
 \n
 \nSi no quieres ver más contenido de este usuario, puedes bloquearlo para ocultar sus mensajes.</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} necesita permiso para guardar tus claves E2E en la memória del dispositivo.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} necesita permiso para guardar tus claves E2E en la memória del dispositivo.
 \n
 \nPorfavor permite el acceso en el siguiente pop-up para poder exportar tus claves manualmente.</string>
     <string name="no_network_indicator">No hay conexión de red</string>
@@ -1697,7 +1697,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="action_copy">Copiar</string>
     <string name="dialog_title_success">Correcto</string>
     <string name="bottom_action_notification">Notificaciones</string>
-    <string name="template_call_failed_no_connection">${app_name} Fallo la Llamada</string>
+    <string name="call_failed_no_connection">${app_name} Fallo la Llamada</string>
     <string name="call_failed_no_connection_description">Fallo al intentar establecer conexion.
 \nTURN Server fallo. Por favor, contacte con el administrador de su Servidor y notifique el fallo.</string>
     <string name="call_select_sound_device">Seleccionar Dispositivo de Sonido</string>
@@ -1740,7 +1740,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="choose_locale_loading_locales">Cargando lenguajes disponibles…</string>
     <string name="open_terms_of">Leer los terminos de %s</string>
     <string name="disconnect_identity_server_dialog_content">Desconectarse del servidor de Identidad %s\?</string>
-    <string name="template_identity_server_error_outdated_identity_server">Servidor de identidad desactualizado. ${app_name} solo soporta API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Servidor de identidad desactualizado. ${app_name} solo soporta API V2.</string>
     <string name="identity_server_error_outdated_home_server">Operación no posible. Servidor desactualizado.</string>
     <string name="identity_server_error_no_identity_server_configured">Por favor, configure primero un Servidor de Identidad.</string>
     <string name="disclaimer_title">Riot ahora es Element!</string>
@@ -1780,7 +1780,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="devices_other_devices">Otras Sesiones</string>
     <string name="autocomplete_limited_results">Mostrando solo el primer resultado, agregue mas letras…</string>
     <string name="settings_developer_mode_fail_fast_title">Fallar rápido (Test)</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} puede fallar con más frecuencia cuando ocurre un error inesperado</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} puede fallar con más frecuencia cuando ocurre un error inesperado</string>
     <string name="command_description_shrug">Antepone ¯\\_(ツ)_/¯ a un mensaje de texto sin formato</string>
     <string name="create_room_encryption_title">Habilitar crifrado</string>
     <string name="create_room_encryption_description">Una vez habilitado, el cifrado no se puede deshabilitar.</string>
@@ -1842,9 +1842,9 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="room_member_power_level_default_in">Nivel Personalizado en %1$s</string>
     <string name="room_member_power_level_custom_in">Nivel Personalizado (%1$d) en %2$s</string>
     <string name="room_member_jump_to_read_receipt">Saltar para leer el recibo</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} no maneja eventos de tipo \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} no maneja el mensaje de tipo \'%1$s\'</string>
-    <string name="template_rendering_event_error_exception">${app_name} encontró un problema al representar el contenido del evento con el ID \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} no maneja eventos de tipo \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} no maneja el mensaje de tipo \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} encontró un problema al representar el contenido del evento con el ID \'%1$s\'</string>
     <string name="unignore">Dejar de ignorar</string>
     <string name="room_list_sharing_header_recent_rooms">Salas recientes</string>
     <string name="room_list_sharing_header_other_rooms">Otras salas</string>
@@ -1885,7 +1885,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="message_action_item_redact">Eliminar…</string>
     <string name="delete_event_dialog_reason_checkbox">Razón</string>
     <string name="delete_event_dialog_reason_hint">Razón para redactar</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="refresh">Refrescar</string>
     <string name="new_session">Nuevo inicio de sesión detectado . ¿Fue usted\?</string>
     <string name="new_session_review">Toca para revisar y verificar</string>
@@ -2093,7 +2093,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
 \nVuelva a iniciar sesión para acceder a los datos y mensajes de su cuenta.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Perderás el acceso a los mensajes seguros a menos que inicies sesión para recuperar tus claves de cifrado.</string>
     <string name="soft_logout_clear_data_dialog_submit">Borrar datos</string>
-    <string name="template_soft_logout_sso_not_same_user_error">La sesión actual es para el usuario %1$s y usted proporciona las credenciales para el usuario %2$s. Esto no está suportado por ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">La sesión actual es para el usuario %1$s y usted proporciona las credenciales para el usuario %2$s. Esto no está suportado por ${app_name}.
 \nPrimero borre los datos, luego inicie sesión nuevamente con otra cuenta.</string>
     <string name="permalink_malformed">Su enlace matrix.to estaba mal formado</string>
     <string name="settings_developer_mode_summary">El modo desarrollador activa funciones ocultas y también puede hacer que la aplicación sea menos estable. ¡Solo para desarrolladores!</string>
@@ -2242,13 +2242,13 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="settings_security_prevent_screenshots_summary">Al habilitar esta configuración, se agrega FLAG_SECURE a todas las actividades. Reinicie la aplicación para que el cambio surta efecto.</string>
     <string name="media_file_added_to_gallery">Archivo multimedia agregado a la Galería</string>
     <string name="error_adding_media_file_to_gallery">No se pudo agregar el archivo multimedia a la Galería</string>
-    <string name="template_use_other_session_content_description">Utilice la última versión de ${app_name} en sus otros dispositivos, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} para Android u otro cliente Matrix con capacidad de firma cruzada</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="use_other_session_content_description">Utilice la última versión de ${app_name} en sus otros dispositivos, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} para Android u otro cliente Matrix con capacidad de firma cruzada</string>
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} de escritorio</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
     <string name="or_other_mx_capable_client">u otro cliente Matrix con capacidad de firma cruzada</string>
-    <string name="template_use_latest_app">Utilice la última versión de ${app_name} en sus otros dispositivos:</string>
+    <string name="use_latest_app">Utilice la última versión de ${app_name} en sus otros dispositivos:</string>
     <string name="command_description_discard_session">Obliga a descartar la sesión de grupo saliente actual en una sala cifrada</string>
     <string name="command_description_discard_session_not_handled">Solo se admite en salas cifradas</string>
     <string name="enter_secret_storage_passphrase_or_key">Use su %1$s o use su %2$s para continuar.</string>
@@ -2268,7 +2268,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="mark_as_verified">Marcar como de confianza</string>
     <string name="create_room_dm_failure">No pudimos crear tu DM. Marque los usuarios que desea invitar y vuelva a intentarlo.</string>
     <string name="identity_server_error_terms_not_signed">Primero acepta los términos del servidor de identidad en la configuración.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Para su privacidad, ${app_name} solo admite el envío de números de teléfono y correos electrónicos de usuario con hash.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Para su privacidad, ${app_name} solo admite el envío de números de teléfono y correos electrónicos de usuario con hash.</string>
     <string name="identity_server_error_binding_error">La asociación ha fallado.</string>
     <string name="identity_server_error_no_current_binding_error">No existe una asociación actual con este identificador.</string>
     <string name="identity_server_set_default_notice">Su servidor doméstico (%1$s) propone utilizar %2$s para su servidor de identidad</string>
@@ -2369,13 +2369,13 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="warning_unsaved_change">Hay cambios sin salvar. ¿Descartar los cambios\?</string>
     <string name="warning_room_not_created_yet">La sala todavía no ha sido creada. ¿Cancelar la creación\?</string>
     <string name="universal_link_malformed">El link está malformado</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">PIN es requerido cada vez que se abre ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">PIN es necesario después de no usar ${app_name} por 2 minutos.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">PIN es requerido cada vez que se abre ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">PIN es necesario después de no usar ${app_name} por 2 minutos.</string>
     <string name="settings_security_pin_code_grace_period_title">Requerir PIN después de 2 minutos</string>
     <string name="settings_security_pin_code_notifications_summary_off">Sólo mostrar el número de mensajes no leídos en una notificación sencilla.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Mostrar detalles, como nombres de salas y contenido de mensajes.</string>
     <string name="settings_security_pin_code_notifications_title">Mostrar contenido de notificaciones</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">${app_name} sólo puede ser desbloqueado vía Código PIN.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">${app_name} sólo puede ser desbloqueado vía Código PIN.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Activar biometría de este dispositivo en particular, como huellas dactilares o reconocimiento facial.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Activar biometría</string>
     <string name="settings_security_application_protection_screen_title">Configurar protecciones</string>
@@ -2420,7 +2420,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="permissions_denied_add_contact">Permitir acceder a sus contactos.</string>
     <string name="error_unauthorized">Desautorizado, credenciales de autenticación no autorizadas</string>
     <string name="login_clear_homeserver_history">Limpiar Historial</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} requiere que ingrese sus credenciales para realizar esta acción.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} requiere que ingrese sus credenciales para realizar esta acción.</string>
     <string name="re_authentication_activity_title">Se necesita una nueva autenticación</string>
     <string name="matrix_to_card_title">Enlace Matrix</string>
     <string name="qr_code_not_scanned">¡Código QR no escaneado!</string>
@@ -2444,8 +2444,8 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="user_code_my_code">Mi código</string>
     <string name="user_code_share">Compartir mi código</string>
     <string name="user_code_scan">Escanear QR</string>
-    <string name="template_invite_friends_rich_title">🔐️ Unirme a ${app_name}</string>
-    <string name="template_invite_friends_text">Hey, contactame por ${app_name}:%s</string>
+    <string name="invite_friends_rich_title">🔐️ Unirme a ${app_name}</string>
+    <string name="invite_friends_text">Hey, contactame por ${app_name}:%s</string>
     <string name="add_people">Adicionar persona</string>
     <string name="user_code_info_text">Comparte este código para que puedan contactar contigo.</string>
     <string name="a11y_create_direct_message_by_mxid">Crear una converzacion por ID Matrix</string>
@@ -2658,7 +2658,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="room_alias_title">Direcciones de la Sala</string>
     <string name="room_settings_alias_title">Direcciones de la sala</string>
     <string name="room_settings_room_access_title">Acceso a la sala</string>
-    <string name="template_settings_add_3pid_flow_not_supported">No puedes hacer eso desde ${app_name} móvil</string>
+    <string name="settings_add_3pid_flow_not_supported">No puedes hacer eso desde ${app_name} móvil</string>
     <string name="option_always_ask">Siempre preguntar</string>
     <string name="spaces_header">Espacios</string>
     <string name="settings_room_directory_show_all_rooms_summary">mostrar todas las salas en el directorio de salas, incluyendo salas con contenido explícito.</string>
@@ -2933,7 +2933,7 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="call_ringing">Llamada sonando…</string>
     <string name="spaces">Espacios</string>
     <string name="learn_more">Aprende más</string>
-    <string name="template_link_this_email_with_your_account">%s en Configuración para recibir invitaciones directamente en ${app_name}.</string>
+    <string name="link_this_email_with_your_account">%s en Configuración para recibir invitaciones directamente en ${app_name}.</string>
     <string name="link_this_email_settings_link">Vincula este correo electrónico con tu cuenta</string>
     <string name="this_invite_to_this_space_was_sent">Esta invitación a este espacio se envió a %s que no está asociado con su cuenta</string>
     <string name="this_invite_to_this_room_was_sent">Esta invitación a esta sala se envió a %s que no está asociado con su cuenta</string>

--- a/vector/src/main/res/values-es/strings.xml
+++ b/vector/src/main/res/values-es/strings.xml
@@ -1452,7 +1452,6 @@ Por favor permite el acceso en la próxima ventana emergente para descubrir usua
     <string name="call_failed_dont_ask_again">No volver a preguntar</string>
     <string name="invite_no_identity_server_error">Para hacer esto, vaya a las opciones y añada un servidor de identidad.</string>
     <string name="settings_add_3pid_confirm_password_title">Confirme su contraseña</string>
-    <string name="settings_add_3pid_flow_not_supported">Eso no se puede hacer en Element para móvil</string>
     <string name="settings_add_3pid_authentication_needed">Se necesita autenticación</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimizado para batería</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimizado para operar en tiempo real</string>

--- a/vector/src/main/res/values-et/strings.xml
+++ b/vector/src/main/res/values-et/strings.xml
@@ -379,7 +379,7 @@
     <string name="user_directory_header">Kasutajate kataloog</string>
     <string name="matrix_only_filter">Vaid need, kellel on Matrixi konto</string>
     <string name="no_conversation_placeholder">Vestlusi ei leidu</string>
-    <string name="template_no_contact_access_placeholder">Sa pole ${app_name}\'ile andnud ligipääsu kohalikele kontaktidele</string>
+    <string name="no_contact_access_placeholder">Sa pole ${app_name}\'ile andnud ligipääsu kohalikele kontaktidele</string>
     <string name="no_result_placeholder">Tulemusi ei ole</string>
     <string name="people_no_identity_server">Isikutuvastusserver ei ole seadistatud.</string>
     <string name="rooms_header">Jututoad</string>
@@ -514,7 +514,7 @@
     <string name="action_copy">Kopeeri</string>
     <string name="dialog_title_success">Õnnestus</string>
     <string name="bottom_action_notification">Teavitused</string>
-    <string name="template_call_failed_no_connection">Kõne ebaõnnestus</string>
+    <string name="call_failed_no_connection">Kõne ebaõnnestus</string>
     <string name="call_failed_no_connection_description">Reaalajas ühenduse loomine ei õnnestunud.
 \nPalu oma koduserveri %@ haldajat, et ta seadistaks kõnede kindlamaks toimimiseks TURN serveri.</string>
     <string name="call_select_sound_device">Vali heliseade</string>
@@ -534,7 +534,7 @@
     <string name="e2e_re_request_encryption_key">Küsi oma muudest sessioonidest krüptimisvõtmed uuesti.</string>
     <string name="e2e_re_request_encryption_key_sent">Võtmete jagamise päring on saadetud.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Päring on saadetud</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Palun käivita ${app_name} mõnes muus seadmes, mis suudab neid sõnumeid dekrüptida ja seega saata krüptovõtmeid siia sessiooni.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Palun käivita ${app_name} mõnes muus seadmes, mis suudab neid sõnumeid dekrüptida ja seega saata krüptovõtmeid siia sessiooni.</string>
     <string name="read_receipts_list">Lugemisteatiste loend</string>
     <string name="groups_list">Gruppide loend</string>
     <plurals name="membership_changes">
@@ -555,7 +555,7 @@
     <string name="room_info_room_name">Jututoa nimi</string>
     <string name="room_info_room_topic">Jututoa teema</string>
     <string name="settings_call_category">Kõned</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Kasuta saabuvate kõnede jaoks ${app_name}\'i vaikimisi helinat</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Kasuta saabuvate kõnede jaoks ${app_name}\'i vaikimisi helinat</string>
     <string name="settings_call_ringtone_use_default_stun">Kasuta kõnehõlbustusserverit</string>
     <string name="settings_call_ringtone_title">Saabuva kõne helin</string>
     <string name="settings_call_ringtone_dialog_title">Vali helin kõnede jaoks:</string>
@@ -577,18 +577,18 @@
     <string name="media_picker_both_capture_title">Tee foto või video</string>
     <string name="media_picker_cannot_record_video">Video salvestamine ei õnnestu</string>
     <string name="permissions_rationale_popup_title">Lisateave õiguste kohta</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} vajab õigusi sinu foto- ja videokataloogide lugemiseks ning manuste salvestamiseks.
+    <string name="permissions_rationale_msg_storage">${app_name} vajab õigusi sinu foto- ja videokataloogide lugemiseks ning manuste salvestamiseks.
 \n
 \nSelleks, et saaksid oma nutiseadmest faile saata palun anna järgmisel lehel vajalikud õigused.</string>
-    <string name="template_permissions_rationale_msg_camera">Fotode ja videote salvestamiseks ning videokõnede tegemiseks vajab ${app_name} õigusi kasutada sinu kaamerat.</string>
+    <string name="permissions_rationale_msg_camera">Fotode ja videote salvestamiseks ning videokõnede tegemiseks vajab ${app_name} õigusi kasutada sinu kaamerat.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nKõnede tegemiseks palun anna järgmisel lehel vajalikud õigused."</string>
-    <string name="template_permissions_rationale_msg_record_audio">Kõnede tegemiseks vajab ${app_name} õigusi kasutada sinu mikrofoni.</string>
+    <string name="permissions_rationale_msg_record_audio">Kõnede tegemiseks vajab ${app_name} õigusi kasutada sinu mikrofoni.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nKõnede tegemiseks palun anna järgmisel lehel vajalikud õigused."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} vajab videokõnedeks õigusi sinu kaamera ja mikrofoni kasutamiseks.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} vajab videokõnedeks õigusi sinu kaamera ja mikrofoni kasutamiseks.
 \n
 \nKõnede tegemiseks palun anna järgmisel lehel vajalikud õigused.</string>
     <string name="permissions_action_not_performed_missing_permissions">Vabandust. Kuna vastavaid õigusi ei olnud, siis toimingut ei saanud teha</string>
@@ -794,7 +794,7 @@
     <string name="please_wait">Palun oota…</string>
     <string name="group_all_communities">Kõik kogukonnad</string>
     <string name="room_preview_no_preview">Sellel jututoal puudub eelvaade</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">${app_name} ei toeta veel kõigile nähtavate jututubade eelvaadet</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">${app_name} ei toeta veel kõigile nähtavate jututubade eelvaadet</string>
     <string name="fab_menu_create_room">Jututoad</string>
     <string name="fab_menu_create_chat">Isiklikud sõnumid</string>
     <string name="create_room_title">Uus jututuba</string>
@@ -840,7 +840,7 @@
     <string name="settings_active_sessions_signout_device">Logi sellest sessioonist välja</string>
     <string name="settings_failed_to_get_crypto_device_info">Teave krüptograafia kohta puudub</string>
     <string name="settings_active_sessions_verified_device_desc">Kuna sina oled selle sessiooni verifitseerinud, siis see sessioon on krüptitud sõnumite saatmiseks usaldusväärne:</string>
-    <string name="template_identity_server_error_outdated_identity_server">See isikutuvastusserver kasutab vana API\'t. ${app_name} toetab aga vaid API versiooni 2.</string>
+    <string name="identity_server_error_outdated_identity_server">See isikutuvastusserver kasutab vana API\'t. ${app_name} toetab aga vaid API versiooni 2.</string>
     <string name="identity_server_error_outdated_home_server">See tegevus ei ole võimalik. Koduserveri versioon on liiga vana.</string>
     <plurals name="directory_search_rooms">
         <item quantity="one">%d jututuba</item>
@@ -877,7 +877,7 @@
     <string name="settings_app_info_link_title">Rakenduse teave</string>
     <string name="settings_app_info_link_summary">Näita rakenduse teavet süsteemi seadistustes.</string>
     <string name="settings_add_3pid_confirm_password_title">Kinnitage oma salasõna</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Seda tegevust ei saa teha ${app_name}\'i nutirakendusest</string>
+    <string name="settings_add_3pid_flow_not_supported">Seda tegevust ei saa teha ${app_name}\'i nutirakendusest</string>
     <string name="settings_add_3pid_authentication_needed">Autentimine on nõutav</string>
     <string name="settings_notification_advanced">Teavituste lisaseadistused</string>
     <string name="settings_notification_by_event">Teavituse olulisus sündmuse alusel</string>
@@ -890,7 +890,7 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Võta kasutusele</string>
     <string name="settings_troubleshoot_test_device_settings_title">Sessiooni seadistused.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Selles sessioonis on teavitused kasutusel.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Selles sessioonis ei ole teavitusi kasutusel.
+    <string name="settings_troubleshoot_test_device_settings_failed">Selles sessioonis ei ole teavitusi kasutusel.
 \nSeda saad muuta ${app_name}\'i seadistuses.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Võta kasutusele</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Kohandatud seadistused.</string>
@@ -1214,7 +1214,7 @@
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Palun kontrolli seadistusi</string>
     <string name="settings_troubleshoot_test_play_services_title">Goolge Play teenuste kontrollimine</string>
     <string name="settings_troubleshoot_test_play_services_success">Google Play Services APK on kättesaadav ja uuendatud.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} kasutab Google Play teenuseid tõuketeavituste edastamiseks, kui see ei tundu olema korrektselt seadistatud:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} kasutab Google Play teenuseid tõuketeavituste edastamiseks, kui see ei tundu olema korrektselt seadistatud:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Paranda Google Play teenused</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase tunnusluba</string>
@@ -1222,11 +1222,11 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">FCM tunnusloa laadimine ei õnnestunud:
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nSee viga on väljaspool ${app_name}\'i kontrolli ning vastavalt Google infole liiga palju rakendusi kasutavad FCM\'i. Selline olukord peaks tekkima vaid siis kui kasutusel on hiidpalju selliseid rakendusi ning ei peaks mõjutama tavakasutajaid.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nSee viga on väljaspool ${app_name}\'i kontrolli ning võib juhtuda eri põhjustel. Võib-olla hilisemal proovimisel seda viga enam ei teki, kuid igaks juhuks vaata, et Google Play teenustele ei oleks süsteemi seadetes määratud andmesidepiirangut ning seadme kell on õige. Samuti võib see viga tekkida, kui sa pruugid kohandatud Androidi varianti (custom ROM).</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nSee viga on väljaspool ${app_name}\'i kontrolli. Telefoni ei ole seadistatud Google\'i kontot. Palun ava seadistustes kontohaldur ning lisa üks Google\'i konto.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Lisa Google\'i konto</string>
     <string name="settings_troubleshoot_test_token_registration_title">Tunnusloa registreerimine</string>
@@ -1238,7 +1238,7 @@
     <string name="settings_troubleshoot_test_service_restart_failed">Teenuse uuesti käivitamine ei õnnestunud</string>
     <string name="settings_troubleshoot_test_service_boot_title">Käivita teenus seadme käivitamisel</string>
     <string name="settings_troubleshoot_test_service_boot_success">Teenus käivitatakse nutiseadme käivitamisel.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Seda teenust ei käivitatata nutiseadme käivitamisel. Sa ei saa teavitusi enne, kui ${app_name} on vähemalt korra avatud.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Seda teenust ei käivitatata nutiseadme käivitamisel. Sa ei saa teavitusi enne, kui ${app_name} on vähemalt korra avatud.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Käivita teenus nutiseadme käivitamisel</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Kontrolli taustapiiranguid</string>
     <plurals name="notification_unread_notified_messages_in_room_rooms">
@@ -1286,21 +1286,21 @@
     <string name="settings_labs_native_camera_summary">Käivita kohandatud vaate asemel süsteemne kaamera vaade.</string>
     <string name="settings_labs_keyboard_options_to_send_message">Kasuta reavahetuse klahvi sõnumi saatmiseks</string>
     <string name="settings_labs_enable_send_voice">Saada häälsõnumeid</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} saab kontrollida teie aadressiraamatut, et leida teisi Matrixi kasutajaid nende e-posti aadressi ja telefoninumbrite põhjal. Kui sa nõustud oma aadressiraamatut sel eesmärgil jagama, luba juurdepääs järgmisel hüpikaknal.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} saab kontrollida teie aadressiraamatut, et leida teisi Matrixi kasutajaid nende e-posti aadresside ja telefoninumbrite põhjal.
+    <string name="permissions_rationale_msg_contacts">${app_name} saab kontrollida teie aadressiraamatut, et leida teisi Matrixi kasutajaid nende e-posti aadressi ja telefoninumbrite põhjal. Kui sa nõustud oma aadressiraamatut sel eesmärgil jagama, luba juurdepääs järgmisel hüpikaknal.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} saab kontrollida teie aadressiraamatut, et leida teisi Matrixi kasutajaid nende e-posti aadresside ja telefoninumbrite põhjal.
 \n
 \nKas sa oled nõus oma aadressiraamatut sel eesmärgil jagama\?</string>
     <string name="room_event_action_report_prompt_ignore_user">Kas sa soovid peita selle kasutaja kõik sõnumid\?
 \n
 \nPane tähele, et antud toiming taaskäivitab rakenduse ja see võib võtta veidi aega.</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Taustapiirangud on Elemendi jaoks keelatud. Seda testi tuleks läbi viia mobiilse andmeside abil (WIFI puudub).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Taustapiirangud on Elemendi jaoks keelatud. Seda testi tuleks läbi viia mobiilse andmeside abil (WIFI puudub).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Elemendi jaoks on taustpiirangud lubatud.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Elemendi jaoks on taustpiirangud lubatud.
 \nTöö, mida rakendus proovib teha, on agressiivselt piiratud, kui see on taustal ja see võib mõjutada teavituste kättesaamist.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Keela piirangud</string>
     <string name="settings_troubleshoot_test_battery_title">Aku optimeerimine</string>
-    <string name="template_settings_troubleshoot_test_battery_success">Aku optimeerimine ei mõjuta ${app_name}.</string>
+    <string name="settings_troubleshoot_test_battery_success">Aku optimeerimine ei mõjuta ${app_name}.</string>
     <string name="settings_troubleshoot_test_battery_failed">Kui kasutaja jätab seadme mõneks ajaks vooluvõrgust välja ja ühele kohale paigale ning ekraan on välja lülitatud, lülitub seade Doze režiimi. See takistab rakendustel juurdepääsu võrgule ja lükkab edasi nende töö, sünkroonimise ja tavalised teated.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Eira optimeerimist</string>
     <string name="settings_notification_privacy_normal">Tavaline</string>
@@ -1330,10 +1330,10 @@
     <string name="settings_background_sync">Andmete sünkroniseerimine taustal</string>
     <string name="settings_background_fdroid_sync_mode">Andmete taustal sünkroniseerimise režiim</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimeeritud akukestust silmas pidades</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} sünkroniseerib taustal nii, et see arvestab seadme piiratud ressursse (aku).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} sünkroniseerib taustal nii, et see arvestab seadme piiratud ressursse (aku).
 \nSõltuvalt seadme olekust võib operatsioonisüsteem sünkroniseerimist edasi lükata.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimeeritud reaalajas</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} sünkroniseerib sõnumeid taustal etteantud aja järel (aeg on seadistatav).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} sünkroniseerib sõnumeid taustal etteantud aja järel (aeg on seadistatav).
 \nSee mõjutab seadme saatjat/vastuvõtjat ja akukasutust ning kuvatakse püsiteade, et ${app_name} kuulab sündmusi.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Taustasünkroonimine puudub</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Kui rakendus töötab taustal, siis sa ei saa saabunud sõnumite kohta teavitusi.</string>
@@ -1401,17 +1401,17 @@
     <string name="settings_discovery_category">Leia kasutajaid</string>
     <string name="settings_discovery_manage">Halda kasutajate otsingu seadistusi.</string>
     <string name="startup_notification_privacy_title">Teavituste privaatsus</string>
-    <string name="template_startup_notification_privacy_message">${app_name} võib taustal töötamise ajal hallata sinu teavitusi turvaliselt ja privaatselt. Aga see võib mõjutada akukasutust.</string>
+    <string name="startup_notification_privacy_message">${app_name} võib taustal töötamise ajal hallata sinu teavitusi turvaliselt ja privaatselt. Aga see võib mõjutada akukasutust.</string>
     <string name="startup_notification_privacy_button_grant">Anna õigused</string>
     <string name="startup_notification_privacy_button_other">Tee muu valik</string>
     <string name="startup_notification_fdroid_battery_optim_title">Taustaühendus</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">Selleks et teavitused toimiksid korralikult peab ${app_name} kasutama vähese kõrvalmõjuga taustaühendust.
+    <string name="startup_notification_fdroid_battery_optim_message">Selleks et teavitused toimiksid korralikult peab ${app_name} kasutama vähese kõrvalmõjuga taustaühendust.
 \nKui järgmisel lehel sinult küsitakse kas lubada, et ${app_name} töötab kogu aeg taustal, siis palun nõustu.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Anna õigused</string>
     <string name="settings_analytics">Analüütika</string>
     <string name="settings_opt_in_of_analytics">Saada arendajatele analüütikat</string>
-    <string name="template_settings_opt_in_of_analytics_summary">Võimaldamaks meil rakendust parandada kogub ${app_name} anonüümset teavet rakenduse kasutuse kohta.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Selleks, et saaksime ${app_name}\'i paremaks teha, palun luba analüütika.</string>
+    <string name="settings_opt_in_of_analytics_summary">Võimaldamaks meil rakendust parandada kogub ${app_name} anonüümset teavet rakenduse kasutuse kohta.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Selleks, et saaksime ${app_name}\'i paremaks teha, palun luba analüütika.</string>
     <string name="settings_opt_in_of_analytics_ok">Jah, ma soovin aidata!</string>
     <string name="settings_data_save_mode">Võrguliikluse mahu säästmise režiim</string>
     <string name="settings_data_save_mode_summary">Võrguliikluse andmemahu säästmiseks kasutatakse filtrit, mille puhul kasutajate olekuid ei uuendata ja sõnumite kirjutamise teavitusi ei laeta.</string>
@@ -1625,7 +1625,7 @@
     <string name="passphrase_passphrase_does_not_match">Paroolifraasid ei klappi mitte</string>
     <string name="passphrase_empty_error_message">Palun sisesta paroolifraas</string>
     <string name="passphrase_passphrase_too_weak">Paroolifraas on liiga nõrk</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Kui sa soovid, et ${app_name} looks taastevõtme, siis palun kustuta paroolifraas.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Kui sa soovid, et ${app_name} looks taastevõtme, siis palun kustuta paroolifraas.</string>
     <string name="keys_backup_no_session_error">Matrix\'i sessioone ei leidu</string>
     <string name="keys_backup_setup_step1_title">Ära kunagi kaota krüptitud sõnumeid</string>
     <string name="keys_backup_setup_step1_description">Sõnumid krüptitud jututubades kasutavad läbivat krüptimist. Ainult sinul ja saaja(te)l on võtmed selliste sõnumite lugemiseks.
@@ -1710,7 +1710,7 @@
     <string name="keys_backup_info_title_signature">Allkiri</string>
     <string name="autodiscover_invalid_response">Vigane vastus koduserveri tuvastamise päringule</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Serveriseadistuste automaatne sõnalõpetus</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} tuvastas kohandatud serveriseadistused sinu kasutajanime domeenis „%1$s“:
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} tuvastas kohandatud serveriseadistused sinu kasutajanime domeenis „%1$s“:
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Kasuta seadistusi</string>
     <string name="invalid_or_expired_credentials">Oled kehtetu või aegunud kasutajanime või salasõna tõttu välja logitud.</string>
@@ -1882,7 +1882,7 @@
     <string name="devices_other_devices">Muud sessioonid</string>
     <string name="autocomplete_limited_results">Kuvan vaid esimesi tulemusi, kirjuta natuke pikemalt…</string>
     <string name="settings_developer_mode_fail_fast_title">Kiire lõppmäng</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">Teadmata vigade puhul võib ${app_name} sagedamini kokku joosta</string>
+    <string name="settings_developer_mode_fail_fast_summary">Teadmata vigade puhul võib ${app_name} sagedamini kokku joosta</string>
     <string name="command_description_shrug">Lisa ¯\\_(ツ)_/¯ smaili vormindamata teksti algusesse</string>
     <string name="create_room_encryption_title">Võta jututoas krüptimine kasutusele</string>
     <string name="create_room_encryption_description">Kui krüptimine on juba kasutusele võetud, siis ei saa seda enam eemaldada.</string>
@@ -1958,7 +1958,7 @@
     <string name="disconnect_identity_server_dialog_content">Kas katkestame ühenduse isikutuvastusserveriga %s\?</string>
     <string name="identity_server_error_no_identity_server_configured">Palun esmalt seadista isikutuvastusserver.</string>
     <string name="identity_server_error_terms_not_signed">Palun esmalt nõustu seadistustes isikutuvastusserveri kasutustingimustega.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Sinu privaatsuse nimel saadab ${app_name} e-posti aadressid ja telefoninumbrid serverisse vaid räsituna.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Sinu privaatsuse nimel saadab ${app_name} e-posti aadressid ja telefoninumbrid serverisse vaid räsituna.</string>
     <string name="identity_server_error_binding_error">Seoste loomine ei õnnestunud.</string>
     <string name="identity_server_error_no_current_binding_error">Selle tunnusega ei ole hetkel ühtegi seost.</string>
     <string name="identity_server_set_default_notice">Sinu koduserver (%1$s) soovitab kasutada sinu isikutuvastusserverina %2$s teenust</string>
@@ -2128,7 +2128,7 @@
     <string name="content_reported_as_inappropriate_content">Haldaja sai nüüd teate, et see sisu ei ole sobilik. 
 \n 
 \nKui sa ei soovi enam näha selle kasutaja sisu, siis sa võid tema sõnumite peitmiseks kasutajat eirata.</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">Läbiva krüptograafia jaoks vajalike võtmete salvestamiseks kohalikule andmekandjale vaajab ${app_name} sinu luba.
+    <string name="permissions_rationale_msg_keys_backup_export">Läbiva krüptograafia jaoks vajalike võtmete salvestamiseks kohalikule andmekandjale vaajab ${app_name} sinu luba.
 \n
 \nSelleks et saaksid võtmed käsitsi eksportida, siis palun anna selleks järgmises vaates luba.</string>
     <string name="no_network_indicator">Hetkel puudub võrguühendus</string>
@@ -2165,7 +2165,7 @@
 \n• Sinu koduserveri haldaja on turvakaalutlustel keelanud sinu ligipääsu.</string>
     <string name="signed_out_submit">Logi uuesti sisse</string>
     <string name="soft_logout_title">Sa oled loginud välja</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Praegune sessioon kuulub kasutajale %1$s, kuid sina üritad siseneda kasutaajaga %2$s. Sellist võimalust ${app_name} hetkel ei toeta.
+    <string name="soft_logout_sso_not_same_user_error">Praegune sessioon kuulub kasutajale %1$s, kuid sina üritad siseneda kasutaajaga %2$s. Sellist võimalust ${app_name} hetkel ei toeta.
 \nPalun eemalda kõik andmed ning siis logi sisse muu kontoga.</string>
     <string name="verification_conclusion_compromised">Mõni järgnevatest võib olla sattunud valedesse kätesse:
 \n 
@@ -2204,9 +2204,9 @@
     <string name="room_member_power_level_default_in">Vaikimisi õigused jututoas %1$s</string>
     <string name="room_member_power_level_custom_in">Kohandatud õigused (%1$d) jututoas %2$s</string>
     <string name="room_member_jump_to_read_receipt">Hüppa lugemisteatise juurde</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} ei oska käsitleda %1$s-tüüpi sündmusi</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} ei oska käsitleda %1$s-tüüpi sünumeid</string>
-    <string name="template_rendering_event_error_exception">Tekkis viga, kui ${app_name} üritas töödelda sõnumi %1$s sisu</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} ei oska käsitleda %1$s-tüüpi sündmusi</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} ei oska käsitleda %1$s-tüüpi sünumeid</string>
+    <string name="rendering_event_error_exception">Tekkis viga, kui ${app_name} üritas töödelda sõnumi %1$s sisu</string>
     <string name="call_notification_answer">Võta vastu</string>
     <string name="call_notification_reject">Keeldu</string>
     <string name="call_notification_hangup">Lõpeta kõne</string>
@@ -2246,7 +2246,7 @@
     <string name="event_redacted_by_user_reason_with_reason">Kasutaja kustutas sündmuse, põhjusena %1$s</string>
     <string name="event_redacted_by_admin_reason_with_reason">Jututoa haldur on sündmust modereerinud, põhjusena %1$s</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Krüptovõtmed on juba uuendatud!</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">Päringud võtmete laadimiseks</string>
     <string name="e2e_use_keybackup">Võta krüptitud sõnumite ajalugu lukust lahti</string>
     <string name="refresh">Värskenda</string>
@@ -2304,13 +2304,13 @@
     <string name="error_adding_media_file_to_gallery">Meediafaili galeriisse lisamine ei õnnestunud</string>
     <string name="error_saving_media_file">Meediafaili salvestamine ei õnnestunud</string>
     <string name="change_password_summary">Määra kontole uus salasõna…</string>
-    <string name="template_use_other_session_content_description">Kasuta kõige uuemat ${app_name}\'i versioon mõnes muus seadmes, nagu näiteks ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} Android. Samuti sobib mõni muu Matrix\'i klient, mis oskab risttunnustamist</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="use_other_session_content_description">Kasuta kõige uuemat ${app_name}\'i versioon mõnes muus seadmes, nagu näiteks ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} Android. Samuti sobib mõni muu Matrix\'i klient, mis oskab risttunnustamist</string>
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
     <string name="or_other_mx_capable_client">või mõnda teist Matrix\'i klienti, mis oskab risttunnustamist</string>
-    <string name="template_use_latest_app">Kasuta oma muus seadmes kõige uuemat ${app_name}\'i versiooni:</string>
+    <string name="use_latest_app">Kasuta oma muus seadmes kõige uuemat ${app_name}\'i versiooni:</string>
     <string name="command_description_discard_session">Sunnib loobuma praeguse krüptitud jututoa rühmavestluse seansist</string>
     <string name="command_description_discard_session_not_handled">Funktsionaalsus on toetatud ainult krüptitud jututubades</string>
     <string name="enter_secret_storage_passphrase_or_key">Jätkamiseks kasuta kas oma %1$s või %2$s.</string>
@@ -2351,13 +2351,13 @@
     <string name="delete_account_data_warning">Kas kustutame %1$s tüüpi kasutajakonto andmed\?
 \n
 \nKuna nii mõndagi ootamatut võib juhtuda, siis kasuta seda võimalust mõningase ettevaatusega.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">PIN-kood on nõutav alati, kui sa ${app_name}\'i avad.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">PIN-kood on nõutav, kui sa kahe minuti jooksul pole ${app_name}\'i kasutanud.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">PIN-kood on nõutav alati, kui sa ${app_name}\'i avad.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">PIN-kood on nõutav, kui sa kahe minuti jooksul pole ${app_name}\'i kasutanud.</string>
     <string name="settings_security_pin_code_grace_period_title">Kahe minuti möödumisel küsi uuesti PIN-koodi</string>
     <string name="settings_security_pin_code_notifications_summary_off">Näita vaid napi teavitusena lugemata sõnumite arvu.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Näita täpsemat teavet nagu jututoa nimi ja sõnumi sisu.</string>
     <string name="settings_security_pin_code_notifications_title">Näita teavitustes sisu</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">PIN-kood on ainus võimalus, kuidas sa saad ${app_name}\'i lukust lahti.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">PIN-kood on ainus võimalus, kuidas sa saad ${app_name}\'i lukust lahti.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Kasuta selles seadmes leiduvaid biomeetrilise tuvastuse võimalusi nagu sõrmejälgede lugejat või näotuvastust.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Kasuta biomeetrilist tuvastust</string>
     <string name="settings_security_application_protection_screen_title">Seadista</string>
@@ -2421,8 +2421,8 @@
     <string name="identity_server_consent_dialog_content">Kas selleks, et leida tuttavaid, oled sa nõus saatma oma kontaktteavet (telefoninumbreid ja/või e-posti aadresse) siin rakenduses seadistatud isikutuvastusserverile (%1$s)\?
 \n
 \nParema turvalisuse nimel me ei saada teavet mitte loetava tekstina, vaid räsina.</string>
-    <string name="template_invite_friends_rich_title">🔐️ Liitu minuga vestlusrakenduses ${app_name}</string>
-    <string name="template_invite_friends_text">Hei, palun suhtle minuga vestlusrakenduses ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Liitu minuga vestlusrakenduses ${app_name}</string>
+    <string name="invite_friends_text">Hei, palun suhtle minuga vestlusrakenduses ${app_name}: %s</string>
     <string name="invite_friends">Kutsu sõpru</string>
     <string name="add_people">Lisa inimesi</string>
     <string name="topic_prefix">"Teema: "</string>
@@ -2545,7 +2545,7 @@
     <string name="room_participants_leave_private_warning">See ei ole avalik jututuba. Ilma kutseta sa ei saa uuesti liituda.</string>
     <string name="system_theme">Süsteemi vaikeseadistused</string>
     <string name="authentication_error">Autentimine ei õnnestunud</string>
-    <string name="template_re_authentication_default_confirm_text">Selle tegevuse jaoks palub ${app_name} sul sisestada oma kasutajanime ja salasõna.</string>
+    <string name="re_authentication_default_confirm_text">Selle tegevuse jaoks palub ${app_name} sul sisestada oma kasutajanime ja salasõna.</string>
     <string name="re_authentication_activity_title">Palun korda autentimist</string>
     <string name="failed_to_initialize_cross_signing">Risttunnustamise alustamine ei õnnestunud</string>
     <string name="error_unauthorized">Volitused puuduvad, kasutajakonto ja/või salasõna on valed</string>
@@ -2860,7 +2860,7 @@
     <string name="upgrade_room_for_restricted_no_param">Kõik hõlmava kogukonna liikmed saavad antud jututuba leida ja sellega liituda - sa ei pea kedagi ükshaaval kutsuma. Neid jututoa seadistusi saad igal hetkel muuta.</string>
     <string name="upgrade_room_for_restricted">Kõik %s jututoa liikmed saavad antud jututuba leida ja sellega liituda - sa ei pea kedagi ükshaaval kutsuma. Neid jututoa seadistusi saad igal hetkel muuta.</string>
     <string name="call_tap_to_return">%1$s - tagasipöördumiseks klõpsi</string>
-    <string name="template_link_this_email_with_your_account">%s ja saa kutsed otse ${app_name}\'i.</string>
+    <string name="link_this_email_with_your_account">%s ja saa kutsed otse ${app_name}\'i.</string>
     <string name="link_this_email_settings_link">Seo see e-posti aadress oma kasutajakontoga</string>
     <string name="this_invite_to_this_space_was_sent">See kutse siia kogukonnakeskusesse saadeti aadressile %s, mis ei ole seotud sinu kontoga</string>
     <string name="this_invite_to_this_room_was_sent">See kutse siia jututuppa saadeti aadressile %s, mis ei ole seotud sinu kontoga</string>
@@ -3021,7 +3021,7 @@
     </plurals>
     <string name="preference_system_settings">Süsteemiseadistused</string>
     <string name="preference_versions">Versioonid</string>
-    <string name="template_preference_help_summary">${app_name}\'i kasutamiseks vajalik abiteave</string>
+    <string name="preference_help_summary">${app_name}\'i kasutamiseks vajalik abiteave</string>
     <string name="preference_help_title">Abiteave ja kasutajatugi</string>
     <string name="preference_help">Abiteave</string>
     <string name="preference_root_legals">Juriidiline teave</string>
@@ -3029,15 +3029,15 @@
     <string name="legals_identity_server_title">Sinu isikutuvastusserveri kasutustingimused</string>
     <string name="legals_third_party_notices">Kolmandate osapoolte litsentsid</string>
     <string name="legals_home_server_title">Sinu koduserveri kasutustingimused</string>
-    <string name="template_legals_application_title">${app_name} kasutustingimused</string>
+    <string name="legals_application_title">${app_name} kasutustingimused</string>
     <string name="analytics_opt_in_list_item_3">Seadistustest saad alati määrata, et see funktsionaalsus pole kasutusel</string>
     <string name="analytics_opt_in_list_item_2">Meie <b>ei</b> jaga teavet kolmandate osapooltega</string>
     <string name="analytics_opt_in_list_item_1">Meie <b>ei</b> salvesta ega profileeri sinu kasutajakonto andmeid</string>
     <string name="analytics_opt_in_content_link">siit</string>
-    <string name="template_analytics_opt_in_content">Võimalike vigade leidmiseks ja ${app_name}\'i arendamiseks jaga meiega anonüümseid andmeid. Selleks, et mõistaksime, kuidas kasutajad erinevaid seadmeid pruugivad me loome sinu seadmetele ühise juhusliku tunnuse.
+    <string name="analytics_opt_in_content">Võimalike vigade leidmiseks ja ${app_name}\'i arendamiseks jaga meiega anonüümseid andmeid. Selleks, et mõistaksime, kuidas kasutajad erinevaid seadmeid pruugivad me loome sinu seadmetele ühise juhusliku tunnuse.
 \n
 \nMeie kasutustingimused leiad siit - %s.</string>
-    <string name="template_analytics_opt_in_title">Aita ${app_name}\'i arendamisel</string>
+    <string name="analytics_opt_in_title">Aita ${app_name}\'i arendamisel</string>
     <string name="action_enable">Võta kasutusele</string>
     <string name="restart_the_application_to_apply_changes">Muudatuste jõustamiseks käivita rakendus uuesti.</string>
     <string name="labs_enable_latex_maths">Kasuta LaTeX-vorminduses matemaatika märgistust</string>
@@ -3061,8 +3061,8 @@
     <string name="settings_enable_location_sharing_summary">Kui see seadistus on kasutusel, siis sa saad oma asukohta jagada igas jututoas</string>
     <string name="settings_enable_location_sharing">Luba asukohta jagada</string>
     <string name="location_share_external">Ava muu rakendusega</string>
-    <string name="template_location_not_available_dialog_content">${app_name} ei saanud asukohta tuvastada. Palun proovi hiljem uuesti.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} ei saanud asukohta tuvastada</string>
+    <string name="location_not_available_dialog_content">${app_name} ei saanud asukohta tuvastada. Palun proovi hiljem uuesti.</string>
+    <string name="location_not_available_dialog_title">${app_name} ei saanud asukohta tuvastada</string>
     <string name="location_share">Jaga asukohta</string>
     <string name="a11y_location_share_icon">Jaga asukohta</string>
     <string name="location_activity_title_preview">Asukoht</string>

--- a/vector/src/main/res/values-eu/strings.xml
+++ b/vector/src/main/res/values-eu/strings.xml
@@ -205,7 +205,7 @@
     <string name="local_address_book_header">Gailuko helbide liburua</string>
     <string name="matrix_only_filter">Matrixeko kontaktuak besterik ez</string>
     <string name="no_conversation_placeholder">Elkarrizketarik ez</string>
-    <string name="template_no_contact_access_placeholder">Ez diozu baimena eman Element aplikazioari zure gailuko kontaktuak atzitzeko</string>
+    <string name="no_contact_access_placeholder">Ez diozu baimena eman Element aplikazioari zure gailuko kontaktuak atzitzeko</string>
     <string name="no_result_placeholder">Emaitzarik ez</string>
 
     <string name="rooms_header">Gelak</string>
@@ -349,15 +349,15 @@ E-mail helbide bat gehitu dezakezu zure profilaren ezarpenetan.</string>
     <string name="media_picker_cannot_record_video">Ezin izan da bideoa grabatu</string>
 
     <string name="permissions_rationale_popup_title">Informazioa</string>
-    <string name="template_permissions_rationale_msg_camera">Elementek zure kamera atzitzeko baimena behar du argazkiak eta bideoak atera ahal izateko.</string>
+    <string name="permissions_rationale_msg_camera">Elementek zure kamera atzitzeko baimena behar du argazkiak eta bideoak atera ahal izateko.</string>
     <string name="permissions_rationale_msg_camera_explanation">
 
 Baimendu sarbidea hurrengo laster-leihoan deia egin ahal izateko.</string>
-    <string name="template_permissions_rationale_msg_record_audio">Elementek zure mikrofonoa atzitzeko baimena behar du ahots deiak egin ahal izateko.</string>
+    <string name="permissions_rationale_msg_record_audio">Elementek zure mikrofonoa atzitzeko baimena behar du ahots deiak egin ahal izateko.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">
 
 Baimendu sarbidea hurrengo laster-leihoan deia egin ahal izateko.</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">Elementek zure kamera eta mikrofonoa atzitzeko baimenak behar ditu bideo deiak egin ahal izateko.
+    <string name="permissions_rationale_msg_camera_and_audio">Elementek zure kamera eta mikrofonoa atzitzeko baimenak behar ditu bideo deiak egin ahal izateko.
 
 Baimendu sarbidea hurrengo laster-leihoan deia egin ahal izateko.</string>
     <string name="permissions_action_not_performed_missing_permissions">Ez da ekintza burutu baimenak falta direlako</string>
@@ -377,11 +377,11 @@ Baimendu sarbidea hurrengo laster-leihoan deia egin ahal izateko.</string>
 
     <string name="room_preview_invitation_format">%s erabiltzaileak gela honetara elkartzera gonbidatu zaitu</string>
 
-    <string name="template_permissions_rationale_msg_storage">${app_name}ek zure argazki eta bideoen liburutegia atzitzeko baimena behar du eranskinak gorde ahal izateko.
+    <string name="permissions_rationale_msg_storage">${app_name}ek zure argazki eta bideoen liburutegia atzitzeko baimena behar du eranskinak gorde ahal izateko.
 
 Baimendu sarbidea hurrengo laster-leihoan zure telefonotik fitxategiak bidali ahal izateko.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name}-ek zure helbide-liburua egiaztatu dezake Matrix erabiltzaileak bere e-mail helbide edo telefono zenbakiaren bidez aurkitzeko. Honetarako zure helbide-liburua partekatzea onartzen baduzu, sakatu onartu hurrengo laster-leihoan.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name}-ek zure helbide-liburua egiaztatu dezake Matrix erabiltzaileak bere e-mail helbide edo telefono zenbakiaren bidez aurkitzeko.
+    <string name="permissions_rationale_msg_contacts">${app_name}-ek zure helbide-liburua egiaztatu dezake Matrix erabiltzaileak bere e-mail helbide edo telefono zenbakiaren bidez aurkitzeko. Honetarako zure helbide-liburua partekatzea onartzen baduzu, sakatu onartu hurrengo laster-leihoan.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name}-ek zure helbide-liburua egiaztatu dezake Matrix erabiltzaileak bere e-mail helbide edo telefono zenbakiaren bidez aurkitzeko.
 \n
 \nHonetarako zure helbide-liburua partekatzea onartzen duzu\?</string>
 
@@ -941,7 +941,7 @@ Abisua: Fitxategi hau ezabatu daiteke aplikazioa desinstalatzen bada.</string>
     <string name="settings_notification_privacy_message_content_not_shown">• Jakinarazpenek <b>ez dute mezuaren edukia erakutsiko</b></string>
 
     <string name="startup_notification_privacy_title">Jakinarazpenen pribatutasuna</string>
-    <string name="template_startup_notification_privacy_message">${app_name} bigarren planoan aritu daiteke zure jakinarazpenak modu seguru eta pribatuan kudeatzeko. Honek baterian eragina izan lezake.</string>
+    <string name="startup_notification_privacy_message">${app_name} bigarren planoan aritu daiteke zure jakinarazpenak modu seguru eta pribatuan kudeatzeko. Honek baterian eragina izan lezake.</string>
     <string name="startup_notification_privacy_button_grant">Eman baimena</string>
     <string name="startup_notification_privacy_button_other">Aukeratu beste zerbait</string>
 
@@ -956,8 +956,8 @@ Baten bat gehitu orain?</string>
     <string name="settings_deactivate_my_account">Desaktibatu nire kontua</string>
 
     <string name="settings_opt_in_of_analytics">Bidali analitiketarako datuak</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name}ek analitika anonimoak biltzen ditu aplikazioa hobetzeko.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Gaitu analitikak ${app_name} hobetzera laguntzeko.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name}ek analitika anonimoak biltzen ditu aplikazioa hobetzeko.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Gaitu analitikak ${app_name} hobetzera laguntzeko.</string>
     <string name="settings_opt_in_of_analytics_ok">Bai, lagundu nahi dut!</string>
 
     <string name="widget_integration_missing_parameter">Behar den parametro bat falta da.</string>
@@ -985,7 +985,7 @@ Matrix-eko mezuen ikusgaitasuna e-mail sistemaren antekoa da. Guk zure mezuak ah
     <string name="e2e_re_request_encryption_key_sent">Gako eskaria bidalita.</string>
 
     <string name="e2e_re_request_encryption_key_dialog_title">Eskaria bidalita</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Abiatu ${app_name} beste mezua deszifratu dezakeen gailu batean, saio honetara gakoak bidali ditzan.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Abiatu ${app_name} beste mezua deszifratu dezakeen gailu batean, saio honetara gakoak bidali ditzan.</string>
 
     <string name="lock_screen_hint">Idatzi hemen…</string>
 
@@ -1106,7 +1106,7 @@ Matrix-eko mezuen ikusgaitasuna e-mail sistemaren antekoa da. Guk zure mezuak ah
 
     <string name="call_anyway">Deitu hala ere</string>
     <string name="settings_call_category">Deiak</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Erabili ${app_name}en lehenetsitako dei-doinua jasotako deientzat</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Erabili ${app_name}en lehenetsitako dei-doinua jasotako deientzat</string>
     <string name="settings_call_ringtone_title">Jasotako deien doinua</string>
     <string name="settings_call_ringtone_dialog_title">Hautatu deientzako doinua:</string>
 
@@ -1158,12 +1158,12 @@ Egiaztatu zure kontuaren ezarpenak.</string>
 
     <string name="settings_troubleshoot_test_device_settings_title">SAioaren ezarpenak.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Jakinarazpenak aktibatuta daude saio honentzat.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Jakinarazpenak ez daude aktibatuta saio honentzat. Egiaztatu ${app_name} ezarpenak.</string>
+    <string name="settings_troubleshoot_test_device_settings_failed">Jakinarazpenak ez daude aktibatuta saio honentzat. Egiaztatu ${app_name} ezarpenak.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Aktibatu</string>
 
     <string name="settings_troubleshoot_test_play_services_title">Play Services egiaztaketa</string>
     <string name="settings_troubleshoot_test_play_services_success">Google Play Services APK eskuragarri eta egunean dago.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name}-ek Google Play Services erabiltzen du baina antza ez dago ondo konfiguratuta:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name}-ek Google Play Services erabiltzen du baina antza ez dago ondo konfiguratuta:
 %1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Konpondu Play Services</string>
 
@@ -1184,19 +1184,19 @@ Egiaztatu zure kontuaren ezarpenak.</string>
 
     <string name="settings_troubleshoot_test_service_boot_title">Hasi abioan</string>
     <string name="settings_troubleshoot_test_service_boot_success">Zerbitzua gailua berrabiaraztean hasiko da.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Zerbitzua ez da hasiko gailua berrabiaraztean, ez duzu jakinarazpenik jasoko ${app_name} behin ireki arte.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Zerbitzua ez da hasiko gailua berrabiaraztean, ez duzu jakinarazpenik jasoko ${app_name} behin ireki arte.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Gaitu abioan hastea</string>
 
     <string name="settings_troubleshoot_test_bg_restricted_title">Egiaztatu bigarren planoko murrizketak</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Bigarren planoko murrizketak desaktibatuta daude ${app_name}-entzat. Proba hau datu mugikorrekin egin behar da (Ez WiFi).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Bigarren planoko murrizketak desaktibatuta daude ${app_name}-entzat. Proba hau datu mugikorrekin egin behar da (Ez WiFi).
 %1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Bigarren planoko murrizketak aktibatuta daude ${app_name}-entzat.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Bigarren planoko murrizketak aktibatuta daude ${app_name}-entzat.
 Aplikazioa egiten saiatzen ari dena agresiboki murriztuko zaio bigarren planoan dagoenean, eta honek jakinarazpenetan eragina izan dezake.
 %1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Desaktibatu murrizketak</string>
 
     <string name="settings_troubleshoot_test_battery_title">Bateria optimizazioa</string>
-    <string name="template_settings_troubleshoot_test_battery_success">Bateria optimizazioak ez du eraginik ${app_name}-engan.</string>
+    <string name="settings_troubleshoot_test_battery_success">Bateria optimizazioak ez du eraginik ${app_name}-engan.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ezikusi optimizazioa</string>
 
     <string name="startup_notification_fdroid_battery_optim_title">Bigaren planoko konexioa</string>
@@ -1210,7 +1210,7 @@ Aplikazioa egiten saiatzen ari dena agresiboki murriztuko zaio bigarren planoan 
     <string name="no_valid_google_play_services_apk">Ez da baliozko Google Play Services APK-rik aurkitu. Jakinarazpenak agian ez dira ongi ibiliko.</string>
 
     <string name="settings_troubleshoot_test_battery_failed">Erabiltzaile batek gailu bat deskonektatuta eta erabili gabe uzten badu denbora batez, pantaila itzalita duela, gailua kuluxka moduan sartzen da. Honek aplikazioak sarera konektatzea eragozten du eta beraien lanak atzeratzen ditu, baita ohiko alarmak.</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name}-ek bigarren planoko konexio arin bat behar du jakinarazpen fidagarriak izateko.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name}-ek bigarren planoko konexio arin bat behar du jakinarazpen fidagarriak izateko.
 Hurrengo pantailan ${app_name}-i bigarren planoan aritzeko baimena eskatuko zaizu, onartu ezazu mesedez.</string>
 
     <string name="video_call_in_progress">Bide-deia abioan…</string>
@@ -1243,7 +1243,7 @@ Hurrengo pantailan ${app_name}-i bigarren planoan aritzeko baimena eskatuko zaiz
     <string name="passphrase_empty_error_message">Idatzi pasaesaldia</string>
     <string name="passphrase_passphrase_too_weak">Pasaesaldia ahulegia da</string>
 
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Ezabatu pasaesaldia ${app_name} aplikazioak berreskuratze gako bat sortu dezan nahi baduzu.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Ezabatu pasaesaldia ${app_name} aplikazioak berreskuratze gako bat sortu dezan nahi baduzu.</string>
     <string name="keys_backup_no_session_error">Ez dago Matrix saiorik eskuragarri</string>
 
     <string name="keys_backup_setup_step1_title">Ez galdu inoiz zifratutako mezuak</string>
@@ -1283,11 +1283,11 @@ Hurrengo pantailan ${app_name}-i bigarren planoan aritzeko baimena eskatuko zaiz
     <string name="settings_troubleshoot_test_bing_settings_success_with_warn">Kontuan izan mezu mota batzuk isilak izateko ezarri direla (soinurik gabeko jakinarazpena sortuko dute).</string>
     <string name="settings_troubleshoot_test_bing_settings_failed">Jakinarazpen batzuk desgaituta daude zure ezarpen pertsonaletan.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">Hutsegitea arau pertsonalak kargatzean, saiatu berriro.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 Errore hau ${app_name}-en kontroletik kanpo dago eta Google-en arabera, errore honek esan nahi du gailuko aplikazio gehiegik erabiltzen dutela FCM. Errore hau ezohiko aplikazio kopuru bat dagoenean gertatzen da, ez lioke erabiltzaile arrunt bati eragingo.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">"[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">"[%1$s]
 Errore hau ${app_name}-en kontroletik kanpo dago. Hainbat arrazoiengatik gerta daiteke eta geroago berriro saiatzen bazara agian badabil,  egiaztatu ere Google Play Service-ek ez duela datuen erabilera mugatua sistemaren ezarpenetan, edo zure gailuaren ordua ondo ezarrita dagoela, ROM pertsonalizatuekin gertatu daiteke ere."</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 Errore hau ${app_name}-en kontroletik kanpo dago. Ez dago Google konturik gailuan. Ireki kontuen kudeatzailea eta gehitu Google kontu bat.</string>
     <string name="keys_backup_setup_step1_description">Zifratutako geletako mezuak muturretik muturrera zifratuta daude. Hartzaileak/ek eta zuk eta ez beste inork irakurri ditzakezue mezuok.
 \n
@@ -1421,7 +1421,7 @@ Abisua: Fitxategi hau ezabatu daiteke aplikazioa desinstalatzen bada.</string>
 
     <string name="autodiscover_invalid_response">Baliogabeko hasiera-zerbitzari deskubritze erantzuna</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Automatikoki osatu zerbitzariaren aukerak</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">"${app_name}-ek pertsonalizatutako zerbitzari konfigurazio bat antzeman du zure erabiltzaile id-arentzat \"%1$s\" domeinuan:
+    <string name="autodiscover_well_known_autofill_dialog_message">"${app_name}-ek pertsonalizatutako zerbitzari konfigurazio bat antzeman du zure erabiltzaile id-arentzat \"%1$s\" domeinuan:
 \n%2$s"</string>
     <string name="autodiscover_well_known_autofill_confirm">Erabili konfigurazioa</string>
 
@@ -1553,7 +1553,7 @@ Abisua: Fitxategi hau ezabatu daiteke aplikazioa desinstalatzen bada.</string>
     <string name="group_all_communities">Komunitate guztiak</string>
 
     <string name="room_preview_no_preview">Gela hau ezin da aurreikusi</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Munduak irakurtzeko moduko gelaren aurrebista ez da oraindik onartzen ${app_name} bezeroan</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Munduak irakurtzeko moduko gelaren aurrebista ez da oraindik onartzen ${app_name} bezeroan</string>
 
     <string name="fab_menu_create_room">Gelak</string>
     <string name="fab_menu_create_chat">Mezu zuzenak</string>
@@ -1673,10 +1673,10 @@ Abisua: Fitxategi hau ezabatu daiteke aplikazioa desinstalatzen bada.</string>
     <string name="invite_no_identity_server_error">Gehitu identitate-zerbitzari bat zure ezarpenetan ekintza hau burutzeko.</string>
     <string name="settings_background_fdroid_sync_mode">Bigarren planoko sinkronizazio modua (Esperimentala)</string>
     <string name="settings_background_fdroid_sync_mode_battery">Bateria erabilerarako optimizatua</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} bigarren planoan sinkronizatuko da gailuaren baliabide mugatuen erabilera ahal beste murriztuz (bateria).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} bigarren planoan sinkronizatuko da gailuaren baliabide mugatuen erabilera ahal beste murriztuz (bateria).
 \nZure gailuaren baliabideen egoeraren arabera, sistema eragileak sinkronizazioa atzeratu dezake.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Denbora errealerako optimizatua</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} bigarren planoan sinkronizatuko da maiztasun finkoarekin (konfiguragarria).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} bigarren planoan sinkronizatuko da maiztasun finkoarekin (konfiguragarria).
 \nHonek irrati eta bateriaren erabileran eragina izango du, eta ${app_name} gertaerei adi dagoela dion jakinarazpen bat bistaratuko da etengabe.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Ez sinkronizatu bigarren planoan</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Ez zaizu jasotako mezuei buruz jakinaraziko aplikazioa bigarren planoan dagoenean.</string>
@@ -1789,14 +1789,14 @@ Abisua: Fitxategi hau ezabatu daiteke aplikazioa desinstalatzen bada.</string>
 \n
 \nEz baduzu erabiltzaile honen eduki gehiago ikusi nahi, bere mezuak ezkutatzeko blokeatu dezakezu</string>
 
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name}-ek zure E2E gakoak diskoan gordetzeko baimena behar du.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name}-ek zure E2E gakoak diskoan gordetzeko baimena behar du.
 \n
 \nBaimendu sarbidea hurrengo laster-leihoan zure gakoak eskuz esportatu ahal izateko.</string>
 
     <string name="no_network_indicator">Ez dago sare konexiorik orain</string>
 
     <string name="settings_add_3pid_confirm_password_title">Berretsi zure pasahitza</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Ezin duzu hau egin mugikorrerako ${app_name} erabiliz</string>
+    <string name="settings_add_3pid_flow_not_supported">Ezin duzu hau egin mugikorrerako ${app_name} erabiliz</string>
     <string name="settings_add_3pid_authentication_needed">Autentifikazioa behar da</string>
 
 
@@ -1999,7 +1999,7 @@ Abisua: Fitxategi hau ezabatu daiteke aplikazioa desinstalatzen bada.</string>
 \nHasi saioa berriro zure kontuaren datuak eta mezuak atzitzeko.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Zure mezu zifratuetara sarbidea galduko duzu ez baduzu saioa hasten zifratze gakoak berreskuratzeko.</string>
     <string name="soft_logout_clear_data_dialog_submit">Garbitu datuak</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Oraingo saioa %1$s erabiltzailearena da eta %2$s erabiltzailearen kredentzialak eman dituzu. ${app_name}-k ez du hau onartzen.
+    <string name="soft_logout_sso_not_same_user_error">Oraingo saioa %1$s erabiltzailearena da eta %2$s erabiltzailearen kredentzialak eman dituzu. ${app_name}-k ez du hau onartzen.
 \nAurretik garbitu datuak, gero hasi saioa berriro beste kontu batekin.</string>
 
     <string name="permalink_malformed">Zure matrix.to esteka gaizki osatua dago</string>
@@ -2022,7 +2022,7 @@ Abisua: Fitxategi hau ezabatu daiteke aplikazioa desinstalatzen bada.</string>
     <string name="autocomplete_limited_results">Soilik lehen emaitzak erakusten, idatzi letra gehiago…</string>
 
     <string name="settings_developer_mode_fail_fast_title">Hutsegin-azkar</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} aplikazioa ustekabeko erroreen aurrean maizago kraskatu daiteke</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} aplikazioa ustekabeko erroreen aurrean maizago kraskatu daiteke</string>
     <string name="command_description_shrug">"Jarri ¯\\_(ツ)_/¯  testu-soileko mezuaren aurretik"</string>
 
     <string name="create_room_encryption_title">Gaitu zifratzea</string>
@@ -2111,9 +2111,9 @@ Abisua: Fitxategi hau ezabatu daiteke aplikazioa desinstalatzen bada.</string>
 
     <string name="room_member_jump_to_read_receipt">Saltatu irakurragirira</string>
 
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} aplikazioak ez ditu \'%1$s\' motako gertaerak kudeatzen</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} aplikazioak ez ditu \'%1$s\' motako mezuak kudeatzen</string>
-    <string name="template_rendering_event_error_exception">${app_name} aplikazioak arazo bat izan du \'%1$s\' id-a duen edukia erakusteko</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} aplikazioak ez ditu \'%1$s\' motako gertaerak kudeatzen</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} aplikazioak ez ditu \'%1$s\' motako mezuak kudeatzen</string>
+    <string name="rendering_event_error_exception">${app_name} aplikazioak arazo bat izan du \'%1$s\' id-a duen edukia erakusteko</string>
 
     <string name="unignore">Utzi ezikusteari</string>
 
@@ -2234,7 +2234,7 @@ Abisua: Fitxategi hau ezabatu daiteke aplikazioa desinstalatzen bada.</string>
 
     <string name="keys_backup_restore_success_title_already_up_to_date">Gakoak egunean daude jada!</string>
 
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
 
     <string name="settings_key_requests">Gako eskaerak</string>
 
@@ -2376,13 +2376,13 @@ Abisua: Fitxategi hau ezabatu daiteke aplikazioa desinstalatzen bada.</string>
     <string name="notification_ticker_text_dm">%1$s: %2$s</string>
     <string name="notification_ticker_text_group">%1$s: %2$s %3$s</string>
 
-    <string name="template_use_other_session_content_description">Erabili azken ${app_name} bertsioa zure beste gailuetan, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} Android plataformarako, edo zeharka sinatzeko gaitasuna duen beste Matrix bezero bat</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="use_other_session_content_description">Erabili azken ${app_name} bertsioa zure beste gailuetan, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} Android plataformarako, edo zeharka sinatzeko gaitasuna duen beste Matrix bezero bat</string>
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
     <string name="or_other_mx_capable_client">edo zeharka sinatzeko gaitasuna duen beste Matrix bezero bat</string>
-    <string name="template_use_latest_app">Erabili azken ${app_name} bertsioa zure beste gailuetan:</string>
+    <string name="use_latest_app">Erabili azken ${app_name} bertsioa zure beste gailuetan:</string>
     <string name="command_description_discard_session">Uneko irteerako talde saioa zifratutako gela batean baztertzera behartzen du</string>
     <string name="command_description_discard_session_not_handled">Zifratutako gelatan onartzen da soilik</string>
     <string name="enter_secret_storage_passphrase_or_key">Erabili zure %1$s edo %2$s jarraitzeko.</string>
@@ -2452,11 +2452,11 @@ Abisua: Fitxategi hau ezabatu daiteke aplikazioa desinstalatzen bada.</string>
 
     <string name="open_terms_of">Ireki %s zerbitzariko baldintzak</string>
     <string name="disconnect_identity_server_dialog_content">Deskonektatu %s identitate zerbitzaritik\?</string>
-    <string name="template_identity_server_error_outdated_identity_server">Identitate zerbitzaria zaharkituta dago. ${app_name}-k API V2 besterik ez du onartzen.</string>
+    <string name="identity_server_error_outdated_identity_server">Identitate zerbitzaria zaharkituta dago. ${app_name}-k API V2 besterik ez du onartzen.</string>
     <string name="identity_server_error_outdated_home_server">Ezin da eragiketa hau burutu. Hasiera-zerbitzaria zaharkituta dago.</string>
     <string name="identity_server_error_no_identity_server_configured">Konfiguratu identitate-zerbitzari bat aurretik.</string>
     <string name="identity_server_error_terms_not_signed">Onartu identitate-zerbitzariaren baldintzak aurretik zerbitzariaren ezarpenetan.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Zure pribatutasuna babesteko, ${app_name}-k erabiltzaileeen e-mail eta telefonoak hasheatuta bidaltzen ditu.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Zure pribatutasuna babesteko, ${app_name}-k erabiltzaileeen e-mail eta telefonoak hasheatuta bidaltzen ditu.</string>
     <string name="identity_server_error_binding_error">Asoziazioak huts egin du.</string>
     <string name="identity_server_error_no_current_binding_error">Ez dago asoziaziorik identifikatzaile honekin.</string>
 

--- a/vector/src/main/res/values-fa/strings.xml
+++ b/vector/src/main/res/values-fa/strings.xml
@@ -347,7 +347,7 @@
     <string name="local_address_book_header">دفترچه نشانی محلّی</string>
     <string name="user_directory_header">فهرست کاربران</string>
     <string name="matrix_only_filter">فقط آشنایان ماتریکس</string>
-    <string name="template_no_contact_access_placeholder">اجازهٔ دسترسی به آشنایان محلّیتان را به ${app_name} نداده‌اید</string>
+    <string name="no_contact_access_placeholder">اجازهٔ دسترسی به آشنایان محلّیتان را به ${app_name} نداده‌اید</string>
     <string name="no_result_placeholder">نتیجه‌ای نیست</string>
     <string name="rooms_directory_header">فهرست اتاق‌ها</string>
     <string name="no_room_placeholder">اتاقی نیست</string>
@@ -502,7 +502,7 @@
     <string name="e2e_re_request_encryption_key"><u>بازدرخواست کلیدهای رمزنگاری</u> از دیگر نشست‌هایتان.</string>
     <string name="e2e_re_request_encryption_key_sent">درخواست کلید ارسال شد.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">درخواست ارسال شد</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">لطفاً المنت را روی افزاره‌ای دیگر که می‌تواند پیام را رمزگشایی کند، اجرا کنید تا بتواند کلیدها را به این نشست بفرستد.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">لطفاً المنت را روی افزاره‌ای دیگر که می‌تواند پیام را رمزگشایی کند، اجرا کنید تا بتواند کلیدها را به این نشست بفرستد.</string>
     <string name="read_receipts_list">فهرست رسیدهای خواندن</string>
     <string name="keys_backup_setup_skip_title">آیا مطمئن هستید؟</string>
     <string name="action_disconnect">قطع اتصال</string>
@@ -541,7 +541,7 @@
     <string name="settings_app_info_link_title">اطّلاعات برنامه</string>
     <string name="settings_app_info_link_summary">نمایش اطّلاعات برنامه در تنظیمات سامانه.</string>
     <string name="settings_add_3pid_confirm_password_title">تأیید گذرواژه‌تان</string>
-    <string name="template_settings_add_3pid_flow_not_supported">نمی‌توانید با المنت همراه، این کار را بکنید</string>
+    <string name="settings_add_3pid_flow_not_supported">نمی‌توانید با المنت همراه، این کار را بکنید</string>
     <string name="settings_add_3pid_authentication_needed">نیاز به تأیید هویت است</string>
     <string name="settings_notification_advanced">تنظمیات پیش‌رفتهٔ آگاهی</string>
     <string name="settings_notification_troubleshoot">آگاهی‌های رفع‌اشکال</string>
@@ -552,7 +552,7 @@
     <string name="settings_troubleshoot_test_account_settings_failed">آگاهی‌ها برای حسابتان از کار افتاده‌اند.
 \nلطفاً تتظیمات حساب را بررسی کنید.</string>
     <string name="settings_troubleshoot_test_device_settings_success">آگاهی‌ها برای این نشست به کار افتاده‌اند.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">آگاهی‌ها برای این نشست به کار نیفتاده‌اند.
+    <string name="settings_troubleshoot_test_device_settings_failed">آگاهی‌ها برای این نشست به کار نیفتاده‌اند.
 \nلطفاً تنظیمات المنت را بررسی کنید.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed">برخی آگاهی‌ها در تنظیمات سفارشیتان از کار افتاده‌اند.</string>
     <string name="settings_troubleshoot_test_service_restart_title">شروع دوبارهٔ خودکار خدمت آگاهی</string>
@@ -683,7 +683,7 @@
     <string name="please_wait">لطفاً شکیبایی کنید…</string>
     <string name="group_all_communities">تمام اجتماع‌ها</string>
     <string name="room_preview_no_preview">این اتاق نمی‌تواند پیش‌نمایش یابد</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">پیش‌نمایش اتاق‌های قابل خواندن به صورت عمومی هنوز در ریوت‌اکس پشتیبانی نمی‌شود</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">پیش‌نمایش اتاق‌های قابل خواندن به صورت عمومی هنوز در ریوت‌اکس پشتیبانی نمی‌شود</string>
     <string name="fab_menu_create_room">اتاق‌ها</string>
     <string name="fab_menu_create_chat">پیام‌های مستقیم</string>
     <string name="create_room_title">اتاق جدید</string>
@@ -787,13 +787,13 @@
     <string name="login_error_not_json">شامل یک JSON معتبر نبود</string>
     <string name="login_error_limit_exceeded">درخواست‌های بیش از حد ارسال شده</string>
     <string name="login_error_login_email_not_yet">هنوز روی پیوند ایمیل کلیک نشده</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">استفاده از صدای زنگ پیش‌گزیدهٔ المنت برای تماس‌های ورودی</string>
+    <string name="settings_call_ringtone_use_app_ringtone">استفاده از صدای زنگ پیش‌گزیدهٔ المنت برای تماس‌های ورودی</string>
     <string name="settings_call_ringtone_title">صدای زنگ تماس ورودی</string>
     <string name="settings_call_ringtone_dialog_title">گزینش صدای زنگ برای تماس‌ها:</string>
     <string name="media_picker_both_capture_title">یک عکس یا ویدیو بگیر</string>
     <string name="media_picker_cannot_record_video">نمی‌توان ویدیو ظبط کرد</string>
     <string name="permissions_rationale_popup_title">اطلاعات</string>
-    <string name="template_permissions_rationale_msg_camera">المنت برای گرفتن عکس و تماس‌های ویدیویی نیاز به اجازه دارد.</string>
+    <string name="permissions_rationale_msg_camera">المنت برای گرفتن عکس و تماس‌های ویدیویی نیاز به اجازه دارد.</string>
     <string name="open_chat_header">گشودن سرایند</string>
     <string name="room_sync_in_progress">در حال هم‌گام‌سازی…</string>
     <string name="room_jump_to_first_unread">پرش به ناخوانده</string>
@@ -860,7 +860,7 @@
     <string name="call_notification_answer">پذیرش</string>
     <string name="call_notification_reject">رد</string>
     <string name="call_notification_hangup">قطع</string>
-    <string name="template_call_failed_no_connection">تماس المنت شکست خورد</string>
+    <string name="call_failed_no_connection">تماس المنت شکست خورد</string>
     <string name="call_select_sound_device">گزینش افزارهٔ صوتی</string>
     <string name="sound_device_phone">تلفن</string>
     <string name="sound_device_speaker">بلندگو</string>
@@ -961,14 +961,14 @@
     <string name="settings_troubleshoot_test_service_boot_success">خدمت هنگام شروع دوبارهٔ افزاره، شروع خواهد شد.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">به کار اندازی شروع هنگام راه‌اندازی</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">بررسی محدودیت‌های پس‌زمینه</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">محدودیت‌های پس‌زمینه برای المنت از کار افتاده‌اند. این آزمون باید با استفاده از دادهٔ همراه (بدون وای‌فای) اجرا شود.
+    <string name="settings_troubleshoot_test_bg_restricted_success">محدودیت‌های پس‌زمینه برای المنت از کار افتاده‌اند. این آزمون باید با استفاده از دادهٔ همراه (بدون وای‌فای) اجرا شود.
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">محدودیت‌های پس‌زمینه برای النت به کار افتاده‌اند.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">محدودیت‌های پس‌زمینه برای النت به کار افتاده‌اند.
 \nکارهایی که کاره می‌خواهد انجام دهد، هنگامی که در پس‌زمینه است به صورت تهاجمی محدود می‌شوند که می‌تواند روی آگاهی‌ها تأثیر بگذارد.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">از کار انداختن محدودیت‌ها</string>
     <string name="settings_troubleshoot_test_battery_title">بهینه‌سازی باتری</string>
-    <string name="template_settings_troubleshoot_test_battery_success">المنت تحت تأثیر بهینه‌سازی باتری نیست.</string>
+    <string name="settings_troubleshoot_test_battery_success">المنت تحت تأثیر بهینه‌سازی باتری نیست.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">نادیده‌گرفتن بهینه‌سازی</string>
     <string name="settings_notification_privacy_normal">عادی</string>
     <string name="settings_notification_privacy_reduced">محرمانگی کاهش‌یافته</string>
@@ -1336,7 +1336,7 @@
     <string name="devices_current_device">نشست جاری</string>
     <string name="autocomplete_limited_results">فقط نمایش نخستین نتایج. حرف‌های بیش‌تری بنویسید…</string>
     <string name="settings_developer_mode_fail_fast_title">شکست سریع</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">المنت ممکن است هنگام رخ دادن خطای نامنتظره،‌بیش‌تر فروبپاشد</string>
+    <string name="settings_developer_mode_fail_fast_summary">المنت ممکن است هنگام رخ دادن خطای نامنتظره،‌بیش‌تر فروبپاشد</string>
     <string name="create_room_encryption_title">به کار انداختن رمزنگاری</string>
     <string name="create_room_encryption_description">پس از به کار افتادن، رمزنگاری قابل از کار انداختن نیست.</string>
     <string name="verification_conclusion_warning">ورود نامطمئن</string>
@@ -1442,7 +1442,7 @@
     </plurals>
     <string name="delete_event_dialog_title">تأیید برداشت</string>
     <string name="delete_event_dialog_reason_checkbox">آوردن دلیل</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">درخواست‌های کلید</string>
     <string name="e2e_use_keybackup">قفل‌گشایی از تاریخچهٔ پیام‌های رمزشده</string>
     <string name="refresh">نوسازی</string>
@@ -1476,9 +1476,9 @@
     <string name="settings_security_prevent_screenshots_title">جلوگیری از نماگرفت کاره</string>
     <string name="settings_security_prevent_screenshots_summary">به کار انداختن این انتخاب، FLAG_SECURE را به تمامی فعّالیت‌ها می‌افزاید. برای اثرگذاری تغییر، برنامه را دوباره شروع کنید.</string>
     <string name="media_file_added_to_gallery">پروندهٔ رسانه‌ای به جُنگ افزوده شد</string>
-    <string name="template_app_desktop_web">المنت وب
+    <string name="app_desktop_web">المنت وب
 \nالمنت میزکار</string>
-    <string name="template_app_ios_android">المنت آی‌اواس
+    <string name="app_ios_android">المنت آی‌اواس
 \nالمنت اندروید</string>
     <string name="use_recovery_key">استفاده از کلید بازیابی</string>
     <string name="encrypted_unverified">رمزشده به دست افزاره‌ای تأییدنشده</string>
@@ -1577,7 +1577,7 @@
     <string name="setup_cross_signing">به کار انداختن ورود چندگانه</string>
     <string name="enter_secret_storage_passphrase_or_key">برای ادامه از %1$s یا %2$sتان استفاده کنید.</string>
     <string name="command_description_discard_session_not_handled">پشتیبانی‌شده فقط در اتاق‌های رمزشده</string>
-    <string name="template_use_latest_app">از آخرین نگارش المنت روی دیگر افزاره‌تان استفاده کنید:</string>
+    <string name="use_latest_app">از آخرین نگارش المنت روی دیگر افزاره‌تان استفاده کنید:</string>
     <string name="or_other_mx_capable_client">یا دیگر کاره‌های ماتریکس دادای قابلیت ورود چندگانه</string>
     <string name="cross_signing_verify_by_text">تأیید دستی با متن</string>
     <string name="verify_this_session">تأیید ورود جدیدی که به حسابتان دسترسی دارد: %1$s</string>
@@ -1625,13 +1625,13 @@
     <string name="room_error_not_found">نمی‌توان این اتاق را یافت. مطمئن شوید وجود دارد.</string>
     <string name="error_opening_banned_room">نمی‌توان اتاقی را که از آن تحریم شده‌اید، گشود.</string>
     <string name="auth_pin_confirm_to_disable_title">برای از کار انداختن پین، تأییدش کنید</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">نیاز به رمز پین، هر بار که المنت را می‌گشایید.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">نیاز به رمز پین، ۲ دقیقه پس از استفاده نشدن از المنت.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">نیاز به رمز پین، هر بار که المنت را می‌گشایید.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">نیاز به رمز پین، ۲ دقیقه پس از استفاده نشدن از المنت.</string>
     <string name="settings_security_pin_code_grace_period_title">نیاز به پین پس از ۲ دقیقه</string>
     <string name="settings_security_pin_code_notifications_summary_off">فقط نمایش تعداد پیام‌های نخوانده در یک آگاهی ساده.</string>
     <string name="settings_security_pin_code_notifications_summary_on">نمایش جزییاتی چون نام اتاق‌ها و محتوای پیام.</string>
     <string name="settings_security_pin_code_notifications_title">نمایش محتوا در آگاهی‌ها</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">کد پین، تنها راه قفل‌گشایی المنت است.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">کد پین، تنها راه قفل‌گشایی المنت است.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">به کار انداختن زیست‌سنجی‌های مختص افزاره، مانند اثرانگشت‌ها و تشخیص چهره.</string>
     <string name="settings_security_pin_code_use_biometrics_title">به کار انداختن زیست‌سنجی‌ها</string>
     <string name="settings_security_pin_code_summary">اگر می‌خواهید پینتان را بازنشانی کنید، فراموشی پین را برای خروج و بازنشانی بزنید.</string>
@@ -1665,7 +1665,7 @@
     <string name="action_reset">بازنشانی</string>
     <string name="startup_notification_privacy_button_other">انتخاب گزینه‌ی دیگر</string>
     <string name="startup_notification_privacy_button_grant">مجوز دادن</string>
-    <string name="template_startup_notification_privacy_message">المنت می تواند در پس‌زمینه اجرا شده تا آگاهی‌هایتان را به صورت ایمن و محرمانه مدیریت کند. ممکن است بر مصرف باتری تأثیر بگذارد.</string>
+    <string name="startup_notification_privacy_message">المنت می تواند در پس‌زمینه اجرا شده تا آگاهی‌هایتان را به صورت ایمن و محرمانه مدیریت کند. ممکن است بر مصرف باتری تأثیر بگذارد.</string>
     <string name="reset_secure_backup_warning">این کار کلید امنیتی قبلی شما را حذف می‌کند.</string>
     <string name="reset_secure_backup_title">یک کلید امنیتی جدید به صورت تصادفی ایجاد کنید یا یک عبارت امنیتی جدید برای فایل‌های پشتیبان موجود خود تنظیم کنید.</string>
     <string name="settings_send_message_with_enter_summary">دکمهٔ ورود صفحه‌کلید نرم، به جای افزودن یک شکست خط، پیام را خواهد فرستاد</string>
@@ -1679,9 +1679,9 @@
     <string name="settings_inline_url_preview_summary">پیش‌نمایشی از آدرس‌های URL در پیام‌ها نمایش داده شود.</string>
     <string name="settings_set_workmanager_delay_summary">%s
 \nبسته به شارژ دستگاه یا وضعیت دستگاه(خاموش بودن صفحه) ممکن است همگام‌سازی به تعویق بیوفتد.</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">المنت بصورت دوره‌ای و در بازه‌های قابل تنظیم در پس زمینه همگام‌سازی می شود.
+    <string name="settings_background_fdroid_sync_mode_real_time_description">المنت بصورت دوره‌ای و در بازه‌های قابل تنظیم در پس زمینه همگام‌سازی می شود.
 \nاین بر مصرف باتری شما تأثیر می‌گذارد، یک اعلان دائمی نمایش داده می‌شود که المنت برای رویدادها گوش می‌دهد.</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">المنت در پس زمینه همگام‌سازی می‌کند به گونه ای که منابع محدود دستگاه (باتری) حفظ می‌شود.
+    <string name="settings_background_fdroid_sync_mode_battery_description">المنت در پس زمینه همگام‌سازی می‌کند به گونه ای که منابع محدود دستگاه (باتری) حفظ می‌شود.
 \nبسته به شارژ گوشی شما، ممکن است همگام‌سازی توسط سیستم‌عامل به تعویق بیوفتد.</string>
     <string name="settings_turn_screen_on">روشن کردن صفحه برای ۳ ثانیه</string>
     <string name="settings_notification_privacy_message_content_not_shown">• آگاهی‌ها <b>محتوای پیام را نشان نخواهند داد</b></string>
@@ -1690,7 +1690,7 @@
     <string name="settings_notification_privacy_metadata">• آگاهی‌ها فقط دارای فراداده هستند</string>
     <string name="settings_notification_privacy_fcm">• آگاهی‌ها با پیام‌رسانی ابری Firebase فرستاده می‌شوند</string>
     <string name="settings_troubleshoot_test_battery_failed">اگر دستگاه برای مدتی از شارژر جدا باشد و از دستگاه نیز استفاده نشود، گوشی وارد حالت غیر هوشیار می‌شود. در این حالت از دسترسی برنامه‌ها به اینترنت جلوگیری می‌شود و همگام سازی و هشدارهای استاندارد آن‌ها به تعویق می‌افتد.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">خدمت، هنگام شروع دوبارهٔ افزاره اجرا نخواهد شد. تا وقتی یک بار المنت باز نشود، آگاهی‌ها را دریافت نخواهید کرد.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">خدمت، هنگام شروع دوبارهٔ افزاره اجرا نخواهد شد. تا وقتی یک بار المنت باز نشود، آگاهی‌ها را دریافت نخواهید کرد.</string>
     <string name="settings_troubleshoot_test_notification_notification_clicked">روی آگاهی کلیک شد!</string>
     <string name="settings_troubleshoot_test_notification_notice">لطفاً روی آگاهی کلیک کنید. اگر آگاهی را نمی‌بینید، لطفاً تنظیمات سامانه را بررسی کنید.</string>
     <string name="settings_troubleshoot_test_notification_title">نمایش آگاهی</string>
@@ -1704,11 +1704,11 @@
     <string name="settings_troubleshoot_test_token_registration_success">ژتون FCM با موفقیت در کارساز خانگی ثبت شد.</string>
     <string name="settings_troubleshoot_test_token_registration_title">ثبت توکن</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">افزودن حساب کاربری</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nاین خطا خارج از مهار ${app_name} است. هیچ حساب گوگلی روی تلفن نیست. لطفاً مدیر حساب را گشوده و حساب گوگلی بیفزایید.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nاین خطا خارج از مهار ${app_name} است و ممکن است به دلایل مختلفی رخ داده باشد. ممکن است اگر بعداً دوباره تلاش کنید، کار کند. می‌توانید بررسی کنید که مصرف دادهٔ خدمات پلی گوگل در تنظیمات سامانه محدود نشده باشد یا ساعت افزاره‌تان درست باشد. همچنین ممکن است روی رام‌های سفارشی اتفاق بیفتد.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nاین خطا، خارج از مهار ${app_name} است و طبق گفتهٔ گوگل، نشانگر ثبت بیش‌از حد کاره‌ها در FCM است. خطا فقط در مواردی که تعداد خیلی زیادی کاره وجود داشته باشد رخ می‌دهد، پس کاربران معمولی نباید تحت تأثیر قرار گیرند.</string>
     <string name="settings_troubleshoot_test_fcm_failed">بازیابی توکن FCM با مشکل مواجه شد:
 \n%1$s</string>
@@ -1716,7 +1716,7 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_title">توکن Firebase</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">مشکل Google Play Services را برطرف کنید</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">المنت برای ارسال آگاهی‌ها از خدمات پلی گوگل استفاده می‌کند اما به نظر می‌رسد به درستی پیکربندی نشده است:
+    <string name="settings_troubleshoot_test_play_services_failed">المنت برای ارسال آگاهی‌ها از خدمات پلی گوگل استفاده می‌کند اما به نظر می‌رسد به درستی پیکربندی نشده است:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_success">Google Play Services در دسترس و بروز است.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">تنظیمات سفارشی بارگذاری نشد، لطفاً دوباره امتحان کنید.</string>
@@ -1771,21 +1771,21 @@
     <string name="room_preview_unlinked_email_warning">این دعوت به %s ارسال شده که ارتباطی با این حساب ندارد.
 \nممکن است بخواهید با حسابی دیگر وارد شده یا این رایانامه را به حسابتان بیفزایید.</string>
     <string name="permissions_action_not_performed_missing_permissions">متاسفانه به دلیل عدم دسترسی، درخواست شما امکان پذیر نمی باشد</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">المنت می‌تواند با دیدن دفترچه تلفن شما کاربرهای دیگر ماتریکس را بر اساس ایمبل و شماره تلفنشان پیدا کند.
+    <string name="permissions_msg_contacts_warning_other_androids">المنت می‌تواند با دیدن دفترچه تلفن شما کاربرهای دیگر ماتریکس را بر اساس ایمبل و شماره تلفنشان پیدا کند.
 \n
 \nآیا موافق با اشتراک‌گذاری دفترچه تلفنتان به این منظور هستید؟</string>
-    <string name="template_permissions_rationale_msg_contacts">المنت می‌تواند با دیدن دفترچه تلفن شما کاربرهای دیگر ماتریکس را بر اساس ایمبل و شماره تلفنشان پیدا کند. اگر مایل به اشتراک گذاری دفترچه تلفنتان به این منظور هستید لطفا در پنجره‌ی بعد اجازه‌ی این کار را بدهید.</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">المنت برای برقراری تماس تصویری نیازمند دسترسی به میکروفون و دوربین است.
+    <string name="permissions_rationale_msg_contacts">المنت می‌تواند با دیدن دفترچه تلفن شما کاربرهای دیگر ماتریکس را بر اساس ایمبل و شماره تلفنشان پیدا کند. اگر مایل به اشتراک گذاری دفترچه تلفنتان به این منظور هستید لطفا در پنجره‌ی بعد اجازه‌ی این کار را بدهید.</string>
+    <string name="permissions_rationale_msg_camera_and_audio">المنت برای برقراری تماس تصویری نیازمند دسترسی به میکروفون و دوربین است.
 \n
 \nلطفا در پنجره های بعدی دسترسی های لازم را بدهید.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nلطفا برای برقراری تماس در پنجره بعدی دسترسی لازم را بدهید."</string>
-    <string name="template_permissions_rationale_msg_record_audio">المنت برای برقراری تماس صوتی نیازمند دسترسی به میکروفون است.</string>
+    <string name="permissions_rationale_msg_record_audio">المنت برای برقراری تماس صوتی نیازمند دسترسی به میکروفون است.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nلطفا برای برقراری تماس در پنجره بعدی دسترسی لازم را بدهید."</string>
-    <string name="template_permissions_rationale_msg_storage">المنت برای ارسال و ذخیره‌ی فایل‌ها نیاز به دسترسی به گالری شما را دارد.
+    <string name="permissions_rationale_msg_storage">المنت برای ارسال و ذخیره‌ی فایل‌ها نیاز به دسترسی به گالری شما را دارد.
 \n
 \nلطفا در پنجره‌ای که باز می‌شود این دسترسی را بدهید.</string>
     <string name="settings_call_ringtone_use_default_stun_sum">هنگامی که کارساز خانگیتان قابلیت تماس نداشته باشد، از %s استفاده خواهد شد (نشانی IPتان در طول تماس هم‌رسانی خواهد شد)</string>
@@ -1805,7 +1805,7 @@
     <string name="keys_backup_recovery_key_error_decrypt">نسخه پشتیبان با این کلید بازیابی رمزگشایی نمی‌شود: لطفاً تأیید کنید که کلید بازیابی درست را وارد کرده‌اید.</string>
     <string name="enter_secret_storage_input_key">کلید پشتیبان خود را انتخاب کنید، یا با تایپ کردن و یا کپی‌کردن، آن را وارد کنید</string>
     <string name="command_description_discard_session">نشست‌های خارجی را مجبور به ترک گروه می‌کند</string>
-    <string name="template_use_other_session_content_description">از آخرین نسخه‌ی المنت روی دستگاه‌های دیگرتان استفاده کنید: نسخه وب المنت، نسخه دسکتاپ المنت، نسخه IOS المنت و نسخه اندروید المنت</string>
+    <string name="use_other_session_content_description">از آخرین نسخه‌ی المنت روی دستگاه‌های دیگرتان استفاده کنید: نسخه وب المنت، نسخه دسکتاپ المنت، نسخه IOS المنت و نسخه اندروید المنت</string>
     <string name="change_password_summary">تنظیم گذرواژه جدید…</string>
     <string name="error_saving_media_file">فایل رسانه ذخیره نشد</string>
     <string name="error_adding_media_file_to_gallery">فایل به گالری افزوده نشد</string>
@@ -1887,9 +1887,9 @@
     <string name="command_description_rainbow">پیام را با رنگ‌بندی رنگین کمان ارسال می کند</string>
     <string name="verify_cannot_cross_sign">این نشست نمی‌تواند تائید را با نشست‌های دیگر شما به اشتراک بگذارد.
 \nتائید به صورت محلی ذخیره می‌شود و در نسخه‌ی بعدی برنامه به اشتراک گذاشته می‌شود.</string>
-    <string name="template_rendering_event_error_exception">المنت هنگام ارائه محتوای رویدادی با شناسه \'%1$s\' با مشکل روبرو شد</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">المنت پیام‌های \'%1$s\' را پشتیبانی نمی‌کند</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">المنت رویداد \'%1$s\' را پشتیبانی نمی‌کند</string>
+    <string name="rendering_event_error_exception">المنت هنگام ارائه محتوای رویدادی با شناسه \'%1$s\' با مشکل روبرو شد</string>
+    <string name="rendering_event_error_type_of_message_not_handled">المنت پیام‌های \'%1$s\' را پشتیبانی نمی‌کند</string>
+    <string name="rendering_event_error_type_of_event_not_handled">المنت رویداد \'%1$s\' را پشتیبانی نمی‌کند</string>
     <string name="verification_conclusion_compromised">ممکن است یکی از موارد زیر به خطر افتاده باشد:
 \n
 \n- سرور میزبان شما
@@ -1902,7 +1902,7 @@
     <string name="login_error_threepid_denied">دامنهٔ رایانامه‌تان مجاز به ثبت‌نام روی این کارساز نیست</string>
     <string name="command_description_shrug">¯\\\\_(ツ)_/¯ را به یک پیام متنی ساده تغییر می دهد</string>
     <string name="permalink_malformed">لینک مشکل دارد</string>
-    <string name="template_soft_logout_sso_not_same_user_error">نشست فعلی مربوط به کاربر %1$s است و شما اطلاعات حساب کاربر %2$s را ارائه داده‌اید. این مورد توسط المنت پشتیبانی نمی‌شود .
+    <string name="soft_logout_sso_not_same_user_error">نشست فعلی مربوط به کاربر %1$s است و شما اطلاعات حساب کاربر %2$s را ارائه داده‌اید. این مورد توسط المنت پشتیبانی نمی‌شود .
 \nلطفا ابتدا داده ها را پاک کنید، سپس با یک حساب دیگر وارد برنامه شوید.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">دسترسی به پیام‌های رمزشده را از دست خواهید داد مگر اینکه برای بازیابی کلیدهای رمزگذاری خود، به حساب خود وارد شوید.</string>
     <string name="soft_logout_clear_data_dialog_content">آیا تمامی اطلاعات ذخیره‌شده در این دستگاه پاک شود؟
@@ -1994,7 +1994,7 @@
     <string name="room_list_quick_actions_low_priority_remove">حذف‌کردن از اولویت پایین</string>
     <string name="room_list_quick_actions_low_priority_add">اضافه‌کردن به اولویت پایین</string>
     <string name="no_network_indicator">در حال حاضر اتصال شبکه‌ای وجود ندارد</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">المنت برای ذخیره کلیدهای رمزنگاری سرتاسر شما بر روی حافظه نیاز به مجوز دارد.
+    <string name="permissions_rationale_msg_keys_backup_export">المنت برای ذخیره کلیدهای رمزنگاری سرتاسر شما بر روی حافظه نیاز به مجوز دارد.
 \n
 \nلطفاً در پنجره بعدی اجازه دسترسی دهید تا بتوانید کلیدهای خود را به صورت دستی ذخیره کنید.</string>
     <string name="content_reported_as_inappropriate_content">این محتوا به عنوان محتوای نامناسب گزارش شده‌است.
@@ -2112,7 +2112,7 @@
     <string name="sas_verify_title">با مقایسه‌کردن یک رشته‌ی متنی کوتاه تایید کنید.</string>
     <string name="invalid_or_expired_credentials">به خاطر ورود منقضی یا نامعتبر، از حسابتان خارج شدید.</string>
     <string name="autodiscover_well_known_autofill_confirm">از پیکربندی استفاده کنید</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">المنت یک پیکربندی اختصاصی سرور برای دامنه‌ی شناسه‌ی کاربری شما \"%1$s\" تشخیص داده است:
+    <string name="autodiscover_well_known_autofill_dialog_message">المنت یک پیکربندی اختصاصی سرور برای دامنه‌ی شناسه‌ی کاربری شما \"%1$s\" تشخیص داده است:
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_dialog_title">تکمیل خودکار گزینه‌های مربوط به سرور</string>
     <string name="keys_backup_info_title_signature">امضاء</string>
@@ -2189,7 +2189,7 @@
 \n
 \nبرای جلوگیری از گم کردن کلیدهایتان، از آن‌ها به صورت امن، پشتیبان بگیرید.</string>
     <string name="keys_backup_no_session_error">هیچ نشست ماتریکسی موجود نیست</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">اگر می خواهید المنت یک کلید بازیابی ایجاد کند، لطفاً عبارت عبور را حذف کنید.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">اگر می خواهید المنت یک کلید بازیابی ایجاد کند، لطفاً عبارت عبور را حذف کنید.</string>
     <string name="passphrase_passphrase_too_weak">عبارت عبور بیش از حد ضعیف است</string>
     <string name="passphrase_empty_error_message">لطفاً عبارت عبوری وارد کنید</string>
     <string name="passphrase_passphrase_does_not_match">عبارت عبور، مطابق نبود</string>
@@ -2329,10 +2329,10 @@
     <string name="settings_data_save_mode_summary">حالت صرفه‌جویی داده، پالایهٔ خاصی را اعمال می‌کند که در نتیجهٔ آن، به‌روزرسانی‌های حضور و آگاهی‌های نوشتن، پالوده می‌شوند.</string>
     <string name="settings_data_save_mode">حالت صرفه‌جویی در مصرف دیتا</string>
     <string name="settings_opt_in_of_analytics_ok">بله ، من می خواهم کمک کنم!</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">لطفاً برای کمک به ما در بهبود المنت، ارسال ناشناس تجزیه و تحلیل را فعال کنید.</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">المنت برای داشتن اعلان‌های قابل اعتماد نیاز به فعالیت در پس زمینه دارد.
+    <string name="settings_opt_in_of_analytics_prompt">لطفاً برای کمک به ما در بهبود المنت، ارسال ناشناس تجزیه و تحلیل را فعال کنید.</string>
+    <string name="startup_notification_fdroid_battery_optim_message">المنت برای داشتن اعلان‌های قابل اعتماد نیاز به فعالیت در پس زمینه دارد.
 \nدر صفحه بعدی از شما خواسته می شود که المنت همیشه در پس زمینه اجرا شود ، لطفاً آن را بپذیرید.</string>
-    <string name="template_settings_opt_in_of_analytics_summary">المنت اطلاعاتی را جمع آوری می کند و با ارسال آنان به صورت ناشناس به ما امکان بهبود برنامه را می‌دهد.</string>
+    <string name="settings_opt_in_of_analytics_summary">المنت اطلاعاتی را جمع آوری می کند و با ارسال آنان به صورت ناشناس به ما امکان بهبود برنامه را می‌دهد.</string>
     <string name="settings_opt_in_of_analytics">ارسال داده های تجزیه و تحلیل</string>
     <string name="settings_analytics">تجزیه و تحلیل</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">مجوز دادن</string>
@@ -2347,7 +2347,7 @@
     <string name="bottom_sheet_setup_secure_backup_security_phrase_subtitle">عبارت رمزی که فقط خودتان می‌دانید را وارد کرده و کلیدی برای پشتیبان تولید کنید.</string>
     <string name="identity_server_set_alternative_notice">به هنوتم جایگزین، می‌توانید نشامی هر کارساز هویت دیگری را وارد کنید</string>
     <string name="identity_server_set_default_notice">کارساز خانگیتان (%1$s) پیشنهاد استفاده از %2$s برای کارساز هویتتان را می‌دهد</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">برای محرمانگیتان، المنت تنها از فرستادن شماره تلفن و رایانامه‌های کاربری در هم ریخته پشتیبانی می‌کند.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">برای محرمانگیتان، المنت تنها از فرستادن شماره تلفن و رایانامه‌های کاربری در هم ریخته پشتیبانی می‌کند.</string>
     <string name="identity_server_error_outdated_home_server">این عملیات ممکن نیست. کارساز خانگی منقضی شده است.</string>
     <string name="invite_users_to_room_failure">نتوانستیم کاربران را دعوت کنیم. لطفاً کاربرانی که می‌خواهید دعوت کنید را بررسی کرده و دوباره تلاش کنید.</string>
     <string name="create_room_dm_failure">نتوانستیم پیامتان را ایجاد کنیم. لطفاً کاربرانی که می‌خواهید دعوت کنید را بررسی کرده و دوباره تلاش کنید.</string>
@@ -2372,14 +2372,14 @@
     <string name="identity_server_user_consent_not_provided">رضایت کاربر فراهم نشده است.</string>
     <string name="identity_server_error_terms_not_signed">لطفاً نخست شرایط کارساز هویت را در تنظیمات بپذیرید.</string>
     <string name="identity_server_error_no_identity_server_configured">لطفاً نخست کارساز هویتی را پیکربندی کنید.</string>
-    <string name="template_identity_server_error_outdated_identity_server">کارساز هویت منقضی شده اسن. المنت تنها نگارش ۲ از API را پشتیبانی می‌کند.</string>
+    <string name="identity_server_error_outdated_identity_server">کارساز هویت منقضی شده اسن. المنت تنها نگارش ۲ از API را پشتیبانی می‌کند.</string>
     <string name="user_code_info_text">این رمز را افراد هم‌رسانی کرده تا بتوانند برای افزودنتان و شروع گپ، بپویندش.</string>
     <string name="user_code_my_code">رمزم</string>
     <string name="user_code_share">هم‌رسانی رمزم</string>
     <string name="user_code_scan">پویش یک رمز QR</string>
     <string name="not_a_valid_qr_code">این یک رمز QR ماتریکس معتبر نیست</string>
-    <string name="template_invite_friends_rich_title">🔐️ پیوستن به من روی المنت</string>
-    <string name="template_invite_friends_text">سلام. روی المنت باهام حرف بزن: %s</string>
+    <string name="invite_friends_rich_title">🔐️ پیوستن به من روی المنت</string>
+    <string name="invite_friends_text">سلام. روی المنت باهام حرف بزن: %s</string>
     <string name="invite_friends">دعوت دوستان</string>
     <string name="add_people">افزودن افراد</string>
     <string name="topic_prefix">"موضوع: "</string>
@@ -2500,7 +2500,7 @@
     <string name="default_message_emote_confetti">فرستادن کاغذ رنگی 🎉</string>
     <string name="default_message_emote_snow">فرستادن برف ❄️</string>
     <string name="authentication_error">تأیید هویت شکست خورد</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} برای انجام این کار، نیاز به ورود گذواژه‌‌تان دارد.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} برای انجام این کار، نیاز به ورود گذواژه‌‌تان دارد.</string>
     <string name="re_authentication_activity_title">نیاز به تأیید هویت دوباره است</string>
     <string name="call_transfer_users_tab_title">کاربران</string>
     <string name="call_transfer_failure">هنگام انتقال تماس خطایی روی داد</string>
@@ -2858,7 +2858,7 @@
     <string name="settings_notification_other">دیگر</string>
     <string name="settings_notification_mentions_and_keywords">اشاره‌ها و کلیدواژگان</string>
     <string name="settings_notification_default">آگاهی‌های پیش‌گزیده</string>
-    <string name="template_link_this_email_with_your_account">%s در تنظیمات برای دریافت مستقیم دعوت‌ها در المنت.</string>
+    <string name="link_this_email_with_your_account">%s در تنظیمات برای دریافت مستقیم دعوت‌ها در المنت.</string>
     <string name="link_this_email_settings_link">این رایانامه را به حسابتان پیوند دهید</string>
     <string name="this_invite_to_this_space_was_sent">این دعوت به این فضا به %s فرستاده شده که با حسابتان در ارتباط نیست</string>
     <string name="this_invite_to_this_room_was_sent">این دعوت به این اتاق به %s فرستاده شده که با حسابتان در ارتباط نیست</string>
@@ -2995,7 +2995,7 @@
     <string name="identity_server_consent_dialog_content_question">با فرستادن این اطّلاعات موافقید؟</string>
     <string name="action_not_now">اکنون نه</string>
     <string name="identity_server_consent_dialog_content_3">برای کشف آشنایان موجود، لازم است اطلاعات آشنایان (رایانامه‌ها و شماره تلفن‌ها) را به کارساز هویتتان بفرستید. برای محرمانگیتان، داده‌هایتان را پیش از فرستادن، در هم می‌ریزیم.</string>
-    <string name="template_analytics_opt_in_content">با هم‌رسانی داده‌ّای استفادهٔ ناشناس، در تشخیص مشکل‌ها و بهبود المنت یاریمان کنید. برای درک چگونگی استفادهٔ مردم از چندین افزاره، شناسه‌ای کاتوره‌ای بین افزاره‌هایتان هم‌رسانی خواهیم کرد.
+    <string name="analytics_opt_in_content">با هم‌رسانی داده‌ّای استفادهٔ ناشناس، در تشخیص مشکل‌ها و بهبود المنت یاریمان کنید. برای درک چگونگی استفادهٔ مردم از چندین افزاره، شناسه‌ای کاتوره‌ای بین افزاره‌هایتان هم‌رسانی خواهیم کرد.
 \n
 \nمی‌توانید از %s قوانینمان را بخوانید.</string>
     <string name="delete_poll_dialog_content">مطمئنید که می خواهید این نظرسنجی را بردارید؟ پس از این کار، قادر به بازگردانیش نیستید.</string>
@@ -3025,7 +3025,7 @@
     </plurals>
     <string name="preference_system_settings">تنظیمات سامانه</string>
     <string name="preference_versions">نگارش‌ها</string>
-    <string name="template_preference_help_summary">کمک در استفاده از المنت</string>
+    <string name="preference_help_summary">کمک در استفاده از المنت</string>
     <string name="preference_help_title">کمک و پشتیانی</string>
     <string name="preference_help">کمک</string>
     <string name="preference_root_legals">موارد حقوقی</string>
@@ -3033,12 +3033,12 @@
     <string name="legals_third_party_notices">کتاب‌خانه‌های سوم شخص</string>
     <string name="legals_identity_server_title">سیاست کارساز هویتتان</string>
     <string name="legals_home_server_title">سیاست کارساز خانگیتان</string>
-    <string name="template_legals_application_title">سیاست ${app_name}</string>
+    <string name="legals_application_title">سیاست ${app_name}</string>
     <string name="analytics_opt_in_list_item_3">می‌توانید هر زمان، در تنظیمات خاموشش کنید</string>
     <string name="analytics_opt_in_list_item_2">ما اطّلاعات را با سوم‌شخص‌ها هم‌رسانی <b>نمی‌کنیم</b></string>
     <string name="analytics_opt_in_list_item_1">ما هیچ دادهٔ حسابی را ذخیره یا نمایه <b>نمی‌کنیم</b></string>
     <string name="analytics_opt_in_content_link">این‌جا</string>
-    <string name="template_analytics_opt_in_title">کمک به بهبود المنت</string>
+    <string name="analytics_opt_in_title">کمک به بهبود المنت</string>
     <string name="action_enable">به کار انداختن</string>
     <string name="restart_the_application_to_apply_changes">برای اثربخشی تغییر، برنامه را دوباره اجرا کنید.</string>
     <string name="labs_enable_latex_maths">به کار انداختن ریاضیات لاتک</string>
@@ -3075,8 +3075,8 @@
     <string name="attachment_type_location">مکان</string>
     <string name="labs_render_locations_in_timeline">پرداخت مکان‌های کاربری در خط زمانی</string>
     <string name="settings_enable_location_sharing_summary">پس از به کار افتادن، قادر خواهید بد مکانتان را به هر اتاقی بفرستید</string>
-    <string name="template_location_not_available_dialog_content">${app_name} نتوانست به مکانتان دست یابد. لطفاً بعداً دوباره تلاش کنید.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} نتوانست به مکانتان دست یابد</string>
+    <string name="location_not_available_dialog_content">${app_name} نتوانست به مکانتان دست یابد. لطفاً بعداً دوباره تلاش کنید.</string>
+    <string name="location_not_available_dialog_title">${app_name} نتوانست به مکانتان دست یابد</string>
     <string name="closed_poll_option_description">نتایج تنها هنگامی که نظرسنجی را پایان دهید آشکار می‌شوند</string>
     <string name="open_poll_option_description">رأی دهندگان به محض دادن رأی، نتایج را می‌بینند</string>
     <string name="a11y_trust_level_misconfigured">سطح اطمنیان بد پیکربندی شده</string>

--- a/vector/src/main/res/values-fi/strings.xml
+++ b/vector/src/main/res/values-fi/strings.xml
@@ -269,7 +269,7 @@
     <string name="local_address_book_header">Paikalliset yhteystiedot</string>
     <string name="matrix_only_filter">Ainoastaan Matrix-yhteyshenkilöt</string>
     <string name="no_conversation_placeholder">Ei keskusteluita</string>
-    <string name="template_no_contact_access_placeholder">Et ole sallinut ${app_name}ille pääsyä paikallisiin yhteystietoihisi</string>
+    <string name="no_contact_access_placeholder">Et ole sallinut ${app_name}ille pääsyä paikallisiin yhteystietoihisi</string>
     <string name="no_result_placeholder">Ei tuloksia</string>
     <string name="rooms_header">Huoneet</string>
     <string name="rooms_directory_header">Huoneluettelo</string>
@@ -392,20 +392,20 @@
     <string name="media_picker_both_capture_title">Ota kuva tai video"</string>
     <string name="media_picker_cannot_record_video">Videointi epäonnistui</string>
     <string name="permissions_rationale_popup_title">Huomio</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} tarvitsee käyttöluvan mediagalleriaasi lähettäkseen liitteitä.\n\nSalli tiedostojen käyttö seuraavalla näytöllä liittääksesi kuvia ja muita tiedostoja viesteihin.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} tarvitsee käyttöluvan kameraan ottaakseen kuvia ja suorittakseen videopuheluita.</string>
+    <string name="permissions_rationale_msg_storage">${app_name} tarvitsee käyttöluvan mediagalleriaasi lähettäkseen liitteitä.\n\nSalli tiedostojen käyttö seuraavalla näytöllä liittääksesi kuvia ja muita tiedostoja viesteihin.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} tarvitsee käyttöluvan kameraan ottaakseen kuvia ja suorittakseen videopuheluita.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nSoittaaksesi videopuhelun, salli seuraavassa ponnahdusikkunassa sovelluksen käyttää kameraa."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} tarvitsee käyttöluvan mikrofoniin suorittakseen puheluita.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} tarvitsee käyttöluvan mikrofoniin suorittakseen puheluita.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nSoittaaksesi äänipuhelun, salli seuraavassa ponnahdusikkunassa sovelluksen käyttää mikrofonia."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} tarvitsee käyttöluvan kameraan ja mikrofoniin suorittakseen videopuheluita.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} tarvitsee käyttöluvan kameraan ja mikrofoniin suorittakseen videopuheluita.
 \n
 \nSalli mikrofonin ja kameran käyttö seuraavilla näytöillä aloittaaksesi tämän puhelun.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} voi tarkistaa yhteystietosi löytääkseen muita Matrixin käyttäjiä sähköpostiosoitteiden ja puhelinnumeroiden perusteella. Jos suostut jakamaan yhteystietosi tätä tarkoitusta varten, salli yhteystietojen käyttö seuraavassa ponnahdusikkunassa.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} pystyy käyttämään yhteystietojasi, etsiäkseen muita Matrix-käyttäjiä sähköpostiosoitteiden sekä puhelinnumeroiden perusteella.
+    <string name="permissions_rationale_msg_contacts">${app_name} voi tarkistaa yhteystietosi löytääkseen muita Matrixin käyttäjiä sähköpostiosoitteiden ja puhelinnumeroiden perusteella. Jos suostut jakamaan yhteystietosi tätä tarkoitusta varten, salli yhteystietojen käyttö seuraavassa ponnahdusikkunassa.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} pystyy käyttämään yhteystietojasi, etsiäkseen muita Matrix-käyttäjiä sähköpostiosoitteiden sekä puhelinnumeroiden perusteella.
 \n
 \nSaako ${app_name} käyttää yhteystietojasi tätä varten\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Toimenpide epäonnistui puuttuvien käyttölupien takia</string>
@@ -875,12 +875,12 @@
     <string name="e2e_re_request_encryption_key"><u>Pyydä salausavaimia uudelleen</u> muista istunnoistasi.</string>
     <string name="e2e_re_request_encryption_key_sent">Avainpyyntö lähetetty.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Pyyntö lähetetty</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Käynnistä ${app_name} toisella laitteella, joka voi purkaa viestin, jotta se voi lähettää avaimet tähän istuntoon.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Käynnistä ${app_name} toisella laitteella, joka voi purkaa viestin, jotta se voi lähettää avaimet tähän istuntoon.</string>
     <plurals name="membership_changes">
         <item quantity="one">yksi jäsenyysmuutos</item>
         <item quantity="other">%d jäsenyysmuutosta</item>
     </plurals>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Käytä ${app_name}in oletussoittoääntä saapuville puheluille</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Käytä ${app_name}in oletussoittoääntä saapuville puheluille</string>
     <string name="settings_call_ringtone_title">Saapuvien puheluiden soittoääni</string>
     <string name="video_call_in_progress">Videopuhelu menossa…</string>
     <string name="list_members">Käyttäjälista</string>
@@ -957,7 +957,7 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Ota käyttöön</string>
     <string name="settings_troubleshoot_test_device_settings_title">Istunnon asetukset.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Ilmoitukset ovat käytössä tässä istunnossa.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Ilmoitukset eivät ole käytössä tässä istunnossa.
+    <string name="settings_troubleshoot_test_device_settings_failed">Ilmoitukset eivät ole käytössä tässä istunnossa.
 \nTarkista ${app_name}in asetukset.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Ota käyttöön</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Mukautetut asetukset.</string>
@@ -967,7 +967,7 @@
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Tarkista asetukset</string>
     <string name="settings_troubleshoot_test_play_services_title">Play Services -palvelun tarkistus</string>
     <string name="settings_troubleshoot_test_play_services_success">Google Play Services APK on saatavilla ja ajan tasalla.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} käyttää Google Play Services -palvelua ilmoitusten välittämiseen, mutta se ei näytä olevan määritetty oikein:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} käyttää Google Play Services -palvelua ilmoitusten välittämiseen, mutta se ei näytä olevan määritetty oikein:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Korjaa Play Services -palvelu</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase-tunniste</string>
@@ -975,11 +975,11 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">FCM-tunnisteen haku epäonnistui: 
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \n${app_name} ei voi vaikuttaa tähän virheeseen, ja Googlen mukaan tämä virhe tarkoittaa, että tällä laitteella on liikaa FCM:ään rekisteröityjä sovelluksia. Tämä virhe ilmenee vain tapauksissa, joissa on erittäin paljon FCM:ään rekisteröityjä sovelluksia asennettuna, joten tätä ei pitäisi tapahtua normaalisti.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nTämä virhe ei ole ${app_name}in ratkaistavissa. Se voi johtua useasta eri syystä. Ehkä tämä toimii, jos yrität myöhemmin. Voit myös tarkistaa, että Google Play Services -palvelu ei ole rajoitettuna järjestelmäasetuksissa, ja että laitteesi kello on oikein. Tämä voi tapahtua myös mukautetun käyttöjärjestelmän kanssa.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nTämä virhe ei ole ${app_name}in ratkaistavissa. Tässä puhelimessa ei ole Google-tiliä. Lisää laitteeseesi Google-tili tätä toimintoa varten.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Lisää tili</string>
     <string name="settings_troubleshoot_test_token_registration_title">Tunnisteen rekisteröinti</string>
@@ -991,17 +991,17 @@
     <string name="settings_troubleshoot_test_service_restart_failed">Palvelun uudelleenkäynnistäminen epäonnistui</string>
     <string name="settings_troubleshoot_test_service_boot_title">Käynnistä laitteen käynnistyessä</string>
     <string name="settings_troubleshoot_test_service_boot_success">Palvelu käynnistetään, kun laite käynnistetään uudelleen.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Palvelua ei käynnistetä laitteen uudelleenkäynnistyksen yhteydessä. Et tule saamaan ilmoituksia ennen kuin ${app_name} on käynnistetty uudelleen.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Palvelua ei käynnistetä laitteen uudelleenkäynnistyksen yhteydessä. Et tule saamaan ilmoituksia ennen kuin ${app_name} on käynnistetty uudelleen.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Ota käyttöön automaattinen käynnistys</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Tarkista taustapalveluiden rajoitukset</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Taustapalveluiden rajoitukset ovat pois käytöstä. Tämä testi tulee ajaa mobiilidatayhteydellä (ilman wlania).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Taustapalveluiden rajoitukset ovat pois käytöstä. Tämä testi tulee ajaa mobiilidatayhteydellä (ilman wlania).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Taustapalveluiden rajoitukset ovat käytössä.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Taustapalveluiden rajoitukset ovat käytössä.
 \nTyötä, jota ${app_name} yrittää tehdä, rajoitetaan aggressiivisesti, kun se on taustalla, mikä saattaa vaikuttaa ilmoituksiin.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Poista rajoitukset</string>
     <string name="settings_troubleshoot_test_battery_title">Akunkäytön optimointi</string>
-    <string name="template_settings_troubleshoot_test_battery_success">Akunkäytön optimointi ei vaikuta ${app_name}in toimintaan.</string>
+    <string name="settings_troubleshoot_test_battery_success">Akunkäytön optimointi ei vaikuta ${app_name}in toimintaan.</string>
     <string name="settings_troubleshoot_test_battery_failed">Jos käyttäjä jättää laitteen paikalleen ilman latausjohtoa niin, että näyttö on pois päältä, laite siirtyy torkkutilaan. Tämä estää sovelluksia käyttämästä verkkoyhteyksiä ja lykkää niiden töitä, synkronointeja ja perushälytyksiä.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Jätä optimointi huomiotta</string>
     <string name="settings_notification_privacy_normal">Normaali</string>
@@ -1024,15 +1024,15 @@
     <string name="settings_show_join_leave_messages_summary">Ei vaikuta kutsuihin, poistamisiin ja porttikieltoihin.</string>
     <string name="settings_show_avatar_display_name_changes_messages_summary">Sisältää hahmokuvat ja näyttönimien vaihdot.</string>
     <string name="startup_notification_privacy_title">Ilmoitusten yksityisyys</string>
-    <string name="template_startup_notification_privacy_message">${app_name} voi ajaa itseään taustalla hallitakseen sinulle näytettäviä ilmoituksia turvallisesti ja yksityisesti. Tämä voi vaikuttaa akunkäyttöön.</string>
+    <string name="startup_notification_privacy_message">${app_name} voi ajaa itseään taustalla hallitakseen sinulle näytettäviä ilmoituksia turvallisesti ja yksityisesti. Tämä voi vaikuttaa akunkäyttöön.</string>
     <string name="startup_notification_privacy_button_grant">Anna oikeus</string>
     <string name="startup_notification_privacy_button_other">Valitse toinen vaihtoehto</string>
     <string name="startup_notification_fdroid_battery_optim_title">Taustayhteys</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name}in tarvitsee käyttää taustayhteyttä, jotta se voi näyttää luotettavia ilmoituksia.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name}in tarvitsee käyttää taustayhteyttä, jotta se voi näyttää luotettavia ilmoituksia.
 \nSeuraavalla ruudulla sinulta kysytään lupaa, jotta ${app_name} voi pitää itsensä käynnissä taustalla.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Anna oikeus</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} kerää anonyymiä analytiikkaa sovelluksen parantamiseksi.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Otathan analytiikan käyttöön ${app_name}in parantamiseksi.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} kerää anonyymiä analytiikkaa sovelluksen parantamiseksi.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Otathan analytiikan käyttöön ${app_name}in parantamiseksi.</string>
     <string name="settings_opt_in_of_analytics_ok">Kyllä, haluan auttaa!</string>
     <string name="settings_data_save_mode_summary">Datansäästötila ottaa käyttöön erityisen suodattimen, joka poistaa paikallaoloilmoitukset ja kirjoittamisen ilmoitukset.</string>
     <string name="account_email_error">Sähköpostiasi varmennettaessa tapahtui virhe.</string>
@@ -1131,7 +1131,7 @@
     <string name="passphrase_passphrase_does_not_match">Salalause ei täsmää</string>
     <string name="passphrase_empty_error_message">Syötä salalause</string>
     <string name="passphrase_passphrase_too_weak">Salalause on liian heikko</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Poista salalause, jos haluat ${app_name} generoivan palautusavaimen.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Poista salalause, jos haluat ${app_name} generoivan palautusavaimen.</string>
     <string name="keys_backup_no_session_error">Matrix-istuntoa ei ole saatavilla</string>
     <string name="keys_backup_setup_step1_title">Älä koskaan menetä salattuja viestejä</string>
     <string name="keys_backup_setup_step1_description">Salatuissa huoneissa viestit ovat suojattuna osapuolten välisellä salauksella. Vain sinä ja vastaanottaja(t) omistavat avaimet näiden viestien lukemiseen.
@@ -1247,7 +1247,7 @@
 \nJos et asettanut uutta palautustapaa, hyökkääjä saattaa yrittää päästä käsiksi tiliisi. Vaihda tilisi salasana ja aseta uusi palautustapa asetuksissa välittömästi.</string>
     <string name="autodiscover_invalid_response">Epäkelpo kotipalvelimen löytövastaus</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Automaattitäydennyksen palvelinasetukset</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} löysi mukautetun palvelinasetuksen userId:si domainille ”%1$s”:
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} löysi mukautetun palvelinasetuksen userId:si domainille ”%1$s”:
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Käytä asetuksia</string>
     <string name="notification_sync_init">Alustetaan palvelua</string>
@@ -1324,7 +1324,7 @@
     <string name="please_wait">Odota…</string>
     <string name="group_all_communities">Kaikki yhteisöt</string>
     <string name="room_preview_no_preview">Tätä huonetta ei voi esikatsella</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">${app_name} ei vielä tue täysin julkisen huoneen esikatselua</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">${app_name} ei vielä tue täysin julkisen huoneen esikatselua</string>
     <string name="fab_menu_create_room">Huoneet</string>
     <string name="fab_menu_create_chat">Yksityisviestit</string>
     <string name="create_room_title">Uusi huone</string>
@@ -1469,10 +1469,10 @@
     <string name="call_failed_no_ice_use_alt">Kokeile käyttää palvelinta %s</string>
     <string name="settings_call_ringtone_use_default_stun_sum">Käyttää palvelinta %s apupalvelimena, jos kotipalvelimesi ei tarjoa sellaista (IP-osoitteesi näkyy palvelimelle puhelun aikana)</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimoitu akunkestoa varten</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} synkronoi taustalla laitteen rajallisia resursseja (akkua) säästäen.
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} synkronoi taustalla laitteen rajallisia resursseja (akkua) säästäen.
 \nLaitteesi resurssien tilasta riippuen käyttöjärjestelmä saattaa lykätä synkronointia.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimoitu reaaliaikaa varten</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} synkronoi taustalla täsmällisin aikavälein (säädettävä).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} synkronoi taustalla täsmällisin aikavälein (säädettävä).
 \nTämä vaikuttaa radion ja akun käyttöön. Näet pysyvän ilmoituksen, joka kertoo, että ${app_name} kuuntelee tapahtumia.</string>
     <string name="message_edits">Viestimuokkaukset</string>
     <string name="terms_description_for_identity_server">Ole löydettävissä</string>
@@ -1575,7 +1575,7 @@
     <string name="content_reported_as_inappropriate_content">Tämä sisältö on ilmiannettu epäsopivana. 
 \n 
 \nJos et halua nähdä enempää sisältöä tältä käyttäjältä, voit estää hänet piilottaaksesi hänen viestit.</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} tarvitsee oikeuden tallentaakseen osapuolten välisen salauksen avaimesi talteen.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} tarvitsee oikeuden tallentaakseen osapuolten välisen salauksen avaimesi talteen.
 \n
 \nSalli pääsy tiedostoihin seuraavassa ponnahdusikkunassa, jotta voit viedä avaimesi käsin.</string>
     <string name="login_error_no_homeserver_found">Tämä ei ole kelvollinen Matrix-palvelimen osoite</string>
@@ -1709,7 +1709,7 @@
 \nKirjaudu sisään päästäksesi käsiksi tunnuksesi tietoihin ja viesteihin.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Menetät pääsyn salattuihin viesteihisi ellet kirjaudu sisään palauttaaksesi salausavaimesi.</string>
     <string name="soft_logout_clear_data_dialog_submit">Poista tiedot</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Nykyinen istunto on käyttäjälle %1$s, ja yritit kirjautuas isään käyttäjälle %2$s. ${app_name} ei tue tätä.
+    <string name="soft_logout_sso_not_same_user_error">Nykyinen istunto on käyttäjälle %1$s, ja yritit kirjautuas isään käyttäjälle %2$s. ${app_name} ei tue tätä.
 \nPoista ensin tietosi ja kirjaudu sen jälkeen toisella tunnuksella. Voit vaihtoehtoisesti käyttää ${app_name}in selainversiota.</string>
     <string name="permalink_malformed">matrix.to-linkkisi oli epämuodostunut</string>
     <string name="bug_report_error_too_short">Kuvaus on liian lyhyt</string>
@@ -1751,7 +1751,7 @@
     <string name="settings_rageshake_detection_threshold_summary">Ravista puhelintasi testataksesi tunnistusrajan</string>
     <string name="rageshake_detected">Ravistus tunnistettu!</string>
     <string name="autocomplete_limited_results">Näytetään vain ensimmäiset tulokset, kirjoita lisää kirjaimia…</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} voi kaatuilla tavallista useammin odottamattomien virheiden vuoksi</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} voi kaatuilla tavallista useammin odottamattomien virheiden vuoksi</string>
     <string name="command_description_shrug">Lisää ¯\\_(ツ)_/¯ tavallisen viestin alkuun</string>
     <string name="login_error_threepid_denied">Käyttämäsi sähköpostipalvelun ei ole sallittu rekisteröityä tälle palvelimelle</string>
     <string name="verification_sas_match">Täsmäävät</string>
@@ -1801,9 +1801,9 @@
     <string name="room_member_power_level_admin_in">Ylläpitäjä %1$s:ssä</string>
     <string name="room_member_power_level_moderator_in">Valvoja %1$s:ssä</string>
     <string name="room_member_jump_to_read_receipt">Siirry lukukuittaukseen</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} ei osaa käsitellä tapahtumia joiden tyyppi on \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} ei osaa käsitellä viestejä joiden tyyppi on \'%1$s\'</string>
-    <string name="template_rendering_event_error_exception">${app_name} ei osannut piirtää tapahtuman jonka tunniste on \'%1$s\' sisältöä</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} ei osaa käsitellä tapahtumia joiden tyyppi on \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} ei osaa käsitellä viestejä joiden tyyppi on \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} ei osannut piirtää tapahtuman jonka tunniste on \'%1$s\' sisältöä</string>
     <string name="room_list_sharing_header_recent_rooms">Viimeaikaiset huoneet</string>
     <string name="room_list_sharing_header_other_rooms">Muut huoneet</string>
     <string name="command_description_rainbow">Lähettää annetun viestin väritettynä sateenkaaren väreillä</string>
@@ -1865,7 +1865,7 @@
     <string name="event_redacted_by_user_reason_with_reason">Käyttäjä poistanut tapahtuman, syynä: %1$s</string>
     <string name="event_redacted_by_admin_reason_with_reason">Tapahtuma moderoitu huoneen ylläpitäjän toimesta, syynä: %1$s</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Avaimet ovat jo ajan tasalla!</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">Avainpyynnöt</string>
     <string name="refresh">Päivitä</string>
     <string name="new_session">Uusi kirjautuminen. Olitko se sinä\?</string>
@@ -1944,7 +1944,7 @@
     <string name="sound_device_speaker">Kaiutin</string>
     <string name="sound_device_phone">Puhelin</string>
     <string name="call_select_sound_device">Valitse äänilaite</string>
-    <string name="template_call_failed_no_connection">${app_name}-puhelu epäonnistui</string>
+    <string name="call_failed_no_connection">${app_name}-puhelu epäonnistui</string>
     <string name="send_bug_report_include_key_share_history">Lähetä avaimen jakopyyntöjen historia</string>
     <string name="no_more_results">Ei enempää tuloksia</string>
     <string name="bottom_action_notification">Ilmoitukset</string>
@@ -2270,7 +2270,7 @@
     <string name="a11y_import_key_from_file">Tuo avain tiedostosta</string>
     <string name="a11y_screenshot">Kuvakaappaus</string>
     <string name="authentication_error">Tunnistautuminen epäonnistui</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} vaatii tämän toimenpiteen suorittamiseksi, että annat kirjautumistietosi.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} vaatii tämän toimenpiteen suorittamiseksi, että annat kirjautumistietosi.</string>
     <string name="re_authentication_activity_title">Tunnistautuminen uudelleen vaaditaan</string>
     <string name="call_slide_to_end_conference">Liu\'uta lopettaaksesi puhelun</string>
     <string name="call_transfer_unknown_person">Tuntematon henkilö</string>
@@ -2318,13 +2318,13 @@
     <string name="auth_pin_confirm_to_disable_title">Vahvista PIN-koodi poistaaksesi PIN-koodin käytöstä</string>
     <string name="settings_security_pin_code_change_pin_summary">Vaihda nykyinen PIN-koodisi</string>
     <string name="settings_security_pin_code_change_pin_title">Vaihda PIN-koodi</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">PIN-koodi vaaditaan joka kerta, kun avaat sovelluksen ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">PIN-koodi vaaditaan, kun sovellusta ${app_name} ei ole käytetty 2 minuuttiin.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">PIN-koodi vaaditaan joka kerta, kun avaat sovelluksen ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">PIN-koodi vaaditaan, kun sovellusta ${app_name} ei ole käytetty 2 minuuttiin.</string>
     <string name="settings_security_pin_code_grace_period_title">Vaadi PIN-koodi 2 minuutin jälkeen</string>
     <string name="settings_security_pin_code_notifications_summary_off">Näytä vain lukemattomien viestien määrä yksinkertaisessa ilmoituksessa.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Näytä tiedot kuten huoneiden nimet ja viestien sisältö.</string>
     <string name="settings_security_pin_code_notifications_title">Näytä sisältö ilmoituksissa</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">PIN-koodi on ainoa tapa avata sovelluksen ${app_name} lukitus.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">PIN-koodi on ainoa tapa avata sovelluksen ${app_name} lukitus.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Ota biometriikka käyttöön</string>
     <string name="settings_security_pin_code_title">Ota PIN-koodi käyttöön</string>
     <string name="settings_security_application_protection_summary">Suojaa pääsy käyttäen PIN-koodia ja biometriikkaa.</string>
@@ -2368,7 +2368,7 @@
     <string name="identity_server_error_terms_not_signed">Hyväksy ensin identiteettipalvelimen ehdot asetusten kautta.</string>
     <string name="identity_server_error_no_identity_server_configured">Määritä ensin identiteettipalvelin.</string>
     <string name="identity_server_error_outdated_home_server">Tämä toiminto ei ole mahdollinen. Kotipalvelin on vanhentunut.</string>
-    <string name="template_identity_server_error_outdated_identity_server">Tämä identiteettipalvelin on vanhentunut. ${app_name} tukee vain API V2:ta.</string>
+    <string name="identity_server_error_outdated_identity_server">Tämä identiteettipalvelin on vanhentunut. ${app_name} tukee vain API V2:ta.</string>
     <string name="disconnect_identity_server_dialog_content">Katkaistaanko yhteys identiteettipalvelimeen %s\?</string>
     <string name="choose_locale_loading_locales">Ladataan käytettävissä olevia kieliä…</string>
     <string name="user_code_my_code">Oma koodi</string>

--- a/vector/src/main/res/values-fr-rCA/strings.xml
+++ b/vector/src/main/res/values-fr-rCA/strings.xml
@@ -44,7 +44,7 @@
     <string name="e2e_use_keybackup">Déverrouiller l’historique des messages chiffrés</string>
     <string name="settings_export_trail">Exporter le rapport d’audit</string>
     <string name="settings_key_requests">Demandes de clé</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Les clés sont déjà à jour !</string>
     <string name="event_redacted_by_admin_reason_with_reason">Évènement modéré par l’administrateur du salon, motif : %1$s</string>
     <string name="event_redacted_by_user_reason_with_reason">Évènement supprimé par l’utilisateur, motif : %1$s</string>
@@ -131,9 +131,9 @@
     <string name="verify_cannot_cross_sign">Cette session est incapable de partager cette vérification avec vos autres sessions.
 \nLa vérification sera sauvegardée localement et partagée dans une version future de l’application.</string>
     <string name="unignore">Ne plus ignorer</string>
-    <string name="template_rendering_event_error_exception">${app_name} a rencontré un problème lors de l’affichage du contenu de l’évènement ayant pour identifiant « %1$s »</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} ne gère pas les messages de type « %1$s »</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} ne gère pas les évènements de type « %1$s »</string>
+    <string name="rendering_event_error_exception">${app_name} a rencontré un problème lors de l’affichage du contenu de l’évènement ayant pour identifiant « %1$s »</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} ne gère pas les messages de type « %1$s »</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} ne gère pas les évènements de type « %1$s »</string>
     <string name="room_member_jump_to_read_receipt">Aller à l’accusé de lecture</string>
     <string name="room_member_open_or_create_dm">Conversation privée</string>
     <string name="room_member_power_level_custom_in">Personnalisé (%1$d) dans %2$s</string>
@@ -220,7 +220,7 @@
     <string name="create_room_encryption_description">Une fois qu’il est activé, le chiffrement ne peut pas être désactivé.</string>
     <string name="create_room_encryption_title">Activer le chiffrement</string>
     <string name="command_description_shrug">Préfixe ¯\\_(ツ)_/¯ à un message en texte brut</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} peut planter plus souvent quand une erreur inattendue survient</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} peut planter plus souvent quand une erreur inattendue survient</string>
     <string name="settings_developer_mode_fail_fast_title">Défaillance rapide</string>
     <string name="autocomplete_limited_results">Seuls les premiers résultats sont affichés, saisissez plus de lettres…</string>
     <string name="devices_other_devices">Autres sessions</string>
@@ -237,7 +237,7 @@
     <string name="notification_initial_sync">Synchronisation initiale…</string>
     <string name="bug_report_error_too_short">La description est trop courte</string>
     <string name="permalink_malformed">Votre lien matrix.to était malformé</string>
-    <string name="template_soft_logout_sso_not_same_user_error">La session en cours est celle de l’utilisateur %1$s et vous fournissez des identifiants pour l’utilisateur %2$s. Ce n’est pas pris en charge par ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">La session en cours est celle de l’utilisateur %1$s et vous fournissez des identifiants pour l’utilisateur %2$s. Ce n’est pas pris en charge par ${app_name}.
 \nEffacez d’abord les données, puis reconnectez-vous avec un autre compte.</string>
     <string name="soft_logout_clear_data_dialog_submit">Effacer les données</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Vous perdrez l’accès à vos messages sécurisés sauf si vous vous connectez pour récupérer vos clés de chiffrement.</string>
@@ -407,7 +407,7 @@
     <string name="room_preview_no_preview_join">Impossible d’afficher un aperçu du salon. Voulez-vous le rejoindre \?</string>
     <string name="room_preview_not_found">Ce salon n’est pas accessible en ce moment.
 \nRéessayez plus tard, ou demandez à un administrateur de ce salon de vérifier que vous pouvez y accéder.</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">L’aperçu des salons visibles par tout le monde n’est pas encore pris en charge par ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">L’aperçu des salons visibles par tout le monde n’est pas encore pris en charge par ${app_name}</string>
     <string name="room_preview_no_preview">Impossible d’avoir un aperçu de ce salon</string>
     <string name="group_all_communities">Toutes les communautés</string>
     <string name="please_wait">Veuillez patienter…</string>
@@ -456,7 +456,7 @@
     <string name="attachment_cancel_upload">Annuler le téléversement\?</string>
     <string name="message_failed_to_upload">Le téléversement de l’image a échoué</string>
     <string name="media_slider_saved_message">Enregistrer dans les téléchargements\?</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} peut accéder à votre carnet d’adresses pour trouver d’autres utilisateurs de Matrix avec leur adresse courriel et leur numéro de téléphone.
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} peut accéder à votre carnet d’adresses pour trouver d’autres utilisateurs de Matrix avec leur adresse courriel et leur numéro de téléphone.
 \n
 \nAutorisez-vous l’accès à vos contacts à cette fin\?</string>
     <string name="attachment_cancel_download">Annuler le téléchargement\?</string>
@@ -750,7 +750,7 @@
     <string name="identity_server_error_terms_not_signed">Veuillez d’abord accepter les termes du serveur d’identité dans les paramètres.</string>
     <string name="identity_server_error_no_identity_server_configured">Veuillez d’abord configurer un serveur d’identité.</string>
     <string name="identity_server_error_outdated_home_server">Cette opération n’est pas possible. Le serveur d’accueil est obsolète.</string>
-    <string name="template_identity_server_error_outdated_identity_server">Ce serveur d’identité est obsolète. ${app_name} ne prend en charge que l’API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Ce serveur d’identité est obsolète. ${app_name} ne prend en charge que l’API V2.</string>
     <string name="disconnect_identity_server_dialog_content">Se déconnecter du serveur d’identité %s \?</string>
     <string name="open_terms_of">Ouvrir les termes de %s</string>
     <string name="choose_locale_loading_locales">Chargement des langues disponibles…</string>
@@ -764,8 +764,8 @@
     <string name="not_a_valid_qr_code">Ce n’est pas un code QR matrix valide</string>
     <string name="invitations_sent_to_two_users">Invitations envoyées à %1$s et %2$s</string>
     <string name="invitation_sent_to_one_user">Invitation envoyée à %1$s</string>
-    <string name="template_invite_friends_rich_title">🔐️ Rejoins-moi sur ${app_name}</string>
-    <string name="template_invite_friends_text">Salut, parle-moi sur ${app_name} : %s</string>
+    <string name="invite_friends_rich_title">🔐️ Rejoins-moi sur ${app_name}</string>
+    <string name="invite_friends_text">Salut, parle-moi sur ${app_name} : %s</string>
     <string name="invite_friends">Ajouter des amis</string>
     <string name="invite_users_to_room_title">Inviter des utilisateurs</string>
     <string name="inviting_users_to_room">Invitation des utilisateurs…</string>
@@ -807,13 +807,13 @@
     <string name="enter_secret_storage_passphrase_or_key">Utilisez votre %1$s ou votre %2$s pour continuer.</string>
     <string name="command_description_discard_session_not_handled">Seulement pris en charge dans les salons chiffrés</string>
     <string name="command_description_discard_session">Force la session de groupe sortante actuelle dans un salon chiffré à être abandonnée</string>
-    <string name="template_use_latest_app">Utilisez la dernière version de ${app_name} sur vos autres appareils :</string>
+    <string name="use_latest_app">Utilisez la dernière version de ${app_name} sur vos autres appareils :</string>
     <string name="or_other_mx_capable_client">ou un autre client Matrix qui prend en charge la signature croisée</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} pour Bureau</string>
-    <string name="template_use_other_session_content_description">Utilisez la dernière version de ${app_name} sur vos autres appareils : ${app_name} Web, ${app_name} pour Bureau, ${app_name} iOS, ${app_name} pour Android, ou un autre client Matrix qui prend en charge la signature croisée</string>
+    <string name="use_other_session_content_description">Utilisez la dernière version de ${app_name} sur vos autres appareils : ${app_name} Web, ${app_name} pour Bureau, ${app_name} iOS, ${app_name} pour Android, ou un autre client Matrix qui prend en charge la signature croisée</string>
     <string name="change_password_summary">Définir un nouveau mot de passe de compte…</string>
     <string name="error_saving_media_file">Impossible d’enregistrer le fichier multimédia</string>
     <string name="error_adding_media_file_to_gallery">Impossible d’ajouter le fichier multimédia à la galerie</string>
@@ -1127,13 +1127,13 @@
     <string name="account_phone_number_already_used_error">Ce numéro de téléphone est déjà utilisé.</string>
     <string name="account_email_validation_title">Vérification en attente</string>
     <string name="settings_select_language">Choisissez une langue</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Le code est requis à l’ouverture d’${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Le code est demandé après 2 minutes d\'inutilisation d’${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Le code est requis à l’ouverture d’${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Le code est demandé après 2 minutes d\'inutilisation d’${app_name}.</string>
     <string name="settings_security_pin_code_grace_period_title">Demander le code après 2 minutes</string>
     <string name="settings_security_pin_code_notifications_summary_off">Afficher uniquement le numéro de messages non-lus dans une simple notification.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Afficher les détails comme les noms des salons et le contenu du message.</string>
     <string name="settings_security_pin_code_notifications_title">Afficher le contenu dans les notifications</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">Le code est la seule façon de déverrouiller ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">Le code est la seule façon de déverrouiller ${app_name}.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Activer les données biométriques comme les empreintes digitales ou la reconnaissance faciale.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Activer les données biométriques</string>
     <string name="settings_security_pin_code_title">Activer le code</string>
@@ -1281,7 +1281,7 @@
     <string name="room_list_quick_actions_notifications_all_noisy">Tous les messages (sonore)</string>
     <string name="message_ignore_user">Bloquer l’utilisateur</string>
     <string name="no_network_indicator">Il n’y a aucune connexion au réseau pour le moment</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} a besoin de votre permission pour sauvegarder vos clés de chiffrement sur le disque.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} a besoin de votre permission pour sauvegarder vos clés de chiffrement sur le disque.
 \n
 \nAutorisez l’accès dans le prochaine fenêtre pour pouvoir exporter vos clés manuellement.</string>
     <string name="content_reported_as_inappropriate_content">Ce contenu a été signalé comme inapproprié.
@@ -1327,8 +1327,8 @@
     <string name="settings_data_save_mode_summary">Le mode d’économie de données utilise un filtre spécifique qui ignore les notifications de présence et de saisie.</string>
     <string name="settings_data_save_mode">Mode économie de données</string>
     <string name="settings_opt_in_of_analytics_ok">Oui, je veux aider !</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Veuillez autoriser la collecte des données pour nous aider à améliorer ${app_name}.</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} collecte des données statistiques anonymes pour nous permettre d’améliorer l’application.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Veuillez autoriser la collecte des données pour nous aider à améliorer ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} collecte des données statistiques anonymes pour nous permettre d’améliorer l’application.</string>
     <string name="settings_opt_in_of_analytics">Envoyer des statistiques d’utilisation</string>
     <string name="settings_analytics">Statistiques d’utilisation</string>
     <string name="settings_notification_privacy_need_permission">L’application a besoin de la permission de fonctionner en arrière-plan</string>
@@ -1336,17 +1336,17 @@
     <string name="settings_notification_privacy_normal">Normal</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignorer l’optimisation</string>
     <string name="settings_troubleshoot_test_battery_failed">Si un utilisateur laisse un appareil débranché et immobile pour une longue durée, avec l’écran éteint, l’appareil entre en mode veille.. Cela empêche les applications d’accéder au réseau et reporte leurs tâches, synchronisations et alarmes standard.</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} n’est pas affecté par l’optimisation de la batterie.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} n’est pas affecté par l’optimisation de la batterie.</string>
     <string name="settings_troubleshoot_test_battery_title">Optimisation de la batterie</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Désactiver les restrictions</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Les restrictions en arrière-plan sont activées pour ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Les restrictions en arrière-plan sont activées pour ${app_name}.
 \nLes tâches que l’application essaiera d’effectuer seront fortement restreintes tant qu’elle sera en arrière-plan et cela pourra affecter les notifications.
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Les restrictions en arrière-plan sont désactivées pour ${app_name}. Ce test devrait être lancé en utilisant les données mobiles (pas le Wi-Fi).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Les restrictions en arrière-plan sont désactivées pour ${app_name}. Ce test devrait être lancé en utilisant les données mobiles (pas le Wi-Fi).
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Vérifier les restrictions en arrière-plan</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Activer le démarrage au démarrage de l’appareil</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Le service ne démarrera pas quand l’appareil sera redémarré, vous ne recevrez pas de notifications tant que ${app_name} n’aura pas été lancé au moins une fois.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Le service ne démarrera pas quand l’appareil sera redémarré, vous ne recevrez pas de notifications tant que ${app_name} n’aura pas été lancé au moins une fois.</string>
     <string name="settings_troubleshoot_test_service_boot_success">Le service démarrera quand l’appareil sera redémarré.</string>
     <string name="settings_troubleshoot_test_service_boot_title">Lancer au démarrage</string>
     <string name="settings_troubleshoot_test_service_restart_failed">Le redémarrage du service a échoué</string>
@@ -1365,11 +1365,11 @@
     <string name="settings_troubleshoot_test_token_registration_success">Le jeton FCM a été correctement enregistré sur le serveur d’accueil.</string>
     <string name="settings_troubleshoot_test_token_registration_title">Enregistrement du jeton</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Ajouter un compte</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nCette erreur est indépendante de ${app_name}. Il n’y pas de compte Google sur l’appareil. Veuillez ouvrir le gestionnaire de comptes et ajouter un compte Google.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nCette erreur est indépendante de ${app_name}. Elle peut survenir pour plusieurs raisons. Cela peut fonctionner si vous réessayez plus tard. Vous pouvez aussi vérifier que le Service Google Play n’a pas un usage limité de données dans les paramètres système. Cela peut aussi arriver sur une ROM personnalisée.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nCette erreur est indépendante de ${app_name} et, selon Google, cette erreur indique que l’appareil a enregistré trop d’applications avec FCM. Cette erreur ne survient que s’il y a un nombre d’applications anormalement élevé, et ne devrait donc pas affecter un utilisateur normal.</string>
     <string name="settings_troubleshoot_test_fcm_failed">Le jeton FCM n’a pas pu être récupéré :
 \n%1$s</string>
@@ -1377,7 +1377,7 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_title">Jeton Firebase</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Réparer les services Google Play</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} utilise les services Google Play pour envoyer les notifications mais ils n’ont pas l’air d’être configurés correctement :
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} utilise les services Google Play pour envoyer les notifications mais ils n’ont pas l’air d’être configurés correctement :
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_success">L’APK des services Google Play est disponible et à jour.</string>
     <string name="settings_troubleshoot_test_play_services_title">Vérification des services Google Play</string>
@@ -1387,7 +1387,7 @@
     <string name="settings_troubleshoot_test_bing_settings_success_with_warn">Remarquez que certains messages sont réglés pour être silencieux (ils produiront une notification sans son).</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Paramètres personnalisés.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Activer</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Les notifications ne sont pas activées pour cette session.
+    <string name="settings_troubleshoot_test_device_settings_failed">Les notifications ne sont pas activées pour cette session.
 \nVeuillez vérifier les paramètres de ${app_name}.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Les notifications sont activées pour cette session.</string>
     <string name="settings_troubleshoot_test_device_settings_title">Paramètres de la session.</string>
@@ -1414,7 +1414,7 @@
     <string name="settings_remove_three_pid_confirmation_content">Supprimer %s \?</string>
     <string name="settings_phone_numbers">Numéros de téléphone</string>
     <string name="settings_add_3pid_authentication_needed">Une authentification est nécessaire</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Vous ne pouvez pas faire ceci depuis ${app_name} mobile</string>
+    <string name="settings_add_3pid_flow_not_supported">Vous ne pouvez pas faire ceci depuis ${app_name} mobile</string>
     <string name="settings_add_3pid_confirm_password_title">Confirmez votre mot de passe</string>
     <string name="settings_app_info_link_summary">Affiche les informations de l’application dans les paramètres système.</string>
     <string name="settings_app_info_link_title">Informations sur l’application</string>
@@ -1546,9 +1546,9 @@
     <string name="login_wait_for_email_title">Vérifiez vos courriels</string>
     <string name="login_wait_for_email_notice">Nous avons envoyé un courriel à %1$s.
 \nCliquez sur le lien qu’il contient pour continuer la création du compte.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Pour votre vie privée, ${app_name} prend uniquement en charge l’envoi des adresses courriel et des numéros de téléphone hachés.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Pour votre vie privée, ${app_name} prend uniquement en charge l’envoi des adresses courriel et des numéros de téléphone hachés.</string>
     <string name="login_login_with_email_error">Cet courriel n’est associé à aucun compte.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} peut accéder à votre carnet d’adresses pour trouver d’autres utilisateurs de Matrix avec leur numéro de téléphone et leur adresse courriel. Veuillez autoriser l’accès dans la prochaine fenêtre pour découvrir les utilisateurs du carnet d’adresses joignables via ${app_name}.</string>
+    <string name="permissions_rationale_msg_contacts">${app_name} peut accéder à votre carnet d’adresses pour trouver d’autres utilisateurs de Matrix avec leur numéro de téléphone et leur adresse courriel. Veuillez autoriser l’accès dans la prochaine fenêtre pour découvrir les utilisateurs du carnet d’adresses joignables via ${app_name}.</string>
     <string name="auth_add_email_and_phone_message_2">Renseignez une adresse courriel pour la récupération de compte. Utilisez ensuite un courriel ou un téléphone pour être éventuellement découvrable par les personnes qui vous connaissent.</string>
     <string name="auth_invalid_phone">Ceci ne ressemble pas à un numéro de téléphone valide</string>
     <string name="auth_invalid_email">Ceci ne ressemble pas à une adresse courriel valide</string>
@@ -1621,7 +1621,7 @@
     <string name="a11y_import_key_from_file">Importer la clé depuis le fichier</string>
     <string name="a11y_screenshot">Capture d’écran</string>
     <string name="authentication_error">Échec d’authentification</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} requiert que vous saisissiez vos identifiants à nouveau pour effectuer cette action.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} requiert que vous saisissiez vos identifiants à nouveau pour effectuer cette action.</string>
     <string name="re_authentication_activity_title">Une nouvelle authentification est requise</string>
     <string name="call_transfer_users_tab_title">Utilisateurs</string>
     <string name="call_transfer_failure">Une erreur s’est produite lors du transfert de l’appel</string>
@@ -1659,7 +1659,7 @@
     <string name="sas_verify_title">Vérifier en comparant une courte chaîne de caractères.</string>
     <string name="invalid_or_expired_credentials">Vous avez été déconnecté car vos identifiants sont incorrects ou ont expiré.</string>
     <string name="autodiscover_well_known_autofill_confirm">Utiliser la configuration</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} a détecté une configuration de serveur personnalisée pour le domaine de votre identifiant « %1$s » :
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} a détecté une configuration de serveur personnalisée pour le domaine de votre identifiant « %1$s » :
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Auto-compléter les options du serveur</string>
     <string name="autodiscover_invalid_response">Réponse de découverte du serveur d’accueil non valide</string>
@@ -1700,7 +1700,7 @@
 \nSauvegardez vos clés de façon sécurisée pour éviter de les perdre.</string>
     <string name="keys_backup_setup_step1_title">Ne perdez jamais vos messages chiffrés</string>
     <string name="keys_backup_no_session_error">Aucune session Matrix n’est disponible</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Veuillez supprimer la phrase secrète si vous voulez que ${app_name} génère une clé de récupération.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Veuillez supprimer la phrase secrète si vous voulez que ${app_name} génère une clé de récupération.</string>
     <string name="passphrase_passphrase_too_weak">La phrase secrète est trop faible</string>
     <string name="passphrase_empty_error_message">Veuillez saisir une phrase secrète</string>
     <string name="passphrase_passphrase_does_not_match">Les phrases secrètes doivent concorder</string>
@@ -1905,7 +1905,7 @@
     <string name="call_select_sound_device">Sélectionner un périphérique audio</string>
     <string name="call_failed_no_connection_description">Impossible d\'établir une connexion en temps réel.
 \nVeuillez demander à l’administrateur de votre serveur d’accueil de configurer un serveur TURN afin que les appels fonctionnent de manière fiable.</string>
-    <string name="template_call_failed_no_connection">Appel échoué</string>
+    <string name="call_failed_no_connection">Appel échoué</string>
     <string name="call_failed_dont_ask_again">Ne plus me demander</string>
     <string name="call_failed_no_ice_use_alt">Essayez d’utiliser %s</string>
     <string name="call_failed_no_ice_description">Demandez à l’administrateur de votre serveur d’accueil (%1$s) de configurer un serveur TURN afin que les appels fonctionnent de manière fiable.
@@ -1951,7 +1951,7 @@
     <string name="people_no_identity_server">Aucun serveur d’identité configuré.</string>
     <string name="no_more_results">Plus aucun résultat</string>
     <string name="no_result_placeholder">Aucun résultat</string>
-    <string name="template_no_contact_access_placeholder">Vous n’avez pas autorisé ${app_name} à accéder à votre carnet d’adresses</string>
+    <string name="no_contact_access_placeholder">Vous n’avez pas autorisé ${app_name} à accéder à votre carnet d’adresses</string>
     <string name="no_conversation_placeholder">Aucune discussion</string>
     <string name="matrix_only_filter">Contacts Matrix uniquement</string>
     <string name="user_directory_header">Répertoire utilisateur</string>
@@ -2130,12 +2130,12 @@
     <string name="keys_backup_setup_override_stop">Arrêter</string>
     <string name="keys_backup_setup_override_replace">Remplacer</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Donner la permission</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} doit garder une connexion à faible empreinte en arrière-plan afin d’avoir des notifications fiables.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} doit garder une connexion à faible empreinte en arrière-plan afin d’avoir des notifications fiables.
 \nSur l’écran suivant on vous demandera d’autoriser ${app_name} à toujours fonctionner en arrière-plan, veuillez accepter.</string>
     <string name="startup_notification_fdroid_battery_optim_title">Connexion en arrière-plan</string>
     <string name="startup_notification_privacy_button_other">Choisir une autre option</string>
     <string name="startup_notification_privacy_button_grant">Donner la permission</string>
-    <string name="template_startup_notification_privacy_message">${app_name} peut fonctionner en arrière-plan pour gérer vos notifications de façon sécurisée et confidentielle. Cela peut affecter l’utilisation de la batterie.</string>
+    <string name="startup_notification_privacy_message">${app_name} peut fonctionner en arrière-plan pour gérer vos notifications de façon sécurisée et confidentielle. Cela peut affecter l’utilisation de la batterie.</string>
     <string name="startup_notification_privacy_title">Confidentialité des notifications</string>
     <string name="settings_discovery_manage">Gérer vos paramètres de découverte.</string>
     <string name="settings_discovery_category">Découverte</string>
@@ -2205,10 +2205,10 @@
     <string name="settings_background_sync_update_error">Échec de la mise à jour des paramètres.</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Vous ne serez pas notifié des messages entrants quand l’application est en arrière-plan.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Aucune synchronisation en arrière-plan</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} se synchronisera en arrière-plan de façon périodique à un moment précis (configurable).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} se synchronisera en arrière-plan de façon périodique à un moment précis (configurable).
 \nCela aura un impact sur l’utilisation des données mobiles et de la batterie, une notification permanente sera affichée indiquant que ${app_name} est à l’écoute des évènements.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimisé pour le temps réel</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} se synchronisera en arrière-plan de façon à préserver les ressources limitées de l’appareil (batterie).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} se synchronisera en arrière-plan de façon à préserver les ressources limitées de l’appareil (batterie).
 \nSelon l’état des ressources de votre appareil, la synchronisation peut être retardée par le système d’exploitation.</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimisé pour préserver la batterie</string>
     <string name="settings_background_fdroid_sync_mode">Mode de synchronisation en arrière-plan</string>
@@ -2506,18 +2506,18 @@
     <string name="permissions_denied_add_contact">Autoriser l’accès à vos contacts.</string>
     <string name="permissions_denied_qr_code">Pour scanner un code QR, vous devez autoriser l’accès à votre appareil photo.</string>
     <string name="permissions_action_not_performed_missing_permissions">Désolé. L’action n’a pas été réalisée faute d’autorisations</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} a besoin d’accéder à votre appareil photo et à votre microphone pour passer des appels vidéo.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} a besoin d’accéder à votre appareil photo et à votre microphone pour passer des appels vidéo.
 \n
 \nVeuillez autoriser l’accès dans les prochaines fenêtres pour pouvoir effectuer l’appel.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nVeuillez autoriser l’accès dans la prochaine fenêtre contextuelle pour pouvoir effectuer l’appel."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} a besoin d’accéder à votre microphone pour passer des appels audio.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} a besoin d’accéder à votre microphone pour passer des appels audio.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nVeuillez autoriser l’accès dans la prochaine fenêtre pour pouvoir effectuer l’appel."</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} a besoin d’accéder à votre appareil photo pour prendre des photos et passer des appels vidéo.</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} a besoin d’accéder à vos photos et vidéos pour envoyer et enregistrer des pièces jointes
+    <string name="permissions_rationale_msg_camera">${app_name} a besoin d’accéder à votre appareil photo pour prendre des photos et passer des appels vidéo.</string>
+    <string name="permissions_rationale_msg_storage">${app_name} a besoin d’accéder à vos photos et vidéos pour envoyer et enregistrer des pièces jointes
 \n
 \nVeuillez autoriser l’accès dans la prochaine fenêtre pour pouvoir envoyer des fichiers depuis votre téléphone.</string>
     <string name="permissions_rationale_popup_title">Information</string>
@@ -2547,7 +2547,7 @@
     <string name="settings_call_ringtone_title">Sonnerie d’appel entrant</string>
     <string name="settings_call_ringtone_use_default_stun_sum">Utilisera %s comme assistant quand votre serveur d’accueil n’en offre pas (votre adresse IP sera partagée lors d’un appel)</string>
     <string name="settings_call_ringtone_use_default_stun">Autoriser le serveur d’assistance d’appel de secours</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Utiliser la sonnerie par défaut de ${app_name} pour les appels entrants</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Utiliser la sonnerie par défaut de ${app_name} pour les appels entrants</string>
     <string name="settings_call_show_confirmation_dialog_summary">Demander une confirmation avant de lancer un appel</string>
     <string name="settings_call_show_confirmation_dialog_title">Éviter les appels accidentels</string>
     <string name="settings_call_category">Appels</string>
@@ -2564,7 +2564,7 @@
     <string name="compression_options">Envoyer en tant que</string>
     <string name="groups_list">Liste des Groupes</string>
     <string name="read_receipts_list">Liste des accusés de lecture</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Veuillez lancer ${app_name} sur un autre appareil qui peut déchiffrer le message pour qu’il puisse envoyer les clés à cette session.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Veuillez lancer ${app_name} sur un autre appareil qui peut déchiffrer le message pour qu’il puisse envoyer les clés à cette session.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Demande envoyée</string>
     <string name="e2e_re_request_encryption_key_sent">Demande de clé envoyée.</string>
     <string name="e2e_re_request_encryption_key">Redemander les clés de chiffrement à vos autres sessions.</string>

--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -293,7 +293,7 @@
     <string name="local_address_book_header">Carnet d’adresses local</string>
     <string name="matrix_only_filter">Contacts Matrix uniquement</string>
     <string name="no_conversation_placeholder">Aucune discussion</string>
-    <string name="template_no_contact_access_placeholder">Vous n’avez pas autorisé ${app_name} à accéder à votre carnet d’adresses</string>
+    <string name="no_contact_access_placeholder">Vous n’avez pas autorisé ${app_name} à accéder à votre carnet d’adresses</string>
     <string name="no_result_placeholder">Aucun résultat</string>
     <string name="rooms_header">Salons</string>
     <string name="rooms_directory_header">Répertoire de salons</string>
@@ -629,22 +629,22 @@
     <string name="call_error_user_not_responding">Le correspondant n’a pas décroché.</string>
     <string name="media_picker_both_capture_title">Prendre une photo ou une vidéo</string>
     <string name="permissions_rationale_popup_title">Information</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} a besoin d’accéder à vos photos et vidéos pour envoyer et enregistrer des pièces jointes
+    <string name="permissions_rationale_msg_storage">${app_name} a besoin d’accéder à vos photos et vidéos pour envoyer et enregistrer des pièces jointes
 \n
 \nVeuillez autoriser l’accès dans la prochaine fenêtre pour pouvoir envoyer des fichiers depuis votre téléphone.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} a besoin d’accéder à votre appareil photo pour prendre des photos et passer des appels vidéo.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} a besoin d’accéder à votre appareil photo pour prendre des photos et passer des appels vidéo.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nVeuillez autoriser l’accès dans la prochaine fenêtre pour pouvoir effectuer l’appel."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} a besoin d’accéder à votre microphone pour passer des appels audio.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} a besoin d’accéder à votre microphone pour passer des appels audio.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nVeuillez autoriser l’accès dans la prochaine fenêtre contextuelle pour pouvoir effectuer l’appel."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} a besoin d’accéder à votre appareil photo et à votre microphone pour passer des appels vidéo.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} a besoin d’accéder à votre appareil photo et à votre microphone pour passer des appels vidéo.
 \n
 \nVeuillez autoriser l’accès dans les prochaines fenêtres pour pouvoir effectuer l’appel.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} peut accéder à votre carnet d’adresses pour trouver d’autres utilisateurs de Matrix avec leur numéro de téléphone et leur adresse e-mail. Veuillez autoriser l’accès dans la prochaine fenêtre pour découvrir les utilisateurs du carnet d’adresses joignables via ${app_name}.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} peut accéder à votre carnet d’adresses pour trouver d’autres utilisateurs de Matrix avec leur adresse e-mail et leur numéro de téléphone.
+    <string name="permissions_rationale_msg_contacts">${app_name} peut accéder à votre carnet d’adresses pour trouver d’autres utilisateurs de Matrix avec leur numéro de téléphone et leur adresse e-mail. Veuillez autoriser l’accès dans la prochaine fenêtre pour découvrir les utilisateurs du carnet d’adresses joignables via ${app_name}.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} peut accéder à votre carnet d’adresses pour trouver d’autres utilisateurs de Matrix avec leur adresse e-mail et leur numéro de téléphone.
 \n
 \nAutorisez-vous l’accès à vos contacts à cette fin \?</string>
     <string name="permissions_action_not_performed_missing_permissions">Désolé. L’action n’a pas été réalisée faute d’autorisations</string>
@@ -912,7 +912,7 @@
     <string name="settings_notification_privacy_nosecure_message_content">• Les notifications contiennent <b>des métadonnées et des messages</b></string>
     <string name="settings_notification_privacy_message_content_not_shown">• Les notifications <b>n’afficheront pas le contenu des messages</b></string>
     <string name="startup_notification_privacy_title">Confidentialité des notifications</string>
-    <string name="template_startup_notification_privacy_message">${app_name} peut fonctionner en arrière-plan pour gérer vos notifications de façon sécurisée et confidentielle. Cela peut affecter l’utilisation de la batterie.</string>
+    <string name="startup_notification_privacy_message">${app_name} peut fonctionner en arrière-plan pour gérer vos notifications de façon sécurisée et confidentielle. Cela peut affecter l’utilisation de la batterie.</string>
     <string name="startup_notification_privacy_button_grant">Donner la permission</string>
     <string name="startup_notification_privacy_button_other">Choisir une autre option</string>
     <string name="notice_avatar">Avatar d’avertissement</string>
@@ -924,8 +924,8 @@
     <string name="settings_deactivate_account_section">Désactiver le compte</string>
     <string name="settings_deactivate_my_account">Désactiver mon compte</string>
     <string name="settings_opt_in_of_analytics">Envoyer des statistiques d’utilisation</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} collecte des données statistiques anonymes pour nous permettre d’améliorer l’application.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Veuillez autoriser la collecte des données pour nous aider à améliorer ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} collecte des données statistiques anonymes pour nous permettre d’améliorer l’application.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Veuillez autoriser la collecte des données pour nous aider à améliorer ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Oui, je veux aider !</string>
     <string name="widget_integration_missing_parameter">Un paramètre requis est manquant.</string>
     <string name="widget_integration_invalid_parameter">Un paramètre n’est pas valide.</string>
@@ -947,7 +947,7 @@
     <string name="e2e_re_request_encryption_key">Redemander les clés de chiffrement à vos autres sessions.</string>
     <string name="e2e_re_request_encryption_key_sent">Demande de clé envoyée.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Demande envoyée</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Veuillez lancer ${app_name} sur un autre appareil qui peut déchiffrer le message pour qu’il puisse envoyer les clés à cette session.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Veuillez lancer ${app_name} sur un autre appareil qui peut déchiffrer le message pour qu’il puisse envoyer les clés à cette session.</string>
     <string name="lock_screen_hint">Saisir du texte ici…</string>
     <string name="option_send_voice">Envoyer un message vocal</string>
     <string name="go_on_with">continuer avec…</string>
@@ -1061,7 +1061,7 @@
     <string name="markdown_has_been_enabled">Le Markdown a été activé.</string>
     <string name="markdown_has_been_disabled">Le Markdown a été désactivé.</string>
     <string name="settings_call_category">Appels</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Utiliser la sonnerie par défaut de ${app_name} pour les appels entrants</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Utiliser la sonnerie par défaut de ${app_name} pour les appels entrants</string>
     <string name="settings_call_ringtone_title">Sonnerie d’appel entrant</string>
     <string name="settings_call_ringtone_dialog_title">Sélectionner la sonnerie pour les appels :</string>
     <string name="action_accept">Accepter</string>
@@ -1085,12 +1085,12 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Activer</string>
     <string name="settings_troubleshoot_test_device_settings_title">Paramètres de la session.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Les notifications sont activées pour cette session.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Les notifications ne sont pas activées pour cette session.
+    <string name="settings_troubleshoot_test_device_settings_failed">Les notifications ne sont pas activées pour cette session.
 \nVeuillez vérifier les paramètres de ${app_name}.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Activer</string>
     <string name="settings_troubleshoot_test_play_services_title">Vérification des services Google Play</string>
     <string name="settings_troubleshoot_test_play_services_success">L’APK des services Google Play est disponible et à jour.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} utilise les services Google Play pour envoyer les notifications mais ils n’ont pas l’air d’être configurés correctement :
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} utilise les services Google Play pour envoyer les notifications mais ils n’ont pas l’air d’être configurés correctement :
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Réparer les services Google Play</string>
     <string name="settings_troubleshoot_test_fcm_title">Jeton Firebase</string>
@@ -1107,21 +1107,21 @@
     <string name="settings_troubleshoot_test_service_restart_failed">Le redémarrage du service a échoué</string>
     <string name="settings_troubleshoot_test_service_boot_title">Lancer au démarrage</string>
     <string name="settings_troubleshoot_test_service_boot_success">Le service démarrera quand l’appareil sera redémarré.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Le service ne démarrera pas quand l’appareil sera redémarré, vous ne recevrez pas de notifications tant que ${app_name} n’aura pas été lancé au moins une fois.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Le service ne démarrera pas quand l’appareil sera redémarré, vous ne recevrez pas de notifications tant que ${app_name} n’aura pas été lancé au moins une fois.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Activer le démarrage au démarrage de l’appareil</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Vérifier les restrictions en arrière-plan</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Les restrictions en arrière-plan sont désactivées pour ${app_name}. Ce test devrait être lancé en utilisant les données mobiles (pas le Wi-Fi).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Les restrictions en arrière-plan sont désactivées pour ${app_name}. Ce test devrait être lancé en utilisant les données mobiles (pas le Wi-Fi).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Les restrictions en arrière-plan sont activées pour ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Les restrictions en arrière-plan sont activées pour ${app_name}.
 \nLes tâches que l’application essaiera d’effectuer seront fortement restreintes tant qu’elle sera en arrière-plan et cela pourra affecter les notifications.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Désactiver les restrictions</string>
     <string name="settings_troubleshoot_test_battery_title">Optimisation de la batterie</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} n’est pas affecté par l’optimisation de la batterie.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} n’est pas affecté par l’optimisation de la batterie.</string>
     <string name="settings_troubleshoot_test_battery_failed">Si un utilisateur laisse un appareil débranché et immobile pour une longue durée, avec l’écran éteint, l’appareil entre en mode veille.. Cela empêche les applications d’accéder au réseau et reporte leurs tâches, synchronisations et alarmes standard.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignorer l’optimisation</string>
     <string name="startup_notification_fdroid_battery_optim_title">Connexion en arrière-plan</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} doit garder une connexion à faible empreinte en arrière-plan afin d’avoir des notifications fiables.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} doit garder une connexion à faible empreinte en arrière-plan afin d’avoir des notifications fiables.
 \nSur l’écran suivant on vous demandera d’autoriser ${app_name} à toujours fonctionner en arrière-plan, veuillez accepter.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Donner la permission</string>
     <string name="account_email_error">Une erreur est survenue lors de la vérification de votre adresse e-mail.</string>
@@ -1141,11 +1141,11 @@
     <string name="settings_troubleshoot_test_bing_settings_failed">Certaines notifications sont désactivées dans vos paramètres personnalisés.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">Échec du chargement de vos règles personnalisées, veuillez réessayer.</string>
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Vérifier les paramètres</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nCette erreur est indépendante de ${app_name} et, selon Google, cette erreur indique que l’appareil a enregistré trop d’applications avec FCM. Cette erreur ne survient que s’il y a un nombre d’applications anormalement élevé, et ne devrait donc pas affecter un utilisateur normal.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nCette erreur est indépendante de ${app_name}. Elle peut survenir pour plusieurs raisons. Cela peut fonctionner si vous réessayez plus tard. Vous pouvez aussi vérifier que le Service Google Play n’a pas un usage limité de données dans les paramètres système. Cela peut aussi arriver sur une ROM personnalisée.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nCette erreur est indépendante de ${app_name}. Il n’y pas de compte Google sur l’appareil. Veuillez ouvrir le gestionnaire de comptes et ajouter un compte Google.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Ajouter un compte</string>
     <string name="settings_noisy_notifications_preferences">Configurer les notifications sonores</string>
@@ -1157,7 +1157,7 @@
     <string name="notification_silent">Silencieuse</string>
     <string name="passphrase_empty_error_message">Veuillez saisir une phrase secrète</string>
     <string name="passphrase_passphrase_too_weak">La phrase secrète est trop faible</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Veuillez supprimer la phrase secrète si vous voulez que ${app_name} génère une clé de récupération.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Veuillez supprimer la phrase secrète si vous voulez que ${app_name} génère une clé de récupération.</string>
     <string name="keys_backup_no_session_error">Aucune session Matrix n’est disponible</string>
     <string name="keys_backup_setup_step1_title">Ne perdez jamais vos messages chiffrés</string>
     <string name="keys_backup_setup_step1_description">Les messages dans les salons chiffrés sont sécurisés avec un chiffrement de bout en bout. Seuls vous et le(s) destinataire(s) avez les clés pour lire ces messages. 
@@ -1287,7 +1287,7 @@
     <string name="passwords_do_not_match">Les mots de passe ne correspondent pas</string>
     <string name="autodiscover_invalid_response">Réponse de découverte du serveur d’accueil non valide</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Auto-compléter les options du serveur</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} a détecté une configuration de serveur personnalisée pour le domaine de votre identifiant « %1$s » :
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} a détecté une configuration de serveur personnalisée pour le domaine de votre identifiant « %1$s » :
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Utiliser la configuration</string>
     <string name="notification_sync_init">Initialisation du service</string>
@@ -1402,7 +1402,7 @@
     <string name="action_change">Changer</string>
     <string name="group_all_communities">Toutes les communautés</string>
     <string name="room_preview_no_preview">Impossible d’avoir un aperçu de ce salon</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">L’aperçu des salons visibles par tout le monde n’est pas encore pris en charge par ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">L’aperçu des salons visibles par tout le monde n’est pas encore pris en charge par ${app_name}</string>
     <string name="fab_menu_create_room">Salons</string>
     <string name="fab_menu_create_chat">Conversations privées</string>
     <string name="create_room_title">Nouveau salon</string>
@@ -1497,10 +1497,10 @@
     <string name="invite_no_identity_server_error">Ajoutez un serveur d’identité dans vos paramètres pour réaliser cette action.</string>
     <string name="settings_background_fdroid_sync_mode">Mode de synchronisation en arrière-plan</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimisé pour préserver la batterie</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} se synchronisera en arrière-plan de façon à préserver les ressources limitées de l’appareil (batterie).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} se synchronisera en arrière-plan de façon à préserver les ressources limitées de l’appareil (batterie).
 \nSelon l’état des ressources de votre appareil, la synchronisation peut être retardée par le système d’exploitation.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimisé pour le temps réel</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} se synchronisera en arrière-plan de façon périodique à un moment précis (configurable).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} se synchronisera en arrière-plan de façon périodique à un moment précis (configurable).
 \nCela aura un impact sur l’utilisation des données mobiles et de la batterie, une notification permanente sera affichée indiquant que ${app_name} est à l’écoute des évènements.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Aucune synchronisation en arrière-plan</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Vous ne serez pas notifié des messages entrants quand l’application est en arrière-plan.</string>
@@ -1585,7 +1585,7 @@
     <string name="content_reported_as_inappropriate_content">Ce contenu a été signalé comme inapproprié.
 \n
 \nSi vous ne voulez plus voir de contenu de cet utilisateur, vous pouvez l’ignorer pour masquer ses messages.</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} a besoin de votre permission pour sauvegarder vos clés de chiffrement sur le disque.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} a besoin de votre permission pour sauvegarder vos clés de chiffrement sur le disque.
 \n
 \nAutorisez l’accès dans le prochaine fenêtre pour pouvoir exporter vos clés manuellement.</string>
     <string name="no_network_indicator">Il n’y a aucune connexion au réseau pour le moment</string>
@@ -1757,7 +1757,7 @@
 \nReconnectez-vous pour accéder aux données et aux messages de votre compte.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Vous perdrez l’accès à vos messages sécurisés sauf si vous vous connectez pour récupérer vos clés de chiffrement.</string>
     <string name="soft_logout_clear_data_dialog_submit">Effacer les données</string>
-    <string name="template_soft_logout_sso_not_same_user_error">La session en cours est celle de l’utilisateur %1$s et vous fournissez des identifiants pour l’utilisateur %2$s. Ce n’est pas pris en charge par ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">La session en cours est celle de l’utilisateur %1$s et vous fournissez des identifiants pour l’utilisateur %2$s. Ce n’est pas pris en charge par ${app_name}.
 \nEffacez d’abord les données, puis reconnectez-vous avec un autre compte.</string>
     <string name="permalink_malformed">Votre lien matrix.to était malformé</string>
     <string name="bug_report_error_too_short">La description est trop courte</string>
@@ -1775,7 +1775,7 @@
     <string name="devices_other_devices">Autres sessions</string>
     <string name="autocomplete_limited_results">Seuls les premiers résultats sont affichés, saisissez plus de lettres…</string>
     <string name="settings_developer_mode_fail_fast_title">Défaillance rapide</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} peut planter plus souvent quand une erreur inattendue survient</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} peut planter plus souvent quand une erreur inattendue survient</string>
     <string name="command_description_shrug">Préfixe ¯\\_(ツ)_/¯ à un message en texte brut</string>
     <string name="create_room_encryption_title">Activer le chiffrement</string>
     <string name="create_room_encryption_description">Une fois qu’il est activé, le chiffrement ne peut pas être désactivé.</string>
@@ -1846,9 +1846,9 @@
     <string name="room_member_power_level_moderator_in">Modérateur dans %1$s</string>
     <string name="room_member_power_level_custom_in">Personnalisé (%1$d) dans %2$s</string>
     <string name="room_member_jump_to_read_receipt">Aller à l’accusé de lecture</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} ne gère pas les évènements de type « %1$s »</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} ne gère pas les messages de type « %1$s »</string>
-    <string name="template_rendering_event_error_exception">${app_name} a rencontré un problème lors de l’affichage du contenu de l’évènement ayant pour identifiant « %1$s »</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} ne gère pas les évènements de type « %1$s »</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} ne gère pas les messages de type « %1$s »</string>
+    <string name="rendering_event_error_exception">${app_name} a rencontré un problème lors de l’affichage du contenu de l’évènement ayant pour identifiant « %1$s »</string>
     <string name="unignore">Ne plus ignorer</string>
     <string name="verify_cannot_cross_sign">Cette session est incapable de partager cette vérification avec vos autres sessions.
 \nLa vérification sera sauvegardée localement et partagée dans une version future de l’application.</string>
@@ -1934,7 +1934,7 @@
     <string name="event_redacted_by_user_reason_with_reason">Évènement supprimé par l’utilisateur, motif : %1$s</string>
     <string name="event_redacted_by_admin_reason_with_reason">Évènement modéré par l’administrateur du salon, motif : %1$s</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Les clés sont déjà à jour !</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">Demandes de clé</string>
     <string name="e2e_use_keybackup">Déverrouiller l’historique des messages chiffrés</string>
     <string name="refresh">Actualiser</string>
@@ -2035,13 +2035,13 @@
     <string name="media_file_added_to_gallery">Fichier multimédia ajouté à la galerie</string>
     <string name="error_adding_media_file_to_gallery">Impossible d’ajouter le fichier multimédia à la galerie</string>
     <string name="change_password_summary">Définir un nouveau mot de passe de compte…</string>
-    <string name="template_use_other_session_content_description">Utilisez la dernière version de ${app_name} sur vos autres appareils : ${app_name} Web, ${app_name} pour Bureau, ${app_name} iOS, ${app_name} pour Android, ou un autre client Matrix qui prend en charge la signature croisée</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="use_other_session_content_description">Utilisez la dernière version de ${app_name} sur vos autres appareils : ${app_name} Web, ${app_name} pour Bureau, ${app_name} iOS, ${app_name} pour Android, ou un autre client Matrix qui prend en charge la signature croisée</string>
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} pour Bureau</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
     <string name="or_other_mx_capable_client">ou un autre client Matrix qui prend en charge la signature croisée</string>
-    <string name="template_use_latest_app">Utilisez la dernière version de ${app_name} sur vos autres appareils :</string>
+    <string name="use_latest_app">Utilisez la dernière version de ${app_name} sur vos autres appareils :</string>
     <string name="command_description_discard_session">Force la session de groupe sortante actuelle dans un salon chiffré à être abandonnée</string>
     <string name="command_description_discard_session_not_handled">Seulement pris en charge dans les salons chiffrés</string>
     <string name="enter_secret_storage_passphrase_or_key">Utilisez votre %1$s ou votre %2$s pour continuer.</string>
@@ -2102,11 +2102,11 @@
     <string name="choose_locale_loading_locales">Chargement des langues disponibles…</string>
     <string name="open_terms_of">Ouvrir les termes de %s</string>
     <string name="disconnect_identity_server_dialog_content">Se déconnecter du serveur d’identité %s \?</string>
-    <string name="template_identity_server_error_outdated_identity_server">Ce serveur d’identité est obsolète. ${app_name} ne prend en charge que l’API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Ce serveur d’identité est obsolète. ${app_name} ne prend en charge que l’API V2.</string>
     <string name="identity_server_error_outdated_home_server">Cette opération n’est pas possible. Le serveur d’accueil est obsolète.</string>
     <string name="identity_server_error_no_identity_server_configured">Veuillez d’abord configurer un serveur d’identité.</string>
     <string name="identity_server_error_terms_not_signed">Veuillez d’abord accepter les termes du serveur d’identité dans les paramètres.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Pour votre vie privée, ${app_name} prend uniquement en charge l’envoi des adresses e-mail et des numéros de téléphone hachés.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Pour votre vie privée, ${app_name} prend uniquement en charge l’envoi des adresses e-mail et des numéros de téléphone hachés.</string>
     <string name="identity_server_error_binding_error">L’association a échoué.</string>
     <string name="identity_server_error_no_current_binding_error">Il n’y a actuellement aucune association avec cet identifiant.</string>
     <string name="identity_server_set_default_notice">Votre serveur d’accueil (%1$s) propose d’utiliser %2$s comme serveur d’identité</string>
@@ -2229,17 +2229,17 @@
     <string name="settings_troubleshoot_test_notification_title">Affichage de la notification</string>
     <string name="settings_troubleshoot_test_push_notification_content">Vous voyez la notification ! Cliquez-moi dessus !</string>
     <string name="settings_troubleshoot_test_notification_notification_clicked">La notification a été cliquée !</string>
-    <string name="template_call_failed_no_connection">Appel échoué</string>
+    <string name="call_failed_no_connection">Appel échoué</string>
     <string name="direct_room_encryption_enabled_tile_description">Les messages de ce salon sont chiffrés de bout en bout.</string>
     <string name="room_created_summary_item_by_you">Vous avez créé et configuré ce salon.</string>
     <string name="auth_pin_confirm_to_disable_title">Confirmer le code PIN pour le désactiver</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Le code est requis à l’ouverture d’${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Le code est demandé après 2 minutes d\'inutilisation d’${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Le code est requis à l’ouverture d’${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Le code est demandé après 2 minutes d\'inutilisation d’${app_name}.</string>
     <string name="settings_security_pin_code_grace_period_title">Demander le code après 2 minutes</string>
     <string name="settings_security_pin_code_notifications_summary_off">Afficher uniquement le numéro de messages non-lus dans une simple notification.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Afficher les détails comme les noms des salons et le contenu du message.</string>
     <string name="settings_security_pin_code_notifications_title">Afficher le contenu dans les notifications</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">Le code est la seule façon de déverrouiller ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">Le code est la seule façon de déverrouiller ${app_name}.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Activer les données biométriques comme les empreintes digitales ou la reconnaissance faciale.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Activer les données biométriques</string>
     <string name="settings_security_pin_code_summary">Si vous voulez réinitialiser votre code, appuyez sur Code PIN oublié pour vous déconnecter et le réinitialiser.</string>
@@ -2434,8 +2434,8 @@
     <string name="user_code_share">Partager mon code</string>
     <string name="user_code_scan">Scanner un code QR</string>
     <string name="not_a_valid_qr_code">Ce n’est pas un code QR matrix valide</string>
-    <string name="template_invite_friends_rich_title">🔐️ Rejoins-moi sur ${app_name}</string>
-    <string name="template_invite_friends_text">Salut, parle-moi sur ${app_name} : %s</string>
+    <string name="invite_friends_rich_title">🔐️ Rejoins-moi sur ${app_name}</string>
+    <string name="invite_friends_text">Salut, parle-moi sur ${app_name} : %s</string>
     <string name="invite_friends">Ajouter des amis</string>
     <string name="add_people">Ajouter des personnes</string>
     <string name="topic_prefix">"Sujet : "</string>
@@ -2444,7 +2444,7 @@
     <string name="create_room_disable_federation_title">Empêcher les personnes qui ne sont pas membres de %s de rejoindre ce salon</string>
     <string name="hide_advanced">Masquer les paramètres avancés</string>
     <string name="show_advanced">Afficher les paramètres avancés</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Vous ne pouvez pas faire ceci depuis ${app_name} mobile</string>
+    <string name="settings_add_3pid_flow_not_supported">Vous ne pouvez pas faire ceci depuis ${app_name} mobile</string>
     <string name="dev_tools_event_content_hint">Contenu de l’événement</string>
     <string name="dev_tools_success_state_event">Événement d’état envoyé !</string>
     <string name="dev_tools_success_event">Événement envoyé !</string>
@@ -2483,7 +2483,7 @@
     <string name="a11y_open_widget">Ouvrir les widgets</string>
     <string name="a11y_screenshot">Capture d’écran</string>
     <string name="authentication_error">Échec d’authentification</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} requiert que vous saisissiez vos identifiants à nouveau pour effectuer cette action.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} requiert que vous saisissiez vos identifiants à nouveau pour effectuer cette action.</string>
     <string name="re_authentication_activity_title">Une nouvelle authentification est requise</string>
     <string name="call_transfer_users_tab_title">Utilisateurs</string>
     <string name="call_transfer_failure">Une erreur s’est produite lors du transfert de l’appel</string>
@@ -2860,7 +2860,7 @@
     <string name="settings_notification_other">Autre</string>
     <string name="settings_notification_mentions_and_keywords">Mentions et mots-clés</string>
     <string name="settings_notification_default">Notifications par défaut</string>
-    <string name="template_link_this_email_with_your_account">%s dans les paramètres pour recevoir les invitations directement dans ${app_name}.</string>
+    <string name="link_this_email_with_your_account">%s dans les paramètres pour recevoir les invitations directement dans ${app_name}.</string>
     <string name="link_this_email_settings_link">Lier cet e-mail à votre compte</string>
     <string name="this_invite_to_this_space_was_sent">Cette invitation à cette espace a été envoyée à %s qui n’est pas associé à votre compte</string>
     <string name="this_invite_to_this_room_was_sent">Cette invitation à ce salon a été envoyée à %s qui n’est pas associé à votre compte</string>
@@ -3023,7 +3023,7 @@
     </plurals>
     <string name="preference_system_settings">Paramètres système</string>
     <string name="preference_versions">Versions</string>
-    <string name="template_preference_help_summary">Obtenir de l’aide pour utiliser ${app_name}</string>
+    <string name="preference_help_summary">Obtenir de l’aide pour utiliser ${app_name}</string>
     <string name="preference_help_title">Aide et support</string>
     <string name="preference_help">Aide</string>
     <string name="preference_root_legals">Mentions légales</string>
@@ -3031,15 +3031,15 @@
     <string name="legals_third_party_notices">Bibliothèques tierces</string>
     <string name="legals_identity_server_title">La politique de votre serveur d’identité</string>
     <string name="legals_home_server_title">La politique de votre serveur d’accueil</string>
-    <string name="template_legals_application_title">Politique de ${app_name}</string>
+    <string name="legals_application_title">Politique de ${app_name}</string>
     <string name="analytics_opt_in_list_item_3">Vous pouvez désactiver ceci à tout moment dans les paramètres</string>
     <string name="analytics_opt_in_list_item_2">Nous ne partageons <b>aucune</b> information avec des tiers</string>
     <string name="analytics_opt_in_list_item_1">Nous n’enregistrons ou ne profilons <b>aucune</b> donnée du compte</string>
     <string name="analytics_opt_in_content_link">ici</string>
-    <string name="template_analytics_opt_in_content">Aidez nous à identifier les problèmes et améliorer ${app_name} en envoyant des rapports d’usage anonymes. Pour comprendre de quelle manière les gens utilisent Element sur plusieurs appareils, nous créeront un identifiant aléatoire commun à tous vos appareils.
+    <string name="analytics_opt_in_content">Aidez nous à identifier les problèmes et améliorer ${app_name} en envoyant des rapports d’usage anonymes. Pour comprendre de quelle manière les gens utilisent Element sur plusieurs appareils, nous créeront un identifiant aléatoire commun à tous vos appareils.
 \n
 \nVous pouvez lire toutes les conditions %s.</string>
-    <string name="template_analytics_opt_in_title">Aider à améliorer ${app_name}</string>
+    <string name="analytics_opt_in_title">Aider à améliorer ${app_name}</string>
     <string name="action_enable">Activer</string>
     <string name="tooltip_attachment_poll">Créer un sondage</string>
     <string name="tooltip_attachment_contact">Ouvrir les contacts</string>
@@ -3064,8 +3064,8 @@
     <string name="settings_enable_location_sharing_summary">Une fois activé il vous sera possible d\'envoyer votre localisation dans n\'importe quel salon</string>
     <string name="settings_enable_location_sharing">Activer le partage de localisation</string>
     <string name="location_share_external">Ouvrir avec</string>
-    <string name="template_location_not_available_dialog_content">${app_name} n\'a pas pu accéder à votre localisation. Veuillez réessayer plus tard.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} n\'a pas pu accéder à votre localisation</string>
+    <string name="location_not_available_dialog_content">${app_name} n\'a pas pu accéder à votre localisation. Veuillez réessayer plus tard.</string>
+    <string name="location_not_available_dialog_title">${app_name} n\'a pas pu accéder à votre localisation</string>
     <string name="location_share">Partager la localisation</string>
     <string name="a11y_location_share_icon">Partager la localisation</string>
     <string name="location_activity_title_preview">Localisation</string>

--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -1590,7 +1590,6 @@
 \nAutorisez l’accès dans le prochaine fenêtre pour pouvoir exporter vos clés manuellement.</string>
     <string name="no_network_indicator">Il n’y a aucune connexion au réseau pour le moment</string>
     <string name="settings_add_3pid_confirm_password_title">Confirmez votre mot de passe</string>
-    <string name="settings_add_3pid_flow_not_supported">Vous ne pouvez pas faire cela depuis Element mobile</string>
     <string name="settings_add_3pid_authentication_needed">Une authentification est nécessaire</string>
     <string name="settings_integrations">Intégrations</string>
     <string name="settings_integrations_summary">Utilisez un gestionnaire d’intégrations pour gérer les robots, les passerelles, les widgets et les jeux d’autocollants.

--- a/vector/src/main/res/values-fy/strings.xml
+++ b/vector/src/main/res/values-fy/strings.xml
@@ -115,7 +115,7 @@
     <string name="user_directory_header">Brûkerskatalogus</string>
     <string name="matrix_only_filter">Allinnich Matrix-kontakten</string>
     <string name="no_conversation_placeholder">Gjin petearen</string>
-    <string name="template_no_contact_access_placeholder">Jo hawwe ${app_name} gjin tagong ta jo lokale kontakten jûn</string>
+    <string name="no_contact_access_placeholder">Jo hawwe ${app_name} gjin tagong ta jo lokale kontakten jûn</string>
     <string name="no_result_placeholder">Gjin resultaten</string>
     <string name="people_no_identity_server">Gjin identiteitsserver konfigurearre.</string>
     <string name="rooms_header">Petearen</string>
@@ -274,7 +274,7 @@
     <string name="room_preview_no_preview_join">Dizze keamer kin net yn it foar toand wurde. Wolle jo de keamer binnen gean\?</string>
     <string name="room_preview_not_found">Dizze keamer jout no gjin tagong.
 \nProbearje it letter nochris, of freegje in behearder om te sjen oft jo wol de nedige rjochten hawwe.</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Ynsjoch yn wrâld-lésbere keamers wurdt noch net stipe troch ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Ynsjoch yn wrâld-lésbere keamers wurdt noch net stipe troch ${app_name}</string>
     <string name="room_preview_no_preview">Dizze keamer kin net yn it foar toand wurde</string>
     <string name="please_wait">Efkes wachtsje…</string>
     <string name="change_room_directory_network">Netwurk wizigje</string>
@@ -586,7 +586,7 @@
     <string name="keys_backup_setup_step1_advanced">(Avansearre)</string>
     <string name="keys_backup_setup_step1_title">Reitsje jo fersifere gegevens nea kwyt</string>
     <string name="keys_backup_no_session_error">Gjin Matrix-sesje beskikber</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Graach de wachtwurdsin fuortsmite as jo wolle dat ${app_name} in nije werstelkaai foar jo oanmakket.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Graach de wachtwurdsin fuortsmite as jo wolle dat ${app_name} in nije werstelkaai foar jo oanmakket.</string>
     <string name="passphrase_empty_error_message">Graach in wachtwurdssin ynfiere</string>
     <string name="passphrase_passphrase_does_not_match">Wachtwurdsinnen komme net oerien</string>
     <string name="passphrase_enter_passphrase">Wachtwurdssin ynfiere</string>
@@ -1102,12 +1102,12 @@
     <string name="room_widget_permission_display_name">Jo werjeftenamme</string>
     <string name="settings_show_avatar_display_name_changes_messages_summary">Befettet wizigingen yn avatar en werjeftenamme.</string>
     <string name="settings_show_room_member_state_events_summary">Befettet útnûging/meidwaan/ferlitten/fuortsmiten/ferballe-barrens en wizigingen avatar/werjeftenamme.</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} sil periodyk op de eftergrûn syngronisearje (konfigurearber).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} sil periodyk op de eftergrûn syngronisearje (konfigurearber).
 \nDit hat in negative ynfloed op jo batterij- en datagebrûk. Der sil in melding toand wurde ta ynformaasje.</string>
     <string name="settings_messages_containing_display_name">Myn werjeftenamme</string>
     <string name="settings_containing_my_display_name">Berjochten dy’t myn werjeftenamme befetsje</string>
-    <string name="template_invite_friends_rich_title">🔐️ Doch mei my mei op ${app_name}</string>
-    <string name="template_invite_friends_text">Ah goeie, praat mei my op ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Doch mei my mei op ${app_name}</string>
+    <string name="invite_friends_text">Ah goeie, praat mei my op ${app_name}: %s</string>
     <string name="invite_friends">Freonen útnûgje</string>
     <string name="room_settings_de_prioritize">Lege prioriteit</string>
     <string name="room_settings_favourite">Favoryt</string>
@@ -1176,7 +1176,7 @@
     <string name="settings_privacy_policy">Privacybelied</string>
     <string name="room_sliding_menu_privacy_policy">Privacybelied</string>
     <string name="create_spaces_default_public_random_room_name">Samar wat</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="encryption_information_name">Iepenbiere namme</string>
     <string name="device_name_warning">De iepenbiere namme fan in sesje is sichtber foar minsken mei wa’t jo kommunisearje</string>
     <string name="encryption_information_device_name_with_warning">Iepenbiere namme (sichtber foar minsken mei wa’t jo kommunisearje)</string>
@@ -1187,7 +1187,7 @@
     <string name="settings_call_ringtone_title">Beltoan foar ynkommende oproppen</string>
     <string name="settings_call_ringtone_use_default_stun_sum">Sil %s brûke om te assistearjen yn it gefal dat jo thússerver der net oer beskikt (jo IP-adres sil wylst in oprop dield wurde)</string>
     <string name="settings_call_ringtone_use_default_stun">Tebekfalopropassistinsjeserver tastean</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Brûk de standertbeltoan fan ${app_name} foar ynkommende oproppen</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Brûk de standertbeltoan fan ${app_name} foar ynkommende oproppen</string>
     <string name="settings_call_show_confirmation_dialog_summary">Befêstiging freegje foar it starten fan in oprop</string>
     <string name="settings_call_show_confirmation_dialog_title">Net bedoele oprop foarkomme</string>
     <string name="attachment_cancel_upload">Oplaad annulearje\?</string>
@@ -1217,7 +1217,7 @@
     <string name="call_select_sound_device">Lûdsapparaten selektearje</string>
     <string name="call_failed_no_connection_description">Live ferbining opsetten mislearre.
 \nFreegje de behearder fan jo thússerver om in TURN-server te konfigurearjen, sadat oproppen betrouber wurkje.</string>
-    <string name="template_call_failed_no_connection">${app_name} Oprop mislearre</string>
+    <string name="call_failed_no_connection">${app_name} Oprop mislearre</string>
     <string name="call_failed_no_ice_description">Freegje de behearder fan jo thússerver (%1$s) om in TURN-server te konfigurearjen om oproppen betrouber wurkje te litten.
 \n
 \nAs alternatyf kinne jo de publike server op %2$s brûke. Dit is minder betrouber en sil ek jo IP-addres diele mei dy server. Jo kinne dit ek konfigurearje yn de Ynstellingen.</string>
@@ -1269,22 +1269,22 @@
     <string name="permissions_denied_add_contact">Tagong jaan ta jo kontaktpersoanen.</string>
     <string name="permissions_denied_qr_code">Om de QR-koade te scannen moatte jo tagong ta de kamera jaan.</string>
     <string name="permissions_action_not_performed_missing_permissions">Sorry. De aksje is net tapast fanwegen ûntbrekkende rjochten</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} kin jo adresboek benaderje om oare Matrix-brûkers te finen oan de hân fan harren e-mailadressen en telefoannûmers.
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} kin jo adresboek benaderje om oare Matrix-brûkers te finen oan de hân fan harren e-mailadressen en telefoannûmers.
 \n
 \nWolle jo jo adresboek hjir foar diele\?</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} kin jo adresboek benaderje om oare Matrix-brûkers te finen oan de hân fan harren e-mailadressen en telefoannûmers. As jo it goed fine om jo adresboek hjirfoar te dielen, jou dan tagong op de folgjende pop-up.</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} hat tagong nedich ta jo kamera en mikrofoan om fideo-oproppen te meitsjen.
+    <string name="permissions_rationale_msg_contacts">${app_name} kin jo adresboek benaderje om oare Matrix-brûkers te finen oan de hân fan harren e-mailadressen en telefoannûmers. As jo it goed fine om jo adresboek hjirfoar te dielen, jou dan tagong op de folgjende pop-up.</string>
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} hat tagong nedich ta jo kamera en mikrofoan om fideo-oproppen te meitsjen.
 \n
 \nJou tagong op de folgjende pop-ups om de oprop te meitsjen.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nJou tagong op de folgjende pop-up om de oprop te meitsjen."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} hat tagong nedich ta jo mikrofoan om spraakoproppen te meitsjen.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} hat tagong nedich ta jo mikrofoan om spraakoproppen te meitsjen.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nJou tagong op de folgjende pop-up om de oprop te meitsjen."</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} hat tagong nedich ta jo kamera om foto’s en fideo-oproppen te meitsjen.</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} hat tagong nedich ta jo mediabestannen om bylagen te ferstjoeren en te bewarjen.
+    <string name="permissions_rationale_msg_camera">${app_name} hat tagong nedich ta jo kamera om foto’s en fideo-oproppen te meitsjen.</string>
+    <string name="permissions_rationale_msg_storage">${app_name} hat tagong nedich ta jo mediabestannen om bylagen te ferstjoeren en te bewarjen.
 \n
 \nJou tagong op de folgjende pop-up om bestannen fan jo telefoan ôf te stjoeren.</string>
     <string name="call_remove_jitsi_widget_progress">Oprop beëinigje…</string>
@@ -1318,7 +1318,7 @@
     <string name="call_ended">Oprop beëinige</string>
     <string name="call_ringing">Giet oer…</string>
     <string name="call_connecting">Oprop is oan it ferbinen…</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Start ${app_name} op in oar apparaat dat it berjocht ûntsiferje kin, sadat it de kaaien nei dizze sesje stjoere kin.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Start ${app_name} op in oar apparaat dat it berjocht ûntsiferje kin, sadat it de kaaien nei dizze sesje stjoere kin.</string>
     <string name="login_error_homeserver_from_url_not_found">Thússerver-URL %s net te berikken. Kontrolearje jo keppeling of kies hânmjittich in oare thússerver.</string>
     <string name="space_participants_ban_prompt_msg">Troch dizze brûker te ferballen, sil dy fuortsmiten wurde út dizze romte en foarkommen wurde dat dy opnij binnen komt.</string>
     <string name="room_participants_ban_prompt_msg">As in brûker ferballe wurdt, wurdt dizze út dizze keamer fuortsmiten en wurdt der foarkommen dat dy opnij lid wurdt.</string>
@@ -1383,7 +1383,7 @@
     <string name="settings_notification_mentions_and_keywords">Fermeldingen en kaaiwurden</string>
     <string name="settings_notification_by_event">Meldingsbelang op barren</string>
     <string name="settings_add_3pid_authentication_needed">Autentikaasje fereaske</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Jo kinne dit net dwaan fan de mobile ${app_name} ôf</string>
+    <string name="settings_add_3pid_flow_not_supported">Jo kinne dit net dwaan fan de mobile ${app_name} ôf</string>
     <string name="room_sliding_menu_copyright">Copyright</string>
     <string name="room_sliding_menu_third_party_notices">Treddepartijfermeldingen</string>
     <string name="room_sliding_menu_term_and_conditions">Algemiene betingsten</string>

--- a/vector/src/main/res/values-gl/strings.xml
+++ b/vector/src/main/res/values-gl/strings.xml
@@ -341,7 +341,7 @@
     <string name="user_directory_header">Directorio de usuario</string>
     <string name="matrix_only_filter">Só contactos Matrix</string>
     <string name="no_conversation_placeholder">Sen conversas</string>
-    <string name="template_no_contact_access_placeholder">Non lle permitiches a ${app_name} acceder ós contactos locais</string>
+    <string name="no_contact_access_placeholder">Non lle permitiches a ${app_name} acceder ós contactos locais</string>
     <string name="no_result_placeholder">Sen resultados</string>
     <string name="rooms_header">Salas</string>
     <string name="rooms_directory_header">Directorio de salas</string>
@@ -520,7 +520,7 @@
     <string name="settings_deactivate_my_account">Desactivar a miña conta</string>
     <string name="settings_analytics">Analytics</string>
     <string name="settings_opt_in_of_analytics">Enviar datos de análises</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} recolle información analítica anónima para permitirnos mellorar o aplicativo.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} recolle información analítica anónima para permitirnos mellorar o aplicativo.</string>
     <string name="settings_opt_in_of_analytics_ok">Si, quero axudar!</string>
     <string name="devices_details_id_title">ID</string>
     <string name="devices_details_name_title">Nome</string>
@@ -715,7 +715,7 @@
     <string name="login_error_login_email_not_yet">Unha ligazón de correo na que aínda non se premeu</string>
     <string name="e2e_re_request_encryption_key"><u>Volver a pedir as chaves de cifrado</u> do outro dispositivo seu.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Petición enviada</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Inicie ${app_name} noutro dispositivo que poida descifrar esta mensaxe e que despois desde alí lle poida enviar as chaves a este dispositivo.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Inicie ${app_name} noutro dispositivo que poida descifrar esta mensaxe e que despois desde alí lle poida enviar as chaves a este dispositivo.</string>
     <plurals name="membership_changes">
         <item quantity="one">1 cambio de participantes</item>
         <item quantity="other">%d cambios de participantes</item>
@@ -798,7 +798,7 @@
     <string name="settings_notifications_targets">Obxectivos das notificacións</string>
     <string name="settings_deactivate_account_section">Desactivar conta</string>
     <string name="startup_notification_privacy_title">Segredo das notificacións</string>
-    <string name="template_startup_notification_privacy_message">${app_name} pode estar agochado e seguir traballando na xestión das notificacións dun xeito seguro e privado (inda que iso podería afectar ao uso da batería).</string>
+    <string name="startup_notification_privacy_message">${app_name} pode estar agochado e seguir traballando na xestión das notificacións dun xeito seguro e privado (inda que iso podería afectar ao uso da batería).</string>
     <string name="startup_notification_privacy_button_grant">Outorgar permisos</string>
     <string name="startup_notification_privacy_button_other">Escolla outra opción</string>
     <string name="settings_logged_in">Accedeuse como</string>

--- a/vector/src/main/res/values-hr/strings.xml
+++ b/vector/src/main/res/values-hr/strings.xml
@@ -115,7 +115,7 @@
     <string name="user_directory_header">Popis korisnika</string>
     <string name="matrix_only_filter">Samo kontakti u Matrixu</string>
     <string name="no_conversation_placeholder">Nema razgovora</string>
-    <string name="template_no_contact_access_placeholder">Niste ${app_name}u omogućili pristup Vašim lokalnim kontaktima</string>
+    <string name="no_contact_access_placeholder">Niste ${app_name}u omogućili pristup Vašim lokalnim kontaktima</string>
     <string name="no_result_placeholder">Nema rezultata</string>
     <string name="people_no_identity_server">Nije podešen poslužitelj identiteta.</string>
     <string name="rooms_header">Sobe</string>
@@ -247,7 +247,7 @@
     <string name="e2e_re_request_encryption_key">Ponovno zatražite ključeve za šifriranje od Vaših drugih sesija.</string>
     <string name="e2e_re_request_encryption_key_sent">Zahtjev za ključ je poslan.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Zahtjev poslan</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Pokrenite ${app_name} na nekom drugom uređaju koji može dešifrirati poruku kako bi poslao ključeve ovoj sesiji.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Pokrenite ${app_name} na nekom drugom uređaju koji može dešifrirati poruku kako bi poslao ključeve ovoj sesiji.</string>
     <string name="read_receipts_list">Popis potvrda o pročitanim porukama</string>
     <string name="groups_list">Popis grupa</string>
     <plurals name="membership_changes">
@@ -269,7 +269,7 @@
     <string name="room_info_room_name">Naziv sobe</string>
     <string name="room_info_room_topic">Tema sobe</string>
     <string name="settings_call_category">Pozivi</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Koristi zadan zvuk tona ${app_name}a za dolazne pozive</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Koristi zadan zvuk tona ${app_name}a za dolazne pozive</string>
     <string name="settings_call_ringtone_use_default_stun">Dozvoli rezervnog poslužitelja za pozivnog pomoćnika</string>
     <string name="settings_call_ringtone_use_default_stun_sum">Koristit će se %s kao pomoćnik u slučaju da ga Vaš poslužitelj nema (Vaša IP adresa će biti podijeljena tijekom poziva)</string>
     <string name="settings_call_ringtone_title">Zvuk tona dolaznog poziva</string>
@@ -291,22 +291,22 @@
     <string name="media_picker_both_capture_title">Napravi fotografiju ili video zapis</string>
     <string name="media_picker_cannot_record_video">Nije moguće snimiti video zapis</string>
     <string name="permissions_rationale_popup_title">Informacije</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} treba dozvolu pristupa Vašoj kolekciji fotografija i video zapisa za slanje i spremanje privitaka.
+    <string name="permissions_rationale_msg_storage">${app_name} treba dozvolu pristupa Vašoj kolekciji fotografija i video zapisa za slanje i spremanje privitaka.
 \n
 \nOmogućite pristup putem sljedećeg skočnog prozora kako biste mogli slati datoteke s Vašeg uređaja.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} treba dozvolu pristupa Vašoj kameri za snimanje fotografija i za video pozive.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} treba dozvolu pristupa Vašoj kameri za snimanje fotografija i za video pozive.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nOmogućite pristup putem sljedećeg skočnog prozora kako biste mogli uspostaviti poziv."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} treba dozvolu pristupa Vašem mikrofonu za obavljanje zvučnih poziva.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} treba dozvolu pristupa Vašem mikrofonu za obavljanje zvučnih poziva.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nOmogućite pristup putem sljedećeg skočnog prozora kako biste mogli uspostaviti poziv."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} treba dozvolu pristupa Vašoj kameri i mikrofonu za obavljanje video poziva.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} treba dozvolu pristupa Vašoj kameri i mikrofonu za obavljanje video poziva.
 \n
 \nOmogućite pristup putem sljedećih skočnih prozora kako biste mogli uspostaviti poziv.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} može provjeriti Vaš imenik kako bi našao druge korisnike Matrixa temeljem njihove e-pošte i telefonskih brojeva. Ako se slažete podijeliti imenik u ove svrhe, dozvolite pristup putem sljedećeg skočnog prozora.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} može provjeriti Vaš imenik kako bi našao druge korisnike Matrixa temeljem njihove e-pošte i telefonskih brojeva.
+    <string name="permissions_rationale_msg_contacts">${app_name} može provjeriti Vaš imenik kako bi našao druge korisnike Matrixa temeljem njihove e-pošte i telefonskih brojeva. Ako se slažete podijeliti imenik u ove svrhe, dozvolite pristup putem sljedećeg skočnog prozora.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} može provjeriti Vaš imenik kako bi našao druge korisnike Matrixa temeljem njihove e-pošte i telefonskih brojeva.
 \n
 \nŽelite li podijeliti imenik u ove svrhe\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Nažalost, radnja nije izvršena zbog nedostatka dozvola</string>
@@ -500,7 +500,7 @@
     <string name="ssl_only_accept">Prihvatite certifikat samo ako je poslužiteljski administrator objavio otisak prsta koji odgovara gore navedenom otisku.</string>
     <string name="room_settings_de_prioritize">Smanji prioritet</string>
     <string name="settings_add_3pid_confirm_password_title">Potvrdite Vašu lozinku</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Ovo nije moguće napraviti iz mobilne inačice ${app_name}a</string>
+    <string name="settings_add_3pid_flow_not_supported">Ovo nije moguće napraviti iz mobilne inačice ${app_name}a</string>
     <string name="settings_add_3pid_authentication_needed">Potrebna je ovjera</string>
     <string name="settings_notification_advanced">Napredne postavke obavijesti</string>
     <string name="settings_notification_by_event">Važnost obavijesti po događajima</string>
@@ -524,7 +524,7 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Uključi</string>
     <string name="settings_troubleshoot_test_device_settings_title">Postavke sesije.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Obavijesti su uključene za ovu sesiju.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Obavijesti su isključene za ovu sesiju.
+    <string name="settings_troubleshoot_test_device_settings_failed">Obavijesti su isključene za ovu sesiju.
 \nProvjerite postavke ${app_name}a.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Uključi</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Prilagođene postavke.</string>
@@ -534,7 +534,7 @@
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Provjeri postavke</string>
     <string name="settings_troubleshoot_test_play_services_title">Provjera Usluga za Play</string>
     <string name="settings_troubleshoot_test_play_services_success">APK Usluga za Google Play je dostupan i ažuriran.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} koristi Usluge za Google Play kako bi isporučio poruke, no čini se da nisu ispravno podešene.
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} koristi Usluge za Google Play kako bi isporučio poruke, no čini se da nisu ispravno podešene.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Popravi Usluge za Play</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebaseova oznaka</string>
@@ -542,11 +542,11 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">Neuspješno dohvaćanje oznake FCM-a:
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \n${app_name} nema kontrolu nad ovom greškom te prema Googleu ova greška ukazuje da uređaj ima previše prijavljenih aplikacija na FCM-u. Greška se pojavljuje samo u slučajevima u kojima postoji krajnje mnogo aplikacija te to ne bi trebao biti slučaj kod prosječnog korisnika.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \n${app_name} nema kontrolu nad ovom greškom. Nekoliko je mogućih razloga za grešku. Možda će raditi ako kasnije ponovno pokušate. Također u postavkama sustava možete provjeriti da Usluge za Google Play nisu ograničene u korištenju podatkovnog prometa i da je sat Vašeg uređaja točan. Greška je moguća i na prilagođenim ROM-ovima.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \n${app_name} nema kontrolu nad ovom greškom. Na uređaju ne postoji račun pri Googleu. Možete otvoriti upravitelja računima i dodati račun pri Googleu.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Dodaj račun</string>
     <string name="settings_troubleshoot_test_token_registration_title">Registracija oznake</string>
@@ -558,17 +558,17 @@
     <string name="settings_troubleshoot_test_service_restart_failed">Neuspjelo ponovno pokretanje servisa</string>
     <string name="settings_troubleshoot_test_service_boot_title">Pokreni pri podizanju sustava</string>
     <string name="settings_troubleshoot_test_service_boot_success">Servis će se pokrenuti prilikom ponovnog pokretanja uređaja.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Servis se neće pokrenuti sa ponovnim pokretanjem uređaja pa nećete primati obavijesti sve dok ne otvorite ${app_name}.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Servis se neće pokrenuti sa ponovnim pokretanjem uređaja pa nećete primati obavijesti sve dok ne otvorite ${app_name}.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Omogući pokretanje pri podizanju sustava</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Provjeri pozadinska ograničenja</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Pozadinska su ograničenja onemogućena za ${app_name}. Ovaj test trebate izvršiti putem podatkovne veze (bez WIFI-ja).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Pozadinska su ograničenja onemogućena za ${app_name}. Ovaj test trebate izvršiti putem podatkovne veze (bez WIFI-ja).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Pozadinska su ograničenja omogućena za ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Pozadinska su ograničenja omogućena za ${app_name}.
 \nRadnje koje aplikacija pokušava napraviti su bitno ograničene dok je u pozadini i ovo možete utjecati na obavijesti.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Onemogući ograničenja</string>
     <string name="settings_troubleshoot_test_battery_title">Optimiranje baterije</string>
-    <string name="template_settings_troubleshoot_test_battery_success">Optimiranje baterije ne utječe na ${app_name}.</string>
+    <string name="settings_troubleshoot_test_battery_success">Optimiranje baterije ne utječe na ${app_name}.</string>
     <string name="settings_troubleshoot_test_battery_failed">Ako korisnik uz ugašen zaslon ostavi uređaj nepriključenog i u mirovanju tijekom nekog vremena, uređaj će ući u način drijemanja. Ovo aplikacijama onemogućuje pristup mreži i odgađa njihove zadatke, sinkronizaciju i uobičajene alarme.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Zanemari optimiranje</string>
     <string name="settings_notification_privacy_normal">Obično</string>
@@ -598,10 +598,10 @@
     <string name="settings_background_sync">Pozadinska sinkronizacija</string>
     <string name="settings_background_fdroid_sync_mode">Način pozadinske sinkronizacije (eksperimentalno)</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimirano za bateriju</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} će sinkronizirati u pozadini na način koji čuva ograničena sredstva uređaja (baterija).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} će sinkronizirati u pozadini na način koji čuva ograničena sredstva uređaja (baterija).
 \nOvisno o stanju sredstava uređaja, operacijski sustav može odgoditi sinkronizaciju.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimirano za stvarno vrijeme</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} će u pozadini i periodično u točno određeno vrijeme koje je podesivo vršiti sinkronizaciju.
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} će u pozadini i periodično u točno određeno vrijeme koje je podesivo vršiti sinkronizaciju.
 \nOvo će imati utjecaja na korištenje radijskog sustava i potrošnju baterije. Uočit ćete stalno prikazanu obavijest da ${app_name} osluškuje događaje.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Bez pozadinske sinkronizacije</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Nećete primati obavijesti o dolaznim porukama kada je aplikacija u pozadini.</string>
@@ -661,17 +661,17 @@
     <string name="settings_discovery_category">Pronalaženje</string>
     <string name="settings_discovery_manage">Upravljajte Vašim postavkama za pronalaženje.</string>
     <string name="startup_notification_privacy_title">Privatnost obavještavanja</string>
-    <string name="template_startup_notification_privacy_message">${app_name} se može izvršavati u pozadini kako bi sigurno i privatno upravljao Vašim obavijestima. Ovo može utjecati na potrošnju baterije.</string>
+    <string name="startup_notification_privacy_message">${app_name} se može izvršavati u pozadini kako bi sigurno i privatno upravljao Vašim obavijestima. Ovo može utjecati na potrošnju baterije.</string>
     <string name="startup_notification_privacy_button_grant">Dozvoli</string>
     <string name="startup_notification_privacy_button_other">Izaberi drugu opciju</string>
     <string name="startup_notification_fdroid_battery_optim_title">Pozadinska veza</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} treba održati pozadinsku vezu s malim utjecajem kako bi imao pouzdane obavijesti.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} treba održati pozadinsku vezu s malim utjecajem kako bi imao pouzdane obavijesti.
 \nNa sljedećem zaslonu potvrdite ${app_name}ov zahtjev za stalnim izvršavanjem u pozadini.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Dozvoli</string>
     <string name="settings_analytics">Analitika</string>
     <string name="settings_opt_in_of_analytics">Pošalji analitičke podatke</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} skuplja anonimnu analitiku kako bi se unaprijedila aplikacija.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Omogućite analitiku ako želite pomoći unaprijediti ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} skuplja anonimnu analitiku kako bi se unaprijedila aplikacija.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Omogućite analitiku ako želite pomoći unaprijediti ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Da, želim pomoći!</string>
     <string name="settings_data_save_mode">Način uštede podataka</string>
     <string name="settings_data_save_mode_summary">Način uštede podataka primjenjuje određeno izdvajanje u kojem se ne navode novosti o prisutnosti i obavijesti o tipkanju.</string>
@@ -884,7 +884,7 @@
     <string name="passphrase_passphrase_does_not_match">Fraza-lozinka se ne podudara</string>
     <string name="passphrase_empty_error_message">Unesite fraza-lozinku</string>
     <string name="passphrase_passphrase_too_weak">Fraza-lozinka je preslaba</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Izbrišite fraza-lozinku ako želite da ${app_name} generira ključ za obnovu.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Izbrišite fraza-lozinku ako želite da ${app_name} generira ključ za obnovu.</string>
     <string name="sas_incoming_request_notif_title">Zahtjev za potvrdom</string>
     <string name="sas_incoming_request_notif_content">%s želi potvrditi Vašu sesiju</string>
     <string name="sas_error_m_user">Korisnik je prekinuo potvrdu</string>
@@ -932,7 +932,7 @@
     <string name="please_wait">Pričekajte…</string>
     <string name="group_all_communities">Sve zajednice</string>
     <string name="room_preview_no_preview">Nije moguće pregledati sobu</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Pregled sobe u koju svatko ima uvid još nije podržan u ${app_name}-u</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Pregled sobe u koju svatko ima uvid još nije podržan u ${app_name}-u</string>
     <string name="fab_menu_create_room">Sobe</string>
     <string name="fab_menu_create_chat">Izravne poruke</string>
     <string name="create_room_title">Nova soba</string>
@@ -1278,9 +1278,9 @@
     <string name="room_member_power_level_moderator_in">Moderator u %1$s</string>
     <string name="room_member_power_level_custom_in">Prilagođeno (%1$d) u %2$s</string>
     <string name="room_member_jump_to_read_receipt">Skoči na potvrdu o pročitanoj poruci</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} ne podržava događaje tipa \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} ne podržava poruke tipa \'%1$s\'</string>
-    <string name="template_rendering_event_error_exception">${app_name} je naišao na problem pri prikazu sadržaja događaja s identitetom \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} ne podržava događaje tipa \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} ne podržava poruke tipa \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} je naišao na problem pri prikazu sadržaja događaja s identitetom \'%1$s\'</string>
     <string name="unignore">Ukloni zanemarivanje</string>
     <string name="room_list_sharing_header_recent_rooms">Nedavne sobe</string>
     <string name="room_list_sharing_header_other_rooms">Druge sobe</string>

--- a/vector/src/main/res/values-hu/strings.xml
+++ b/vector/src/main/res/values-hu/strings.xml
@@ -254,7 +254,7 @@
     <string name="local_address_book_header">Helyi címjegyzék</string>
     <string name="matrix_only_filter">Csak Matrix névjegyek</string>
     <string name="no_conversation_placeholder">Nincsenek beszélgetések</string>
-    <string name="template_no_contact_access_placeholder">Nem adtál hozzáférést a ${app_name}nek a helyi névjegyeidhez</string>
+    <string name="no_contact_access_placeholder">Nem adtál hozzáférést a ${app_name}nek a helyi névjegyeidhez</string>
     <string name="no_result_placeholder">Nincs találat</string>
     <string name="rooms_header">Szobák</string>
     <string name="rooms_directory_header">Szobalista</string>
@@ -381,22 +381,22 @@
     <string name="media_picker_both_capture_title">Kép vagy videó készítése</string>
     <string name="media_picker_cannot_record_video">Videorögzítés sikertelen</string>
     <string name="permissions_rationale_popup_title">Információ</string>
-    <string name="template_permissions_rationale_msg_storage">A ${app_name}nek szüksége van a fénykép- és videótárad elérési engedélyéhez a mellékletek küldéséhez és mentéséhez.
+    <string name="permissions_rationale_msg_storage">A ${app_name}nek szüksége van a fénykép- és videótárad elérési engedélyéhez a mellékletek küldéséhez és mentéséhez.
 \n
 \nEngedélyezd a hozzáférést a következő felugró ablakon, hogy fájlokat tudj küldeni a telefonodról.</string>
-    <string name="template_permissions_rationale_msg_camera">Az ${app_name}nek engedélyre van szüksége a kamera eléréséhez, hogy képeket tudj készítsen és videóhívást tudj indítani.</string>
+    <string name="permissions_rationale_msg_camera">Az ${app_name}nek engedélyre van szüksége a kamera eléréséhez, hogy képeket tudj készítsen és videóhívást tudj indítani.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nEngedélyezd a hozzáférést a következő felugró ablakon, hogy hívást tudj indítani."</string>
-    <string name="template_permissions_rationale_msg_record_audio">A ${app_name}nek engedélyre van szüksége a mikrofon eléréséhez, hogy hanghívás tudjon indítani.</string>
+    <string name="permissions_rationale_msg_record_audio">A ${app_name}nek engedélyre van szüksége a mikrofon eléréséhez, hogy hanghívás tudjon indítani.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nEngedélyezd a hozzáférést a következő felugró ablakon, hogy hívást tudj indítani."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">A ${app_name}nek engedélyre van szüksége a mikrofonod és kamerád eléréséhez, hogy videohívást tudj indítani.
+    <string name="permissions_rationale_msg_camera_and_audio">A ${app_name}nek engedélyre van szüksége a mikrofonod és kamerád eléréséhez, hogy videohívást tudj indítani.
 \n
 \nEngedélyezd a hozzáférést a következő felugró ablakon, hogy hívást tudj indítani.</string>
-    <string name="template_permissions_rationale_msg_contacts">A ${app_name} a névjegyekben lévő e-mail és telefonszám alapján képes felkutatni más Matrix felhasználókat. Ha egyetértesz a névjegyek ilyen célú megosztásával, kérlek engedélyezd a hozzáférést a következő felugró üzenetben.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">A ${app_name} a névjegyekben lévő e-mail és telefonszám alapján képes felkutatni más Matrix felhasználókat.
+    <string name="permissions_rationale_msg_contacts">A ${app_name} a névjegyekben lévő e-mail és telefonszám alapján képes felkutatni más Matrix felhasználókat. Ha egyetértesz a névjegyek ilyen célú megosztásával, kérlek engedélyezd a hozzáférést a következő felugró üzenetben.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">A ${app_name} a névjegyekben lévő e-mail és telefonszám alapján képes felkutatni más Matrix felhasználókat.
 \n
 \nEgyetértesz a névjegyek ilyen célú megosztásával\?</string>
     <string name="permissions_action_not_performed_missing_permissions">"Elnézést.  A művelet nem lett végre hajtva hiányzó engedélyek miatt"</string>
@@ -866,7 +866,7 @@ Figyelmeztetés: ez a fájl törlésre kerülhet, ha az alkalmazást törli.</st
     <string name="settings_notification_privacy_metadata">• Az értesítések csak metaadatokat tartalmaznak</string>
     <string name="settings_notification_privacy_secure_message_content">• Az értesítés tartalma <b>közvetlenül a Matrix szerverről kerül letöltésre</b></string>
     <string name="settings_notification_privacy_nosecure_message_content">Az értesítések <b>meta- és üzenet adatot is</b> tartalmaznak</string>
-    <string name="template_startup_notification_privacy_message">${app_name} futtatható a háttérben az értesítések biztonságos és titkos kezeléséhez, ami hatással lehet az akkumulátor használatra.</string>
+    <string name="startup_notification_privacy_message">${app_name} futtatható a háttérben az értesítések biztonságos és titkos kezeléséhez, ami hatással lehet az akkumulátor használatra.</string>
     <string name="startup_notification_privacy_button_grant">Engedély megadása</string>
     <string name="startup_notification_privacy_button_other">Más lehetőség választása</string>
     <string name="settings_notification_privacy">Értesítés adatvédelme</string>
@@ -882,8 +882,8 @@ Figyelmeztetés: ez a fájl törlésre kerülhet, ha az alkalmazást törli.</st
     <string name="settings_deactivate_account_section">Fiók felfüggesztése</string>
     <string name="settings_deactivate_my_account">Saját fiók felfüggesztése</string>
     <string name="settings_opt_in_of_analytics">Analitikai adatok küldése</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} anonim analitikai adatokat gyűjt, hogy javítani tudjuk az alkalmazást.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Kérlek engedélyezd az analitikai adatok gyűjtését ezzel segítve a ${app_name} fejlesztését.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} anonim analitikai adatokat gyűjt, hogy javítani tudjuk az alkalmazást.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Kérlek engedélyezd az analitikai adatok gyűjtését ezzel segítve a ${app_name} fejlesztését.</string>
     <string name="settings_opt_in_of_analytics_ok">Igen, segíteni akarok!</string>
     <string name="widget_integration_missing_parameter">A szükséges paraméter hiányzik.</string>
     <string name="widget_integration_invalid_parameter">Nem érvényes paraméter.</string>
@@ -905,7 +905,7 @@ Matrixban az üzenetek láthatósága hasonlít az e-mailre. Az üzenet törlés
     <string name="e2e_re_request_encryption_key">Végpontok közötti titkosításhoz használt kulcsok újrakérése a többi munkamenetedtől.</string>
     <string name="e2e_re_request_encryption_key_sent">Kulcs újrakérve.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Kérés elküldve</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Índítsd el a ${app_name}et egy olyan eszközön, amely vissza tudja fejteni az üzenetet, hogy elküldhesse a kulcsot ennek a munkamenetnek.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Índítsd el a ${app_name}et egy olyan eszközön, amely vissza tudja fejteni az üzenetet, hogy elküldhesse a kulcsot ennek a munkamenetnek.</string>
     <string name="lock_screen_hint">Ide írj…</string>
     <string name="option_send_voice">Hangüzenet küldése</string>
     <string name="go_on_with">tovább ezzel…</string>
@@ -1019,7 +1019,7 @@ Matrixban az üzenetek láthatósága hasonlít az e-mailre. Az üzenet törlés
     <string name="markdown_has_been_enabled">Markdown engedélyezve.</string>
     <string name="markdown_has_been_disabled">Markdown tiltva.</string>
     <string name="settings_call_category">Hívások</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Az alapértelmezett ${app_name} csengőhang használata bejövő hívásokhoz</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Az alapértelmezett ${app_name} csengőhang használata bejövő hívásokhoz</string>
     <string name="settings_call_ringtone_title">Bejövő hívás csengőhangja</string>
     <string name="settings_call_ringtone_dialog_title">Csengőhang kiválasztása a hívásokhoz:</string>
     <string name="action_accept">Elfogadás</string>
@@ -1043,11 +1043,11 @@ Kérlek ellenőrizd a fiókbeállításokat.</string>
     <string name="settings_troubleshoot_test_account_settings_quickfix">Engedélyez</string>
     <string name="settings_troubleshoot_test_device_settings_title">Munkamenet beállítások.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Az értesítések engedélyezve vannak ezen az munkameneten.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Az értesítések tiltva vannak ezen a munkameneten. Kérlek ellenőrizd a ${app_name} beállításokat.</string>
+    <string name="settings_troubleshoot_test_device_settings_failed">Az értesítések tiltva vannak ezen a munkameneten. Kérlek ellenőrizd a ${app_name} beállításokat.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Engedélyez</string>
     <string name="settings_troubleshoot_test_play_services_title">Play Szolgáltatások ellenőrzése</string>
     <string name="settings_troubleshoot_test_play_services_success">Google Play Services APK elérhető és a legújabb verziójú.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">"${app_name} a Google Play Services-t használja  a „push” értesítések fogadásához, de úgy tűnik az nincs megfelelően beállítva:
+    <string name="settings_troubleshoot_test_play_services_failed">"${app_name} a Google Play Services-t használja  a „push” értesítések fogadásához, de úgy tűnik az nincs megfelelően beállítva:
 \n%1$s"</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Play Services javítása</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase token</string>
@@ -1064,21 +1064,21 @@ Kérlek ellenőrizd a fiókbeállításokat.</string>
     <string name="settings_troubleshoot_test_service_restart_failed">A szolgáltatást nem sikerült újraindítani</string>
     <string name="settings_troubleshoot_test_service_boot_title">Indítás az eszköz indulásakor</string>
     <string name="settings_troubleshoot_test_service_boot_success">A szolgáltatás az eszköz újraindulásakor elindul.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">A szolgáltatás az eszköz újraindulásakor nem fog elindulni, addig nem kapsz értesítést amíg egyszer el nem indítod a ${app_name}-ot.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">A szolgáltatás az eszköz újraindulásakor nem fog elindulni, addig nem kapsz értesítést amíg egyszer el nem indítod a ${app_name}-ot.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Indulás engedélyezése amikor az eszköz elindul</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Háttér korlátozások ellenőrzése</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">A háttér korlátozások nincsenek érvényben a ${app_name}-hoz. Ezt a tesztet mobil hálózaton kell elvégezni (WiFi nélkül).
+    <string name="settings_troubleshoot_test_bg_restricted_success">A háttér korlátozások nincsenek érvényben a ${app_name}-hoz. Ezt a tesztet mobil hálózaton kell elvégezni (WiFi nélkül).
 %1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Háttér korlátozások vannak érvényben a ${app_name}-hoz.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Háttér korlátozások vannak érvényben a ${app_name}-hoz.
 Bármi amit a ${app_name} el akar végezni amíg a háttérben fut, agresszívan korlátozva van. Ez érintheti az értesítéseket is.
 %1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Korlátozások tiltása</string>
     <string name="settings_troubleshoot_test_battery_title">Akkumulátor optimalizáció</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name}ot nem érinti az akkumulátor optimalizáció.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name}ot nem érinti az akkumulátor optimalizáció.</string>
     <string name="settings_troubleshoot_test_battery_failed">Ha a felhasználó töltés nélkül kikapcsolt képernyővel egy ideig magára hagyja az eszközt, az eszköz „Doze” módba kerül. Ez megakadályozza az alkalmazás számára, hogy hozzáférjen a hálózathoz, nem engedi elvégezni a feladatait, szinkronizációt és az alapértelmezett riasztásait.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Optimalizáció figyelmen kívül hagyása</string>
     <string name="startup_notification_fdroid_battery_optim_title">Háttér kapcsolat</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">Az ${app_name}nek szüksége van egy minimális háttér kapcsolat fenntartására ahhoz, hogy az értesítések megbízhatóan megérkezhessenek. A következő képernyőn el kell fogadnod, hogy a ${app_name} folyamatosan fusson a háttérben.</string>
+    <string name="startup_notification_fdroid_battery_optim_message">Az ${app_name}nek szüksége van egy minimális háttér kapcsolat fenntartására ahhoz, hogy az értesítések megbízhatóan megérkezhessenek. A következő képernyőn el kell fogadnod, hogy a ${app_name} folyamatosan fusson a háttérben.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Jogosultság megadása</string>
     <string name="account_email_error">Az e-mail címed ellenőrzésekor hiba történt.</string>
     <string name="account_phone_number_error">A telefonszámod ellenőrzésekor hiba történt.</string>
@@ -1097,11 +1097,11 @@ Bármi amit a ${app_name} el akar végezni amíg a háttérben fut, agresszívan
     <string name="settings_troubleshoot_test_bing_settings_failed">Az egyedi beállításaidban néhány értesítés ki van kapcsolva.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">Az egyedi szabályokat nem sikerült betölteni, kérlek próbáld újra.</string>
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Beállítások ellenőrzése</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 Ez a hiba a ${app_name}on kívül van és a Google szerint ez a hiba azt jelzi, hogy túl sok alkalmazás használja az FCM-et. Ez a hiba akkor szokott előfordulni, ha nagyon sok alkalmazás van ezért egy átlagos felhasználót nem nagyon érinthet.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 Ez a hiba a ${app_name}on kívül van. Több okból is előjöhet. Lehet, ha később próbálod már működni fog, de megnézheted, hogy a Google Play szolgáltatásnak nincs beállítva adathasználati korlátozás a rendszer beállításokban vagy, hogy az eszközöd órája helyesen jár-e de ezt előfordulhat egyedi ROM esetén is.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 Ez a hiba a ${app_name}on kívül van. Nincs Google fiók az eszközön. Kérlek nyisd meg a fiókkezelőt és adj hozzá egy Google fiókot.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Fiók hozzáadása</string>
     <string name="settings_noisy_notifications_preferences">Hangos értesítések beállítása</string>
@@ -1113,7 +1113,7 @@ Ez a hiba a ${app_name}on kívül van. Nincs Google fiók az eszközön. Kérlek
     <string name="notification_silent">Csendes</string>
     <string name="passphrase_empty_error_message">Kérlek adj meg egy jelmondatot</string>
     <string name="passphrase_passphrase_too_weak">A jelmondat túl gyenge</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Ha azt szeretnéd, hogy a ${app_name} Visszaállítási Kulcsot generáljon akkor kérlek töröld a jelmondatot.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Ha azt szeretnéd, hogy a ${app_name} Visszaállítási Kulcsot generáljon akkor kérlek töröld a jelmondatot.</string>
     <string name="keys_backup_no_session_error">Jelenleg nincs Matrix munkamenet</string>
     <string name="keys_backup_setup_step1_title">Soha ne veszíts el titkosított üzenetet</string>
     <string name="keys_backup_setup_step1_description">A titkosított szobákban az üzenetek végponttól-végpontig titkosítva vannak. Csak neked és a címzetteknek vannak meg az üzenet elolvasásához szükséges kulcsok.
@@ -1241,7 +1241,7 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="passwords_do_not_match">A jelszavak nem egyeznek meg</string>
     <string name="autodiscover_invalid_response">A Matrix szerver felderítésére érvénytelen válasz érkezett</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Szerver beállítások automatikus kiegészítése</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} egyedi szerver beállítást észlelt a felhasználói azonosítód domain-jéhez: \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} egyedi szerver beállítást észlelt a felhasználói azonosítód domain-jéhez: \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Beállítás használata</string>
     <string name="notification_sync_init">Szolgáltatás indítása</string>
@@ -1356,7 +1356,7 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="please_wait">Kérlek várj…</string>
     <string name="group_all_communities">Minden közösség</string>
     <string name="room_preview_no_preview">Ennek a szobának nincs előnézete</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">A ${app_name}-ben a nyilvános szoba előnézete egyelőre nem támogatott</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">A ${app_name}-ben a nyilvános szoba előnézete egyelőre nem támogatott</string>
     <string name="fab_menu_create_room">Szobák</string>
     <string name="fab_menu_create_chat">Közvetlen üzenetek</string>
     <string name="create_room_title">Új szoba</string>
@@ -1451,10 +1451,10 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="invite_no_identity_server_error">A beállításokban adj hozzá egy azonosítási szervert ehhez a művelethez.</string>
     <string name="settings_background_fdroid_sync_mode">Háttér Szinkronizálási Mód</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimalizált akkumulátor használat</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} a háttérben úgy szinkronizál, hogy a leginkább kímélje az eszköz korlátozott erőforrásait (akkumulátor).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} a háttérben úgy szinkronizál, hogy a leginkább kímélje az eszköz korlátozott erőforrásait (akkumulátor).
 \nAz eszköz erőforrásainak állapotától függően a szinkronizációt az operációs rendszer elhalaszthatja.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimalizálás valós idejű használatra</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} a háttérben rendszeresen, pontosan a megadott időközönként, szinkronizálni fog (beállítható).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} a háttérben rendszeresen, pontosan a megadott időközönként, szinkronizálni fog (beállítható).
 \nEz befolyásolja a rádió és az akkumulátor használatot, és folyamatosan egy értesítés fog megjelenni arról, hogy a ${app_name} figyel a neki küldött eseményekre.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Nincs szinkroniziálás a háttérben</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Nem leszel értesítve az érkező üzenetekről, ha az alkalmazás csak a háttérben fut.</string>
@@ -1539,12 +1539,12 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="content_reported_as_inappropriate_content">Ez a tartalom nem idevalónak lett bejelentve.
 \n
 \n Ha nem akarsz ettől a felhasználótól több üzenetet látni akkor blokkolhatod, hogy az üzenetei ne jelenjenek meg számodra.</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name}nak engedélyre van szüksége ahhoz, hogy a végponttól végpontig titkosító kulcsokat a lemezre menthesse.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name}nak engedélyre van szüksége ahhoz, hogy a végponttól végpontig titkosító kulcsokat a lemezre menthesse.
 \n
 \nKérlek a következő felugró ablakban engedélyezd a hozzáférést, hogy a kulcsokat kézzel kimenthesd.</string>
     <string name="no_network_indicator">Jelenleg nincs hálózati kapcsolat</string>
     <string name="settings_add_3pid_confirm_password_title">Jelszó megerősítés</string>
-    <string name="template_settings_add_3pid_flow_not_supported">${app_name} mobilról ezt nem teheted meg</string>
+    <string name="settings_add_3pid_flow_not_supported">${app_name} mobilról ezt nem teheted meg</string>
     <string name="settings_add_3pid_authentication_needed">Azonosítás szükséges</string>
     <string name="settings_integrations">Integrációk</string>
     <string name="settings_integrations_summary">Botok, hidak, kisalkalmazások és matrica csomagok kezeléséhez használj Integrációs Menedzsert.
@@ -1712,7 +1712,7 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
 \nA fiók és az üzeneteid eléréséhez jelentkezz be.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Elveszted a hozzáférésedet a titkosított üzeneteidhez ha nem jelentkezel be a titkosítási kulcsok visszaállításához.</string>
     <string name="soft_logout_clear_data_dialog_submit">Adat törlése</string>
-    <string name="template_soft_logout_sso_not_same_user_error">A jelenlegi munkamenet %1$s felhasználóhoz tartozik és %2$s azonosítási adatait adtad meg. Ez ${app_name}-ben nem támogatott.
+    <string name="soft_logout_sso_not_same_user_error">A jelenlegi munkamenet %1$s felhasználóhoz tartozik és %2$s azonosítási adatait adtad meg. Ez ${app_name}-ben nem támogatott.
 \nElőször töröld az adatokat, utána lépj be a másik fiókba!</string>
     <string name="permalink_malformed">A matrix.to linked hibás</string>
     <string name="bug_report_error_too_short">A leírás túl rövid</string>
@@ -1730,7 +1730,7 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="devices_other_devices">Más munkamenetek</string>
     <string name="autocomplete_limited_results">Csak az első találat megmutatása, gépelj több betűt…</string>
     <string name="settings_developer_mode_fail_fast_title">Összeomlás-hamar</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} a nem várt hibák esetén többször fog összeomlani</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} a nem várt hibák esetén többször fog összeomlani</string>
     <string name="command_description_shrug">Hozzáteszi a sima szöveges üzenethez ezt: ¯\\_(ツ)_/¯</string>
     <string name="create_room_encryption_title">Titkosítás engedélyezése</string>
     <string name="create_room_encryption_description">Ha egyszer bekapcsolod, már nem lehet kikapcsolni.</string>
@@ -1801,9 +1801,9 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="room_member_power_level_moderator_in">Moderátor itt: %1$s</string>
     <string name="room_member_power_level_custom_in">Egyedi (%1$d) itt: %2$s</string>
     <string name="room_member_jump_to_read_receipt">Olvasási visszaigazolásra ugrás</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} nem kezeli ezt az eseményt: \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} nem kezeli ezt az üzenet típust: \'%1$s\'</string>
-    <string name="template_rendering_event_error_exception">${app_name} problémába ütközött az esemény (azon: %1$s) megjelenítésekor</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} nem kezeli ezt az eseményt: \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} nem kezeli ezt az üzenet típust: \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} problémába ütközött az esemény (azon: %1$s) megjelenítésekor</string>
     <string name="unignore">Figyelembe vesz</string>
     <string name="verify_cannot_cross_sign">Ez a munkamenet nem tudja megosztani ezt az ellenőrzést a másik munkameneteddel.
 \nAz ellenőrzés helyileg elmentésre kerül és az alkalmazás jövőbeli verziójával meg lesz osztva.</string>
@@ -1889,7 +1889,7 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="event_redacted_by_user_reason_with_reason">Az eseményt a felhasználó törölte, ezért: %1$s</string>
     <string name="event_redacted_by_admin_reason_with_reason">Az eseményt a szoba adminisztrátora moderálta, ezért: %1$s</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">A kulcsok már frissek!</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">Kulcs kérések</string>
     <string name="e2e_use_keybackup">Régi titkosított üzenetek feloldása</string>
     <string name="refresh">Frissítés</string>
@@ -1990,12 +1990,12 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="media_file_added_to_gallery">A média fájl a Galériához hozzáadva</string>
     <string name="error_adding_media_file_to_gallery">A média fájlt nem sikerült hozzáadni a Galériához</string>
     <string name="change_password_summary">Új fiók jelszó beállítása…</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
     <string name="or_other_mx_capable_client">"vagy más eszközök közötti hitelesítést támogató  Matrix-klienst"</string>
-    <string name="template_use_latest_app">Az ${app_name} legújabb kliensét használd a többi eszközödön:</string>
+    <string name="use_latest_app">Az ${app_name} legújabb kliensét használd a többi eszközödön:</string>
     <string name="command_description_discard_session">A jelenlegi csoport munkamenet törlését kikényszeríti a titkosított szobában</string>
     <string name="command_description_discard_session_not_handled">Csak a titkosított szobákban támogatott</string>
     <string name="enter_secret_storage_passphrase_or_key">Használd ezt: %1$s vagy ezt: %2$s a továbblépéshez.</string>
@@ -2016,7 +2016,7 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="error_empty_field_choose_password">Kérlek válassz jelszót.</string>
     <string name="external_link_confirmation_title">Ezt a hivatkozást ellenőrizd le még egyszer</string>
     <string name="create_room_dm_failure">A közvetlen beszélgetést nem sikerült létrehozni. Ellenőrizd azokat a felhasználókat akiket meg szeretnél hívni és próbáld újra.</string>
-    <string name="template_use_other_session_content_description">"Használd a legújabb ${app_name}et a többi eszközödön, azaz az ${app_name} Webet, az ${app_name} Desktopot, az ${app_name} for Androidot vagy más eszközök közötti hitelesítést támogató  Matrix-klienst"</string>
+    <string name="use_other_session_content_description">"Használd a legújabb ${app_name}et a többi eszközödön, azaz az ${app_name} Webet, az ${app_name} Desktopot, az ${app_name} for Androidot vagy más eszközök közötti hitelesítést támogató  Matrix-klienst"</string>
     <string name="confirm_your_identity">Erősítsd meg ebben a bejelentkezésben a személyazonosságodat egy másik munkamenetből, hogy hozzáférhess a titkosított üzenetekhez.</string>
     <string name="external_link_confirmation_message">%1$s hivatkozás egy másik oldalra visz: %2$s.
 \n
@@ -2058,11 +2058,11 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="choose_locale_other_locales_title">További elérhető nyelvek</string>
     <string name="choose_locale_loading_locales">Elérhető nyelvek betöltése…</string>
     <string name="open_terms_of">Megnyitás: %s feltételek</string>
-    <string name="template_identity_server_error_outdated_identity_server">Ez az azonosítási szerver régi. ${app_name} csak az API V2-t támogatja.</string>
+    <string name="identity_server_error_outdated_identity_server">Ez az azonosítási szerver régi. ${app_name} csak az API V2-t támogatja.</string>
     <string name="identity_server_error_outdated_home_server">Ez a művelet nem támogatott. A Matrix szerver elavult.</string>
     <string name="identity_server_error_no_identity_server_configured">Kérlek először állíts be egy azonosítási szervert.</string>
     <string name="identity_server_error_terms_not_signed">Kérlek először fogadd el az azonosítási szerver felhasználási feltételeit a beállításokban.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">A biztonságod érdekében ${app_name} csak hash-selt e-mail cím és telefonszám küldését támogatja.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">A biztonságod érdekében ${app_name} csak hash-selt e-mail cím és telefonszám küldését támogatja.</string>
     <string name="identity_server_error_binding_error">A megfeleltetés sikertelen.</string>
     <string name="identity_server_error_no_current_binding_error">Ezzel az azonosítóval jelenleg nincs megfeleltetve semmi.</string>
     <string name="identity_server_set_default_notice">A Matrix szervered (%1$s) ezt az azonosítási szervert javasolja: %2$s</string>
@@ -2113,7 +2113,7 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="cannot_call_yourself_with_invite">Nem hívhatod fel saját magad, várj amíg a résztvevők elfogadják a meghívást</string>
     <string name="failed_to_add_widget">Kisalkalmazás hozzáadása sikertelen</string>
     <string name="failed_to_remove_widget">Kisalkalmazás eltávolítása sikertelen</string>
-    <string name="template_call_failed_no_connection">${app_name} hívás sikertelen</string>
+    <string name="call_failed_no_connection">${app_name} hívás sikertelen</string>
     <string name="call_failed_no_connection_description">Nem sikerült felépíteni a valós idejű kapcsolatot.
 \nKérd meg a Matrix-kiszolgálód rendszergazdáját, hogy állítson be egy TURN-kiszolgálót, hogy a hívások megbízhatóan működjenek.</string>
     <string name="login_error_ssl_peer_unverified">SSL hiba: a partner személyazonossága nem lett megerősítve.</string>
@@ -2249,7 +2249,7 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="auth_pin_confirm_to_disable_title">Erősítsd meg a PIN-kódot a PIN-kód kikapcsolásához</string>
     <string name="settings_security_pin_code_notifications_summary_on">Részletek mutatása, mint például a szoba neve, vagy az üzenet tartalma.</string>
     <string name="settings_security_pin_code_notifications_title">Üzenetek tartalmának mutatása az értesítésekben</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">Az ${app_name} feloldása csak PIN kóddal lehetséges.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">Az ${app_name} feloldása csak PIN kóddal lehetséges.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Biometrikus azonosítás engedélyezése</string>
     <string name="settings_security_application_protection_screen_title">Védelem beállítása</string>
     <string name="settings_security_application_protection_summary">Hozzáférés védése PIN kóddal és biometrikus azonosítással.</string>
@@ -2278,8 +2278,8 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="no_permissions_to_start_webrtc_call_in_direct_room">Nincs jogosultságod hívást indítani</string>
     <string name="no_permissions_to_start_webrtc_call">Nincs jogosultságod hívást indítani ebben a szobában</string>
     <string name="user_code_info_text">Mutasd meg ezt a kódot az ismerőseidnek, hogy be tudják olvasni, és elkezdődhessen a csevegés!</string>
-    <string name="template_invite_friends_rich_title">🔐️ Csatlakozz hozzám ${app_name}-en</string>
-    <string name="template_invite_friends_text">Hey, beszélgessünk ${app_name}-en: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Csatlakozz hozzám ${app_name}-en</string>
+    <string name="invite_friends_text">Hey, beszélgessünk ${app_name}-en: %s</string>
     <string name="invite_friends">Ismerősök meghívása</string>
     <string name="user_code_my_code">Saját kódom</string>
     <string name="user_code_share">Saját kód megosztása</string>
@@ -2559,7 +2559,7 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="a11y_open_widget">Kisalkalmazások megnyitása</string>
     <string name="a11y_screenshot">Képernyőkép</string>
     <string name="authentication_error">Azonosítás sikertelen</string>
-    <string name="template_re_authentication_default_confirm_text">A művelet elvégzéséhez ${app_name} kéri, hogy adja meg az azonosításhoz az adatokat.</string>
+    <string name="re_authentication_default_confirm_text">A művelet elvégzéséhez ${app_name} kéri, hogy adja meg az azonosításhoz az adatokat.</string>
     <string name="re_authentication_activity_title">Újra-Azonosítás szükséges</string>
     <string name="call_transfer_users_tab_title">Felhasználók</string>
     <string name="call_transfer_failure">A hívás átadásánál hiba történt</string>
@@ -2603,8 +2603,8 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="error_opening_banned_room">A szoba nem nyitható meg ahonnan kitiltottak.</string>
     <string name="settings_security_pin_code_change_pin_summary">Jelenlegi PIN kód megváltoztatása</string>
     <string name="settings_security_pin_code_change_pin_title">PIN megváltoztatása</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">${app_name} megnyitásához mindig PIN kód szükséges.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Ha 2 percnél hosszabb ideig nem használod az ${app_name} Element alkalmazást, PIN kódot fog kérni.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">${app_name} megnyitásához mindig PIN kód szükséges.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Ha 2 percnél hosszabb ideig nem használod az ${app_name} Element alkalmazást, PIN kódot fog kérni.</string>
     <string name="settings_security_pin_code_grace_period_title">2 perc elteltével PIN szükséges</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Eszköz specifikus biometrikus azonosítás engedélyezése, mint ujjlenyomat vagy arcfelismerés.</string>
     <plurals name="entries">
@@ -2856,7 +2856,7 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="voice_message_slide_to_cancel">Elhúzás a megszakításhoz</string>
     <string name="a11y_start_voice_message">Hang üzenet felvétele</string>
     <string name="allow_anyone_in_room_to_access">%s tér tagság megtalálhatja és hozzáférhet. Más tereket is beállíthatsz.</string>
-    <string name="template_link_this_email_with_your_account">%s a Beállításokba a közvetlen meghívások fogadásához az ${app_name}.</string>
+    <string name="link_this_email_with_your_account">%s a Beállításokba a közvetlen meghívások fogadásához az ${app_name}.</string>
     <string name="this_invite_to_this_space_was_sent">Ehhez a térhez a meghívó ide lett elküldve: %s, ami nincs összefüggésben a fiókoddal</string>
     <string name="this_invite_to_this_room_was_sent">Ehhez a szobához a meghívó ide lett elküldve: %s, ami nincs összefüggésben a fiókoddal</string>
     <string name="link_this_email_settings_link">Ennek az e-mailnek a fiókhoz való kötése</string>
@@ -3019,22 +3019,22 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     </plurals>
     <string name="preference_system_settings">Rendszerbeállítások</string>
     <string name="preference_versions">Verziók</string>
-    <string name="template_preference_help_summary">Segítség az ${app_name} használatában</string>
+    <string name="preference_help_summary">Segítség az ${app_name} használatában</string>
     <string name="preference_help_title">Segítség és támogatás</string>
     <string name="preference_help">Segítség</string>
     <string name="legals_no_policy_provided">Ez a szerver nem adott meg szabályzatot.</string>
     <string name="legals_third_party_notices">Harmadik féltől származó programkönyvtárak</string>
     <string name="legals_identity_server_title">Az azonosítási szervered szabályzata</string>
     <string name="legals_home_server_title">A Matrix szervered szabályzata</string>
-    <string name="template_legals_application_title">${app_name} szabályzat</string>
+    <string name="legals_application_title">${app_name} szabályzat</string>
     <string name="analytics_opt_in_list_item_3">Később akármikor kikapcsolhatod a beállításokban</string>
     <string name="analytics_opt_in_list_item_2"><b>Nem</b> osztjuk meg az információt harmadik féllel</string>
     <string name="analytics_opt_in_list_item_1"><b>Nem</b> küldünk és nem profilozunk semmilyen fiók adatot</string>
     <string name="analytics_opt_in_content_link">itt</string>
-    <string name="template_analytics_opt_in_content">Segíts észrevennünk a hibákat, és jobbá tenni az ${app_name}-et a névtelen használati adatok küldése által. Ahhoz, hogy megértsük, hogyan használnak a felhasználók egyszerre több eszközt, egy véletlenszerű azonosítót generálunk, ami az eszközeid között meg lesz osztva.
+    <string name="analytics_opt_in_content">Segíts észrevennünk a hibákat, és jobbá tenni az ${app_name}-et a névtelen használati adatok küldése által. Ahhoz, hogy megértsük, hogyan használnak a felhasználók egyszerre több eszközt, egy véletlenszerű azonosítót generálunk, ami az eszközeid között meg lesz osztva.
 \n
 \nElolvashatod a feltételeinket %s.</string>
-    <string name="template_analytics_opt_in_title">Segíts az ${app_name}-et jobbá tenni</string>
+    <string name="analytics_opt_in_title">Segíts az ${app_name}-et jobbá tenni</string>
     <string name="a11y_poll_winner_option">nyerő válasz</string>
     <string name="preference_root_legals">Jogi dolgok</string>
     <string name="restart_the_application_to_apply_changes">A változások életbelépéséhez indítsd újra az alkalmazást.</string>
@@ -3058,8 +3058,8 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="settings_enable_location_sharing_summary">A beállítás után bármelyik szobában megoszthatod a földrajzi helyzetedet</string>
     <string name="settings_enable_location_sharing">Földrajzi hely megosztás engedélyezése</string>
     <string name="location_share_external">Megnyitás ezzel</string>
-    <string name="template_location_not_available_dialog_content">Az ${app_name} nem fér hozzá a tartózkodási helyedhez. Próbáld újra később.</string>
-    <string name="template_location_not_available_dialog_title">Az ${app_name} nem tudott hozzáférni a tartózkodási helyedhez</string>
+    <string name="location_not_available_dialog_content">Az ${app_name} nem fér hozzá a tartózkodási helyedhez. Próbáld újra később.</string>
+    <string name="location_not_available_dialog_title">Az ${app_name} nem tudott hozzáférni a tartózkodási helyedhez</string>
     <string name="location_share">Tartózkodási hely megosztása</string>
     <string name="a11y_location_share_icon">Tartózkodási hely megosztása</string>
     <string name="location_activity_title_preview">Földrajzi helyzet</string>

--- a/vector/src/main/res/values-in/strings.xml
+++ b/vector/src/main/res/values-in/strings.xml
@@ -135,7 +135,7 @@
     <string name="action_reject">Tolak</string>
     <string name="later">Nanti</string>
     <string name="send_anyway">Kirim Saja</string>
-    <string name="template_no_contact_access_placeholder">${app_name} belum diizinkan untuk mengakses kontak lokal</string>
+    <string name="no_contact_access_placeholder">${app_name} belum diizinkan untuk mengakses kontak lokal</string>
     <string name="send_bug_report_include_crash_logs">Kirim catat gangguan</string>
     <string name="huge">Raksasa</string>
     <string name="small">Kecil</string>
@@ -220,18 +220,18 @@
     <string name="call_error_answered_elsewhere">panggilan terjawab di tempat lain</string>
     <string name="media_picker_both_capture_title">Ambil gambar atau video</string>
     <string name="media_picker_cannot_record_video">Tidak dapat merekam video</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} membutuhkan izin untuk mengakses galeri foto dan video Anda untuk mengirim dan menyimpan lampiran.
+    <string name="permissions_rationale_msg_storage">${app_name} membutuhkan izin untuk mengakses galeri foto dan video Anda untuk mengirim dan menyimpan lampiran.
 \n
 \nHarap berikan akses pada halaman berikut ini agar berkas dapat dikirim dari ponsel Anda.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} membutuhkan izin Anda untuk mengakses kamera untuk mengambil gambar dan melakukan panggilan video.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} membutuhkan izin Anda untuk mengakses kamera untuk mengambil gambar dan melakukan panggilan video.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nHarap berikan akses pada halaman berikut ini agar dapat melakukan panggilan."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} membutuhkan permisi atas akses mikrofon Anda untuk melakukan panggilan audio.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} membutuhkan permisi atas akses mikrofon Anda untuk melakukan panggilan audio.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nHarap berikan akses pada halaman berikut ini agar dapat melakukan panggilan."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} membutuhkan izin untuk mengakses kamera dan mikrofon Anda untuk melakukan panggilan video.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} membutuhkan izin untuk mengakses kamera dan mikrofon Anda untuk melakukan panggilan video.
 \n
 \nHarap berikan akses pada halaman berikut ini untuk melakukan panggilan.</string>
     <string name="light_theme">Tema Terang</string>
@@ -274,16 +274,16 @@
     <string name="e2e_re_request_encryption_key"><u>Meminta ulang kunci enkripsi</u> dari perangkat Anda yang lain.</string>
     <string name="e2e_re_request_encryption_key_sent">Permintaan kunci terkirim.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Permintaan terkirim</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Jalankan ${app_name} di perangkat yang dapat mendekripsi pesan tersebut agar kunci dapat dikirim ke perangkat ini.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Jalankan ${app_name} di perangkat yang dapat mendekripsi pesan tersebut agar kunci dapat dikirim ke perangkat ini.</string>
     <string name="groups_list">Daftar Grup</string>
     <plurals name="membership_changes">
         <item quantity="other">%d perubahan keanggotaan</item>
     </plurals>
     <string name="call">Panggilan</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} memerlukan permisi untuk mengakses daftar kontak agar dapat mencari pengguna Matrix lain berdasarkan email dan nomor telepon.
+    <string name="permissions_rationale_msg_contacts">${app_name} memerlukan permisi untuk mengakses daftar kontak agar dapat mencari pengguna Matrix lain berdasarkan email dan nomor telepon.
 
 Ijinkan akses lewat halaman selanjutnya untuk menemukan pengguna ${app_name} yang terdapat di daftar kontak Anda.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} memerlukan izin untuk mengakses daftar kontak Anda untuk menemukan pengguna Matrix lain berdasarkan email dan nomor telepon mereka.
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} memerlukan izin untuk mengakses daftar kontak Anda untuk menemukan pengguna Matrix lain berdasarkan email dan nomor telepon mereka.
 \n
 \nApakah anda bersedia bila ${app_name} mengakses daftar kontak Anda\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Mohon maaf. Aksi tidak dilakukan karena izin-izin yang kurang</string>
@@ -711,13 +711,13 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="settings_deactivate_account_section">Nonaktifkan akun</string>
     <string name="settings_deactivate_my_account">Nonaktifkan akun saya</string>
     <string name="startup_notification_privacy_title">Kerahasiaan Notifikasi</string>
-    <string name="template_startup_notification_privacy_message">${app_name} dapat beroperasi di balik layar untuk mengurus pemberitahuan Anda dengan aman dan rahasia. Ini dapat mempengaruhi masa tahan baterai.</string>
+    <string name="startup_notification_privacy_message">${app_name} dapat beroperasi di balik layar untuk mengurus pemberitahuan Anda dengan aman dan rahasia. Ini dapat mempengaruhi masa tahan baterai.</string>
     <string name="startup_notification_privacy_button_grant">Beri izin</string>
     <string name="startup_notification_privacy_button_other">Pilih opsi lain</string>
     <string name="settings_analytics">Analitik</string>
     <string name="settings_opt_in_of_analytics">Kirim data analitik</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} mengumpulkan data analitik anonim dalam upaya kami meningkatkan aplikasi.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Silakan aktifkan analitik untuk membantu kami meningkatkan ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} mengumpulkan data analitik anonim dalam upaya kami meningkatkan aplikasi.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Silakan aktifkan analitik untuk membantu kami meningkatkan ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Ya, saya ingin membantu!</string>
     <string name="settings_data_save_mode">Mode hemat data</string>
     <string name="devices_details_dialog_title">Rincian perangkat</string>
@@ -784,7 +784,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="dialog_title_error">Error</string>
     <string name="auth_accept_policies">Mohon telaah dan terima kebijakan homeserver ini:</string>
     <string name="settings_call_category">Panggilan</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Gunakan nada dering bawaan ${app_name} untuk panggilan masuk</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Gunakan nada dering bawaan ${app_name} untuk panggilan masuk</string>
     <string name="settings_call_ringtone_title">Nada dering panggilan masuk</string>
     <string name="settings_call_ringtone_dialog_title">Pilih nada dering untuk panggilan:</string>
     <string name="video_call_in_progress">Panggilan Video Sedang Berlangsung…</string>
@@ -810,12 +810,12 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="settings_troubleshoot_test_account_settings_quickfix">Perbolehkan</string>
     <string name="settings_troubleshoot_test_device_settings_title">Pengaturan Perangkat.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Pemberitahuan diperbolehkan untuk perangkat ini.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Notifikasi tidak diaktifkan pada sesi ini. 
+    <string name="settings_troubleshoot_test_device_settings_failed">Notifikasi tidak diaktifkan pada sesi ini.
 \nMohon periksa pengaturan ${app_name}.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Perbolehkan</string>
     <string name="settings_troubleshoot_test_play_services_title">Pemeriksaan Layanan Google Play</string>
     <string name="settings_troubleshoot_test_play_services_success">APK Layanan Google Play ditemukan dan telah diperbaharui.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} menggunakan Layanan Google Play untuk mendorong pesan tapi tampaknya tidak diatur sebagaimana harusnya.
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} menggunakan Layanan Google Play untuk mendorong pesan tapi tampaknya tidak diatur sebagaimana harusnya.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Perbaiki Layanan Google Play</string>
     <string name="settings_troubleshoot_test_fcm_title">Token Firebase</string>
@@ -832,17 +832,17 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="settings_troubleshoot_test_service_restart_failed">Layanan tidak dapat dinyalakan kembali</string>
     <string name="settings_troubleshoot_test_service_boot_title">Mulai ketika menyalakan perangkat</string>
     <string name="settings_troubleshoot_test_service_boot_success">Layanan akan dimulai ketika perangkat dinyalakan kembali.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Layanan tidak akan mulai ketika perangkat dinyalakan kembali, Anda tidak akan menerima pemberitahuan hingga Anda membuka ${app_name}.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Layanan tidak akan mulai ketika perangkat dinyalakan kembali, Anda tidak akan menerima pemberitahuan hingga Anda membuka ${app_name}.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Perbolehkan memulai ketika perangkat dinyalakan</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Periksa halangan di balik layar</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Larangan background dinonaktifkan untuk ${app_name}. Percobaan ini sebaiknya dijalankan menggunakan jaringan mobile data (bukan WIFI).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Larangan background dinonaktifkan untuk ${app_name}. Percobaan ini sebaiknya dijalankan menggunakan jaringan mobile data (bukan WIFI).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Larangan background dinonaktifkan untuk ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Larangan background dinonaktifkan untuk ${app_name}.
 \nAktivitas yang dilakukan aplikasi ini akan terhalang ketika beroperasi di balik layar, dan ini dapat mempengaruhi pemunculan notifikasi.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Matikan penghalang</string>
     <string name="settings_troubleshoot_test_battery_title">Optimisasi Baterai</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} tidak terpengaruh oleh Optimisasi Baterai.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} tidak terpengaruh oleh Optimisasi Baterai.</string>
     <string name="title_activity_keys_backup_setup">Cadangkan Kunci</string>
     <string name="title_activity_keys_backup_restore">Gunakan Cadangan Kunci</string>
     <string name="keys_backup_is_not_finished_please_wait">Pencadangan kunci belum selesai, mohon tunggu…</string>
@@ -866,11 +866,11 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed">Sebagian pemberitahuan dimatikan dalam aturan Anda.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">Gagal memuat aturan, mohon coba lagi.</string>
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Periksa Aturan</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nError ini di luar kendali ${app_name} dan menurut Google, error ini muncul ketika terlalu banyak aplikasi terdaftar dengan FCM pada perangkat tersebut. Error ini tidak seharusnya mempengaruhi pengguna biasa.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nError ini di luar kendali ${app_name}, dan dapat muncul karena berbagai alasan. Coba lagi nanti, atau Anda juga dapat memeriksa apabila penggunaan jaringan data Layanan Google Play tidak terhalang oleh sistem, atau waktu pada perangkat sudah benar, atau ini dapat terjadi pada ROM tidak resmi.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nError ini di luar kendali ${app_name}. Tidak terdapat akun Google pada perangkat. Mohon buka pengelola akun dan tambahkan akun Google.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Tambah Akun</string>
     <string name="settings_troubleshoot_test_battery_failed">Apabila perangkat tidak sedang diisi atau dipergunakan dengan layar dimatikan, perangkat masuk mode Doze. Ini akan menghalangi aplikasi mengakses jaringan dan menunda tugas, sinkronisasi, dan alarm standar.</string>
@@ -966,7 +966,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="summary_user_sent_image">%1$s mengirim sebuah gambar.</string>
     <string name="summary_message">%1$s: %2$s</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Dioptimalkan untuk real-time</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} akan mengsinkron di latar belakang dengan cara yang akan mempertahankan sumber daya (baterai) yang terbatas.
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} akan mengsinkron di latar belakang dengan cara yang akan mempertahankan sumber daya (baterai) yang terbatas.
 \nTergantung pada keadaan sumber daya perangkat Anda, sinkronisasi dapat ditangguhkan oleh operasi sistem.</string>
     <string name="settings_background_fdroid_sync_mode_battery">Dioptimalkan untuk baterai</string>
     <string name="settings_background_fdroid_sync_mode">Mode Sinkronisasi Latar Belakang</string>
@@ -982,7 +982,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="error_threepid_auth_failed">Pastikan Anda mengklik tautan di email yang telah kami kirimkan kepada Anda.</string>
     <string name="settings_remove_three_pid_confirmation_content">Hapus %s\?</string>
     <string name="settings_add_3pid_authentication_needed">Diperlukan otentikasi</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Anda tidak dapat melakukan ini dari ponsel ${app_name}</string>
+    <string name="settings_add_3pid_flow_not_supported">Anda tidak dapat melakukan ini dari ponsel ${app_name}</string>
     <string name="settings_add_3pid_confirm_password_title">Konfirmasi kata sandi Anda</string>
     <string name="settings_phone_number_empty">Tidak ada nomor telepon yang ditambahkan ke akun Anda</string>
     <string name="search_banned_user_hint">Saring pengguna yang dicekal</string>
@@ -1078,7 +1078,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="call_select_sound_device">Pilih Perangkat Suara</string>
     <string name="call_failed_no_connection_description">Gagal membuat koneksi real-time.
 \nSilakan minta administrator homeserver Anda untuk mengkonfigurasi server TURN agar panggilan untuk bekerja dengan andal.</string>
-    <string name="template_call_failed_no_connection">${app_name} Panggilan Gagal</string>
+    <string name="call_failed_no_connection">${app_name} Panggilan Gagal</string>
     <string name="call_failed_dont_ask_again">Jangan tanya saya lagi</string>
     <string name="call_failed_no_ice_use_alt">Coba menggunakan %s</string>
     <string name="call_failed_no_ice_description">Silakan minta administrator homeserver Anda (%1$s) untuk mengkonfigurasi server TURN agar panggilan dapat bekerja dengan andal.
@@ -1484,7 +1484,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Berikan izin</string>
     <string name="settings_integration_allow">Izinkan integrasi</string>
     <string name="settings_data_save_mode_summary">Mode data saver menerapkan filter tertentu sehingga pembaruan kehadiran dan pemberitahuan ketikan difilter.</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} perlu menjaga koneksi latar belakang rendah agar memiliki notifikasi yang handal.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} perlu menjaga koneksi latar belakang rendah agar memiliki notifikasi yang handal.
 \nPada layar berikutnya Anda akan diminta untuk mengizinkan ${app_name} untuk selalu berjalan di latar belakang, mohon diterima.</string>
     <string name="startup_notification_fdroid_battery_optim_title">Koneksi Latar Belakang</string>
     <string name="reset_secure_backup_warning">Ini akan menggantikan Kunci atau Frasa Anda saat ini.</string>
@@ -1516,7 +1516,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="settings_background_sync_update_error">Gagal memperbarui setelan.</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Anda tidak akan diberitahu tentang pesan masuk saat aplikasi berada di latar belakang.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Tidak ada sinkronisasi latar belakang</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} akan disinkronkan di latar belakang secara berkala pada waktu yang tepat (dapat dikonfigurasi).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} akan disinkronkan di latar belakang secara berkala pada waktu yang tepat (dapat dikonfigurasi).
 \nIni akan memengaruhi penggunaan radio dan baterai, dan ada juga pemberitahuan yang ditampilkan permanen menyatakan bahwa ${app_name} sedang mendengarkan peristiwa.</string>
     <string name="settings_mentions_and_keywords_encryption_notice">Anda tidak akan mendapatkan notifikasi untuk sebutan &amp; keyword di ruangan terenkripsi di ponsel.</string>
     <string name="settings_room_upgrades">Peningkatan ruangan</string>
@@ -1634,7 +1634,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="room_list_quick_actions_notifications_all_noisy">Semua pesan (brisik)</string>
     <string name="message_ignore_user">Abaikan pengguna</string>
     <string name="no_network_indicator">Tidak ada koneksi jaringan sekarang</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} memerlukan izin untuk menyimpan kunci E2E Anda di penyimpanan.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} memerlukan izin untuk menyimpan kunci E2E Anda di penyimpanan.
 \n
 \nHarap izinkan akses pada pop-up berikutnya untuk dapat mengekspor kunci Anda secara manual.</string>
     <string name="content_reported_as_inappropriate_content">Konten ini telah dilaporkan sebagai tidak pantas.
@@ -1842,7 +1842,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="sas_verify_title">Verifikasi dengan membandingkan string teks pendek.</string>
     <string name="invalid_or_expired_credentials">Anda telah keluar karena kredensial yang tidak valid atau kedaluwarsa.</string>
     <string name="autodiscover_well_known_autofill_confirm">Gunakan Konfigurasi</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} mendeteksi konfigurasi server khusus untuk domain userId Anda \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} mendeteksi konfigurasi server khusus untuk domain userId Anda \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_invalid_response">Respons penemuan homeserver tidak valid</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Opsi Server Pelengkapan Otomatis</string>
@@ -1952,7 +1952,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
 \nCadangkan kunci Anda dengan aman untuk menghindari kehilangan kunci Anda.</string>
     <string name="keys_backup_setup_step1_title">Jangan pernah kehilangan pesan terenkripsi</string>
     <string name="keys_backup_no_session_error">Tidak ada sesi Matrix yang tersedia</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Mohon hapus frasa sandinya jika Anda ingin ${app_name} untuk membuat kunci pemulihan.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Mohon hapus frasa sandinya jika Anda ingin ${app_name} untuk membuat kunci pemulihan.</string>
     <string name="passphrase_passphrase_too_weak">Frasa sandi terlalu lemah</string>
     <string name="passphrase_empty_error_message">Mohon masukkan frasa sandi</string>
     <string name="passphrase_passphrase_does_not_match">Frasa sandi tidak cocok</string>
@@ -1990,7 +1990,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="room_preview_no_preview_join">Ruangan ini tidak dapat ditampilkan. Apakah Anda masih mau bergabung\?</string>
     <string name="room_preview_not_found">Ruangan ini tidak dapat di akses di waktu ini.
 \nCoba lagi nanti, atau tanya admin ruangan untuk memeriksa jika Anda punya akses.</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Tampilan ruangan yang dapat dibaca oleh dunia belum didukung di ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Tampilan ruangan yang dapat dibaca oleh dunia belum didukung di ${app_name}</string>
     <string name="sas_view_request_action">Tampilkan permintaan</string>
     <string name="settings_info_area_show">Tampilkan area info</string>
     <string name="room_preview_no_preview">Ruangan ini tidak dapat di tampilkan</string>
@@ -2090,10 +2090,10 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="verify_cannot_cross_sign">Sesi ini tidak dapat berbagi verifikasi ini dengan sesi Anda yang lain.
 \nVerifikasi akan disimpan secara lokal dan dibagikan dalam versi aplikasi di masa depan.</string>
     <string name="unignore">Hapus pengabaian</string>
-    <string name="template_rendering_event_error_exception">${app_name} menemukan sebuah masalah ketika rendering konten dengan id \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} menemukan sebuah masalah ketika rendering konten dengan id \'%1$s\'</string>
     <string name="room_member_jump_to_read_receipt">Ke laporan dibaca</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} tidak mendukung peristiwa dengan tipe \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} tidak mendukung peristiwa dengan tipe \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} tidak mendukung peristiwa dengan tipe \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} tidak mendukung peristiwa dengan tipe \'%1$s\'</string>
     <string name="room_member_open_or_create_dm">Pesan langsung</string>
     <string name="room_member_power_level_default_in">Bawaan di %1$s</string>
     <string name="room_member_power_level_custom_in">Kustom (%1$d) di %2$s</string>
@@ -2184,7 +2184,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="create_room_encryption_description">Ketika diaktifkan, enkripsi tidak dapat dinonaktifkan.</string>
     <string name="create_room_encryption_title">Aktifkan enkripsi</string>
     <string name="command_description_shrug">Menambahkan ¯\\_(ツ)_/¯ ke pesan teks biasa</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} mungkin sering crash ketika ada kesalahan yang tidak terduga</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} mungkin sering crash ketika ada kesalahan yang tidak terduga</string>
     <string name="settings_developer_mode_fail_fast_title">Gagal-cepat</string>
     <string name="autocomplete_limited_results">Menunjukkan hanya hasil pertama, ketik huruf lagi…</string>
     <string name="devices_other_devices">Sesi lainnya</string>
@@ -2201,7 +2201,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="notification_initial_sync">Sinkronisasi Awal…</string>
     <string name="bug_report_error_too_short">Deskripsi terlalu pendek</string>
     <string name="permalink_malformed">Tautan matrix.to Anda tidak benar</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Sesi saat ini hanya untuk pengguna %1$s dan Anda memberikan kredensial untuk pengguna %2$s. Ini tidak didukung oleh ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">Sesi saat ini hanya untuk pengguna %1$s dan Anda memberikan kredensial untuk pengguna %2$s. Ini tidak didukung oleh ${app_name}.
 \nMohon bersihkan data, terus masuk lagi ke akun lainnya.</string>
     <string name="soft_logout_clear_data_dialog_submit">Bersihkan data</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Anda akan kehilangan akses ke pesan yang aman kecuali jika Anda masuk untuk memulihkan kunci enkripsi Anda.</string>
@@ -2487,13 +2487,13 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="auth_pin_confirm_to_disable_title">Konfirmasi PIN untuk menonaktifkan PIN</string>
     <string name="settings_security_pin_code_change_pin_summary">Ubah PIN sekarang</string>
     <string name="settings_security_pin_code_change_pin_title">Ubah PIN</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Kode PIN dibutuhkan setiap kali Anda buka ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Kode PIN dibutuhkan setelah 2 menit tidak menggunakan ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Kode PIN dibutuhkan setiap kali Anda buka ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Kode PIN dibutuhkan setelah 2 menit tidak menggunakan ${app_name}.</string>
     <string name="settings_security_pin_code_grace_period_title">Membutuhkan PIN setelah 2 menit</string>
     <string name="settings_security_pin_code_notifications_summary_off">Hanya tampilkan berapa pesan yang belum dibaca dalam notifikasi sederhana.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Tampilkan detail seperti nama ruangan dan konten pesan.</string>
     <string name="settings_security_pin_code_notifications_title">Tampilkan konten di notifikasi</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">Kode PIN hanya cara satu-satunya untuk membuka ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">Kode PIN hanya cara satu-satunya untuk membuka ${app_name}.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Aktifkan biometrik spesifik perangkat, seperti sidik jari dan pengenalan wajah.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Aktifkan biometrik</string>
     <string name="settings_security_pin_code_summary">Jika Anda ingin mengatur ulang PIN Anda, ketuk Lupa PIN untuk keluar dan mengatur ulang.</string>
@@ -2584,10 +2584,10 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="identity_server_user_consent_not_provided">Izin pengguna belum diberikan.</string>
     <string name="identity_server_error_no_current_binding_error">Tidak ada asosiasi saat ini dengan pengenal ini.</string>
     <string name="identity_server_error_binding_error">Asosiasi telah gagal.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Untuk pricvasi Anda, ${app_name} hanya mendukung pengiriman email pengguna yang telah di-hash dan nomor telepon.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Untuk pricvasi Anda, ${app_name} hanya mendukung pengiriman email pengguna yang telah di-hash dan nomor telepon.</string>
     <string name="identity_server_error_terms_not_signed">Mohon terima ketentuan server identitas ini di pengaturan.</string>
     <string name="identity_server_error_no_identity_server_configured">Mohon konfigurasi server identitas.</string>
-    <string name="template_identity_server_error_outdated_identity_server">Server identitas ini telah usang. ${app_name} hanya mendukung API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Server identitas ini telah usang. ${app_name} hanya mendukung API V2.</string>
     <string name="identity_server_error_outdated_home_server">Operasi ini tidak memungkinkan. Homeserver ini telah usang.</string>
     <string name="disconnect_identity_server_dialog_content">Putuskan koneksi dari server identitas %s\?</string>
     <string name="open_terms_of">Buka ketentuan %s</string>
@@ -2604,8 +2604,8 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="not_a_valid_qr_code">Bukan kode QR Matrix yang valid</string>
     <string name="invitations_sent_to_two_users">Undangan terkirim ke %1$s dan %2$s</string>
     <string name="invitation_sent_to_one_user">Undangan terkirim ke %1$s</string>
-    <string name="template_invite_friends_rich_title">🔐️ Bergabung dengan saya di ${app_name}</string>
-    <string name="template_invite_friends_text">Halo, bicara dengan saya di ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Bergabung dengan saya di ${app_name}</string>
+    <string name="invite_friends_text">Halo, bicara dengan saya di ${app_name}: %s</string>
     <string name="invite_friends">Undang teman</string>
     <string name="invite_users_to_room_title">Undang Pengguna</string>
     <string name="inviting_users_to_room">Mengundang pengguna…</string>
@@ -2619,7 +2619,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="space_add_space_to_any_space_you_manage">Tambahkan sebuah space ke space apa saja yang Anda dapat kelola.</string>
     <string name="create_space_error_empty_field_space_name">Beri nama untuk melanjutkan.</string>
     <string name="create_pin_confirm_failure">Gagal untuk memvalidasi PIN, mohon ketuk yang baru.</string>
-    <string name="template_link_this_email_with_your_account">%s di Pengaturan untuk menerima undangan secara langsung di ${app_name}.</string>
+    <string name="link_this_email_with_your_account">%s di Pengaturan untuk menerima undangan secara langsung di ${app_name}.</string>
     <string name="link_this_email_settings_link">Tautkan email ini ke akun Anda</string>
     <string name="this_invite_to_this_space_was_sent">Undangan space ini telah dikirim ke %s yang tidak diasosiasikan dengan akun Anda</string>
     <string name="this_invite_to_this_room_was_sent">Undangan ruangan ini telah dikirim ke %s yang tidak diasosiasikan dengan akun Anda</string>
@@ -2654,12 +2654,12 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="use_recovery_key">Gunakan Kunci Pemulihan</string>
     <string name="command_description_discard_session_not_handled">Hanya didukung di ruangan terenkripsi</string>
     <string name="command_description_discard_session">Memaksa sesi kelompok outbound saat ini di ruangan terenkripsi untuk dihapus</string>
-    <string name="template_use_latest_app">Gunakan ${app_name} di perangkat Anda yang lain:</string>
-    <string name="template_use_other_session_content_description">Gunakan ${app_name} di perangkat Anda yang lain, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} untuk Android, atau client Matrix lainnya yang mendukung tanda tangan silang</string>
+    <string name="use_latest_app">Gunakan ${app_name} di perangkat Anda yang lain:</string>
+    <string name="use_other_session_content_description">Gunakan ${app_name} di perangkat Anda yang lain, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} untuk Android, atau client Matrix lainnya yang mendukung tanda tangan silang</string>
     <string name="or_other_mx_capable_client">atau client Matrix lainnya yang mendukung tanda tangan silang</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
     <string name="change_password_summary">Atur kata sandi akun baru…</string>
     <string name="error_saving_media_file">Tidak dapat menyimpan file media</string>
@@ -2773,7 +2773,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="e2e_use_keybackup">Akses riwayat pesan terenkripsi</string>
     <string name="settings_export_trail">Ekspor Audit</string>
     <string name="settings_key_requests">Permintaan Kunci</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Kunci telah mutakhir!</string>
     <string name="event_redacted_by_admin_reason_with_reason">Peristiwa dimoderasi oleh admin ruangan, alasannya: %1$s</string>
     <string name="event_redacted_by_user_reason_with_reason">Peristiwa dihapus oleh pengguna, alasannya: %1$s</string>
@@ -2809,7 +2809,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="a11y_open_widget">Buka widget</string>
     <string name="a11y_screenshot">Tangkap layar</string>
     <string name="authentication_error">Gagal mengotentikasi</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} meminta Anda untuk memasukkan kredential untuk melakukan aksi ini.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} meminta Anda untuk memasukkan kredential untuk melakukan aksi ini.</string>
     <string name="re_authentication_activity_title">Otentikasi Ulang Dibutuhkan</string>
     <string name="call_slide_to_end_conference">Geser untuk mengakhirkan panggilan</string>
     <string name="call_transfer_unknown_person">Orang tak dikenal</string>
@@ -2967,7 +2967,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     </plurals>
     <string name="preference_system_settings">Pengaturan sistem</string>
     <string name="preference_versions">Versi</string>
-    <string name="template_preference_help_summary">Dapatkan bantuan dalam menggunakan ${app_name}</string>
+    <string name="preference_help_summary">Dapatkan bantuan dalam menggunakan ${app_name}</string>
     <string name="preference_help_title">Bantuan dan dukungan</string>
     <string name="preference_help">Bantuan</string>
     <string name="preference_root_legals">Hukum</string>
@@ -2975,16 +2975,16 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="legals_third_party_notices">Perpustakaan pihak ketiga</string>
     <string name="legals_identity_server_title">Kebijakan server identitas Anda</string>
     <string name="legals_home_server_title">Kebijakan homeserver Anda</string>
-    <string name="template_legals_application_title">Kebijakan ${app_name}</string>
+    <string name="legals_application_title">Kebijakan ${app_name}</string>
     <string name="analytics_opt_in_list_item_3">Anda dapat mematikannya kapan saja di pengaturan</string>
     <string name="analytics_opt_in_list_item_2">Kami <b>tidak</b> membagikan informasi ini dengan pihak ketiga</string>
     <string name="analytics_opt_in_list_item_1">Kami <b>tidak</b> merekam atau memprofil data akun apapun</string>
     <string name="analytics_opt_in_content_link">di sini</string>
-    <string name="template_analytics_opt_in_content">Bantu kami mengidentifikasi masalah-masalah dan membuat ${app_name} lebih baik dengan membagikan data penggunaan anonim. Untuk memahami bagaimana orang-orang menggunakan beberapa perangkat-perangkat, kami akan membuat pengenal acak, yang dibagikan oleh perangkat Anda.
+    <string name="analytics_opt_in_content">Bantu kami mengidentifikasi masalah-masalah dan membuat ${app_name} lebih baik dengan membagikan data penggunaan anonim. Untuk memahami bagaimana orang-orang menggunakan beberapa perangkat-perangkat, kami akan membuat pengenal acak, yang dibagikan oleh perangkat Anda.
 \n
 \n
 \nAnda dapat membaca semua kebijakan kami %s.</string>
-    <string name="template_analytics_opt_in_title">Bantu buat ${app_name} lebih baik</string>
+    <string name="analytics_opt_in_title">Bantu buat ${app_name} lebih baik</string>
     <string name="action_enable">Aktifkan</string>
     <string name="restart_the_application_to_apply_changes">Mulai ulang aplikasi ini untuk menerapkan perubahan.</string>
     <string name="labs_enable_latex_maths">Aktifkan matematika LaTeX</string>
@@ -3007,8 +3007,8 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="settings_enable_location_sharing_summary">Setelah diaktifkan Anda akan dapat mengirim lokasi Anda ke ruangan apa saja</string>
     <string name="settings_enable_location_sharing">Aktifkan pembagian lokasi</string>
     <string name="location_share_external">Buka dengan</string>
-    <string name="template_location_not_available_dialog_content">${app_name} tidak dapat mengakses lokasi Anda. Silakan coba lagi nanti.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} tidak dapat mengakses lokasi Anda</string>
+    <string name="location_not_available_dialog_content">${app_name} tidak dapat mengakses lokasi Anda. Silakan coba lagi nanti.</string>
+    <string name="location_not_available_dialog_title">${app_name} tidak dapat mengakses lokasi Anda</string>
     <string name="location_share">Bagikan lokasi</string>
     <string name="a11y_location_share_icon">Bagikan lokasi</string>
     <string name="location_activity_title_preview">Lokasi</string>

--- a/vector/src/main/res/values-is/strings.xml
+++ b/vector/src/main/res/values-is/strings.xml
@@ -628,7 +628,7 @@
     <string name="room_settings_addresses_invalid_format_dialog_title">Ógilt snið samnefnis</string>
     <string name="directory_server_fail_to_retrieve_server">Netþjónninn gæti verið undir miklu álagi eða ekki til taks</string>
     <string name="missing_permissions_warning">Þar sem ýmsar heimildir vantar, eru sumir eiginleikar ekki tiltækir…</string>
-    <string name="template_no_contact_access_placeholder">Þú heimilaðir ${app_name} ekki aðgang að tengiliðum á tækinu</string>
+    <string name="no_contact_access_placeholder">Þú heimilaðir ${app_name} ekki aðgang að tengiliðum á tækinu</string>
     <string name="send_bug_report_rage_shake">Hristu ákveðið til að senda villutilkynningu</string>
     <string name="send_bug_report_sent">Það tókst að senda villuskýrsluna</string>
     <string name="send_bug_report_failed">Mistókst að senda villuskýrsluna (%s)</string>
@@ -646,7 +646,7 @@
     <string name="room_unknown_devices_messages_notification">Skilaboð ekki send vegna þess að vart var við óþekkt tæki. %1$s eða %2$s núna?</string>
     <string name="settings_set_sync_delay">Hlé milli tveggja samstillingarbeiðna</string>
     <string name="settings_keep_media">Halda gögnum</string>
-    <string name="template_startup_notification_privacy_message">${app_name} getur keyrt í bakgrunni og stýrt tilkynningum á öruggan hátt (getur haft áhrif á rafhlöðunotkun).</string>
+    <string name="startup_notification_privacy_message">${app_name} getur keyrt í bakgrunni og stýrt tilkynningum á öruggan hátt (getur haft áhrif á rafhlöðunotkun).</string>
     <string name="account_email_validation_message">Skoðaðu tölvupóstinn þinn og smelltu á tengilinn sem hann inniheldur. Þegar því er lokið skaltu smella á að halda áfram.</string>
     <string name="account_email_validation_error">Tókst ekki að sannreyna tölvupóstfang. Skoðaðu tölvupóstinn þinn og smelltu á tengilinn sem hann inniheldur. Þegar því er lokið skaltu smella á að halda áfram.</string>
     <string name="room_settings_room_access_entry_only_invited">Aðeins fólk sem hefur verið boðið</string>
@@ -672,24 +672,24 @@
 \nÞú hefur verið skráður út af öllum tækjum og munt ekki lengur fá ýti-tilkynningar. Til að endurvirkja tilkynningar, þarf að skrá sig aftur inn á hverju tæki fyrir sig.</string>
     <string name="login_error_unknown_token">Tiltekið aðgangsteikn þekktist ekki</string>
     <string name="call_error_user_not_responding">Ekki var svarað á fjartengda endanum.</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} þarf heimild til að nota mynda- og myndskeiðasafn svo hægt sé að senda og vista viðhengi.
+    <string name="permissions_rationale_msg_storage">${app_name} þarf heimild til að nota mynda- og myndskeiðasafn svo hægt sé að senda og vista viðhengi.
 \n
 \nLeyfðu aðgang í næsta sprettglugga til þess að geta sent skrár úr símanum.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} þarf heimild til að nota myndavélina svo hægt sé að taka myndir og hringja myndsímtöl.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} þarf heimild til að nota myndavélina svo hægt sé að taka myndir og hringja myndsímtöl.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nLeyfðu aðgang í næsta sprettglugga til þess að geta hringt."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} þarf heimild til að nota hljóðnemann svo hægt sé að hringja hljóðsímtöl.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} þarf heimild til að nota hljóðnemann svo hægt sé að hringja hljóðsímtöl.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nLeyfðu aðgang í næsta sprettglugga til þess að geta hringt."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} þarf heimild til að nota myndavélina og hljóðnemann svo hægt sé að hringja myndsímtöl.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} þarf heimild til að nota myndavélina og hljóðnemann svo hægt sé að hringja myndsímtöl.
 \n
 \nLeyfðu aðgang í næstu sprettgluggum til þess að geta hringt.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} þarf heimild til að nota tengiliði í nafnaskránni svo hægt sé að finna aðra Matrix-notendur eftir tölvupóstföngum og símanúmerum þeirra.
+    <string name="permissions_rationale_msg_contacts">${app_name} þarf heimild til að nota tengiliði í nafnaskránni svo hægt sé að finna aðra Matrix-notendur eftir tölvupóstföngum og símanúmerum þeirra.
 
 Leyfðu aðgang í næsta sprettglugga til þess að finna þá notendur í nafnaskránni sem hægt er að hafa samband við úr ${app_name}.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} þarf heimild til að nota tengiliði í nafnaskránni svo hægt sé að finna aðra Matrix-notendur eftir tölvupóstföngum og símanúmerum þeirra.
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} þarf heimild til að nota tengiliði í nafnaskránni svo hægt sé að finna aðra Matrix-notendur eftir tölvupóstföngum og símanúmerum þeirra.
 \n
 \nLeyfa ${app_name} að nota tengiliðina\?</string>
     <string name="settings_deactivate_account_section">Gera notandaaðgang óvirkann</string>
@@ -713,8 +713,8 @@ Leyfðu aðgang í næsta sprettglugga til þess að finna þá notendur í nafn
     <string name="option_send_sticker">Senda límmerki</string>
     <string name="login_error_login_email_not_yet">Tölvupósttengill sem ekki er enn búið að smella á</string>
     <string name="malformed_id">Rangt formað auðkenni. Ætti að vera tölvupóstfang eða Matrix-auðkenni á borð við\'@sérheiti:lén\'</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} safnar nafnlausum greiningargögnum til að gera okkur kleift að bæta forritið.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Endilega virkjaðu greiningargögn til að hjálpa okkur að bæta ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} safnar nafnlausum greiningargögnum til að gera okkur kleift að bæta forritið.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Endilega virkjaðu greiningargögn til að hjálpa okkur að bæta ${app_name}.</string>
     <string name="room_settings_room_access_warning">Til að tengja við spjallrás verður hún að vera með vistfang.</string>
     <string name="room_preview_try_join_an_unknown_room">Þú ert að reyna að tengjast %s. Myndirðu vilja gerast meðlimur til að geta tekið þátt í samræðunni?</string>
     <string name="room_preview_room_interactions_disabled">Þetta er forskoðun á spjallrásinni. Samskipti spjallrásarinnar hafa verið gerð óvirk.</string>

--- a/vector/src/main/res/values-it/strings.xml
+++ b/vector/src/main/res/values-it/strings.xml
@@ -328,7 +328,7 @@
     <string name="user_directory_header">Elenco utenti</string>
     <string name="matrix_only_filter">Mostra solo i contatti Matrix</string>
     <string name="no_conversation_placeholder">Nessuna conversazione</string>
-    <string name="template_no_contact_access_placeholder">${app_name} non ha avuto l\'autorizzazione ad accedere alla tua Rubrica locale</string>
+    <string name="no_contact_access_placeholder">${app_name} non ha avuto l\'autorizzazione ad accedere alla tua Rubrica locale</string>
     <string name="no_result_placeholder">Nessun risultato</string>
     <string name="rooms_header">Stanze</string>
     <string name="rooms_directory_header">Elenco stanze</string>
@@ -458,22 +458,22 @@
     <string name="media_picker_both_capture_title">Fai una foto o un video</string>
     <string name="media_picker_cannot_record_video">Impossibile registrare video</string>
     <string name="permissions_rationale_popup_title">Informazione</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} deve essere autorizzato ad accedere alla tua Galleria di foto e video per poter inviare e salvare allegati.
+    <string name="permissions_rationale_msg_storage">${app_name} deve essere autorizzato ad accedere alla tua Galleria di foto e video per poter inviare e salvare allegati.
 \n
 \nNel prossimo pop-up concedi l\'autorizzazione per poteri inviare file dal tuo dispositivo.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} deve essere autorizzato ad accedere alla tua fotocamera per poter fare foto e video.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} deve essere autorizzato ad accedere alla tua fotocamera per poter fare foto e video.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nNel prossimo pop-up concedi l\'autorizzazione per poter fare la chiamata."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} deve essere autorizzato ad accedere al microfono e poter così fare chiamate audio.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} deve essere autorizzato ad accedere al microfono e poter così fare chiamate audio.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nNel prossimo pop-up concedi l\'autorizzazione per poter fare la chiamata."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} deve essere autorizzato ad accedere a fotocamera e microfono per poter fare chiamate video.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} deve essere autorizzato ad accedere a fotocamera e microfono per poter fare chiamate video.
 \n
 \nNel prossimo pop-up concedi le autorizzazioni per poter fare la chiamata.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} può usare tua rubrica per trovare altri utenti Matrix grazie alle loro email e numeri di telefono. Se accetti di condividere la tua rubrica per questo scopo, puoi concedere l\'autorizzazione nella prossima finestra.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} può usare tua Rubrica locale per trovare altri utenti Matrix grazie alle loro email e numeri di telefono.
+    <string name="permissions_rationale_msg_contacts">${app_name} può usare tua rubrica per trovare altri utenti Matrix grazie alle loro email e numeri di telefono. Se accetti di condividere la tua rubrica per questo scopo, puoi concedere l\'autorizzazione nella prossima finestra.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} può usare tua Rubrica locale per trovare altri utenti Matrix grazie alle loro email e numeri di telefono.
 \n
 \nTi sta bene comunicare i dati di tutti i tuoi contatti per questo scopo\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Purtroppo l\'azione non è stata eseguita a causa di autorizzazioni mancanti</string>
@@ -942,7 +942,7 @@
     <string name="settings_notification_privacy_nosecure_message_content">• Le notifiche contengono <b>metadati e contenuto del messaggio</b></string>
     <string name="settings_notification_privacy_message_content_not_shown">• Le notifiche <b>non mostreranno il contenuto del messaggio</b></string>
     <string name="startup_notification_privacy_title">Privacy delle notifiche</string>
-    <string name="template_startup_notification_privacy_message">${app_name} può esser sempre attivo in background in modo da gestire le tue notifiche in modo costante e sicuro. Ciò può influire sulla durata della batteria.</string>
+    <string name="startup_notification_privacy_message">${app_name} può esser sempre attivo in background in modo da gestire le tue notifiche in modo costante e sicuro. Ciò può influire sulla durata della batteria.</string>
     <string name="startup_notification_privacy_button_grant">Concedi l\'autorizzazione</string>
     <string name="startup_notification_privacy_button_other">Scegli un\'altra opzione</string>
     <string name="title_activity_choose_sticker">Invia uno sticker</string>
@@ -953,8 +953,8 @@
     <string name="settings_deactivate_account_section">Disattiva l\'account</string>
     <string name="settings_deactivate_my_account">Disattiva il mio account</string>
     <string name="settings_opt_in_of_analytics">Invia le statistiche di utilizzo</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} raccoglie statistiche anonime per permettere il miglioramento dell\'applicazione.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Attiva le statistiche per aiutare a migliorare ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} raccoglie statistiche anonime per permettere il miglioramento dell\'applicazione.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Attiva le statistiche per aiutare a migliorare ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Sì, voglio aiutare!</string>
     <string name="widget_integration_missing_parameter">Manca un parametro indispensabile.</string>
     <string name="widget_integration_invalid_parameter">Uno dei parametri non è valido.</string>
@@ -976,7 +976,7 @@
     <string name="e2e_re_request_encryption_key">Richiedi di nuovo le chiavi di crittografia dalle tue altre sessioni.</string>
     <string name="e2e_re_request_encryption_key_sent">La richiesta della chiave è stata inviata.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Richiesta inviata</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Avvia ${app_name} su un altro dispositivo capace di decrittare il messaggio in modo che poi possa inviarti le chiavi su questa sessione.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Avvia ${app_name} su un altro dispositivo capace di decrittare il messaggio in modo che poi possa inviarti le chiavi su questa sessione.</string>
     <string name="lock_screen_hint">Digita qui…</string>
     <string name="option_send_voice">Invia messaggio vocale</string>
     <string name="go_on_with">prosegui con…</string>
@@ -1091,7 +1091,7 @@
     <string name="markdown_has_been_enabled">Markdown è stato abilitato.</string>
     <string name="markdown_has_been_disabled">Markdown è stato disabilitato.</string>
     <string name="settings_call_category">Chiamate</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Usa la suoneria predefinita di ${app_name} per le chiamate in arrivo</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Usa la suoneria predefinita di ${app_name} per le chiamate in arrivo</string>
     <string name="settings_call_ringtone_title">Suoneria delle chiamate in arrivo</string>
     <string name="settings_call_ringtone_dialog_title">Scegli la suoneria per le chiamate:</string>
     <string name="action_accept">Accetta</string>
@@ -1114,12 +1114,12 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Abilita</string>
     <string name="settings_troubleshoot_test_device_settings_title">Impostazioni sessione.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Le notifiche sono attive per questa sessione.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Le notifiche non sono attive per questa sessione.
+    <string name="settings_troubleshoot_test_device_settings_failed">Le notifiche non sono attive per questa sessione.
 \nControlla le impostazioni di ${app_name}.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Abilita</string>
     <string name="settings_troubleshoot_test_play_services_title">Esegui un controllo dei servizi</string>
     <string name="settings_troubleshoot_test_play_services_success">L\'APK Google Play Services è disponibile e aggiornato.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} usa Google Play Services per consegnare i messaggi a comparsa, ma sembra non sia stato configurato correttamente:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} usa Google Play Services per consegnare i messaggi a comparsa, ma sembra non sia stato configurato correttamente:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Correggi i Play Services</string>
     <string name="settings_troubleshoot_test_fcm_title">Token di Firebase</string>
@@ -1136,21 +1136,21 @@
     <string name="settings_troubleshoot_test_service_restart_failed">L\'avvio del servizio è fallito</string>
     <string name="settings_troubleshoot_test_service_boot_title">Esegui all\'avvio</string>
     <string name="settings_troubleshoot_test_service_boot_success">Il servizio inizierà quando il dispositivo sarà riavviato.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Il servizio non partirà al riavvio del dispositivo. Non riceverai notifiche finché ${app_name} non verrà aperto almeno una volta.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Il servizio non partirà al riavvio del dispositivo. Non riceverai notifiche finché ${app_name} non verrà aperto almeno una volta.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Abilita l\'esecuzione all\'avvio</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Verifica se Element sia stato configurato per funzionare in modo limitato quando lavora in background</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">${app_name} non funziona senza alcuna restrizione anche quando è eseguito in background. Questo test andrebbe eseguito usando dati mobili (non WIFI).
+    <string name="settings_troubleshoot_test_bg_restricted_success">${app_name} non funziona senza alcuna restrizione anche quando è eseguito in background. Questo test andrebbe eseguito usando dati mobili (non WIFI).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">${app_name} è stato configurato per funzionare in modo limitato quando è eseguito in background.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">${app_name} è stato configurato per funzionare in modo limitato quando è eseguito in background.
 \nIl funzionamento dell\'App, quando è eseguita in background, è stato fortemente limitato e ciò potrebbe influenzare la ricezione delle notifiche.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Disabilita le restrizioni</string>
     <string name="settings_troubleshoot_test_battery_title">Ottimizzazione della batteria</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} non è influenzato dall\'ottimizzazione della batteria.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} non è influenzato dall\'ottimizzazione della batteria.</string>
     <string name="settings_troubleshoot_test_battery_failed">Se si lascia un dispositivo scollegato, fermo e con lo schermo spento, dopo un certo tempo questo entra in modalità Doze. Ciò impedisce alle App di accedere alla rete e ritarda le attività, le sincronizzazioni e la ricezione dei normali allarmi.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignora l\'ottimizzazione</string>
     <string name="startup_notification_fdroid_battery_optim_title">Connessione in background</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">Per poter ricevere le notifiche in tempo reale, ${app_name} deve potersi sempre connettere. Anche quando funziona in background.
+    <string name="startup_notification_fdroid_battery_optim_message">Per poter ricevere le notifiche in tempo reale, ${app_name} deve potersi sempre connettere. Anche quando funziona in background.
 \nNella schermata successiva ti verrà chiesto di consentire a ${app_name} di funzionare anche quando è in background, accetta per favore.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Concedi il permesso</string>
     <string name="account_email_error">Si è verificato un errore durante la verifica dell\'indirizzo email.</string>
@@ -1186,11 +1186,11 @@
     <string name="settings_troubleshoot_test_bing_settings_failed">Alcune notifiche sono disattivate nelle tue impostazioni personalizzate.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">Il caricamento delle regole personalizzate è fallito, riprova.</string>
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Controlla le Impostazioni</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nQuesto errore non dipende da ${app_name}. Secondo Google dipende dal fatto che questo dispositivo ha troppe App registrate con FCM. L\'errore si verifica solo in casi in cui ci sia un numero estremo di app, quindi non dovrebbe affliggere l\'utente medio.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nQuesto errore non dipende da ${app_name} e può avere diverse cause. Potresti riprovare più tardi o controllare che Google Play Service non abbia configurato nelle Impostazioni di sistema dei limiti di utilizzo di dati. Anche un orologio di sistema regolato male potrebbe esserne la causa. Oppure può verificarsi se hai una ROM customizzata.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nQuesto errore non dipende da ${app_name}. Non c\'è alcun account Google nel telefono. Apri il gestore di account ed aggiungi un account Google.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Aggiungi account</string>
     <string name="settings_noisy_notifications_preferences">Configura le notifiche rumorose</string>
@@ -1210,7 +1210,7 @@
     <string name="error_empty_field_enter_user_name">Inserisci un nome utente.</string>
     <string name="passphrase_empty_error_message">Inserisci una Passphrase</string>
     <string name="passphrase_passphrase_too_weak">La Passphrase è troppo debole</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Cancella la Passphrase se vuoi che ${app_name} generi un codice di recupero.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Cancella la Passphrase se vuoi che ${app_name} generi un codice di recupero.</string>
     <string name="keys_backup_no_session_error">Non c\'è alcuna sessione Matrix disponibile</string>
     <string name="keys_backup_setup_step1_title">Non perdere mai i messaggi cifrati</string>
     <string name="keys_backup_setup_step1_description">I messaggi nelle stanze cifrate sono protetti con crittografia E2E. Solo tu e i destinatarii avete le chiavi crittografiche per leggere questi messaggi.
@@ -1316,7 +1316,7 @@
     <string name="keys_backup_info_title_signature">Firma</string>
     <string name="autodiscover_invalid_response">Risposta home server non valida</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Opzioni autocompletamento server</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} ha rilevato una configurazione server personalizzata per il tuo dominio userID \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} ha rilevato una configurazione server personalizzata per il tuo dominio userID \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Usa configurazione</string>
     <string name="notification_sync_init">Inizializzazione del servizio</string>
@@ -1427,7 +1427,7 @@
     <string name="please_wait">Attendere prego…</string>
     <string name="group_all_communities">Tutte le comunità</string>
     <string name="room_preview_no_preview">Anteprima non disponibile per questa stanza</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">L\'anteprima di stanze leggibili da tutti non è ancora supportata in ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">L\'anteprima di stanze leggibili da tutti non è ancora supportata in ${app_name}</string>
     <string name="fab_menu_create_room">Stanze</string>
     <string name="fab_menu_create_chat">Messaggi diretti</string>
     <string name="create_room_title">Nuova stanza</string>
@@ -1523,10 +1523,10 @@
     <string name="invite_no_identity_server_error">Per poterlo fare, aggiungi un server d\'identità nelle Impostazioni.</string>
     <string name="settings_background_fdroid_sync_mode">Modalità sync in background</string>
     <string name="settings_background_fdroid_sync_mode_battery">Ottimizzato per la batteria</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} si sincronizzerà in background in modo da non consumare la poca batteria disponibile.
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} si sincronizzerà in background in modo da non consumare la poca batteria disponibile.
 \nA seconda del livello della batteria, il sistema operativo potrebbe ritardare la sincronizzazione.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Ottimizzato per la performance</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} si sincronizzerà in background ad intervalli regolari (configurabili).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} si sincronizzerà in background ad intervalli regolari (configurabili).
 \nCiò avrà un certo impatto sulla quantità di dati e batteria utilizzati. Una notifica sempre accesa comunicherà che ${app_name} è attivo.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Nessuna sincronizzazione in background</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Quando l\'App è in background non ti verranno notificati i messaggi in arrivo.</string>
@@ -1611,12 +1611,12 @@
     <string name="content_reported_as_inappropriate_content">Questo contenuto è stato segnalato come inappropriato.
 \n
 \nSe non vuoi più vedere i contenuti di questo utente puoi ignorarlo. Ciò nasconderà i suoi messaggi dalla tua vista.</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} richiede l\'autorizzazione per salvare sul disco le tue chiavi crittografiche.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} richiede l\'autorizzazione per salvare sul disco le tue chiavi crittografiche.
 \n
 \nPermetti l\'accesso nel prossimo pop-up per poter esportare le chiavi manualmente.</string>
     <string name="no_network_indicator">In questo momento non c\'è nessuna connessione di rete</string>
     <string name="settings_add_3pid_confirm_password_title">Conferma la tua password</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Non puoi farlo da ${app_name} mobile</string>
+    <string name="settings_add_3pid_flow_not_supported">Non puoi farlo da ${app_name} mobile</string>
     <string name="settings_add_3pid_authentication_needed">E\'necessaria l\'autenticazione</string>
     <string name="settings_integrations">Integrazioni</string>
     <string name="settings_integrations_summary">Usa un gestore di integrazioni per gestire bot, bridge, widget e pacchetti di sticker.
@@ -1783,7 +1783,7 @@
 \nAccedi nuovamente per avere accesso ai dati dell\'account e ai messaggi.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Se non accedi per recuperare le tue chiavi crittografiche perderai l\'accesso ai messaggi criptati.</string>
     <string name="soft_logout_clear_data_dialog_submit">Elimina i dati</string>
-    <string name="template_soft_logout_sso_not_same_user_error">La sessione attuale è per l\'utente %1$s e hai fornito le credenziali per l\'utente %2$s. Ciò non è supportato da ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">La sessione attuale è per l\'utente %1$s e hai fornito le credenziali per l\'utente %2$s. Ciò non è supportato da ${app_name}.
 \nPrima elimina i dati, poi accedi di nuovo con un altro account.</string>
     <string name="permalink_malformed">Il tuo link matrix.to non è corretto</string>
     <string name="bug_report_error_too_short">La descrizione è troppo breve</string>
@@ -1801,7 +1801,7 @@
     <string name="devices_other_devices">Altre sessioni</string>
     <string name="autocomplete_limited_results">Si vedono solo i primi risultati: digita più lettere…</string>
     <string name="settings_developer_mode_fail_fast_title">Fail-fast</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">Se si verifica un errore imprevisto ${app_name} potrebbe crashare più spesso</string>
+    <string name="settings_developer_mode_fail_fast_summary">Se si verifica un errore imprevisto ${app_name} potrebbe crashare più spesso</string>
     <string name="command_description_shrug">Antepone ¯\\_(ツ)_/¯ in un messaggio testuale</string>
     <string name="create_room_encryption_title">Attiva la crittografia</string>
     <string name="create_room_encryption_description">Una volta attivata, la crittografia non può più essere disattivata.</string>
@@ -1867,9 +1867,9 @@
     <string name="room_member_power_level_moderator_in">Moderatore in %1$s</string>
     <string name="room_member_power_level_custom_in">Personalizzato (%1$d) in %2$s</string>
     <string name="room_member_jump_to_read_receipt">Vai alla ricevuta di lettura</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} non gestisce eventi del tipo \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} non gestisce messaggi del tipo \'%1$s\'</string>
-    <string name="template_rendering_event_error_exception">${app_name} ha riscontrato un errore con il rendering del contenuto dell\'evento con id \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} non gestisce eventi del tipo \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} non gestisce messaggi del tipo \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} ha riscontrato un errore con il rendering del contenuto dell\'evento con id \'%1$s\'</string>
     <string name="unignore">Non ignorare più</string>
     <string name="verify_cannot_cross_sign">Questa sessione non riesce a condividere questa verifica con le tue altre sessioni.
 \nLa verifica sarà salvata in locale e condivisa in una versione futura dell\'app.</string>
@@ -1955,7 +1955,7 @@
     <string name="event_redacted_by_user_reason_with_reason">Evento eliminato dall\'utente, motivo: %1$s</string>
     <string name="event_redacted_by_admin_reason_with_reason">Evento moderato dll\'Amministratore della stanza, motivo: %1$s</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Le chiavi sono già aggiornate!</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">Richieste di chiavi</string>
     <string name="e2e_use_keybackup">Sblocca la cronologia dei messaggi cifrati</string>
     <string name="refresh">Ricarica</string>
@@ -2056,13 +2056,13 @@
     <string name="media_file_added_to_gallery">File multimediale aggiunto alla galleria</string>
     <string name="error_adding_media_file_to_gallery">Impossibile aggiungere il file multimediale alla galleria</string>
     <string name="change_password_summary">Imposta una nuova password dell\'account…</string>
-    <string name="template_use_other_session_content_description">Usa l\'ultima versione di ${app_name} sui tuoi altri dispositivi, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} Android o un altro client Matrix che supporti la firma incrociata</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="use_other_session_content_description">Usa l\'ultima versione di ${app_name} sui tuoi altri dispositivi, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} Android o un altro client Matrix che supporti la firma incrociata</string>
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
     <string name="or_other_mx_capable_client">o un altro client Matrix che supporti la firma incrociata</string>
-    <string name="template_use_latest_app">Usa l\'ultima versione di ${app_name} anche sui tuoi altri dispositivi:</string>
+    <string name="use_latest_app">Usa l\'ultima versione di ${app_name} anche sui tuoi altri dispositivi:</string>
     <string name="command_description_discard_session">Forza l\'attuale sessione di gruppo in uscita in una stanza cifrata ad essere scartata</string>
     <string name="command_description_discard_session_not_handled">Supportato solo nelle stanze criptate</string>
     <string name="enter_secret_storage_passphrase_or_key">Usa la tua %1$s o la %2$s per continuare.</string>
@@ -2123,11 +2123,11 @@
     <string name="choose_locale_loading_locales">Caricamento lingue disponibili…</string>
     <string name="open_terms_of">Apri condizioni di %s</string>
     <string name="disconnect_identity_server_dialog_content">Disconnettere dal server d\'identità %s\?</string>
-    <string name="template_identity_server_error_outdated_identity_server">Questo server d\'identità è obsoleto. ${app_name} supporta solo API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Questo server d\'identità è obsoleto. ${app_name} supporta solo API V2.</string>
     <string name="identity_server_error_outdated_home_server">Questa operazione non è possibile. L\'Home Server è obsoleto.</string>
     <string name="identity_server_error_no_identity_server_configured">Prima configura un server d\'identità.</string>
     <string name="identity_server_error_terms_not_signed">Prima accetta le condizioni del server d\'identità nelle impostazioni.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Per la tua privacy, ${app_name} supporta solo l\'invio di email e numeri di telefono degli utenti in modalità oscurata (hash).</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Per la tua privacy, ${app_name} supporta solo l\'invio di email e numeri di telefono degli utenti in modalità oscurata (hash).</string>
     <string name="identity_server_error_binding_error">L\'associazione è fallita.</string>
     <string name="identity_server_error_no_current_binding_error">Non c\'è alcuna associazione con questo identificativo.</string>
     <string name="identity_server_set_default_notice">Il tuo home server (%1$s) propone di usare %2$s come tuo server d\'identità</string>
@@ -2141,7 +2141,7 @@
     <string name="action_copy">Copia</string>
     <string name="dialog_title_success">Completato</string>
     <string name="bottom_action_notification">Notifiche</string>
-    <string name="template_call_failed_no_connection">Telefonata di ${app_name} fallita</string>
+    <string name="call_failed_no_connection">Telefonata di ${app_name} fallita</string>
     <string name="call_failed_no_connection_description">Connessione in tempo reale fallita.
 \nChiedi all\'amministratore del tuo homeserver di configurare un server TURN per fare funzionare le chiamate.</string>
     <string name="call_select_sound_device">Seleziona dispositivo audio</string>
@@ -2344,7 +2344,7 @@
     <string name="settings_security_pin_code_notifications_summary_off">Mostra solo il numero di messaggi non letti in una semplice notifica.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Mostra dettagli come il nome delle stanze e il contenuto dei messaggi.</string>
     <string name="settings_security_pin_code_notifications_title">Mostra il contenuto nelle notifiche</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">Il codice PIN è l\'unico modo per sbloccare ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">Il codice PIN è l\'unico modo per sbloccare ${app_name}.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Attiva la biometria specifica del dispositivo, come le impronte digitali e il riconoscimento facciale.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Attiva la biometria</string>
     <string name="settings_security_application_protection_screen_title">Configura protezione</string>
@@ -2388,8 +2388,8 @@
     <string name="no_permissions_to_start_webrtc_call_in_direct_room">Non hai il permesso di avviare una chiamata</string>
     <string name="no_permissions_to_start_conf_call_in_direct_room">Non hai il permesso di avviare una chiamata di gruppo</string>
     <string name="action_reset">Reimposta</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Il codice PIN è richiesto ogni volta che apri ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Il codice PIN è richiesto dopo 2 minuti di inattività su ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Il codice PIN è richiesto ogni volta che apri ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Il codice PIN è richiesto dopo 2 minuti di inattività su ${app_name}.</string>
     <string name="settings_security_pin_code_grace_period_title">Richiedi il PIN dopo 2 minuti</string>
     <string name="direct_room_created_summary_item">%s è entrato.</string>
     <string name="settings_troubleshoot_test_push_loop_waiting_for_push">L\'applicazione è in attesa del PUSH</string>
@@ -2421,8 +2421,8 @@
     <string name="user_code_share">Condividi il mio codice</string>
     <string name="user_code_scan">Scansiona un codice QR</string>
     <string name="not_a_valid_qr_code">Non è un codice QR Matrix valido</string>
-    <string name="template_invite_friends_rich_title">🔐️ Puoi trovarmi su ${app_name}</string>
-    <string name="template_invite_friends_text">Ehy, chattiamo su ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Puoi trovarmi su ${app_name}</string>
+    <string name="invite_friends_text">Ehy, chattiamo su ${app_name}: %s</string>
     <string name="invite_friends">Invita amici</string>
     <string name="add_people">Aggiungi persone</string>
     <string name="topic_prefix">"Argomento: "</string>
@@ -2535,7 +2535,7 @@
     <string name="room_participants_leave_private_warning">Questa non è una stanza pubblica. Senza un invito non potrai rientrare.</string>
     <string name="system_theme">Predefinito di sistema</string>
     <string name="authentication_error">Autenticazione fallita</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} chiede siano reinserite le credenziali per eseguire questa azione.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} chiede siano reinserite le credenziali per eseguire questa azione.</string>
     <string name="re_authentication_activity_title">È necessario riautenticarsi</string>
     <string name="call_transfer_users_tab_title">Utenti</string>
     <string name="call_transfer_failure">Si è verificato un errore trasferendo la chiamata</string>
@@ -2849,7 +2849,7 @@
     <string name="settings_notification_other">Altro</string>
     <string name="settings_notification_mentions_and_keywords">Menzioni e parole chiave</string>
     <string name="settings_notification_default">Notifiche predefinite</string>
-    <string name="template_link_this_email_with_your_account">%s nella impostazioni per ricevere inviti direttamente in ${app_name}.</string>
+    <string name="link_this_email_with_your_account">%s nella impostazioni per ricevere inviti direttamente in ${app_name}.</string>
     <string name="link_this_email_settings_link">Collega questa email con il tuo account</string>
     <string name="this_invite_to_this_space_was_sent">Questo invito per questo spazio è stato inviato a %s, la quale non è associata al tuo account</string>
     <string name="this_invite_to_this_room_was_sent">Questo invito per questa stanza è stato inviato a %s, la quale non è associata al tuo account</string>
@@ -3012,7 +3012,7 @@
     </plurals>
     <string name="preference_system_settings">Impostazioni di sistema</string>
     <string name="preference_versions">Versioni</string>
-    <string name="template_preference_help_summary">Ricevi aiuto nell\'uso di ${app_name}</string>
+    <string name="preference_help_summary">Ricevi aiuto nell\'uso di ${app_name}</string>
     <string name="preference_help_title">Aiuto e supporto</string>
     <string name="preference_help">Aiuto</string>
     <string name="preference_root_legals">Informazioni legali</string>
@@ -3020,15 +3020,15 @@
     <string name="legals_third_party_notices">Librerie di terze parti</string>
     <string name="legals_identity_server_title">L\'informativa del tuo server d\'identità</string>
     <string name="legals_home_server_title">L\'informativa del tuo homeserver</string>
-    <string name="template_legals_application_title">Informativa di ${app_name}</string>
+    <string name="legals_application_title">Informativa di ${app_name}</string>
     <string name="analytics_opt_in_list_item_3">Puoi disattivarlo in qualsiasi momento nelle impostazioni</string>
     <string name="analytics_opt_in_list_item_2"><b>Non</b> condividiamo informazioni con terze parti</string>
     <string name="analytics_opt_in_list_item_1"><b>Non</b> registriamo o profiliamo alcun dato dell\'account</string>
     <string name="analytics_opt_in_content_link">qui</string>
-    <string name="template_analytics_opt_in_content">Aiutaci a identificare problemi e a migliorare ${app_name} condividendo dati di utilizzo anonimi. Per capire come le persone usano diversi dispositivi, genereremo un identificativo casuale, condiviso dai tuoi dispositivi.
+    <string name="analytics_opt_in_content">Aiutaci a identificare problemi e a migliorare ${app_name} condividendo dati di utilizzo anonimi. Per capire come le persone usano diversi dispositivi, genereremo un identificativo casuale, condiviso dai tuoi dispositivi.
 \n
 \nPuoi leggere i nostri termini di servizio %s.</string>
-    <string name="template_analytics_opt_in_title">Aiuta a migliorare ${app_name}</string>
+    <string name="analytics_opt_in_title">Aiuta a migliorare ${app_name}</string>
     <string name="action_enable">Attiva</string>
     <string name="restart_the_application_to_apply_changes">Riavvia l\'applicazione per applicare le modifiche.</string>
     <string name="labs_enable_latex_maths">Attiva la matematica LaTeX</string>
@@ -3051,8 +3051,8 @@
     <string name="settings_enable_location_sharing_summary">Una volta attivata, potrai inviare la tua posizione in qualsiasi stanza</string>
     <string name="settings_enable_location_sharing">Attiva condivisione posizione</string>
     <string name="location_share_external">Apri con</string>
-    <string name="template_location_not_available_dialog_content">${app_name} non ha potuto rilevare la tua posizione. Riprova più tardi.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} non ha potuto rilevare la tua posizione</string>
+    <string name="location_not_available_dialog_content">${app_name} non ha potuto rilevare la tua posizione. Riprova più tardi.</string>
+    <string name="location_not_available_dialog_title">${app_name} non ha potuto rilevare la tua posizione</string>
     <string name="location_share">Condividi posizione</string>
     <string name="a11y_location_share_icon">Condividi posizione</string>
     <string name="location_activity_title_preview">Posizione</string>

--- a/vector/src/main/res/values-iw/strings.xml
+++ b/vector/src/main/res/values-iw/strings.xml
@@ -151,7 +151,7 @@
     <string name="people_no_identity_server">לא הוגדר שרת זהות.</string>
     <string name="no_more_results">אין תוצאות נוספות</string>
     <string name="no_result_placeholder">אין תוצאות</string>
-    <string name="template_no_contact_access_placeholder">לא אפשרת לאלמנט לגשת לאנשי הקשר המקומיים שלך</string>
+    <string name="no_contact_access_placeholder">לא אפשרת לאלמנט לגשת לאנשי הקשר המקומיים שלך</string>
     <string name="start_new_chat_prompt_msg">האם אתה בטוח שברצונך להתחיל צ\'אט חדש עם %s\?</string>
     <string name="option_send_voice">שלח קול</string>
     <string name="start_video_call">התחל שיחת וידאו</string>
@@ -279,7 +279,7 @@
     <string name="call_select_sound_device">בחר מכשיר סאונד</string>
     <string name="call_failed_no_connection_description">נכשל החיבור בזמן אמת.
 \nאנא בקש ממנהל שרת הבית שלך להגדיר שרת TURN על מנת שהשיחות יעבדו בצורה אמינה.</string>
-    <string name="template_call_failed_no_connection">שיחת האלמנט נכשלה</string>
+    <string name="call_failed_no_connection">שיחת האלמנט נכשלה</string>
     <string name="call_failed_dont_ask_again">אל תשאל אותי שוב</string>
     <string name="call_failed_no_ice_use_alt">נסה להשתמש ב-%s</string>
     <string name="call_failed_no_ice_title">השיחה נכשלה עקב שרת שהוגדר כהלכה</string>
@@ -309,22 +309,22 @@
     <string name="permissions_denied_add_contact">אפשר הרשאה לגשת לאנשי הקשר שלך.</string>
     <string name="permissions_denied_qr_code">כדי לסרוק קוד QR, עליך לאפשר גישה למצלמה.</string>
     <string name="permissions_action_not_performed_missing_permissions">מצטער. הפעולה לא בוצעה בגלל הרשאות חסרות</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">אלמנט יכול לבדוק את פנקס הכתובות שלך כדי למצוא משתמשי מטריקס אחרים על סמך מספרי הדוא\"ל והטלפון שלהם.
+    <string name="permissions_msg_contacts_warning_other_androids">אלמנט יכול לבדוק את פנקס הכתובות שלך כדי למצוא משתמשי מטריקס אחרים על סמך מספרי הדוא\"ל והטלפון שלהם.
 \n
 \nהאם אתה מסכים לשתף את פנקס הכתובות שלך למטרה זו\?</string>
-    <string name="template_permissions_rationale_msg_contacts">אלמנט יכול לבדוק את פנקס הכתובות שלך כדי למצוא משתמשי מטריקס אחרים על סמך מספרי הדוא\"ל והטלפון שלהם. אם אתה מסכים לשתף את פנקס הכתובות שלך למטרה זו, אנא הגש גישה בחלון הקופץ הבא.</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">אלמנט זקוק להרשאה כדי לגשת למצלמה ולמיקרופון שלך כדי לבצע שיחות וידאו.
+    <string name="permissions_rationale_msg_contacts">אלמנט יכול לבדוק את פנקס הכתובות שלך כדי למצוא משתמשי מטריקס אחרים על סמך מספרי הדוא\"ל והטלפון שלהם. אם אתה מסכים לשתף את פנקס הכתובות שלך למטרה זו, אנא הגש גישה בחלון הקופץ הבא.</string>
+    <string name="permissions_rationale_msg_camera_and_audio">אלמנט זקוק להרשאה כדי לגשת למצלמה ולמיקרופון שלך כדי לבצע שיחות וידאו.
 \n
 \nאנא אפשר גישה בחלונות הקופצים הבאים כדי להיות מסוגל לבצע את השיחה.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nאנא אפשר גישה בחלון הקופץ הבא כדי שתוכל לבצע את השיחה."</string>
-    <string name="template_permissions_rationale_msg_record_audio">אלמנט זקוק להרשאה כדי לגשת למיקרופון שלך כדי לבצע שיחות שמע.</string>
+    <string name="permissions_rationale_msg_record_audio">אלמנט זקוק להרשאה כדי לגשת למיקרופון שלך כדי לבצע שיחות שמע.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nאנא אפשר גישה בחלון הקופץ הבא כדי שתוכל לבצע את השיחה."</string>
-    <string name="template_permissions_rationale_msg_camera">אלמנט זקוק להרשאה כדי לגשת למצלמה שלך כדי לצלם תמונות ושיחות וידאו.</string>
-    <string name="template_permissions_rationale_msg_storage">אלמנט זקוק להרשאה כדי לגשת לספריית התמונות והווידיאו שלך כדי לשלוח ולשמור קבצים מצורפים.
+    <string name="permissions_rationale_msg_camera">אלמנט זקוק להרשאה כדי לגשת למצלמה שלך כדי לצלם תמונות ושיחות וידאו.</string>
+    <string name="permissions_rationale_msg_storage">אלמנט זקוק להרשאה כדי לגשת לספריית התמונות והווידיאו שלך כדי לשלוח ולשמור קבצים מצורפים.
 \n
 \nאנא אפשר גישה בחלון הקופץ הבא כדי שתוכל לשלוח קבצים מהטלפון שלך.</string>
     <string name="permissions_rationale_popup_title">מידע</string>
@@ -350,7 +350,7 @@
     <string name="settings_call_ringtone_title">רינגטון שיחה נכנסת</string>
     <string name="settings_call_ringtone_use_default_stun_sum">ישתמש ב-%s כסיוע כאשר השרת הבית שלך אינו מציע כזה (כתובת ה- IP שלך תשותף במהלך שיחה)</string>
     <string name="settings_call_ringtone_use_default_stun">אפשר שרת עזרה לשיחות</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">השתמש ברינגטון ברירת המחדל של אלמנט לשיחות נכנסות</string>
+    <string name="settings_call_ringtone_use_app_ringtone">השתמש ברינגטון ברירת המחדל של אלמנט לשיחות נכנסות</string>
     <string name="settings_call_show_confirmation_dialog_summary">בקש אישור לפני שמתחילים בשיחה</string>
     <string name="settings_call_show_confirmation_dialog_title">מנע שיחה מקרית</string>
     <string name="settings_call_category">שיחות</string>
@@ -375,7 +375,7 @@
     </plurals>
     <string name="groups_list">רשימת קבוצות</string>
     <string name="read_receipts_list">קרא את רשימת הקבלות</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">הפעל את Element במכשיר אחר שיכול לפענח את ההודעה כדי שיוכל לשלוח את המפתחות להפעלה זו.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">הפעל את Element במכשיר אחר שיכול לפענח את ההודעה כדי שיוכל לשלוח את המפתחות להפעלה זו.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">הבקשה נשלחה</string>
     <string name="e2e_re_request_encryption_key_sent">בקשת המפתח נשלחה.</string>
     <string name="e2e_re_request_encryption_key">בקש מחדש מפתחות הצפנה מהפעלות האחרות שלך.</string>
@@ -421,10 +421,10 @@
     <string name="settings_background_sync_update_error">עדכון ההגדרות נכשל.</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">לא תקבל הודעה על הודעות נכנסות כאשר האפליקציה ברקע.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">אין סנכרון רקע</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">אלמנט יסונכרן ברקע מעת לעת בזמן מדויק (ניתן להגדרה).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">אלמנט יסונכרן ברקע מעת לעת בזמן מדויק (ניתן להגדרה).
 \nזה ישפיע על השימוש ברדיו ובסוללה, תוצג הודעה קבועה לפיה אלמנט מאזין לאירועים.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">מותאם לזמן אמת</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">אלמנט יסונכרן ברקע באופן שישמור על המשאבים המוגבלים של המכשיר (סוללה).
+    <string name="settings_background_fdroid_sync_mode_battery_description">אלמנט יסונכרן ברקע באופן שישמור על המשאבים המוגבלים של המכשיר (סוללה).
 \nבהתאם למצב משאבי המכשיר שלך, ייתכן שהסנכרון יידחה על ידי מערכת ההפעלה.</string>
     <string name="settings_background_fdroid_sync_mode_battery">מותאם לסוללה</string>
     <string name="settings_background_fdroid_sync_mode">מצב סנכרון רקע</string>
@@ -455,17 +455,17 @@
     <string name="settings_notification_privacy_normal">רגיל</string>
     <string name="settings_troubleshoot_test_battery_quickfix">התעלם מאופטימיזציה</string>
     <string name="settings_troubleshoot_test_battery_failed">אם משתמש משאיר מכשיר מחובר לחשמל ויציב לתקופה מסוימת, כשהמסך כבוי, המכשיר עובר למצב Doze. זה מונע מאפליקציות גישה לרשת ומגדיר את העבודות, הסנכרונים וההתראות הסטנדרטיות שלהם.</string>
-    <string name="template_settings_troubleshoot_test_battery_success">אלמנט אינו מושפע מתהליך מיטוב הסוללה.</string>
+    <string name="settings_troubleshoot_test_battery_success">אלמנט אינו מושפע מתהליך מיטוב הסוללה.</string>
     <string name="settings_troubleshoot_test_battery_title">אופטימיזציה של הסוללה</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">השבת הגבלות</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">מגבלות רקע מופעלות עבור Element.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">מגבלות רקע מופעלות עבור Element.
 \nהעבודה שהאפליקציה מנסה לעשות תוגבל באגרסיביות בזמן שהיא ברקע, וזה עלול להשפיע על ההודעות.
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">מגבלות רקע מושבתות עבור Element. יש להריץ בדיקה זו באמצעות נתונים ניידים (ללא WIFI).
+    <string name="settings_troubleshoot_test_bg_restricted_success">מגבלות רקע מושבתות עבור Element. יש להריץ בדיקה זו באמצעות נתונים ניידים (ללא WIFI).
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">בדוק מגבלות רקע</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">הפעל את התחלה לאחר אתחול</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">השירות לא יופעל עם הפעלת המכשיר מחדש, לא תקבל התראות עד שאלמנט ייפתח לפחות פעם אחת.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">השירות לא יופעל עם הפעלת המכשיר מחדש, לא תקבל התראות עד שאלמנט ייפתח לפחות פעם אחת.</string>
     <string name="settings_troubleshoot_test_service_boot_success">השירות יתחיל עם הפעלת המכשיר מחדש.</string>
     <string name="settings_troubleshoot_test_service_boot_title">הפעל לאחר אתחול</string>
     <string name="settings_troubleshoot_test_service_restart_failed">השירות נכשל מלעלות מחדש</string>
@@ -484,11 +484,11 @@
     <string name="settings_troubleshoot_test_token_registration_success">אסימון FCM נרשם בהצלחה ל- HomeServer.</string>
     <string name="settings_troubleshoot_test_token_registration_title">רישום אסימונים</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">הוסף חשבון</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nשגיאה זו אינה בשליטה על אלמנט. אין חשבון Google בטלפון. אנא פתח את מנהל החשבון והוסף חשבון Google.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nשגיאה זו אינה בשליטה על אלמנט. זה יכול להתרחש מכמה סיבות. אולי זה יעבוד אם תנסה שוב מאוחר יותר, תוכל גם לבדוק ששירות Google Play אינו מוגבל בשימוש נתונים בהגדרות המערכת, או ששעון המכשיר שלך תקין, או שזה יכול לקרות ב- ROM מותאם אישית.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nשגיאה זו איננה בשליטה על Element ולפי גוגל, שגיאה זו מצביעה על כך שלמכשיר יש יותר מדי אפליקציות הרשומות ב- FCM. השגיאה מתרחשת רק במקרים שבהם ישנם מספרים קיצוניים של אפליקציות, כך שהיא לא אמורה להשפיע על המשתמש הממוצע.</string>
     <string name="settings_troubleshoot_test_fcm_failed">נכשל באחזור אסימון FCM:
 \n%1$s</string>
@@ -496,7 +496,7 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_title">אסימון Firebase</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">תקן שירותי Google Play</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">אלמנט משתמש בשירותי Google Play כדי להעביר הודעות פוש אך נראה שהוא אינו מוגדר כהלכה:
+    <string name="settings_troubleshoot_test_play_services_failed">אלמנט משתמש בשירותי Google Play כדי להעביר הודעות פוש אך נראה שהוא אינו מוגדר כהלכה:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_success">ה- APK של שירותי Google Play זמין ומעודכן.</string>
     <string name="settings_troubleshoot_test_play_services_title">בדיקת שירותי הפעלה</string>
@@ -614,7 +614,7 @@
     <string name="settings_troubleshoot_test_bing_settings_success_with_warn">שים לב שחלק מסוגי ההודעות מוגדרים כשתיקים (יפיקו התראה ללא צליל).</string>
     <string name="settings_troubleshoot_test_bing_settings_title">הגדרות מותאמות אישית.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">אפשר</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">התראות אינן מופעלות עבור הפעלה זו.
+    <string name="settings_troubleshoot_test_device_settings_failed">התראות אינן מופעלות עבור הפעלה זו.
 \nאנא בדוק את הגדרות האלמנט.</string>
     <string name="settings_troubleshoot_test_device_settings_success">התראות מופעלות להפעלה זו.</string>
     <string name="settings_troubleshoot_test_device_settings_title">הגדרות מושב.</string>
@@ -643,7 +643,7 @@
     <string name="settings_emails_empty">לא הוספה כתובת דוא\"ל לחשבונך</string>
     <string name="settings_emails">כתובות דוא\"ל</string>
     <string name="settings_add_3pid_authentication_needed">נדרש אימות</string>
-    <string name="template_settings_add_3pid_flow_not_supported">אינך יכול לעשות זאת ממכשיר נייד</string>
+    <string name="settings_add_3pid_flow_not_supported">אינך יכול לעשות זאת ממכשיר נייד</string>
     <string name="settings_add_3pid_confirm_password_title">אשר את סיסמתך</string>
     <string name="settings_app_info_link_summary">הצג את פרטי היישום בהגדרות המערכת.</string>
     <string name="settings_app_info_link_title">מידע על האפליקציה</string>
@@ -1053,7 +1053,7 @@
 \nגבה את המפתחות שלך בצורה מאובטחת כדי לא לאבד אותם.</string>
     <string name="keys_backup_setup_step1_title">לעולם אל תאבד הודעות מוצפנות</string>
     <string name="keys_backup_no_session_error">אין מושב מטריקס זמין</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">אנא מחק את משפט הסיסמה אם ברצונך ש- Element ייצור מפתח שחזור.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">אנא מחק את משפט הסיסמה אם ברצונך ש- Element ייצור מפתח שחזור.</string>
     <string name="passphrase_passphrase_too_weak">משפט הסיסמה חלש מדי</string>
     <string name="passphrase_empty_error_message">אנא הזן משפט סיסמה</string>
     <string name="passphrase_passphrase_does_not_match">משפט הסיסמה אינו תואם</string>
@@ -1297,7 +1297,7 @@
     <string name="create_room_encryption_description">לאחר הפעלתו, לא ניתן להשבית את ההצפנה.</string>
     <string name="create_room_encryption_title">אפשר הצפנה</string>
     <string name="command_description_shrug">הוסף לפני ¯ \\ _ (ツ) _ / ¯ להודעת טקסט רגיל</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">אלמנט עלול לקרוס לעיתים קרובות יותר כאשר מתרחשת שגיאה בלתי צפויה</string>
+    <string name="settings_developer_mode_fail_fast_summary">אלמנט עלול לקרוס לעיתים קרובות יותר כאשר מתרחשת שגיאה בלתי צפויה</string>
     <string name="settings_developer_mode_fail_fast_title">כישלון-מהיר</string>
     <string name="autocomplete_limited_results">מציג רק את התוצאות הראשונות, הקלד עוד אותיות …</string>
     <string name="devices_other_devices">פעולות אחרות</string>
@@ -1314,7 +1314,7 @@
     <string name="notification_initial_sync">סנכרון ראשוני …</string>
     <string name="bug_report_error_too_short">התיאור קצר מדי</string>
     <string name="permalink_malformed">הקישור שלך ל- matrix.to היה תקין</string>
-    <string name="template_soft_logout_sso_not_same_user_error">ההפעלה הנוכחית מיועדת למשתמש %1$s ואתה מספק אישורי משתמש %2$s. זה אינו נתמך על ידי אלמנט.
+    <string name="soft_logout_sso_not_same_user_error">ההפעלה הנוכחית מיועדת למשתמש %1$s ואתה מספק אישורי משתמש %2$s. זה אינו נתמך על ידי אלמנט.
 \nראשית נקה נתונים ואז היכנס שוב לחשבון אחר.</string>
     <string name="soft_logout_clear_data_dialog_submit">נקה נתונים</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">תאבד את הגישה להודעות מאובטחות אלא אם תיכנס בכדי לשחזר את מפתחות ההצפנה שלך.</string>
@@ -1471,7 +1471,7 @@
     <string name="room_list_quick_actions_notifications_all_noisy">כל ההודעות (רועשות)</string>
     <string name="message_ignore_user">התעלם ממשתמש זה</string>
     <string name="no_network_indicator">אין חיבור רשת כרגע</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">אלמנט זקוק להרשאה כדי לשמור את מפתחות ה- E2E שלך בדיסק.
+    <string name="permissions_rationale_msg_keys_backup_export">אלמנט זקוק להרשאה כדי לשמור את מפתחות ה- E2E שלך בדיסק.
 \n
 \nאנא אפשר גישה בחלון הקופץ הבא כדי שתוכל לייצא את המפתחות שלך באופן ידני.</string>
     <string name="content_reported_as_inappropriate_content">תוכן זה דווח כבלתי הולם.
@@ -1693,7 +1693,7 @@
     <string name="room_preview_no_preview_join">לא ניתן להציג תצוגה מקדימה של חדר זה. האם אתה רוצה להצטרף אליו\?</string>
     <string name="room_preview_not_found">בשלב זה אין גישה לחדר זה.
 \nנסה שוב מאוחר יותר, או בקש ממנהל החדר לבדוק אם יש לך גישה.</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">התצוגה המקדימה של החדר הקריא בעולם עדיין אינה נתמכת ב- Element</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">התצוגה המקדימה של החדר הקריא בעולם עדיין אינה נתמכת ב- Element</string>
     <string name="room_preview_no_preview">לא ניתן להציג תצוגה מקדימה של חדר זה</string>
     <string name="group_all_communities">כל הקהילות</string>
     <string name="please_wait">אנא המתינו…</string>
@@ -1770,7 +1770,7 @@
     <string name="sas_verify_title">אמת את זה על ידי השוואה של מחרוזת טקסט קצרה.</string>
     <string name="invalid_or_expired_credentials">הוצאת מחשבון בגלל אישורים לא חוקיים או שפג תוקפם.</string>
     <string name="autodiscover_well_known_autofill_confirm">השתמש בקונפיגורציה</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">אלמנט זיהה תצורת שרת מותאמת אישית לדומיין userId שלך \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">אלמנט זיהה תצורת שרת מותאמת אישית לדומיין userId שלך \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_dialog_title">השלם אוטומטית אפשרויות שרת</string>
     <string name="autodiscover_invalid_response">תגובת גילוי שרת בית לא חוקית</string>
@@ -1796,13 +1796,13 @@
     <string name="auth_pin_confirm_to_disable_title">אשר PIN כדי להשבית PIN</string>
     <string name="settings_security_pin_code_change_pin_summary">שנה את קוד ה- PIN הנוכחי שלך</string>
     <string name="settings_security_pin_code_change_pin_title">שנה PIN</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">קוד PIN נדרש בכל פעם שאתה פותח את Element.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">קוד PIN נדרש לאחר שתי דקות של אי שימוש ב- Element.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">קוד PIN נדרש בכל פעם שאתה פותח את Element.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">קוד PIN נדרש לאחר שתי דקות של אי שימוש ב- Element.</string>
     <string name="settings_security_pin_code_grace_period_title">דרוש מספר PIN לאחר 2 דקות</string>
     <string name="settings_security_pin_code_notifications_summary_off">הצג רק מספר הודעות שלא נקראו בהודעה פשוטה.</string>
     <string name="settings_security_pin_code_notifications_summary_on">הצג פרטים כמו שמות החדרים ותוכן ההודעה.</string>
     <string name="settings_security_pin_code_notifications_title">הצג תוכן בהתראות</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">קוד PIN הוא הדרך היחידה לפתוח את Element.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">קוד PIN הוא הדרך היחידה לפתוח את Element.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">אפשר ביומטריה ספציפית למכשירים, כמו טביעות אצבע וזיהוי פנים.</string>
     <plurals name="directory_search_rooms_for">
         <item quantity="one">%2$s חדר נמצא עבור %1$s</item>
@@ -1951,17 +1951,17 @@
     <string name="settings_data_save_mode_summary">מצב שמירת נתונים מחיל מסנן ספציפי כך שמסוננים עדכוני נוכחות והודעות הקלדה.</string>
     <string name="settings_data_save_mode">מצב שמירת נתונים</string>
     <string name="settings_opt_in_of_analytics_ok">כן, אני רוצה לעזור!</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">אנא אפשר ניתוח נתונים כדי לעזור לנו לשפר את Element.</string>
-    <string name="template_settings_opt_in_of_analytics_summary">אלמנט אוסף ניתוח אנונימי כדי לאפשר לנו לשפר את היישום.</string>
+    <string name="settings_opt_in_of_analytics_prompt">אנא אפשר ניתוח נתונים כדי לעזור לנו לשפר את Element.</string>
+    <string name="settings_opt_in_of_analytics_summary">אלמנט אוסף ניתוח אנונימי כדי לאפשר לנו לשפר את היישום.</string>
     <string name="settings_opt_in_of_analytics">שלח נתוני ניתוח</string>
     <string name="settings_analytics">ניתוח נתונים</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">הענק הרשאה</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">אלמנט צריך לשמור על חיבור רקע בעל השפעה נמוכה על מנת לקבל הודעות אמינות.
+    <string name="startup_notification_fdroid_battery_optim_message">אלמנט צריך לשמור על חיבור רקע בעל השפעה נמוכה על מנת לקבל הודעות אמינות.
 \nבמסך הבא תתבקש לאפשר לאלמנט לרוץ תמיד ברקע, אנא קבל.</string>
     <string name="startup_notification_fdroid_battery_optim_title">חיבור ברקע</string>
     <string name="startup_notification_privacy_button_other">בחר באפשרות אחרת</string>
     <string name="startup_notification_privacy_button_grant">מתן הרשאה</string>
-    <string name="template_startup_notification_privacy_message">אלמנט יכול לרוץ ברקע כדי לנהל את ההתראות שלך בצורה מאובטחת ופרטית. זה עשוי להשפיע על השימוש בסוללה.</string>
+    <string name="startup_notification_privacy_message">אלמנט יכול לרוץ ברקע כדי לנהל את ההתראות שלך בצורה מאובטחת ופרטית. זה עשוי להשפיע על השימוש בסוללה.</string>
     <string name="startup_notification_privacy_title">פרטיות הודעות</string>
     <string name="settings_discovery_manage">נהל את הגדרות הגילוי שלך.</string>
     <string name="settings_discovery_category">תַגלִית</string>
@@ -1984,7 +1984,7 @@
     <string name="e2e_use_keybackup">בטל את נעילת היסטוריית ההודעות המוצפנות</string>
     <string name="settings_export_trail">ייצוא ביקורת</string>
     <string name="settings_key_requests">בקשות מפתח</string>
-    <string name="template_login_default_session_public_name">אלמנט אנדרואיד</string>
+    <string name="login_default_session_public_name">אלמנט אנדרואיד</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">המפתחות כבר מעודכנים!</string>
     <string name="event_redacted_by_admin_reason_with_reason">האירוע בהנחיית מנהל החדר, סיבה: %1$s</string>
     <string name="event_redacted_by_user_reason_with_reason">האירוע נמחק על ידי המשתמש, הסיבה: %1$s</string>
@@ -2089,7 +2089,7 @@
     <string name="verify_cannot_cross_sign">הפעלה זו אינה יכולה לשתף את האימות הזה עם הפעלות אחרות שלך.
 \nהאימות יישמר באופן מקומי וישותף בגרסה עתידית של האפליקציה.</string>
     <string name="unignore">בטל התעלמות</string>
-    <string name="template_rendering_event_error_exception">אלמנט נתקל בבעיה בעת הצגת תוכן האירוע עם המזהה \'%1$s\'</string>
+    <string name="rendering_event_error_exception">אלמנט נתקל בבעיה בעת הצגת תוכן האירוע עם המזהה \'%1$s\'</string>
     <string name="devices_details_last_seen_format">%1$s @ %2$s</string>
     <string name="command_confetti">שולח את ההודעה הנתונה עם קונפטי</string>
     <string name="secure_backup_reset_no_history">תתחיל מחדש ללא היסטוריה, ללא הודעות, מכשירים מאומתים או משתמשים מאומתים</string>
@@ -2104,13 +2104,13 @@
     <string name="enter_secret_storage_passphrase_or_key">השתמש ב- %1$s שלך או השתמש ב- %2$s שלך כדי להמשיך.</string>
     <string name="command_description_discard_session_not_handled">נתמך רק בחדרים מוצפנים</string>
     <string name="command_description_discard_session">מכריח את ההפעלה הקבוצתית החוצה הנוכחית בחדר מוצפן להיזרק</string>
-    <string name="template_use_latest_app">השתמש באלמנט האחרון במכשירים האחרים שלך:</string>
+    <string name="use_latest_app">השתמש באלמנט האחרון במכשירים האחרים שלך:</string>
     <string name="or_other_mx_capable_client">או לקוח מטריקס אחר עם יכולת חתימה צולבת</string>
-    <string name="template_app_ios_android">אלמנט iOS
+    <string name="app_ios_android">אלמנט iOS
 \nאלמנט אנדרואיד</string>
-    <string name="template_app_desktop_web">רשת האינטרנט
+    <string name="app_desktop_web">רשת האינטרנט
 \nשולחן העבודה של אלמנט</string>
-    <string name="template_use_other_session_content_description">השתמש באלמנט העדכני ביותר במכשירים האחרים שלך, Element Web, Element Desktop, Element iOS, Element for Android, או לקוח מטריקס אחר עם יכולת חתימה צולבת</string>
+    <string name="use_other_session_content_description">השתמש באלמנט העדכני ביותר במכשירים האחרים שלך, Element Web, Element Desktop, Element iOS, Element for Android, או לקוח מטריקס אחר עם יכולת חתימה צולבת</string>
     <string name="change_password_summary">הגדר סיסמת חשבון חדשה …</string>
     <string name="error_saving_media_file">לא ניתן היה לשמור את קובץ המדיה</string>
     <string name="error_adding_media_file_to_gallery">לא ניתן היה להוסיף קובץ מדיה לגלריה</string>
@@ -2292,11 +2292,11 @@
     <string name="identity_server_user_consent_not_provided">הסכמת המשתמש לא סופקה.</string>
     <string name="identity_server_error_no_current_binding_error">אין קשר נוכחי למזהה זה.</string>
     <string name="identity_server_error_binding_error">העמותה נכשלה.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">למען הפרטיות שלך, אלמנט תומך רק בשליחת הודעות דוא\"ל של משתמשים, בליל ומספר טלפון.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">למען הפרטיות שלך, אלמנט תומך רק בשליחת הודעות דוא\"ל של משתמשים, בליל ומספר טלפון.</string>
     <string name="identity_server_error_terms_not_signed">אנא קבל תחילה את התנאים של שרת הזהות בהגדרות.</string>
     <string name="identity_server_error_no_identity_server_configured">אנא הגדר תחילה שרת זהות.</string>
     <string name="identity_server_error_outdated_home_server">פעולה זו אינה אפשרית. שרת הבית מיושן.</string>
-    <string name="template_identity_server_error_outdated_identity_server">שרת זהות זה מיושן .Element תומך רק ב- API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">שרת זהות זה מיושן .Element תומך רק ב- API V2.</string>
     <string name="disconnect_identity_server_dialog_content">להתנתק משרת הזהות%s\?</string>
     <string name="open_terms_of">תנאים פתוחים של%s</string>
     <string name="choose_locale_loading_locales">טוען שפות זמינות …</string>
@@ -2315,8 +2315,8 @@
     <string name="not_a_valid_qr_code">זה לא קוד QR מטריציוני תקף</string>
     <string name="invitations_sent_to_two_users">הזמנות נשלחו אל%1$s ו-%2$s</string>
     <string name="invitation_sent_to_one_user">ההזמנה נשלחה אל%1$s</string>
-    <string name="template_invite_friends_rich_title">🔐️ הצטרפו אלי באלמנט</string>
-    <string name="template_invite_friends_text">היי, דבר איתי באלמנט:%s</string>
+    <string name="invite_friends_rich_title">🔐️ הצטרפו אלי באלמנט</string>
+    <string name="invite_friends_text">היי, דבר איתי באלמנט:%s</string>
     <string name="invite_friends">להזמין חברים</string>
     <string name="invite_users_to_room_title">הזמן משתמשים</string>
     <string name="inviting_users_to_room">מזמין משתמשים …</string>
@@ -2585,8 +2585,8 @@
     <string name="settings_enable_location_sharing_summary">לאחר ההפעלה, תוכל לשלוח את המיקום שלך לכל חדר</string>
     <string name="settings_enable_location_sharing">אפשר שיתוף מיקום</string>
     <string name="location_share_external">לפתוח בעזרת</string>
-    <string name="template_location_not_available_dialog_content">${app_name} לא הצליח לגשת למיקום שלך. בבקשה נסה שוב מאוחר יותר.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} לא הצליח לגשת למיקום שלך</string>
+    <string name="location_not_available_dialog_content">${app_name} לא הצליח לגשת למיקום שלך. בבקשה נסה שוב מאוחר יותר.</string>
+    <string name="location_not_available_dialog_title">${app_name} לא הצליח לגשת למיקום שלך</string>
     <string name="location_share">שתף מיקום</string>
     <string name="settings_notification_emails_enable_for_email">אפשר התראת דוא\"ל עבור %s</string>
     <string name="settings_notification_keyword_contains_invalid_character">מילות מפתח לא יכולות להכיל \'%s\'</string>

--- a/vector/src/main/res/values-ja/strings.xml
+++ b/vector/src/main/res/values-ja/strings.xml
@@ -353,7 +353,7 @@
     <string name="start_video_call">ビデオ通話を開始</string>
     <string name="option_take_photo_video">写真または動画を撮影</string>
     <string name="auth_send_reset_email">再設定用のメールを送信</string>
-    <string name="template_permissions_rationale_msg_camera">写真撮影やビデオ通話には、${app_name}端末のカメラの使用を許可する必要があります。</string>
+    <string name="permissions_rationale_msg_camera">写真撮影やビデオ通話には、${app_name}端末のカメラの使用を許可する必要があります。</string>
     <string name="cannot_start_call">通話を開始できませんでした。後ほど試してください</string>
     <string name="missing_permissions_warning">権限がないため、一部の機能を利用できない可能性があります…</string>
     <string name="missing_permissions_to_start_conf_call">このルームで会議を開始するためには招待の権限が必要です</string>
@@ -361,7 +361,7 @@
     <string name="action_sign_out">サインアウト</string>
     <string name="bottom_action_home">ホーム</string>
     <string name="no_conversation_placeholder">会話なし</string>
-    <string name="template_no_contact_access_placeholder">端末の電話帳を${app_name}アプリが読み取ることは許可されていません</string>
+    <string name="no_contact_access_placeholder">端末の電話帳を${app_name}アプリが読み取ることは許可されていません</string>
     <string name="no_result_placeholder">結果がありません</string>
     <string name="rooms_header">ルーム</string>
     <string name="rooms_directory_header">ルームディレクトリ</string>
@@ -499,21 +499,21 @@
     <string name="matrix_only_filter">Matrixの連絡先のみ</string>
     <string name="call_error_user_not_responding">通信先が通話の受取に失敗しました。</string>
     <string name="permissions_rationale_popup_title">情報</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name}は、添付ファイルを送信および保存するために、写真とビデオライブラリにアクセスするための許可を必要としています。
+    <string name="permissions_rationale_msg_storage">${app_name}は、添付ファイルを送信および保存するために、写真とビデオライブラリにアクセスするための許可を必要としています。
 \n
 \n端末からファイルを送信できるようにするには、次のポップアップでアクセスを許可してください。</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \n通話をするためには、次のポップアップでアクセスを許可してください。"</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name}は、音声通話を実行するためにマイクへアクセスするための許可を必要としています。</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name}は、音声通話を実行するためにマイクへアクセスするための許可を必要としています。</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \n通話をするためには、次のポップアップでアクセスを許可してください。"</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name}はビデオ通話を行うためにカメラとマイクにアクセスする許可を必要としています。
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name}はビデオ通話を行うためにカメラとマイクにアクセスする許可を必要としています。
 \n
 \n通話をするためには、次のポップアップでアクセスを許可してください。</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name}では、あなたの端末の電話帳のメールアドレスや電話番号をもとに、他のユーザーを検索することができます。${app_name}による電話帳の検索を許可する場合は、次のポップアップでアクセスを許可してください。</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name}はあなたの電話帳のメールアドレスや電話番号をもとに他のユーザーを見つけることができます。
+    <string name="permissions_rationale_msg_contacts">${app_name}では、あなたの端末の電話帳のメールアドレスや電話番号をもとに、他のユーザーを検索することができます。${app_name}による電話帳の検索を許可する場合は、次のポップアップでアクセスを許可してください。</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name}はあなたの電話帳のメールアドレスや電話番号をもとに他のユーザーを見つけることができます。
 \n
 \nこのアプリがあなたの電話帳へアクセスすることを許可しますか？</string>
     <string name="permissions_action_not_performed_missing_permissions">申し訳ありません。権限がないために操作が実行されませんでした</string>
@@ -742,7 +742,7 @@
     <string name="e2e_re_request_encryption_key">あなたの他のセッションに暗号鍵を再要求する。</string>
     <string name="e2e_re_request_encryption_key_sent">鍵のリクエストが送信されました。</string>
     <string name="e2e_re_request_encryption_key_dialog_title">要求が送信されました</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">鍵をこのセッションに送信できるように、メッセージを復号化できる他の端末で${app_name}を起動してください。</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">鍵をこのセッションに送信できるように、メッセージを復号化できる他の端末で${app_name}を起動してください。</string>
     <plurals name="format_time_s">
         <item quantity="other">%d秒</item>
     </plurals>
@@ -774,12 +774,12 @@
     <string name="settings_deactivate_account_section">アカウントを停止</string>
     <string name="settings_deactivate_my_account">自分のアカウントを停止</string>
     <string name="startup_notification_privacy_title">通知のプライバシー</string>
-    <string name="template_startup_notification_privacy_message">${app_name}はバックグラウンドで動作し、通知を安全で内密に扱います。これによりバッテリー使用に影響が出ることがあります。</string>
+    <string name="startup_notification_privacy_message">${app_name}はバックグラウンドで動作し、通知を安全で内密に扱います。これによりバッテリー使用に影響が出ることがあります。</string>
     <string name="startup_notification_privacy_button_grant">許可を与える</string>
     <string name="startup_notification_privacy_button_other">他のオプションを選択</string>
     <string name="settings_opt_in_of_analytics">分析データを送信</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name}はアプリを改善するため、匿名の分析データを収集します。</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">分析を有効にして、${app_name}の改善を手伝ってくれませんか？</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name}はアプリを改善するため、匿名の分析データを収集します。</string>
+    <string name="settings_opt_in_of_analytics_prompt">分析を有効にして、${app_name}の改善を手伝ってくれませんか？</string>
     <string name="settings_opt_in_of_analytics_ok">はい、手伝いたいです！</string>
     <string name="settings_without_flair">あなたは現在どのコミュニティーのメンバーでもありません。</string>
     <string name="lock_screen_hint">ここに入力…</string>
@@ -869,7 +869,7 @@
     <string name="action_accept">承諾</string>
     <string name="auth_accept_policies">このホームサーバーの方針を確認し承諾してください：</string>
     <string name="settings_call_category">通話設定画面</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">着信に${app_name}の既定の着信音を使用</string>
+    <string name="settings_call_ringtone_use_app_ringtone">着信に${app_name}の既定の着信音を使用</string>
     <string name="settings_call_ringtone_title">着信音</string>
     <string name="settings_call_ringtone_dialog_title">着信音を選んでください:</string>
     <string name="room_participants_action_remove">会話から追放</string>
@@ -1084,7 +1084,7 @@
     <string name="settings_emails_and_phone_numbers_summary">あなたのMatrixアカウントに登録されたメールアドレスと電話番号を管理</string>
     <string name="settings_emails_and_phone_numbers_title">メールアドレスと電話番号</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">有効化</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">このセッションで通知が無効化されています。
+    <string name="settings_troubleshoot_test_device_settings_failed">このセッションで通知が無効化されています。
 \n${app_name} の設定をご確認ください。</string>
     <string name="settings_troubleshoot_test_device_settings_success">このセッションで通知は有効化されています。</string>
     <string name="settings_troubleshoot_test_device_settings_title">セッションの設定。</string>
@@ -1172,7 +1172,7 @@
     <string name="qr_code">QRコード</string>
     <string name="add_by_qr_code">QRコードによる追加</string>
     <string name="user_code_share">コードを共有</string>
-    <string name="template_invite_friends_text">${app_name} で会話しましょう：%s</string>
+    <string name="invite_friends_text">${app_name} で会話しましょう：%s</string>
     <string name="invite_friends">友達を招待</string>
     <string name="direct_room_user_list_known_title">既知のユーザー</string>
     <string name="invalid_qr_code_uri">無効なQRコード（無効なURI）！</string>
@@ -1263,7 +1263,7 @@
     <string name="video_call_in_progress">ビデオ通話が行われています…</string>
     <string name="settings_call_ringtone_use_default_stun">フォールバックコールアシストサーバーを許可</string>
     <string name="error_unauthorized">有効な認証情報がないため、権限がありません</string>
-    <string name="template_call_failed_no_connection">${app_name} 呼び出し失敗</string>
+    <string name="call_failed_no_connection">${app_name} 呼び出し失敗</string>
     <string name="call_failed_no_ice_description">確実に通話できるようにするためには、ホームサーバー（%1$s）の管理者にTURNサーバーの設定を依頼してください。
 \n
 \n代わりに、%2$sのパブリックサーバーを使用することもできますが、信頼性は低く、あなたのIPアドレスがそのサーバーと共有されてしまいます。これは設定から管理することができます。</string>
@@ -1444,7 +1444,7 @@
     <string name="notice_room_topic_removed_by_you">ルームの説明を削除しました</string>
     <string name="notice_room_name_removed_by_you">ルーム名を削除しました</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">許可を与える</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name}は、確実に通知を受け取るために、影響の少ないバックグラウンド接続を維持する必要があります。
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name}は、確実に通知を受け取るために、影響の少ないバックグラウンド接続を維持する必要があります。
 \n次の画面で、${app_name}を常にバックグラウンドで実行することを許可するように求められますので、承認してください。</string>
     <string name="startup_notification_fdroid_battery_optim_title">バックグラウンド接続</string>
     <string name="settings_discovery_manage">ディスカバリー設定を管理します。</string>
@@ -1468,9 +1468,9 @@
     <string name="settings_background_sync_update_error">設定の更新に失敗しました。</string>
     <string name="settings_integrations">インテグレーション（統合）</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">アプリがバックグラウンドにある場合、着信メッセージは通知されません。</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name}は正確な時間に定期的にバックグラウンドで同期します（構成可能）。
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name}は正確な時間に定期的にバックグラウンドで同期します（構成可能）。
 \nこれは無線とバッテリーの使用量に影響し、$ {app_name}がイベントを待機していることを示す永続的な通知が表示されます。</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name}は、端末の限られたリソース（バッテリーの残量）を維持する方法でバックグラウンド同期をします。
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name}は、端末の限られたリソース（バッテリーの残量）を維持する方法でバックグラウンド同期をします。
 \n端末の状態によっては、OSによって同期が延期される場合があります。</string>
     <string name="settings_system_preferences_summary">LEDの色、振動、音を選択してください…</string>
     <string name="settings_silent_notifications_preferences">通知（サイレント）を設定</string>
@@ -1479,16 +1479,16 @@
     <string name="settings_notification_privacy_no_background_sync">アプリはバックグラウンドでホームサーバーに接続する<b>必要がない</b>ためバッテリー使用量を減らすことができます</string>
     <string name="settings_troubleshoot_test_battery_quickfix">最適化を無視</string>
     <string name="settings_troubleshoot_test_battery_failed">画面をオフにした状態で端末のプラグを抜いて一定時間静止したままにすると、端末は機内モードになります。 これにより、アプリがネットワークにアクセスできなくなり、ジョブ、同期、および標準のアラームが防止されます。</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">${app_name}のバックグラウンド制限が有効になっています。
+    <string name="settings_troubleshoot_test_bg_restricted_failed">${app_name}のバックグラウンド制限が有効になっています。
 \nアプリがバックグラウンドで実行しようとする作業が積極的に制限されるため、通知に影響を与える可能性があります。
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">${app_name}のバックグラウンド制限が無効になっています。 このテストは、モバイル（WIFIでない）を使用して実行する必要があります。
+    <string name="settings_troubleshoot_test_bg_restricted_success">${app_name}のバックグラウンド制限が無効になっています。 このテストは、モバイル（WIFIでない）を使用して実行する必要があります。
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">端末を再起動してもサービスは開始しません。${app_name}を一度開くまで通知は届きません。</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">［%1$s］
+    <string name="settings_troubleshoot_test_service_boot_failed">端末を再起動してもサービスは開始しません。${app_name}を一度開くまで通知は届きません。</string>
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">［%1$s］
 \nこのエラーは${app_name}の管理外です。 これはいくつかの理由で発生する可能性があります。 後で再試行するとうまくいくかもしれません。システム設定でGoogle Playサービスのデータ使用量が制限されていないか、端末の時刻が正しいかどうかを確認してください。カスタムROMで生じることもあります。</string>
-    <string name="template_settings_add_3pid_flow_not_supported">${app_name}モバイルからこれを行うことはできません</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name}はバッテリー最適化の影響を受けません。</string>
+    <string name="settings_add_3pid_flow_not_supported">${app_name}モバイルからこれを行うことはできません</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name}はバッテリー最適化の影響を受けません。</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">制限を無効にする</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">起動時の開始を有効にする</string>
     <string name="settings_troubleshoot_test_service_boot_success">端末を再起動するとサービスが開始します。</string>
@@ -1508,11 +1508,11 @@
     <string name="settings_troubleshoot_test_token_registration_success">FCMトークンのホームサーバーへの登録が成功しました。</string>
     <string name="settings_troubleshoot_test_token_registration_title">トークンの登録</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">アカウントを追加</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nこのエラーは${app_name}の管理外です。このスマートフォンにはGoogleアカウントが登録されていません。アカウントマネージャーを開いて、Googleアカウントを追加してください。</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">［%1$s］
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">［%1$s］
 \nこのエラーは${app_name}の管理外です。Googleによると、このエラーは、FCMに登録されている端末上のアプリの数が多すぎることを示唆しています。 このエラーは、アプリの数が極端に多い場合にのみ発生するため、平均的なユーザーには影響しません。</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name}はGoogle Playサービスを使用してプッシュメッセージを配信していますが、正しく設定されていないようです:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name}はGoogle Playサービスを使用してプッシュメッセージを配信していますが、正しく設定されていないようです:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">FCMトークンの取得に失敗しました:
 \n%1$s</string>
@@ -1669,7 +1669,7 @@
     <string name="keys_backup_setup_step1_advanced">（高度）</string>
     <string name="keys_backup_setup_step1_title">暗号化されたメッセージを決して失わないために</string>
     <string name="keys_backup_no_session_error">利用可能なMatrixセッションがありません</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">${app_name}によるリカバリーキーの生成を望む場合、パスフレーズを削除してください。</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">${app_name}によるリカバリーキーの生成を望む場合、パスフレーズを削除してください。</string>
     <string name="markdown_has_been_disabled">マークダウンが無効です。</string>
     <string name="markdown_has_been_enabled">マークダウンが有効です。</string>
     <string name="command_problem_with_parameters">”%s”とのコマンドはいくつかのパラメータが欠けているか不正です。</string>
@@ -1854,7 +1854,7 @@
     <string name="room_preview_no_preview_join">このルームはプレビューできません。参加しますか？</string>
     <string name="room_preview_not_found">現在、このルームにはアクセスできません。
 \n後でもう一度やり直すか、ルームの管理者にアクセス権があるかどうかを確認するよう依頼してください。</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">${app_name}では、誰でも読めるルームのプレビューがまだサポートされていません</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">${app_name}では、誰でも読めるルームのプレビューがまだサポートされていません</string>
     <string name="room_preview_no_preview">このルームはプレビューできません</string>
     <string name="please_wait">お待ち下さい…</string>
     <string name="error_no_network">ネットワークがありません。インターネット接続を確認してください。</string>
@@ -1919,7 +1919,7 @@
     <string name="sas_verify_title">短い文字列を比較して検証します。</string>
     <string name="invalid_or_expired_credentials">認証情報が不正または期限切れのため、ログアウトしました。</string>
     <string name="autodiscover_well_known_autofill_confirm">構成を使用</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name}がuserIdドメイン\"%1$s\"のカスタムサーバー構成を検出しました。
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name}がuserIdドメイン\"%1$s\"のカスタムサーバー構成を検出しました。
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_dialog_title">サーバーオプションをおまかせする</string>
     <string name="autodiscover_invalid_response">無効なホームサーバーディスカバリーレスポンス</string>
@@ -2066,7 +2066,7 @@
     <string name="content_reported_title">コンテンツが報告されました</string>
     <string name="preference_help_title">ヘルプとサポート</string>
     <string name="preference_help">ヘルプ</string>
-    <string name="template_legals_application_title">${app_name}のポリシー</string>
+    <string name="legals_application_title">${app_name}のポリシー</string>
     <string name="analytics_opt_in_content_link">ここ</string>
     <string name="settings_notification_new_keyword">キーワードを追加</string>
     <string name="thread_list_modal_my_threads_title">自分のスレッド</string>
@@ -2258,8 +2258,8 @@
     <string name="send_attachment">添付ファイルを送信</string>
     <string name="labs_allow_extended_logging">詳細なログを有効にする。</string>
     <string name="settings_agree_to_terms">メールアドレスか電話番号でアカウントを見つけてもらえるようにするには、IDサーバー（%s）の利用規約への同意が必要です。</string>
-    <string name="template_location_not_available_dialog_title">${app_name}は位置情報にアクセスできませんでした</string>
-    <string name="template_location_not_available_dialog_content">${app_name}は位置情報にアクセスできませんでした。後でもう一度やり直してください。</string>
+    <string name="location_not_available_dialog_title">${app_name}は位置情報にアクセスできませんでした</string>
+    <string name="location_not_available_dialog_content">${app_name}は位置情報にアクセスできませんでした。後でもう一度やり直してください。</string>
     <string name="voice_message_reply_content">音声メッセージ（%1$s）</string>
     <string name="room_upgrade_to_recommended_version">推奨のルームバージョンへとアップグレード</string>
     <string name="a11y_start_voice_message">音声メッセージを録音</string>
@@ -2312,7 +2312,7 @@
     <string name="analytics_opt_in_list_item_3">これはいつでも設定から無効にできます</string>
     <string name="analytics_opt_in_list_item_2">私たちは、情報を第三者と共有することは<b>ありません</b></string>
     <string name="analytics_opt_in_list_item_1">私たちは、アカウントのデータを記録したり分析したりすることは<b>ありません</b></string>
-    <string name="template_analytics_opt_in_title">${app_name}の改善を手伝う</string>
+    <string name="analytics_opt_in_title">${app_name}の改善を手伝う</string>
     <string name="room_join_rules_public_by_you">このルームを「リンクを知っている人が参加可能」に設定しました。</string>
     <string name="no_ignored_users">どのユーザーも無視していません</string>
     <string name="reaction_search_type_hint">キーワードを入力するとリアクションを検索できます。</string>
@@ -2346,7 +2346,7 @@
     <string name="rageshake_detected">シェイクを検出しました！</string>
     <string name="settings_rageshake_detection_threshold_summary">電話を振って、しきい値を試してください</string>
     <string name="settings_rageshake_detection_threshold">検出のしきい値</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">予期しないエラーが生じた際に、${app_name}はより頻繁にクラッシュする可能性があります</string>
+    <string name="settings_developer_mode_fail_fast_summary">予期しないエラーが生じた際に、${app_name}はより頻繁にクラッシュする可能性があります</string>
     <string name="settings_developer_mode_fail_fast_title">素早くクラッシュ</string>
     <string name="settings_developer_mode_summary">開発者モードは隠された機能を有効にするため、アプリケーションが不安定になる恐れがあります。開発者向けです！</string>
     <string name="labs_auto_report_uisi_desc">復号エラーが生じた際に、自動的にログを送信</string>
@@ -2379,9 +2379,9 @@
     <string name="location_share_external">以下で開く</string>
     <string name="upgrade_security">暗号化のアップグレードが利用可能です</string>
     <string name="bootstrap_progress_generating_ssss_recovery">SSSSキーをリカバリーキーから生成しています</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
-    <string name="template_app_desktop_web">${app_name}ウェブ版
+    <string name="app_desktop_web">${app_name}ウェブ版
 \n${app_name}デスクトップ版</string>
     <string name="enter_secret_storage_input_key">リカバリーキーを選択、直接入力、あるいはクリップボードからペースト</string>
     <string name="use_recovery_key">リカバリーキーを使用</string>
@@ -2485,7 +2485,7 @@
     <string name="ftue_auth_carousel_secure_title">自分の会話は、自分のもの。</string>
     <string name="room_join_rules_invite">%1$sがこのルームを「招待者のみ参加可能」に設定しました。</string>
     <string name="command_description_spoiler">選択したメッセージをネタバレとして送信</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} がエンドツーエンド暗号鍵をディスクに保存する許可を要求しています。
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} がエンドツーエンド暗号鍵をディスクに保存する許可を要求しています。
 \n
 \n鍵を手動でエクスポートできるように、次のポップアップでアクセスを許可してください。</string>
     <string name="room_join_rules_public">%1$sはこのルームを「リンクを知っている人が参加可能」に設定しました。</string>
@@ -2506,7 +2506,7 @@
     <string name="ftue_auth_carousel_secure_body">お宅での対面会話と同じぐらいのプライバシーを提供する、セキュアで独立したコミュニケーション。</string>
     <string name="ftue_auth_carousel_encrypted_title">セキュアメッセージング</string>
     <string name="ftue_auth_carousel_control_title">管理権を握るのは、あなたです。</string>
-    <string name="template_preference_help_summary">${app_name}の使用に関するヘルプ</string>
+    <string name="preference_help_summary">${app_name}の使用に関するヘルプ</string>
     <string name="labs_allow_extended_logging_summary">詳細なログは、イライラシェイクでログを送信する際に、より多くのログを提供することで、開発者にとっての助けになります。有効にした場合でも、メッセージの内容やその他のプライベートな情報は記録されません。</string>
     <string name="upgrade_room_warning">ルームのアップグレードは高度な作業であり、不具合や欠けている機能、セキュリティー上の脆弱性がある場合に推奨されます。
 \nアップグレードは通常、ルームがサーバー上で処理される仕方にだけ影響します。</string>
@@ -2702,7 +2702,7 @@
     <string name="verify_user_sas_emoji_help_text">次の絵文字が相手の画面にも同じ順番で現れるのを確認し、このユーザーを検証してください。</string>
     <string name="verification_conclusion_warning">信頼できないサインイン</string>
     <string name="create_room_alias_invalid">使用できない文字が含まれています</string>
-    <string name="template_analytics_opt_in_content">${app_name}の改善と課題抽出のために、匿名の使用状況データの送信をお願いします。複数の端末での使用を分析するために、あなたの全端末共通のランダムな識別子を生成します。
+    <string name="analytics_opt_in_content">${app_name}の改善と課題抽出のために、匿名の使用状況データの送信をお願いします。複数の端末での使用を分析するために、あなたの全端末共通のランダムな識別子を生成します。
 \n
 \n%sで利用規約を閲覧できます。</string>
     <string name="autocomplete_limited_results">最初の検索結果のみ表示しています。文字をもっと入力してください…</string>
@@ -2712,7 +2712,7 @@
 \nこの端末での使用を終了、または他のアカウントにサインインしたい場合、このデータをクリアしてください。</string>
     <string name="soft_logout_clear_data_dialog_content">この端末に現在保存されている全てのデータをクリアしますか？
 \nアカウントデータとメッセージにアクセスするにはもう一度サインインしてください。</string>
-    <string name="template_soft_logout_sso_not_same_user_error">現在のセッションはユーザー %1$s のものですが、あなたが提供している認証情報はユーザー %2$s のものです。この操作は${app_name}ではサポートされていません。
+    <string name="soft_logout_sso_not_same_user_error">現在のセッションはユーザー %1$s のものですが、あなたが提供している認証情報はユーザー %2$s のものです。この操作は${app_name}ではサポートされていません。
 \nまずデータをクリアし、その後、別のアカウントにサインインしてください。</string>
     <string name="soft_logout_signin_e2e_warning_notice">暗号化されたメッセージがどの端末でも読めるように、サインインしてこの端末にのみ保存されている暗号鍵を取り戻してください。</string>
     <string name="soft_logout_signin_notice">あなたのホームサーバー（%1$s）の管理者があなたを%2$sのアカウントからサインアウトしました（%3$s）。</string>
@@ -2746,7 +2746,7 @@
     <string name="bottom_sheet_setup_secure_backup_title">セキュアバックアップ</string>
     <string name="settings_setup_secure_backup">セキュアバックアップを設定</string>
     <string name="a11y_open_chat">会話を開く</string>
-    <string name="template_identity_server_error_outdated_identity_server">このIDサーバーは最新のバージョンではありません。${app_name}はAPIのバージョン2のみをサポートしています。</string>
+    <string name="identity_server_error_outdated_identity_server">このIDサーバーは最新のバージョンではありません。${app_name}はAPIのバージョン2のみをサポートしています。</string>
     <string name="invite_users_to_room_failure">ユーザーを招待できませんでした。招待したいユーザーを確認して、もう一度試してください。</string>
     <string name="open_terms_of">%sの利用規約を開く</string>
     <string name="identity_server_user_consent_not_provided">ユーザーによる同意は与えられていません。</string>
@@ -2801,7 +2801,7 @@
     <plurals name="secure_backup_reset_devices_you_can_verify">
         <item quantity="other">いま検証できる%d個の端末を表示</item>
     </plurals>
-    <string name="template_re_authentication_default_confirm_text">この操作を実行するには ${app_name}に認証情報を入力する必要があります。</string>
+    <string name="re_authentication_default_confirm_text">この操作を実行するには ${app_name}に認証情報を入力する必要があります。</string>
     <string name="bottom_sheet_setup_secure_backup_security_phrase_subtitle">あなただけが知っている秘密のパスワードを入力してください。バックアップ用にセキュリティーキーを生成します。</string>
     <string name="confirm_your_identity_quad_s">暗号化されたメッセージにアクセスするには、ログインを検証し、本人確認を行う必要があります。</string>
     <string name="confirm_your_identity">暗号化されたメッセージにアクセスするには、あなたの他のセッションからログインを検証し、本人確認を行う必要があります。</string>
@@ -2819,9 +2819,9 @@
     <string name="verification_request_start_notice">セキュリティーを高めるために、対面で行うか、他の信頼できる通信手段を利用しましょう。</string>
     <string name="command_description_rainbow_emote">選択されたエモートを虹色にして送信します</string>
     <string name="command_description_rainbow">選択されたテキストを虹色にして送信します</string>
-    <string name="template_rendering_event_error_exception">${app_name}がID%1$sのイベントを処理中にエラーが発生しました</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name}は%1$sという種類のメッセージに対応していません</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name}は%1$sという種類のイベントに対応していません</string>
+    <string name="rendering_event_error_exception">${app_name}がID%1$sのイベントを処理中にエラーが発生しました</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name}は%1$sという種類のメッセージに対応していません</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name}は%1$sという種類のイベントに対応していません</string>
     <string name="room_member_jump_to_read_receipt">既読通知へ移動</string>
     <string name="keep_it_safe">大切に保護しましょう</string>
     <string name="bootstrap_finish_title">完了！</string>
@@ -2838,7 +2838,7 @@
     <string name="verify_new_session_notice">新しいセッションを検証して、暗号化されたメッセージにアクセスできるようにしましょう。</string>
     <string name="new_session_review">タップして確認及び検証</string>
     <string name="new_session">新しいログイン。あなたですか？</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="event_redacted_by_admin_reason_with_reason">ルームの管理者によって削除されています。理由：%1$s</string>
     <string name="event_redacted_by_user_reason_with_reason">ユーザーによって削除されています。理由：%1$s</string>
     <string name="delete_event_dialog_reason_hint">削除した理由</string>

--- a/vector/src/main/res/values-kab/strings.xml
+++ b/vector/src/main/res/values-kab/strings.xml
@@ -666,7 +666,7 @@
     <string name="user_directory_header">Akaram n useqdac</string>
     <string name="matrix_only_filter">Inermisen kan n Matrix</string>
     <string name="no_conversation_placeholder">Ulac idiwenniyen</string>
-    <string name="template_no_contact_access_placeholder">Ur teǧǧiḍ ara ${app_name} ad yekcem ɣer yinermisen-ik·im idiganen</string>
+    <string name="no_contact_access_placeholder">Ur teǧǧiḍ ara ${app_name} ad yekcem ɣer yinermisen-ik·im idiganen</string>
     <string name="people_no_identity_server">Ulac aqeddac n timagit yettusiwlen.</string>
     <string name="no_room_placeholder">Ulac tixxamin</string>
     <string name="no_public_room_placeholder">Ulac tixxamin tizuyaz yellan</string>
@@ -701,7 +701,7 @@
 \nDeg wadeg n wayen, tzemreḍ ad tesqedceḍ aqeddac azayez ɣef %2$s, maca aya ur yettettkal ara fell-as, ad yebḍu tansa-ik·im IP d uqeddac-a. Tzemreḍ ad tesferkeḍ aya deg yiɣewwaren.</string>
     <string name="call_failed_no_ice_use_alt">Ɛreḍ aseqdec n %s</string>
     <string name="call_failed_dont_ask_again">Ur iyi-d-ssutur ara tikkelt-nniḍen</string>
-    <string name="template_call_failed_no_connection">Asiwel s ${app_name} ur yeddi ara</string>
+    <string name="call_failed_no_connection">Asiwel s ${app_name} ur yeddi ara</string>
     <string name="call_select_sound_device">Fren ibenk n yimesli</string>
     <string name="sound_device_speaker">Amennay</string>
     <string name="sound_device_headset">Kask</string>
@@ -1188,11 +1188,11 @@
     <string name="new_session_review_with_info">%1$s (%2$s)</string>
     <string name="error_saving_media_file">Ur yezmir ara ad isekles afaylu n umidya</string>
     <string name="change_password_summary">Sbadu awal uffir amaynut n umiḍan…</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
-    <string name="template_use_latest_app">Seqdec aferdis aneggaru ɣef yibenkan-nniḍen:</string>
+    <string name="use_latest_app">Seqdec aferdis aneggaru ɣef yibenkan-nniḍen:</string>
     <string name="command_description_discard_session_not_handled">Yettusefrak kan deg texxamin yettwawgelhen</string>
     <string name="enter_secret_storage_passphrase_or_key">Seqdec %1$s-inek·inem neɣ seqdec %2$s-inek.inem i wakken ad tkemmleḍ.</string>
     <string name="keys_backup_recovery_key_error_decrypt">Aḥraz ur yezmir ara ad yekkes awgelhen s tsarut-a n tririt: ttxil-k·m sefqed ma d tasarut n tririt tameɣtut i teskecmeḍ.</string>
@@ -1304,20 +1304,20 @@
     <string name="call_error_camera_init_failed">Awennez n tkamiṛat d awezɣi</string>
     <string name="call_error_answered_elsewhere">tiririt ɣef usiwel seg wadeg-nniḍen</string>
     <string name="media_picker_cannot_record_video">Ur yezmir ara ad isekles tavidyut</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} yesra tasiregt n unekcum ɣer temkarḍit-inek·inem n tewlafin d tvidyut i tuzna d usekles n tceqqufin yeddan.
+    <string name="permissions_rationale_msg_storage">${app_name} yesra tasiregt n unekcum ɣer temkarḍit-inek·inem n tewlafin d tvidyut i tuzna d usekles n tceqqufin yeddan.
 \n
 \nMa ulac aɣilif sireg anekcum deg yisfuyla udhimen i d-iteddun i wakken ad tizmireḍ ad tazneḍ ifuyla seg tiliɣri-inek·inem.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nMa ulac aɣilif sireg anekcum ɣer isfuyla udhimen i d-iteddun i wakken tizmireḍ ad tessiwleḍ."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} yesra tasiregt n unekcum ɣer usawaḍ-inek·inem i wakken ad iseddu isawalen s umeslaw.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} yesra tasiregt n unekcum ɣer usawaḍ-inek·inem i wakken ad iseddu isawalen s umeslaw.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nMa ulac aɣilif sireg anekcum ɣer isfuyla udhimen i d-iteddun i wakken tizmireḍ ad tessiwleḍ."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} yesra tasiregt n unekcum ɣer temkarḍit-inek·inem n tewlafin d tvidyut i tuzna d usekles n tceqqufin yeddan.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} yesra tasiregt n unekcum ɣer temkarḍit-inek·inem n tewlafin d tvidyut i tuzna d usekles n tceqqufin yeddan.
 \n
 \nMa ulac aɣilif sireg anekcum deg yisfuyla udhimen i d-iteddun i wakken ad tizmireḍ ad tazneḍ ifuyla seg tiliɣri-inek·inem.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} yezmer ad issenqed adlis-inek·inem n tansiwin i wakken ad d-yaf iseqdacen-nniḍen n Matrix s usenned ɣer yimaylen d wuṭṭunen n tiliɣri nsen.
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} yezmer ad issenqed adlis-inek·inem n tansiwin i wakken ad d-yaf iseqdacen-nniḍen n Matrix s usenned ɣer yimaylen d wuṭṭunen n tiliɣri nsen.
 \n
 \nTebɣiḍ ad tebduḍ adlis-inek·inem n tansiwin i yiswi-a\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Nesḥassef. Tiggawt-a ur tezmir ara ad d-tili imi llant tsirag i ixuṣṣen</string>
@@ -1416,7 +1416,7 @@
     <string name="passphrase_passphrase_does_not_match">Tafyirt tuffirt ur temṣada ara</string>
     <string name="passphrase_empty_error_message">Ma ulac aɣilif sekcem tafyirt tuffirt</string>
     <string name="passphrase_passphrase_too_weak">Tafyirt tuffirt ur teǧhid ara aṭas</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Ma ulac aɣilif kkes tafyirt tuffirt ma yella tebɣiḍ ${app_name} ad isirew tasarut n tririt.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Ma ulac aɣilif kkes tafyirt tuffirt ma yella tebɣiḍ ${app_name} ad isirew tasarut n tririt.</string>
     <string name="keys_backup_no_session_error">Ulac tiɣimit n Matrix i yellan</string>
     <string name="keys_backup_setup_step1_advanced">(Leqqayen)</string>
     <string name="keys_backup_setup_step2_button_title">Sbadu tafyirt tuffirt</string>
@@ -1444,7 +1444,7 @@
     <string name="enter_secret_storage_passphrase">Sekcem tasarut tuffirt n uḥraz uffir</string>
     <string name="enter_secret_storage_passphrase_warning">Ɣur-k·m:</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Tisur ttwaleqqment yakan!</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">Isutar n tsura</string>
     <string name="qr_code_scanned_verif_waiting">Ittraju %s…</string>
     <string name="settings_troubleshoot_title">Tifrat n wugur</string>
@@ -1452,7 +1452,7 @@
     <string name="enter_backup_passphrase">Kcem %s</string>
     <string name="call_error_ice_failed">Tuqqna n umidyat ur teddi ara</string>
     <string name="media_picker_both_capture_title">Ṭṭef-d tawlaft neɣ tavidyut</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} yesra tasiregt n unekcum er tkamiat-ik·im i wakken ad d-yeṭṭef tawlafin d yisawalen s tvidyut.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} yesra tasiregt n unekcum er tkamiat-ik·im i wakken ad d-yeṭṭef tawlafin d yisawalen s tvidyut.</string>
     <string name="room_settings_room_access_entry_anyone_with_link_apart_guest">Yal win·tin yessnen aseɣwen n texxamt, slid inebgawen</string>
     <string name="room_settings_room_access_entry_anyone_with_link_including_guest">Yal win·tin yessnen aseɣwen n texxamt rnu-d ɣer-sen inebgawen</string>
     <plurals name="room_settings_banned_users_count">
@@ -1560,13 +1560,13 @@
 \n
 \nIlaq-ak·am ad ternuḍ imayl-ik·im ɣer umaɣun-inek·inem deg yiɣewwaren.</string>
     <string name="login_error_ssl_handshake">Ibenk-inek·inem yesseqdac aneggaf n tɣellist TLS aqbur, yemzer i uḍfar s waṭas, i tɣellist-inek·inem ur tettizmireḍ ara a teqqneḍ</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Ma ulac aɣilif err ${app_name} deg yibenk-nniḍen i izemren ad yekkes awgelhen i yiznan, akken ad yizmir ad yazen tisura ɣer tɣimit-a.</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Seqdec taṭenṭunt n ${app_name} tamezwert i yisawalin ara d-ikecmen</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Ma ulac aɣilif err ${app_name} deg yibenk-nniḍen i izemren ad yekkes awgelhen i yiznan, akken ad yizmir ad yazen tisura ɣer tɣimit-a.</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Seqdec taṭenṭunt n ${app_name} tamezwert i yisawalin ara d-ikecmen</string>
     <string name="settings_call_ringtone_use_default_stun_sum">Ad isseqdec %s d tallalt mi ara yili uqeddac-ik·im agejdan ur d-imudd ara yiwen (tansa-inek·inem IP ad tettwabḍu ayen akk ara yeqqim usiwel)</string>
     <string name="settings_call_ringtone_title">Taṭenṭunt n usiwel i d-ikecmen</string>
     <string name="settings_call_ringtone_dialog_title">Fren asṭeṭen i yisawalen:</string>
     <string name="call_error_user_not_responding">Agalis anmeggag ur yessaweḍ ara ad yerfed.</string>
-    <string name="template_permissions_rationale_msg_contacts">Matrix yezmer ad isenqed adlis-ik·im n tansiwin i wakken ad yaf iseqdacen-nniḍen n Matrix s ttawil n yimaylen d wuṭṭunen n tiliɣri nsen. Ma yella tqebleḍ ad tebduḍ adlis-ik·im n tansiwin i waya, ma ulac aɣilif sireg anekcum deg yisfuyla udhimen i d-iteddun.</string>
+    <string name="permissions_rationale_msg_contacts">Matrix yezmer ad isenqed adlis-ik·im n tansiwin i wakken ad yaf iseqdacen-nniḍen n Matrix s ttawil n yimaylen d wuṭṭunen n tiliɣri nsen. Ma yella tqebleḍ ad tebduḍ adlis-ik·im n tansiwin i waya, ma ulac aɣilif sireg anekcum deg yisfuyla udhimen i d-iteddun.</string>
     <string name="invite_no_identity_server_error">Rnu aqeddac n timagit deg yiɣewwaren-ik·im i wakken ad tesnetmeḍ tigawt-a.</string>
     <string name="room_participants_leave_prompt_msg">S tidet tebɣiḍ ad teǧǧeḍ taxxamt\?</string>
     <string name="room_participants_power_level_prompt">Ur tettizmireḍ ara ad tesfesxeḍ asnifel-a acku tessebɣaseḍ aseqdac ad yesɛu aswir n tezmert am kečč·kemm.
@@ -1592,7 +1592,7 @@
     <string name="room_sliding_menu_third_party_notices">Turagin n wis tlata</string>
     <string name="settings_phone_number_empty">Ulac uṭṭun n tiliɣri i yettwarnan ɣer umiḍan-inek·inem</string>
     <string name="settings_app_info_link_summary">Sken talɣut n usnas deg yiɣewwaren n unagraw.</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Ur tezmireḍ ara ad tgeḍ aya seg ${app_name} n uziraz</string>
+    <string name="settings_add_3pid_flow_not_supported">Ur tezmireḍ ara ad tgeḍ aya seg ${app_name} n uziraz</string>
     <string name="settings_emails_empty">Ulac imayl yettwarnan ɣer umiḍan-ik·im</string>
     <string name="error_threepid_auth_failed">Ttkel tettekkaḍ ɣef useɣwen yellan deg yimayl i ak·am-n-uznen.</string>
     <string name="settings_notification_advanced">Iɣewwaren n yilɣa leqqayen</string>
@@ -1602,13 +1602,13 @@
     <string name="settings_troubleshoot_test_account_settings_failed">Ilɣa ttwasensen i umiḍan-inek·inem.
 \nMa ulac aɣilif senqed iɣewwaren n umiḍan.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Ttwaremden yilɣa i tɣimit-a.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Ur ttwaremden ara yilɣa i tɣimit-a.
+    <string name="settings_troubleshoot_test_device_settings_failed">Ur ttwaremden ara yilɣa i tɣimit-a.
 \nMa ulac aɣilif senqed iɣewwaren n ${app_name}.</string>
     <string name="settings_troubleshoot_test_bing_settings_success_with_warn">Ẓer belli kra n yiznan yettwarun, ttusbadun ad ilin s tsusmi (ad d-neg alɣu s war imesli).</string>
     <string name="settings_troubleshoot_test_bing_settings_failed">Kra n yilɣa ttusensen deg yiɣewwaren-ik·im udmawanen.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">Asali n yilugan udmawanen ur yeddi ara, ma ulac aɣilif ɛreḍ tikkelt-nniḍen.</string>
     <string name="settings_troubleshoot_test_play_services_success">Imeẓla APK n Google Play llan rnu d imaynuten.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} yesseqdac imeẓla n Google Play i wakken ad d-iserreḥ i yiznan push maca ur yettban ara ttusewlen akken iwata:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} yesseqdac imeẓla n Google Play i wakken ad d-iserreḥ i yiznan push maca ur yettban ara ttusewlen akken iwata:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_token_registration_success">Ajuṭu FCM yettwasekles akken iwata ɣef uqeddac agejdan.</string>
     <string name="settings_troubleshoot_test_token_registration_failed">Asekles n ujuṭu FCM ɣef uqeddac agejdan ur yeddi ara.
@@ -1617,12 +1617,12 @@
     <string name="settings_troubleshoot_test_service_restart_success">Ameẓlu yettwanɣa syen yules asenker s wudem awurman.</string>
     <string name="settings_troubleshoot_test_service_restart_failed">Allus n usenker n umeẓlu ur yeddi ara</string>
     <string name="settings_troubleshoot_test_service_boot_success">Ameẓlu ad yenker mi ara yales yibenk asenker.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">"Ameẓlu ur yettenker ara mi ara yales yibenk asenker, ur d-tremseḍ ara ilɣa alamma yettwaldi ${app_name} xerṣum yiwet n tikkelt."</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">"Ameẓlu ur yettenker ara mi ara yales yibenk asenker, ur d-tremseḍ ara ilɣa alamma yettwaldi ${app_name} xerṣum yiwet n tikkelt."</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Rmed asenker seg tnekra</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Senqed ilugan n ugilal</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Iluggan n ugilal ttusensen i ${app_name}. Asekyed-a ilaq ad yeddu s useqdec n yisefka n uziraz (ulac WIFI).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Iluggan n ugilal ttusensen i ${app_name}. Asekyed-a ilaq ad yeddu s useqdec n yisefka n uziraz (ulac WIFI).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Ilugan n ugilal ttwaremden i ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Ilugan n ugilal ttwaremden i ${app_name}.
 \nAmahil i yettaɛraḍ usnas ad t-yeg yesɛa talast ma mazal-it yella ɣef ugilal, aya yezmer ad d-yawi ugur i yilɣa.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Sens ilugan</string>
@@ -1639,7 +1639,7 @@
     <string name="settings_containing_my_display_name">Iznan ideg yella yisem-iw yettwaskanen</string>
     <string name="settings_invited_to_room">Mi ara d-ttunecdeɣ ɣer texxamt</string>
     <string name="settings_background_fdroid_sync_mode_battery">Yettusesfer i uẓru</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} ad yemtawi deg ugilal akken ara yeḥrez tilisa n teɣbula n yibenk (aẓru).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} ad yemtawi deg ugilal akken ara yeḥrez tilisa n teɣbula n yibenk (aẓru).
 \nAlmend n waddad n teɣbalut n yibenk-inek·inem, amtawi yezmer ad iɛeṭṭel seg anagraw n wammud.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Yettusesfer i wakud ilaw</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Ur d-tetteṭṭfeḍ ara ulɣu n yiznan i d-ikecmen ma yili asnas ɣef ugilal i yella.</string>
@@ -1690,8 +1690,8 @@
     <string name="startup_notification_privacy_button_other">Fren taxtiṛit-nniḍen</string>
     <string name="startup_notification_fdroid_battery_optim_title">Tuqqna n ugilal</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Mudd tasiregt</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} ileqqeḍ tasleḍt tudrigt i wakken ad aɣ-iɛawen ad nesnerni asnas.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Ma ulac aɣilif rmed tasleḍt i wakken ad aɣ-ɛiwnent ad nesnerni ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} ileqqeḍ tasleḍt tudrigt i wakken ad aɣ-iɛawen ad nesnerni asnas.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Ma ulac aɣilif rmed tasleḍt i wakken ad aɣ-ɛiwnent ad nesnerni ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Ih, bɣiɣ ad d-muddeɣ tallalt!</string>
     <string name="settings_data_save_mode">Askar n usekles n yisefka</string>
     <string name="devices_details_device_name">Leqqem isem azayez</string>
@@ -1828,7 +1828,7 @@
         <item quantity="other">Aḥraz n tsura %d…</item>
     </plurals>
     <string name="autodiscover_well_known_autofill_dialog_title">Iɣewwaren n uqeddac ummid awurman</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} yufa-d tawila n uqeddac udmawan i taɣult usulay—inek·inem n uqeddac \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} yufa-d tawila n uqeddac udmawan i taɣult usulay—inek·inem n uqeddac \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Seqdec tawila</string>
     <string name="invalid_or_expired_credentials">Tettusuffɣeḍ ssebba n yinekcam arimeɣta neɣ yemmuten.</string>
@@ -1942,7 +1942,7 @@
     <string name="content_reported_as_inappropriate_content">Agbur-a yettwakter-d mačči d win i iwulmen.
 \n
 \nMa yella dayen ur tebɣiḍ ara ad twaliḍ agbur-nniḍen sɣur aseqdac-a, tzemreḍ ad t-tesweḥleḍ i wakken ad teffreḍ iznan-ines</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} yesra tasiregt i usekles n tsura-inek·inem E2E ɣef uḍebsi.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} yesra tasiregt i usekles n tsura-inek·inem E2E ɣef uḍebsi.
 \n
 \nMa ulac aɣilif sireg anekcum ɣef yisfuyla udhimen i d-iteddun i wakken ad tizmireḍ ad tsifḍeḍ tisura-ik·im s ufus.</string>
     <string name="no_network_indicator">Ulac akk tuqqna n uzeṭṭa i igerrzen akka tura</string>
@@ -2006,7 +2006,7 @@
 \nKcem tikkelt-nniḍen i wakken ad tkecmeḍ ɣer yisefka d yiznan n umiḍan-inek·inem.</string>
     <string name="permalink_malformed">Aseɣwen-inek·inem n Matrix.to ur yemsil ara akken iwata</string>
     <string name="autocomplete_limited_results">Ala igmaḍ imezwura i d-yettwaseknen, aru ugar n yisekkilen…</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} yezmer ad yewḥel ugar n tikkal mi ara d-tili tuccḍa ur nettwaṛǧa ara</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} yezmer ad yewḥel ugar n tikkal mi ara d-tili tuccḍa ur nettwaṛǧa ara</string>
     <string name="login_error_threepid_denied">Taɣult n yimayl—ik·im ur tesɛi ara azref i wakken ad tettwasekles ɣef uqeddac-a</string>
     <string name="verification_conclusion_warning">Tuqqna ur nettwattkal ara</string>
     <string name="verify_user_sas_emoji_help_text">Senqed aseqdac-a s usentem n yimujit-a asuf i d-yettbanen ɣef ugdil-ines, deg yiwem umsizwer.</string>
@@ -2045,9 +2045,9 @@
     <string name="room_member_power_level_moderator_in">D amaẓrag deg %1$s</string>
     <string name="room_member_power_level_default_in">Amezwer deg %1$s</string>
     <string name="room_member_power_level_custom_in">D udmawan (%1$d) deg %2$s</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">"${app_name} ur isekker ara ineḍruyen n wanaw  \'%1$s\'"</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">"${app_name} ur isekker ara izen n wanaw  \'%1$s\'"</string>
-    <string name="template_rendering_event_error_exception">${app_name} yemlal-d ugur mi ara d-yettarra agbur n uneḍru s usulay \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">"${app_name} ur isekker ara ineḍruyen n wanaw  \'%1$s\'"</string>
+    <string name="rendering_event_error_type_of_message_not_handled">"${app_name} ur isekker ara izen n wanaw  \'%1$s\'"</string>
+    <string name="rendering_event_error_exception">${app_name} yemlal-d ugur mi ara d-yettarra agbur n uneḍru s usulay \'%1$s\'</string>
     <string name="verify_cannot_cross_sign">Tiɣimit-a ulamek ara tebḍu aselken-a akked tqimiyin-nniḍen.
 \nAselken ad yettwaseklas s wudem adigan syen yettwabḍu deg lqem i d-iteddun n usnas.</string>
     <string name="room_list_sharing_header_recent_rooms">Tixxamin n melmi kan</string>
@@ -2168,7 +2168,7 @@
     <string name="settings_security_prevent_screenshots_summary">Armad n uɣewwar-a ad yernu FLAG_SECURE ɣer meṛṛa irmad. Ales asenker n usnas i wakken ad yemmed usnifel.</string>
     <string name="media_file_added_to_gallery">Afaylu n umidyat yettwarna ɣer temsikent</string>
     <string name="error_adding_media_file_to_gallery">D awezɣi ad yernu ufaylu n umidyat ɣer temsikent</string>
-    <string name="template_use_other_session_content_description">Seqdec lqem akk aneggaru n ${app_name} ɣef yibenkan-inek·inem-nniḍen: ${app_name} Web, ${app_name} n tnarit, ${app_name} iOS, ${app_name} i Android neɣ amsaɣ-nniḍen n Matrix yessefraken azmul anmidag</string>
+    <string name="use_other_session_content_description">Seqdec lqem akk aneggaru n ${app_name} ɣef yibenkan-inek·inem-nniḍen: ${app_name} Web, ${app_name} n tnarit, ${app_name} iOS, ${app_name} i Android neɣ amsaɣ-nniḍen n Matrix yessefraken azmul anmidag</string>
     <string name="enter_secret_storage_input_key">Fren tasarut-ik·im n tririt, neɣ err-itt s ufus s tira-ines s uasiw neɣ s usenteḍ-ines seg ɣefafus-inek·inem</string>
     <string name="cross_signing_verify_by_emoji">Senqed amyigew s yimujit</string>
     <string name="confirm_your_identity_quad_s">Sentem timagit-inek·inem s usenqed n yinekcam-a, anef-as ad yekcem ɣer yiznan yettwawgelhen.</string>
@@ -2177,11 +2177,11 @@
 \n
 \nTebɣiḍ s tidet ad tkemmleḍ\?</string>
     <string name="disconnect_identity_server_dialog_content">Ffeɣ seg tuqqna n uqeddac n timagit %s\?</string>
-    <string name="template_identity_server_error_outdated_identity_server">Aqeddac-a n timagit iɛedda d aqbur. ${app_name} yessafrak kan API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Aqeddac-a n timagit iɛedda d aqbur. ${app_name} yessafrak kan API V2.</string>
     <string name="identity_server_error_outdated_home_server">Tamahekt-a ulamek tedda. Aqeddac agejdan d aqbur.</string>
     <string name="identity_server_error_no_identity_server_configured">Ma ulac aɣilif qbel deg tazwara swel aqeddac n timagit.</string>
     <string name="identity_server_error_terms_not_signed">Ma ulac aɣilif qbel deg tazwara tiwtilin n uqeddac n timagit deg yiɣewwaren.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">I tɣellist n tbaḍnit-ik·im, ${app_name} yessefrak kan tuzna n yimaylen d wuṭṭunen n tiliɣri yettudwin i useqdac.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">I tɣellist n tbaḍnit-ik·im, ${app_name} yessefrak kan tuzna n yimaylen d wuṭṭunen n tiliɣri yettudwin i useqdac.</string>
     <string name="identity_server_error_binding_error">Assaɣ ur yeddi ara.</string>
     <string name="identity_server_error_no_current_binding_error">Akka tura ulac akk assaɣ d unekcam-a.</string>
     <string name="identity_server_set_default_notice">Aqeddac-ik·im agejdan (%1$s) yefka-d takti n useqdec n %2$s d aqeddac-ik·im n timagit</string>
@@ -2194,7 +2194,7 @@
     <string name="error_opening_banned_room">Ur tezmireḍ ara ad teldiḍ taxxamt ansi i d-tettwagedleḍ.</string>
     <string name="room_error_not_found">Ur nessaweḍ ara ad d-naf taxamt-a. Muqel ma tella d tidet.</string>
     <string name="room_settings_de_prioritize">Senqes deg wazal</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} ur t-iḥuza ara usesfer n uẓru.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} ur t-iḥuza ara usesfer n uẓru.</string>
     <string name="devices_delete_dialog_text">Tamahelt-a tesra asentem-nniḍen.
 \nI ukemmel, ma ulac aɣilif sekcem awal-ik·im uffir.</string>
     <string name="failed_to_load_timeline_position">%s yettaɛraḍ ad d-isali tazmilt tufrint deg tesnakudt n texxamt-a, maca ur yessaweḍ ara ad tt-naf.</string>
@@ -2220,21 +2220,21 @@
     <string name="ssl_unexpected_existing_expl">Aselken yettubeddel deg ubdil n win yettwamanen deg tiliɣri-inek·inem. Aya MAČČI D AYEN IGERRZEN. Issefk UR TETTAQBALEḌ ARA aselkin-a amaynut.</string>
     <string name="ssl_expected_existing_expl">Aselkin yettwabeddel seg win yettwamanen ɣer win ur nettwaman ara. Ahat aqeddac iɛawed-d aselkin-ines. Nermes anedbal n uqeddac ɣef udsil umḍin yetturaǧun.</string>
     <string name="ssl_only_accept">Ur qebbel ara aselkin alamma isuffeɣ-d unedbal n uqeddac adsil umḍin yemṣadan d win yellan ddaw-a.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nTuccḍa yekka nnig tezmert n ${app_name}, akken i d-yenna Google, tuccḍa-a teskan-d belli ibenk ɣer-s aqettun n yisnasen yettwaskelsen s FCM. Tuccḍa ur d-tettili ara ala ma yilin umiḍan n yisnasen aṭas, ɣef waya ur ilaq ara ad tḥaz aseqdac n tlemmast.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nTuccḍa-a tekka nnig tezmert n ${app_name}. Aya yezmer ad d-yili seg waṭas n ssebbat. Ahat ad yeddu ma yella tɛerḍeḍ tikkelt-nniḍen ticki, daɣen tzemreḍ ad tesneqdeḍ ma yella ameẓlu Google Play ur yesɛi ara talast deg useqdec n yisefka deg yiɣewwaren n unagraw, neɣ tamrilt n yibenk-inek·inem tṣeḥḥa, neɣ yezmer ad d-yili waya ɣef Rom tudmawant.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nTuccḍ-a tekka nnig tezmert n ${app_name}. Ulac amiḍan Google ɣe tiliɣri. Ma ulac aɣilif, ldi amsefrak n umiḍan syen rnu amiḍan n Google.</string>
     <string name="settings_troubleshoot_test_battery_failed">Ma yella aseqdac yeǧǧa ibenk ur t-isfurek ara rnu i kra n wakud, s ugdil yensan, ibenk ad yekcem deg uskar Doze. Aya ur yettaǧǧa ara isnasen ad kecmen ɣer uzeṭṭa i wakken ad aznen imahilen, amtawi d tesluɣin tiluganin nsen.</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} ad yemtawi ɣef ugilal sya ɣer da deg yiwen n wakud (yettuswal).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} ad yemtawi ɣef ugilal sya ɣer da deg yiwen n wakud (yettuswal).
 \nAya ad iḥaz aseqdec n ṛṛadyu d uẓru, ad yili wulɣu ad d-yettwaskanen i lebda i d-yemmalen belli ${app_name} yettɛassa ineḍruyen.</string>
     <string name="settings_integrations_summary">Seqdec amsefrak n yimsidaf i usefrek n yibuḍen, n tleggiyin, n yiwiǧiten d yikemmusen n ustiker.
 \nImsefrak n yimsidaf temmsen-d isefka n twila, syen zemren ad snilen iwiǧiten, ad aznen tinubgiwin ɣer teamin yerna ad sbadun iswiren n tezmert s yisem-ik·im.</string>
     <string name="settings_send_markdown_summary">Msel iznan s useqdec n tseddast n markdown send ad ttwaznen. Aya ad isireg amsal leqqayen am useqdec n yizamulen n yitran i uskan n uḍris uknan.</string>
     <string name="settings_send_message_with_enter_summary">Taqeffalt Kcem n unasiw n useɣzan ad tazen izen ideg ara teg angaz gar yizirigen</string>
-    <string name="template_startup_notification_privacy_message">${app_name} yezmer ad yeddu deg ugilal i usefrek n yilɣa-inek·inem s wudem aɣelsan, uslig. Aya yezmer ad iḥaz aseqdec n uẓru.</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} yesra ad yeǧǧ tuqqna s usemdu meẓẓiyen ɣef ugilal i wakken ad d-yawi ilɣa yettwamanen.
+    <string name="startup_notification_privacy_message">${app_name} yezmer ad yeddu deg ugilal i usefrek n yilɣa-inek·inem s wudem aɣelsan, uslig. Aya yezmer ad iḥaz aseqdec n uẓru.</string>
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} yesra ad yeǧǧ tuqqna s usemdu meẓẓiyen ɣef ugilal i wakken ad d-yawi ilɣa yettwamanen.
 \nƔef ugdil i d-iteddun, ad tettusnubegteḍ i wakken ad tmuddeḍ tisirag i ${app_name} ad yeddu i lebda ɣef ugilal, ttxil-k·m qbel.</string>
     <string name="settings_data_save_mode_summary">Askar n usekles n yisefka yessemras imsizdeg afrayan i wakken ileqman n tihawt d yilɣa n tira ad ttwasizedgen.</string>
     <string name="room_settings_labs_warning_message">Tigi d timahilin tarmitanin i izemren ad rẓent s wayen ur nettwaṛǧa ara. Seqdec-itent maca ɣur-k·m.</string>
@@ -2252,14 +2252,14 @@
     <string name="sas_incoming_request_description">Senqed tiɣimit-a i wakken ad tcerḍeḍ fell-as tettwaḍman. Attkal ɣef tɣimiyin n yimendiden yettakk-ak·am-d lehna n uqerru mi ara tesseqdaceḍ iznan yettwawgelhen seg yixef ɣer yixef.</string>
     <string name="sas_error_m_unknown_method">Tiɣimit ur tessaweḍ ara ad teqbel amtawi n tsarut, agbar, MAC neɣ tarrayt SAS</string>
     <string name="room_list_catchup_welcome_body">Af-d iznan ur nettwaɣra ara da</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Taskant n texxamt ara yettwaɣran deg umaḍal ur tettusefrak ara ar tura deg ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Taskant n texxamt ara yettwaɣran deg umaḍal ur tettusefrak ara ar tura deg ${app_name}</string>
     <string name="settings_push_gateway_no_pushers">Ulac tinezgarin push ikelsen</string>
     <string name="send_file_step_sending_thumbnail">Tuzna n tenfult (%1$s / %2$s)</string>
     <string name="labs_swipe_to_reply_in_timeline">Rmed afraḍ i tririt deg tesnakudt</string>
     <string name="settings_discovery_no_terms">Aqeddac n timagit i tferneḍ ulac ɣer-s akk tiwtilin n yimeẓla. Ur ttkemmil ara ala ma yella tettekleḍ ɣef umeẓlu</string>
     <string name="labs_allow_extended_logging_summary">Iɣmisen ɣezzifen ad ɛawnen ineflayen s umuddu n wugar n yiɣemisen mi ara tazneḍ aneqqis RageShake, ula ma yili yermed asnas ur yettazen ara agbur n yiznan neɣ isefka-nniḍen usligen.</string>
     <string name="error_network_timeout">Akka d-yettban aqeddac yettaṭṭaf aṭas n wakud ɣef tririt. Yezmer aya yekka-d seg yir tuqqna neɣ seg tuccḍa deg uqeddac. Ma ulac aɣilif ɛreḍ tikkelt-nniḍen ticki.</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Tiɣimit-a tamirant n useqdac %1$s ma d kečč·kemm ad tesnetmeḍ inekcam i useqdac %2$s. Aya ur t-yessefrak ara ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">Tiɣimit-a tamirant n useqdac %1$s ma d kečč·kemm ad tesnetmeḍ inekcam i useqdac %2$s. Aya ur t-yessefrak ara ${app_name}.
 \nMa ulac aɣilif, deg tazwara sfeḍ isefka, syen kcem tikkelt-nniḍen s umiḍan-nniḍen.</string>
     <string name="settings_developer_mode_summary">Askar n uneflay yermed timahilin i yeffren yerna yezmer daɣen ad yerr asnas ur yerkid ara akken iwata. I yineflayen kan!</string>
     <string name="settings_developer_mode_fail_fast_title">Abrir arurad</string>
@@ -2290,7 +2290,7 @@
     <string name="warning_room_not_created_yet">Mazal ur tettwarna ara texxamt ar tura. Sefsex timerna n texxamt\?</string>
     <string name="invalid_qr_code_uri">Tangalt QR d tarameɣtut (URI d arameɣtu)!</string>
     <string name="settings_security_pin_code_change_pin_summary">Senfel PIN inek·inem amiran</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Tangalt PIN tettusra yal mi ara teldiḍ ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Tangalt PIN tettusra yal mi ara teldiḍ ${app_name}.</string>
     <string name="warning_unsaved_change">Llan yisenfal ur nettusekles ara. Sefsex isenfal\?</string>
     <string name="room_settings_set_avatar">Sbadu avaṭar</string>
     <string name="matrix_to_card_title">Aseɣwen n Matrix</string>
@@ -2327,8 +2327,8 @@
     <string name="user_code_scan">Smiḍen tangalt QR</string>
     <string name="room_alias_address_hint">Tansa tamynut i d-yettusuffɣen (am. #alias:server)</string>
     <string name="direct_room_user_list_suggestions_title">Isumar</string>
-    <string name="template_invite_friends_rich_title">🔐️ Rnu-d ɣur-i ɣer ${app_name}</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">Tangalt PIN d nettat kan i d ttawil s wayes ara teldiḍ ${app_name}.</string>
+    <string name="invite_friends_rich_title">🔐️ Rnu-d ɣur-i ɣer ${app_name}</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">Tangalt PIN d nettat kan i d ttawil s wayes ara teldiḍ ${app_name}.</string>
     <string name="add_a_topic_link_text">Rnu asentel</string>
     <string name="invite_friends">Snubget-d imeddukkal</string>
     <string name="user_code_my_code">Tangalt-inu</string>
@@ -2362,7 +2362,7 @@
         <item quantity="one">%d tinubga</item>
         <item quantity="other">%d n tnubgiwin</item>
     </plurals>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Tangalt PIN tettusra seld 2 tesdatin n war aseqdec n ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Tangalt PIN tettusra seld 2 tesdatin n war aseqdec n ${app_name}.</string>
     <string name="direct_room_profile_not_encrypted_subtitle">Iznan dagi ur ttwawgelhen ara seg yixef ɣer yixef</string>
     <string name="qr_code_not_scanned">Tangalt QR ur tettusmiḍen ara!</string>
     <string name="user_code_share">Bḍu tangalt-inu</string>

--- a/vector/src/main/res/values-ko/strings.xml
+++ b/vector/src/main/res/values-ko/strings.xml
@@ -195,7 +195,7 @@
     <string name="done">완료</string>
     <string name="action_sign_out_confirmation_simple">정말 로그아웃하시겠습니까\?</string>
     <string name="action_mark_room_read">읽음으로 표시</string>
-    <string name="template_no_contact_access_placeholder">${app_name}이 연락처에 접근할 수 없게 되어 있습니다</string>
+    <string name="no_contact_access_placeholder">${app_name}이 연락처에 접근할 수 없게 되어 있습니다</string>
     <plurals name="public_room_nb_users">
         <item quantity="other">%d명의 사용자</item>
     </plurals>
@@ -311,7 +311,7 @@
     <string name="e2e_re_request_encryption_key">다른 기기에서 온 <u>다시 요청된 암호 키</u>.</string>
     <string name="e2e_re_request_encryption_key_sent">키 요청을 보냈습니다.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">요청 보냄</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">다른 기기에서 ${app_name}을 설치해서 메시지를 암호화하고 이 기기로 키를 보내도록 합니다.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">다른 기기에서 ${app_name}을 설치해서 메시지를 암호화하고 이 기기로 키를 보내도록 합니다.</string>
     <string name="read_receipts_list">읽은 기록 읽기</string>
     <string name="groups_list">그룹 목록</string>
     <plurals name="membership_changes">
@@ -331,7 +331,7 @@
     <string name="room_info_room_name">방 이름</string>
     <string name="room_info_room_topic">방 주제</string>
     <string name="settings_call_category">전화</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">수신 전화에 ${app_name} 기본 벨소리를 사용합니다</string>
+    <string name="settings_call_ringtone_use_app_ringtone">수신 전화에 ${app_name} 기본 벨소리를 사용합니다</string>
     <string name="settings_call_ringtone_title">수신 전화 벨소리</string>
     <string name="settings_call_ringtone_dialog_title">전화에 사용할 벨소리를 선택하세요:</string>
     <string name="call">전화</string>
@@ -351,22 +351,22 @@
     <string name="media_picker_both_capture_title">사진이나 영상 촬영</string>
     <string name="media_picker_cannot_record_video">영상을 촬영할 수 없음</string>
     <string name="permissions_rationale_popup_title">정보</string>
-    <string name="template_permissions_rationale_msg_storage">첨부 파일을 보내고 저장하려면 ${app_name}은 영상과 사진 보관함에 접근하는 권한이 필요합니다.
+    <string name="permissions_rationale_msg_storage">첨부 파일을 보내고 저장하려면 ${app_name}은 영상과 사진 보관함에 접근하는 권한이 필요합니다.
 \n
 \n당신의 휴대 전화에서 파일을 보내려면 다음 팝업에서 접근을 허용해주세요.</string>
-    <string name="template_permissions_rationale_msg_camera">사진을 찍고 영상 통화를 하려면 ${app_name}은 카메라에 접근하는 권한이 필요합니다.</string>
+    <string name="permissions_rationale_msg_camera">사진을 찍고 영상 통화를 하려면 ${app_name}은 카메라에 접근하는 권한이 필요합니다.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \n전화를 하려면 다음 팝업에서 접근을 허용해주세요."</string>
-    <string name="template_permissions_rationale_msg_record_audio">음성 통화를 하려면 ${app_name}은 마이크에 접근하는 권한이 필요합니다.</string>
+    <string name="permissions_rationale_msg_record_audio">음성 통화를 하려면 ${app_name}은 마이크에 접근하는 권한이 필요합니다.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \n전화를 하려면 다음 팝업에서 접근을 허용해주세요."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">영상 통화를 하려면 ${app_name}은 카메라와 마이크에 접근하는 권한이 필요합니다.
+    <string name="permissions_rationale_msg_camera_and_audio">영상 통화를 하려면 ${app_name}은 카메라와 마이크에 접근하는 권한이 필요합니다.
 \n
 \n전화를 하려면 다음 팝업에서 접근을 허용해주세요.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name}은 당신의 연락처를 확인해서 이메일과 전화번호를 기반으로 다른 Matrix 사용자를 찾을 수 있습니다. 이런 이유로 연락처를 공유하는 것을 허용한다면, 다음 팝업에서 접근을 허용해주세요.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">"${app_name}은  당신의 연락처를 확인하여 이메일과 전화번호를 기반으로 다른 Matrix 사용자를 찾을 수 있습니다.
+    <string name="permissions_rationale_msg_contacts">${app_name}은 당신의 연락처를 확인해서 이메일과 전화번호를 기반으로 다른 Matrix 사용자를 찾을 수 있습니다. 이런 이유로 연락처를 공유하는 것을 허용한다면, 다음 팝업에서 접근을 허용해주세요.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">"${app_name}은  당신의 연락처를 확인하여 이메일과 전화번호를 기반으로 다른 Matrix 사용자를 찾을 수 있습니다.
 \n 
 \n이런 이유로 연락처를 공유하는 것을 허용하겠습니까\?"</string>
     <string name="permissions_action_not_performed_missing_permissions">죄송합니다. 권한이 없어서, 작업이 수행되지 않았습니다</string>
@@ -560,7 +560,7 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">켜기</string>
     <string name="settings_troubleshoot_test_device_settings_title">기기 설정.</string>
     <string name="settings_troubleshoot_test_device_settings_success">알림이 이 기기에서 켜집니다.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">알림이 이 기기에서 허용되지 않습니다.
+    <string name="settings_troubleshoot_test_device_settings_failed">알림이 이 기기에서 허용되지 않습니다.
 \n${app_name} 설정을 확인해주세요.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">켜기</string>
     <string name="settings_troubleshoot_test_bing_settings_title">맞춤 설정.</string>
@@ -570,7 +570,7 @@
     <string name="settings_troubleshoot_test_bing_settings_quickfix">설정 확인</string>
     <string name="settings_troubleshoot_test_play_services_title">Play 서비스 확인</string>
     <string name="settings_troubleshoot_test_play_services_success">Google Play 서비스 APK는 최신 버전입니다.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name}은 Google Play 서비스를 사용해 푸시 메시지를 보내지만 올바르게 설정되지 않은 모양입니다:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name}은 Google Play 서비스를 사용해 푸시 메시지를 보내지만 올바르게 설정되지 않은 모양입니다:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Play 서비스 고치기</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase 토큰</string>
@@ -578,11 +578,11 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">FCM 토큰을 검색하는데 실패했습니다:
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \n이 오류는 ${app_name}의 통제 밖에 있으며 Google과 관련이 있습니다, 이 오류는 기기가 FCM에 등록된 앱이 너무 많다는 것을 나타냅니다. 오류는 수 많은 앱이 있는 경우에만 발생하고, 일반 사용자에게 영향을 미치지 않아야 합니다.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \n이 오류는 ${app_name}의 통제 밖입니다. 여러 이유로 발생할 수 있습니다. 나중에 다시 시도하면 작동할 지도 모릅니다, 시스템 설정에서 Google Play 서비스의 데이터 사용이 제한되었는지, 기기의 시간은 맞는 지 확인해보세요, 혹은 커스텀 롬 환경에서 발생할 수 있습니다.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \n이 오류는 ${app_name}의 통제 밖에 있습니다. 휴대 전화에 Google 계정이 없습니다. 계정 관리자를 열어 Google 계정을 추가하세요.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">계정 추가</string>
     <string name="settings_troubleshoot_test_token_registration_title">토큰 등록</string>
@@ -594,17 +594,17 @@
     <string name="settings_troubleshoot_test_service_restart_failed">서비스 다시 시작에 실패함</string>
     <string name="settings_troubleshoot_test_service_boot_title">부팅 시 시작</string>
     <string name="settings_troubleshoot_test_service_boot_success">기기가 다시 시작되면 서비스가 시작됩니다.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">기기가 다시 시작될 때 서비스가 시작되지 않습니다, 다시 시작한 후 ${app_name}을 한 번이라도 열지 않으면 알림을 받을 수 없습니다.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">기기가 다시 시작될 때 서비스가 시작되지 않습니다, 다시 시작한 후 ${app_name}을 한 번이라도 열지 않으면 알림을 받을 수 없습니다.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">부팅 시 시작 활성화</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">백그라운드 제한 사항 확인</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">${app_name}에 대한 백그라운드 제한 사항을 비활성화합니다. 이 테스트는 모바일 데이터를 사용해야 합니다 (WIFI 없음).
+    <string name="settings_troubleshoot_test_bg_restricted_success">${app_name}에 대한 백그라운드 제한 사항을 비활성화합니다. 이 테스트는 모바일 데이터를 사용해야 합니다 (WIFI 없음).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">${app_name}에 대한 백그라운드 제한 사항이 활성화됩니다.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">${app_name}에 대한 백그라운드 제한 사항이 활성화됩니다.
 \n앱이 백그라운드에서 작업하는 동안 앱이 시도하는 작업은 적극적으로 제한되며, 이는 알림에 영향을 줄 수 있습니다.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">제한 사항 비활성화</string>
     <string name="settings_troubleshoot_test_battery_title">배터리 최적화</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name}은 배터리 최적화의 영향을 받지 않습니다.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name}은 배터리 최적화의 영향을 받지 않습니다.</string>
     <string name="settings_troubleshoot_test_battery_failed">사용자가 기기 화면을 끈 상태로 일정 시간 동안 연결되지 않은 상태로 두면, 기기는 Doze 모드에 들어갑니다. 이렇게 하면 앱이 네트워크에 접근하지 못하고 작업, 동기화 및 표준 경보가 지연됩니다.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">최적화 무시하기</string>
     <string name="settings_notification_privacy_normal">보통</string>
@@ -681,17 +681,17 @@
     <string name="settings_deactivate_account_section">계정 비활성화</string>
     <string name="settings_deactivate_my_account">내 계정 비활성화</string>
     <string name="startup_notification_privacy_title">알림 개인 정보</string>
-    <string name="template_startup_notification_privacy_message">${app_name}은 백그라운드에서 실행되어 알림을 안전하고 은밀하게 관리할 수 있습니다. 이것은 배터리 사용량에 영향을 줄 수 있습니다.</string>
+    <string name="startup_notification_privacy_message">${app_name}은 백그라운드에서 실행되어 알림을 안전하고 은밀하게 관리할 수 있습니다. 이것은 배터리 사용량에 영향을 줄 수 있습니다.</string>
     <string name="startup_notification_privacy_button_grant">권한 부여</string>
     <string name="startup_notification_privacy_button_other">다른 설정을 선택하세요</string>
     <string name="startup_notification_fdroid_battery_optim_title">백그라운드 연결</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name}은 신뢰가 있는 알림을 위해 낮은 영향의 백그라운드 연결을 유지해야 합니다.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name}은 신뢰가 있는 알림을 위해 낮은 영향의 백그라운드 연결을 유지해야 합니다.
 \n다른 화면에서 ${app_name}이 항상 백그라운드에서 실행하도록 허용하는 메시지가 표시됩니다, 수락해주세요.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">권한 부여</string>
     <string name="settings_analytics">정보 분석</string>
     <string name="settings_opt_in_of_analytics">정보 분석 데이터 보내기</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name}은 애플리케이션을 개선할 수 있도록 익명의 분석을 수집합니다.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">분석을 활성화해서 ${app_name}이 개선할 수 있도록 도와주세요.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name}은 애플리케이션을 개선할 수 있도록 익명의 분석을 수집합니다.</string>
+    <string name="settings_opt_in_of_analytics_prompt">분석을 활성화해서 ${app_name}이 개선할 수 있도록 도와주세요.</string>
     <string name="settings_opt_in_of_analytics_ok">예, 저도 돕고 싶습니다!</string>
     <string name="settings_data_save_mode">데이터 절약 모드</string>
     <string name="settings_data_save_mode_summary">데이터 절약 모드는 특정 필터를 적용하여 현재 상태 업데이트와 입력 중 알림을 걸러냅니다.</string>
@@ -1046,7 +1046,7 @@
     <string name="passphrase_passphrase_does_not_match">암호가 맞지 않음</string>
     <string name="passphrase_empty_error_message">암호를 입력하세요</string>
     <string name="passphrase_passphrase_too_weak">암호가 너무 약합니다</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">${app_name}으로 복구 키를 생성하려면 암호를 지워주세요.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">${app_name}으로 복구 키를 생성하려면 암호를 지워주세요.</string>
     <string name="keys_backup_no_session_error">이용할 수 있는 Matrix 세션이 없음</string>
     <string name="keys_backup_setup_step1_title">암호화된 메시지를 잃지 마세요</string>
     <string name="keys_backup_setup_step1_description">암호화된 방의 메시지는 종단간 암호화로 보호됩니다. 자신과 수신자만이 메시지를 읽을 수 있는 키를 갖습니다.
@@ -1154,7 +1154,7 @@
     <string name="keys_backup_info_title_signature">서명</string>
     <string name="autodiscover_invalid_response">잘못된 홈서버 검색 응답</string>
     <string name="autodiscover_well_known_autofill_dialog_title">자동 완성 서버 설정</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name}이 userId 도메인 \"%1$s\"에 대한 맞춤 서버 설정을 감지했습니다:
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name}이 userId 도메인 \"%1$s\"에 대한 맞춤 서버 설정을 감지했습니다:
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">설정 사용</string>
     <string name="invalid_or_expired_credentials">올바르지 않거나 만료된 자격 때문에 로그아웃되었습니다.</string>
@@ -1226,7 +1226,7 @@
     <string name="please_wait">기다려주세요…</string>
     <string name="group_all_communities">모든 커뮤니티</string>
     <string name="room_preview_no_preview">이 방은 미리 볼 수 없습니다</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">세계가 읽을 수 있는 방의 미리보기는 아직 ${app_name}X에서 지원하지 않습니다</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">세계가 읽을 수 있는 방의 미리보기는 아직 ${app_name}X에서 지원하지 않습니다</string>
     <string name="fab_menu_create_room">방</string>
     <string name="fab_menu_create_chat">다이렉트 메시지</string>
     <string name="create_room_title">새 방</string>
@@ -1319,10 +1319,10 @@
     <string name="invite_no_identity_server_error">이 작업을 하려면 설정에서 ID 서버를 추가하세요.</string>
     <string name="settings_background_fdroid_sync_mode">백그라운드 동기화 모드 (실험적)</string>
     <string name="settings_background_fdroid_sync_mode_battery">배터리에 최적화됨</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name}은 기기의 제한된 자원 (배터리)을 유지하기 위해 백그라운드에서 동기화합니다.
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name}은 기기의 제한된 자원 (배터리)을 유지하기 위해 백그라운드에서 동기화합니다.
 \n기기 자원 상태에 따라 운영체제에 의해 동기화는 지연될 수 있습니다.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">실시간으로 최적화됨</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name}은 (설정할 수 있는) 특정 시간에 주기적으로 백그라운드에거 동기화됩니다.
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name}은 (설정할 수 있는) 특정 시간에 주기적으로 백그라운드에거 동기화됩니다.
 \n이는 라디오와 배터리 사용에 영향을 주며 ${app_name}이 이벤트를 수신하고 있는 상태라는 알림이 영구적으로 표시됩니다.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">백그라운드 동기화 없음</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">앱이 백그라운드에 있을 때 수신 메시지의 알림을 받지 않습니다.</string>
@@ -1406,12 +1406,12 @@
     <string name="content_reported_as_inappropriate_content">이 내용을 부적절한 문자로 신고했습니다.
 \n
 \n이 사용자의 내용을 더 이상 보고 싶지 않다면, 사용자를 차단하거나 메시지를 감출 수 있습니다.</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name}은 종단간 키를 디스크에 저장하려면 권한이 필요합니다.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name}은 종단간 키를 디스크에 저장하려면 권한이 필요합니다.
 \n
 \n키를 수동으로 내보내려면 다음 팝업에서 접근을 허용해주세요.</string>
     <string name="no_network_indicator">현재 네트워크 연결이 없습니다</string>
     <string name="settings_add_3pid_confirm_password_title">비밀번호가 정확하지 않습니다</string>
-    <string name="template_settings_add_3pid_flow_not_supported">라이엇 모바일에서 불가능한 것입니다</string>
+    <string name="settings_add_3pid_flow_not_supported">라이엇 모바일에서 불가능한 것입니다</string>
     <string name="settings_add_3pid_authentication_needed">인증이 요구됩니다</string>
     <string name="settings_integrations">통합</string>
     <string name="settings_integration_allow">통합 수락</string>
@@ -1486,7 +1486,7 @@
     <string name="settings_active_sessions_show_all">모든 세션 보기</string>
     <string name="settings_active_sessions_list">활성 세션</string>
     <string name="settings_security_application_protection_screen_title">보안 설정</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">${app_name}을 2분 동안 사용하지 않으면 PIN을 사용하도록 설정합니다.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">${app_name}을 2분 동안 사용하지 않으면 PIN을 사용하도록 설정합니다.</string>
     <string name="settings_security_pin_code_grace_period_title">2분 후 PIN 잠금</string>
     <string name="settings_security_pin_code_notifications_summary_on">방 이름이나 메시지 내용같은 자세한 정보를 표시합니다.</string>
     <string name="settings_security_pin_code_notifications_title">알림에 내용 표시</string>

--- a/vector/src/main/res/values-lv/strings.xml
+++ b/vector/src/main/res/values-lv/strings.xml
@@ -304,7 +304,7 @@
     <string name="local_address_book_header">Vietējā adrešu grāmata</string>
     <string name="matrix_only_filter">Vienīgi Matrix kontakti</string>
     <string name="no_conversation_placeholder">Nav sarunu</string>
-    <string name="template_no_contact_access_placeholder">Tu neesi atļāvis/usi ${app_name} piekļūt taviem vietējiem kontaktiem</string>
+    <string name="no_contact_access_placeholder">Tu neesi atļāvis/usi ${app_name} piekļūt taviem vietējiem kontaktiem</string>
     <string name="no_result_placeholder">Nav rezultātu</string>
     <string name="rooms_header">Istabas</string>
     <string name="rooms_directory_header">Istabu katalogs</string>
@@ -457,24 +457,24 @@
     <string name="media_picker_both_capture_title">Uzņemt foto vai video</string>
     <string name="media_picker_cannot_record_video">Neizdodas ierakstīt video</string>
     <string name="permissions_rationale_popup_title">Element informācija</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} nepieciešama atļauja piekļūt jūsu fotoattēlu un video bibliotēkai, lai nosūtītu un saglabātu pielikumus.
+    <string name="permissions_rationale_msg_storage">${app_name} nepieciešama atļauja piekļūt jūsu fotoattēlu un video bibliotēkai, lai nosūtītu un saglabātu pielikumus.
 \n
 \nLūdzu, atļaujiet piekļuvi nākamajā uznirstošajā logā, lai varētu nosūtīt failus no sava tālruņa.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name}-am nepieciešama atļauja piekļūt kamerai, lai uzņemtu foto un nodrošinātu video zvanus.</string>
+    <string name="permissions_rationale_msg_camera">${app_name}-am nepieciešama atļauja piekļūt kamerai, lai uzņemtu foto un nodrošinātu video zvanus.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nLūdzu dot piekļuves atļauju nākamajā uznirstošajā logā, lai būtu iespēja veikt zvanus."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name}-am nepieciešama atļauja piekļūt mikrofonam, lai nodrošinātu audio zvanus.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name}-am nepieciešama atļauja piekļūt mikrofonam, lai nodrošinātu audio zvanus.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nLūdzu dod piekļuves atļauju nākamajā uznirstošajā logā, lai būtu iespēja veikt zvanus."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} nepieciešama atļauja piekļūt kamerai un mikrofonam, lai veiktu videozvanus.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} nepieciešama atļauja piekļūt kamerai un mikrofonam, lai veiktu videozvanus.
 \n
 \nLūdzu, dodiet piekļuves atļauju nākamajā uznirstošajā logā, lai būtu iespēja veikt zvanus.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name}-am nepieciešama atļauja piekļūt kontaktiem, lai varētu atrast citus lietotājus tīklā pēc to epasta adreses vai tālruņa #.
+    <string name="permissions_rationale_msg_contacts">${app_name}-am nepieciešama atļauja piekļūt kontaktiem, lai varētu atrast citus lietotājus tīklā pēc to epasta adreses vai tālruņa #.
 
 Lūdzu dod piekļuves atļauju nākamajā uznirstošajā logā, lai būtu iespēja atrast Tavus kontaktus, kuri ir sasniedzami ${app_name}ā.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} var pārbaudīt jūsu adrešu grāmatu, lai atrastu citus Matrix lietotājus pāc viņu epasta adresēm un tālruņa numuriem.
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} var pārbaudīt jūsu adrešu grāmatu, lai atrastu citus Matrix lietotājus pāc viņu epasta adresēm un tālruņa numuriem.
 \n
 \nVai piekrītat koplietot savu adrešu grāmatu šim nolūkam\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Atvaino… Darbība nav veikta dēļ nepietiekamām piekļuves atļaujām</string>
@@ -1140,7 +1140,7 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="settings_emails_empty">Jūsu kontam nav pievienota neviena epasta adrese</string>
     <string name="settings_emails">Epasta adreses</string>
     <string name="settings_add_3pid_authentication_needed">Nepieciešama autentifikācija</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Jūs nevarat to izdarīt ar ${app_name} mobile</string>
+    <string name="settings_add_3pid_flow_not_supported">Jūs nevarat to izdarīt ar ${app_name} mobile</string>
     <string name="settings_add_3pid_confirm_password_title">Apstipriniet paroli</string>
     <string name="settings_phone_number_empty">Jūsu kontam nav pievienots neviens tālruņa numurs</string>
     <string name="room_sliding_menu_version_x">Versija %s</string>
@@ -1469,8 +1469,8 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="secure_backup_reset_all">Pilna atiestatīšana</string>
     <string name="bad_passphrase_key_reset_all_action">Aizmirsāt vai pazaudējāt visas atkopšanās iespējas\? Atiestatiet visu</string>
     <string name="enter_secret_storage_passphrase_or_key">Izmantojiet savu %1$s vai savu %2$s, lai turpinātu.</string>
-    <string name="template_use_latest_app">Izmantojiet jaunāko ${app_name} citās savās ierīcēs:</string>
-    <string name="template_use_other_session_content_description">Izmantojiet jaunāko ${app_name} citās savās ierīcēs, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} Android, vai kādu citu Matrix lietotni ar cross-signing atbalstu</string>
+    <string name="use_latest_app">Izmantojiet jaunāko ${app_name} citās savās ierīcēs:</string>
+    <string name="use_other_session_content_description">Izmantojiet jaunāko ${app_name} citās savās ierīcēs, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} Android, vai kādu citu Matrix lietotni ar cross-signing atbalstu</string>
     <string name="change_password_summary">Iestatiet jaunu konta paroli…</string>
     <string name="this_is_the_beginning_of_dm">Šis ir sākums jūsu tiešās sarakstes vēsturei ar %s.</string>
     <string name="this_is_the_beginning_of_room_no_name">Šis ir šīs sarakstes pats sākums.</string>
@@ -1837,7 +1837,7 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="settings_troubleshoot_test_fcm_failed">FCM žetons netika saņemts:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_token_registration_title">Žetona Reģistrācija</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} izmanto Google Play pakalpojumus, lai nodrošinātu ziņu pakalpojumu, bet tas nešķiet pareizi konfigurēts:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} izmanto Google Play pakalpojumus, lai nodrošinātu ziņu pakalpojumu, bet tas nešķiet pareizi konfigurēts:
 \n%1$s</string>
     <string name="no_sticker_application_dialog_content">Jums pašlaik nav iespējotas uzlīmes.
 \n
@@ -1864,11 +1864,11 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="settings_troubleshoot_test_notification_title">Notifikāciju Displejs</string>
     <string name="settings_troubleshoot_test_play_services_success">Google Play Servisu APK ir pieejams un atjaunināts.</string>
     <string name="search_banned_user_hint">Filtrēt aizliegtos lietotājus</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Lūdzu palaidiet ${app_name} citā ierīcē, kas var atšifrēt ziņu, lai tā varētu nosūtīt šīs sesijas atslēgas.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Lūdzu palaidiet ${app_name} citā ierīcē, kas var atšifrēt ziņu, lai tā varētu nosūtīt šīs sesijas atslēgas.</string>
     <string name="error_unauthorized">Neautorizēts, trūkstošas autentifikācijas apliecības</string>
     <string name="error_no_external_application_found">Atvainojiet, nav atrasta ārēja aplikācija, lai pabeigtu šo darbību.</string>
     <string name="go_on_with">turpināt ar…</string>
-    <string name="template_call_failed_no_connection">${app_name} Zvans Neizdevās</string>
+    <string name="call_failed_no_connection">${app_name} Zvans Neizdevās</string>
     <string name="call_failed_dont_ask_again">Nejautāt man atkal</string>
     <string name="call_failed_no_ice_use_alt">Mēģiniet izmantot %s</string>
     <string name="send_bug_report_include_key_share_history">Sūtīt atslēgu dalības vēsturi</string>
@@ -2003,15 +2003,15 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="room_alias_published_alias_add_manually">Publicēt jaunu adresi manuāli</string>
     <string name="room_alias_published_alias_main">Šī ir galvenā adrese</string>
     <string name="settings_without_flair">Jūs pašlaik neesat kādas kopienas dalībnieks.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Lūdzu, ieslēdziet analītiku, lai palīdzētu mums uzlabot ${app_name}.</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} apkopo anonīmu analītiku, lai ļautu mums uzlabot aplikāciju.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Lūdzu, ieslēdziet analītiku, lai palīdzētu mums uzlabot ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} apkopo anonīmu analītiku, lai ļautu mums uzlabot aplikāciju.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Iedot atļauju</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} ir nepieciešams fona savienojums, lai spētu laicīgi piegādāt notifikācijas.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} ir nepieciešams fona savienojums, lai spētu laicīgi piegādāt notifikācijas.
 \nNākamajā ekrānā tiks piedāvāts atļaut ${app_name}, lai vienmēr darbotos fonā, lūdzu piekrītat.</string>
     <string name="startup_notification_fdroid_battery_optim_title">Fona savienojums</string>
     <string name="startup_notification_privacy_button_other">Izvēlaties citu opciju</string>
     <string name="startup_notification_privacy_button_grant">Dot atļauju</string>
-    <string name="template_startup_notification_privacy_message">${app_name} var darboties fonā, lai droši un privāti pārvaldītu jūsu paziņojumus. Tas var ietekmēt akumulatora izmantošanu.</string>
+    <string name="startup_notification_privacy_message">${app_name} var darboties fonā, lai droši un privāti pārvaldītu jūsu paziņojumus. Tas var ietekmēt akumulatora izmantošanu.</string>
     <string name="startup_notification_privacy_title">Notifikāciju Privātums</string>
     <string name="reset_secure_backup_warning">Šis aizvietos jūsu esošo Atslēgu vai Frāzi.</string>
     <string name="reset_secure_backup_title">Izveidot jaunu Drošības Atslēgu vai iestatīt jaunu Drošības Frāzi jūsu esošajam dublējumam.</string>
@@ -2041,12 +2041,12 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Salabot Play Servisus</string>
     <string name="error_threepid_auth_failed">Pārliecinieties, ka esat nospiedis uz saites e-pasta ziņojumā, ko esam nosūtījuši jums.</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimizēts akumulatoram</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} sinhronizēsies fonā, tā lai ietaupītu telefona bateriju.
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} sinhronizēsies fonā, tā lai ietaupītu telefona bateriju.
 \nAtkarībā no ierīces baterijas stāvokļa, sinhronizāciju var atcelt operētājsistēma.</string>
     <string name="settings_notification_privacy_need_permission">Aplikācijai vajag atļauju, lai strādātu fonā</string>
     <string name="settings_notification_privacy_reduced">Samazināts privātums</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignorēt optimizāciju</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} neietekmē akumulatora optimizācija.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} neietekmē akumulatora optimizācija.</string>
     <string name="settings_troubleshoot_test_battery_title">Akumulatora Optimizācija</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Ieslēgt Aplikācijas palaišanu kopā ar telefonu</string>
     <string name="settings_troubleshoot_test_play_services_title">Play Servisu Pārbaude</string>
@@ -2055,7 +2055,7 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed">Daži paziņojumi ir izslēgti jūsu pielāgotos iestatījumos.</string>
     <string name="settings_troubleshoot_test_bing_settings_success_with_warn">Ievērojiet, ka daži ziņojumi ir iestatīti kā klusi (paziņojumi pienāks bez skaņas).</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Pielāgoti Iestatījumi.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Paziņojumi nav ieslēgti šai sesijai.
+    <string name="settings_troubleshoot_test_device_settings_failed">Paziņojumi nav ieslēgti šai sesijai.
 \nLūdzu, pārbaudiet ${app_name} iestatījumus.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Paziņojumi ir ieslēgti šai sesijai.</string>
     <string name="settings_troubleshoot_test_device_settings_title">Sesijas Iestatījumi.</string>
@@ -2084,7 +2084,7 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="settings_call_ringtone_title">Ienākoša zvana signāls</string>
     <string name="settings_call_ringtone_use_default_stun_sum">Izmantos %s kā rezervi, kad jūsu mājasservers nepiedāvā vienu (jūsu IP adrese tiks dalīta sarunas laikā)</string>
     <string name="settings_call_ringtone_use_default_stun">Atļaut rezerves zvanu palīdzības serveri</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Izmantot noklusējuma $ {app_name} zvana signālu ienākošajiem zvaniem</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Izmantot noklusējuma $ {app_name} zvana signālu ienākošajiem zvaniem</string>
     <string name="settings_call_show_confirmation_dialog_summary">Pirms zvana uzsākšanas lūgt apstiprinājumu</string>
     <string name="settings_call_show_confirmation_dialog_title">Novērst nejaušu zvanu</string>
     <string name="login_error_ssl_handshake">Jūsu ierīce izmanto novecojušu TLS drošības protokolu, jūsu drošībai jūs nevarēsiet savienoties</string>
@@ -2128,7 +2128,7 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="set_recovery_passphrase">Iestatīt kā %s</string>
     <string name="recovery_passphrase">Atjaunošanas Frāze</string>
     <string name="e2e_use_keybackup">Atbloķēt šifrēto ziņu vēsturi</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Atslēgas jau ir atjauninātas!</string>
     <string name="event_redacted_by_admin_reason_with_reason">Pasākumu moderē telpas administrators, iemesls: %1$s</string>
     <string name="event_redacted_by_user_reason_with_reason">Lietotājs izdzēsa notikumu, iemesls: %1$s</string>
@@ -2288,11 +2288,11 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="settings_discovery_manage">Pārvaldiet atklāšanas iestatījumus.</string>
     <string name="settings_discovery_category">Atklāšana</string>
     <string name="settings_preview_media_before_sending">Priekšskatīt failu pirms nosūtīšanas</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} sinhronizēsies fonā periodiski, precīzi, noteiktā laikā (konfigurējams).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} sinhronizēsies fonā periodiski, precīzi, noteiktā laikā (konfigurējams).
 \nTas ietekmēs radio un akumulatora izmantošanu, tiks parādīts pastāvīgs paziņojums par to, ka ${app_name} klausās notikumus.</string>
     <string name="settings_notification_privacy_fcm">• Paziņojumi tiek nosūtīti, izmantojot Firebase Cloud Messaging</string>
     <string name="settings_troubleshoot_test_battery_failed">Ja lietotājs kādu laiku atstāj ierīci atvienotu no tīkla un nekustīgu, ar izslēgtu ekrānu, ierīcē tiek ieslēgts dīkstāves režīms. Tas neļauj lietotnēm piekļūt tīklam un atliek to darbu izpildi, sinhronizāciju un standarta trauksmes signālus.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Pakalpojums nesāksies, kad ierīce tiks restartēta, jūs nesaņemsiet paziņojumus, kamēr vismaz vienreiz nebūsiet atvēris ${app_name}.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Pakalpojums nesāksies, kad ierīce tiks restartēta, jūs nesaņemsiet paziņojumus, kamēr vismaz vienreiz nebūsiet atvēris ${app_name}.</string>
     <string name="settings_troubleshoot_test_notification_notice">Lūdzu, noklikšķiniet uz paziņojuma. Ja paziņojums nav redzams, pārbaudiet sistēmas iestatījumus.</string>
     <plurals name="room_details_selected">
         <item quantity="zero">%d izvēlēti</item>
@@ -2437,7 +2437,7 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="identity_server_set_alternative_notice">Varat arī ievadīt jebkuru citu identitātes servera URL.</string>
     <string name="identity_server_set_default_submit">Izmantot %1$s</string>
     <string name="identity_server_set_default_notice">Jūsu mājasserveris (%1$s) ierosina identitātes serverim izmantot %2$s</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Jūsu privātuma dēļ ${app_name} atbalsta tikai šifrētu lietotāja e-pasta vēstules un tālruņa numura nosūtīšanu.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Jūsu privātuma dēļ ${app_name} atbalsta tikai šifrētu lietotāja e-pasta vēstules un tālruņa numura nosūtīšanu.</string>
     <string name="identity_server_error_terms_not_signed">Vispirms iestatījumos pieņemiet identitātes servera noteikumus.</string>
     <string name="identity_server_error_no_identity_server_configured">Vispirms konfigurējiet identitātes serveri.</string>
     <string name="identity_server_error_outdated_home_server">Šī darbība nav iespējama. Mājasserveris ir novecojis.</string>
@@ -2445,8 +2445,8 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="choose_locale_other_locales_title">Citas pieejamās valodas</string>
     <string name="choose_locale_current_locale_title">Pašreizējā valoda</string>
     <string name="invitations_sent_to_two_users">Uzaicinājumi nosūtīti uz %1$s un %2$s</string>
-    <string name="template_invite_friends_rich_title">🔐️ Pievienojies ${app_name}</string>
-    <string name="template_invite_friends_text">Sazinieties ar mani izmantojot ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Pievienojies ${app_name}</string>
+    <string name="invite_friends_text">Sazinieties ar mani izmantojot ${app_name}: %s</string>
     <string name="error_empty_field_choose_password">Lūdzu, izvēlieties paroli.</string>
     <string name="error_empty_field_choose_user_name">Lūdzu, izvēlieties lietotājvārdu.</string>
     <string name="error_saving_media_file">Nevarēja saglabāt multivides failu</string>
@@ -2542,9 +2542,9 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="settings_category_timeline">Hronoloģija</string>
     <string name="verify_cannot_cross_sign">Šī sesija nevar kopīgot šo verifikāciju ar citām sesijām.
 \nVerifikācija tiks saglabāta lokāli un kopīgota kādā no nākamajām lietotnes versijām.</string>
-    <string name="template_rendering_event_error_exception">${app_name} saskārās ar problēmu, atveidojot notikuma ar id \'%1$s\' saturu</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} neapstrādā \'%1$s\' tipa ziņojumu</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} neapstrādā \'%1$s\' tipa notikumus</string>
+    <string name="rendering_event_error_exception">${app_name} saskārās ar problēmu, atveidojot notikuma ar id \'%1$s\' saturu</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} neapstrādā \'%1$s\' tipa ziņojumu</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} neapstrādā \'%1$s\' tipa notikumus</string>
     <string name="verification_scan_self_emoji_subtitle">Tā vietā pārbaudiet, salīdzinot emocijzīmes</string>
     <string name="verification_scan_with_this_device">Noskenēt ar šo ierīci</string>
     <string name="verification_scan_self_notice">Noskenējiet kodu ar citu ierīci vai pārslēdziet un skenējiet ar šo ierīci</string>
@@ -2557,8 +2557,8 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="command_description_lenny">Pievieno ( ͡° ͜ʖ ͡°) parasta teksta ziņai</string>
     <string name="settings_developer_mode_show_info_on_screen_summary">Rādīt kādu noderīgu informāciju, lai palīdzētu atkļūdošanas programmā</string>
     <string name="settings_developer_mode_show_info_on_screen_title">Parādīt atkļūdošanas informāciju ekrānā</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} var biežāk avarēt, ja rodas neparedzēta kļūda</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Pašreizējā sesija ir lietotājam %1$s, un jūs sniedzat lietotāja %2$s akreditācijas datus. To neatbalsta ${app_name}.
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} var biežāk avarēt, ja rodas neparedzēta kļūda</string>
+    <string name="soft_logout_sso_not_same_user_error">Pašreizējā sesija ir lietotājam %1$s, un jūs sniedzat lietotāja %2$s akreditācijas datus. To neatbalsta ${app_name}.
 \nLūdzu, vispirms notīriet datus un pēc tam pierakstieties vēlreiz, izmantojot citu kontu.</string>
     <string name="soft_logout_clear_data_dialog_content">Izdzēst visus šajā ierīcē pašlaik saglabātos datus\?
 \nPierakstieties vēlreiz, lai piekļūtu konta datiem un ziņojumiem.</string>
@@ -2576,7 +2576,7 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
 \n• Jūsu servera administrators ir anulējis jūsu piekļuvi drošības apsvērumu dēļ.</string>
     <string name="does_not_look_like_valid_email">Neizskatās pēc derīgas e-pasta adreses</string>
     <string name="command_description_spoiler">Nosūta doto ziņojumu kā pārsteigumu</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} nepieciešama atļauja, lai saglabātu jūsu šifrēšanas atslēgas diskā.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} nepieciešama atļauja, lai saglabātu jūsu šifrēšanas atslēgas diskā.
 \n
 \nLūdzu, nākamajā uznirstošajā logā atļaujiet piekļuvi, lai varētu eksportēt atslēgas manuāli.</string>
     <string name="uploads_files_subtitle">%1$s pie %2$s</string>
@@ -2627,7 +2627,7 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="settings_push_gateway_no_pushers">Nav reģistrētu Palaišanas vārtu</string>
     <string name="settings_push_rules_no_rules">Nav iestatīti Palaišanas Noteikumi</string>
     <string name="settings_push_rules">Palaišanas Noteikumi</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Lasāmo telpu priekšskatījums vēl nav atbalstīts ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Lasāmo telpu priekšskatījums vēl nav atbalstīts ${app_name}</string>
     <string name="create_new_space">Radīt jaunu Telpu</string>
     <string name="error_user_already_logged_in">Izskatās, ka mēģināt izveidot savienojumu ar citu mājasserveri. Vai vēlaties izrakstīties\?</string>
     <string name="identity_server_not_defined_for_password_reset">Identitātes serveris nav konfigurēts, tas ir nepieciešams, lai atiestatītu paroli.</string>
@@ -2648,7 +2648,7 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="settings_messages_direct_messages">Tiešās ziņas</string>
     <string name="sas_verifying_keys">Nekas neparādās\? Vēl ne visi klienti atbalsta interaktīvu verifikāciju. Izmantojiet veco verifikāciju.</string>
     <string name="settings_messages_containing_username">Mans lietotājvārds</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} atklāja pielāgotu servera konfigurāciju jūsu lietotāja ID domēnam \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} atklāja pielāgotu servera konfigurāciju jūsu lietotāja ID domēnam \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Automātiskās servera pabeigšanas opcijas</string>
     <string name="autodiscover_invalid_response">Nederīga mājasservera atbilde</string>
@@ -2663,7 +2663,7 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="keys_backup_setup_backup_started_message">Tagad jūsu šifrēšanas atslēgas fona režīmā tiek dublētas mājasserverī. Sākotnējā dublēšana var aizņemt vairākas minūtes.</string>
     <string name="keys_backup_setup_step3_generating_key_status">Atjaunošanas atslēgas ģenerēšana, izmantojot paroli, šis process var aizņemt vairākas sekundes.</string>
     <string name="keys_backup_setup_override_backup_prompt_description">Izskatās, ka jums jau ir izveidots atslēgas dublējums no citas sesijas. Vai vēlaties to aizstāt ar izveidoto\?</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Lūdzu, dzēsiet parolesfrāzi, ja vēlaties, lai ${app_name} ģenerētu atkopšanas atslēgu.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Lūdzu, dzēsiet parolesfrāzi, ja vēlaties, lai ${app_name} ģenerētu atkopšanas atslēgu.</string>
     <string name="no_valid_google_play_services_apk">Nav atrasts derīgs Google Play Services APK. Paziņojumi var nedarboties pareizi.</string>
     <string name="error_lazy_loading_not_supported_by_home_server">Jūsu mājasserveris vēl neatbalsta fona istabas lietotāju ielādēšanu. Izmēģiniet vēlāk.</string>
     <string name="markdown_has_been_disabled">Marķēšana ir izslēgta.</string>
@@ -2676,20 +2676,20 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="settings_notification_privacy_message_content_not_shown">• Paziņojumos <b>nebūs redzams ziņas saturs</b></string>
     <string name="settings_notification_privacy_secure_message_content">• Paziņojuma saturs ir <b>nosūtīts tieši no Matrix mājasservera</b></string>
     <string name="settings_notification_privacy_no_background_sync">Lietotnēm <b>nav</b> fona režīmā jāizveido savienojums ar mājasserveri, un tas samazinātu akumulatora enerģijas patēriņu</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Fona ierobežojumi ir ieslēgti lietotnei ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Fona ierobežojumi ir ieslēgti lietotnei ${app_name}.
 \nDarbs, ko lietotne mēģina veikt, tiks agresīvi ierobežots, kamēr tā atrodas fonā, un tas var ietekmēt paziņojumus.
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Fona ierobežojumi ir izslēgti priekš ${app_name}. Šis tests jāveic, izmantojot mobilos datus (bez WIFI).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Fona ierobežojumi ir izslēgti priekš ${app_name}. Šis tests jāveic, izmantojot mobilos datus (bez WIFI).
 \n%1$s</string>
     <string name="settings_troubleshoot_test_push_loop_failed">Neizdevās saņemt palaišanu. Iespējams, vajag pārielādēt lietotni.</string>
     <string name="settings_troubleshoot_test_push_loop_success">Lietotne saņem Palaišanu</string>
     <string name="settings_troubleshoot_test_push_loop_waiting_for_push">Lietotne gaida Palaišanu</string>
     <string name="settings_troubleshoot_test_push_loop_title">Testa Palaišana</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nŠī kļūda ir ārpus ${app_name} kontroles. Tālrunī nav Google konta. Lūdzu, atveriet kontu pārvaldnieku un pievienojiet Google kontu.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nŠī kļūda ir ārpus ${app_name} kontroles. Tā var rasties vairāku iemeslu dēļ. Iespējams, tā darbosies, ja vēlāk mēģināsiet vēlreiz, varat arī pārbaudīt, vai sistēmas iestatījumos nav ierobežota Google Play pakalpojuma datu izmantošana, vai ierīces pulkstenis ir pareizs, vai arī tā var notikt uz atsevišķām sistēmām.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nŠī kļūda nav kontrolējama ar ${app_name}, un saskaņā ar Google datiem šī kļūda norāda, ka ierīcē ir pārāk daudz lietotņu, kas reģistrētas FCM. Kļūda rodas tikai gadījumos, kad ir ārkārtīgi liels lietotņu skaits, tāpēc šim nevajadzētu ietekmēt parastu lietotāju.</string>
     <string name="settings_troubleshoot_diagnostic_running_status">Izpilda… (%1$d of %2$d)</string>
     <string name="settings_notification_keyword_contains_invalid_character">Atslēgvārds nevar saturēt \'%s\'</string>

--- a/vector/src/main/res/values-ml/strings.xml
+++ b/vector/src/main/res/values-ml/strings.xml
@@ -19,7 +19,7 @@
     <string name="invite_friends">സുഹൃത്തുക്കളെ ക്ഷണിക്കുക</string>
     <string name="user_code_share">എന്റെ കോഡ് പങ്കിടുക</string>
     <string name="user_code_my_code">എന്റെ കോഡ്</string>
-    <string name="template_invite_friends_rich_title">🔐️ ${app_name}-ൽ എന്നോടൊപ്പം ചേരുക</string>
+    <string name="invite_friends_rich_title">🔐️ ${app_name}-ൽ എന്നോടൊപ്പം ചേരുക</string>
     <string name="identity_server_set_alternative_submit">സമർപ്പിക്കൂ</string>
     <string name="a11y_open_chat">ചാറ്റ് തുറക്കുക</string>
     <string name="a11y_stop_camera">ക്യാമറ നിർത്തുക</string>
@@ -232,7 +232,7 @@
     <string name="auth_password_placeholder">രഹസ്യവാക്ക്</string>
     <string name="auth_user_id_placeholder">ഇമെയിൽ അല്ലെങ്കിൽ ഉപയോക്തൃനാമം</string>
     <string name="go_on_with">തുടരുക…</string>
-    <string name="template_call_failed_no_connection">${app_name} കോൾ പരാജയപ്പെട്ടു</string>
+    <string name="call_failed_no_connection">${app_name} കോൾ പരാജയപ്പെട്ടു</string>
     <string name="option_send_voice">ശബ്ദം അയയ്ക്കൂ</string>
     <string name="hs_url">ഹോം സെർവർ URL</string>
     <string name="no_public_room_placeholder">പൊതു മുറിക‍ൾ ഒന്നും ലഭ്യമല്ല</string>

--- a/vector/src/main/res/values-nb-rNO/strings.xml
+++ b/vector/src/main/res/values-nb-rNO/strings.xml
@@ -405,7 +405,7 @@
     <string name="room_settings_mention_only">Kun nevninger</string>
     <string name="settings_olm_version">olm-versjon</string>
     <string name="settings_deactivate_account_section">Deaktiver kontoen</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} samler inn anonyme statistikker for å hjelpe oss med å forbedre programmet.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} samler inn anonyme statistikker for å hjelpe oss med å forbedre programmet.</string>
     <string name="devices_details_last_seen_format">%1$s @ %2$s</string>
     <string name="settings_integration_manager">Integreringsbehandler</string>
     <string name="room_settings_room_name">Rommets navn</string>
@@ -580,7 +580,7 @@
     <string name="user_directory_header">Brukerkatalog</string>
     <string name="matrix_only_filter">Bare matrix-kontakter</string>
     <string name="no_conversation_placeholder">Ingen samtaler</string>
-    <string name="template_no_contact_access_placeholder">Du ga ikke ${app_name} tilgang til dine lokale kontakter</string>
+    <string name="no_contact_access_placeholder">Du ga ikke ${app_name} tilgang til dine lokale kontakter</string>
     <string name="people_no_identity_server">Ingen identitetsserver konfigurert.</string>
     <string name="rooms_directory_header">Romkatalog</string>
     <string name="no_public_room_placeholder">Ingen offentlige rom tilgjengelig</string>
@@ -626,7 +626,7 @@
     <string name="call_failed_no_ice_title">Oppringing feilet som følge av feilkonfigurert tjener</string>
     <string name="call_failed_no_ice_use_alt">Prøv med %s</string>
     <string name="call_failed_dont_ask_again">Ikke spør meg igjen</string>
-    <string name="template_call_failed_no_connection">${app_name} samtale feilet</string>
+    <string name="call_failed_no_connection">${app_name} samtale feilet</string>
     <string name="call_select_sound_device">Velg lydenhet</string>
     <string name="sound_device_phone">Telefon</string>
     <string name="sound_device_speaker">Høytaler</string>
@@ -942,13 +942,13 @@
     <string name="settings_security_pin_code_summary">Hvis du vil tilbakestille PIN-koden, trykker du på Glemt PIN-kode for å logge av og tilbakestille.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Aktiver biometri</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Aktiver enhetsspesifikk biometri, som fingeravtrykk og ansiktsgjenkjenning.</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">PIN-kode er den eneste måten å låse opp ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">PIN-kode er den eneste måten å låse opp ${app_name}.</string>
     <string name="settings_security_pin_code_notifications_title">Vis innhold i varsler</string>
     <string name="settings_security_pin_code_notifications_summary_on">Vis detaljer som romnavn og meldingsinnhold.</string>
     <string name="settings_security_pin_code_notifications_summary_off">Vis bare antall uleste meldinger i et enkelt varsel.</string>
     <string name="settings_security_pin_code_grace_period_title">Krev PIN etter 2 minutter</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">PIN-kode kreves etter 2 minutter uten bruk av ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">PIN-kode kreves hver gang du åpner ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">PIN-kode kreves etter 2 minutter uten bruk av ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">PIN-kode kreves hver gang du åpner ${app_name}.</string>
     <string name="settings_security_pin_code_change_pin_title">Endre PIN-kode</string>
     <string name="settings_security_pin_code_change_pin_summary">Endre din nåværende PIN-kode</string>
     <string name="auth_pin_confirm_to_disable_title">Bekreft PIN for å deaktivere PIN</string>
@@ -966,10 +966,10 @@
     <string name="settings_troubleshoot_test_push_notification_content">Du ser på varselet! Klikk på meg!</string>
     <string name="settings_troubleshoot_test_push_loop_failed">Kunne ikke motta push. Løsningen kan være å installere applikasjonen på nytt.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Legg til konto</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nDenne feilen er utenfor kontroll av ${app_name}. Det er ingen Google-konto på telefonen. Åpne kontoadministratoren og legg til en Google-konto.</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Fiks Play Services</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} bruker Google Play Services for å levere push-meldinger, men det ser ikke ut til å være konfigurert riktig:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} bruker Google Play Services for å levere push-meldinger, men det ser ikke ut til å være konfigurert riktig:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_success">Google Play Services APK er tilgjengelig og oppdatert.</string>
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Sjekk innstillinger</string>
@@ -977,7 +977,7 @@
     <string name="settings_troubleshoot_test_bing_settings_failed">Noen varsler er deaktivert i dine tilpassede innstillinger.</string>
     <string name="settings_troubleshoot_test_bing_settings_success_with_warn">Legg merke til at enkelte meldinger er satt til å være lydløse (gir et varsel uten lyd).</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Egendefinerte innstillinger.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Varsler er ikke aktivert for denne økten.
+    <string name="settings_troubleshoot_test_device_settings_failed">Varsler er ikke aktivert for denne økten.
 \nKontroller ${app_name}innstillingene.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Varsler er aktivert for denne økten.</string>
     <string name="settings_troubleshoot_test_device_settings_title">Sesjonsinnstillinger.</string>
@@ -1002,7 +1002,7 @@
     <string name="settings_emails_empty">Ingen e-post er lagt til kontoen din</string>
     <string name="settings_emails">E-post adresser</string>
     <string name="settings_add_3pid_authentication_needed">Autentisering er påkrevd</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Du kan ikke gjøre dette fra ${app_name} mobile</string>
+    <string name="settings_add_3pid_flow_not_supported">Du kan ikke gjøre dette fra ${app_name} mobile</string>
     <string name="settings_add_3pid_confirm_password_title">Bekreft passordet ditt</string>
     <string name="settings_app_info_link_summary">Vis applikasjonsinformasjonen i systeminnstillingene.</string>
     <string name="settings_app_info_link_title">App info</string>
@@ -1091,22 +1091,22 @@
     <string name="permissions_denied_add_contact">Tillat tillatelse til å få tilgang til kontaktene dine.</string>
     <string name="permissions_denied_qr_code">For å skanne en QR-kode, må du gi tilgang til kameraet.</string>
     <string name="permissions_action_not_performed_missing_permissions">Beklager. Handlingen ble ikke utført på grunn av manglende tillatelser</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} kan sjekke adresseboken din for å finne andre Matrix-brukere basert på e-post og telefonnummer.
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} kan sjekke adresseboken din for å finne andre Matrix-brukere basert på e-post og telefonnummer.
 \n
 \nEr du enig i å dele adresseboken for dette formålet\?</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} kan sjekke adresseboken din for å finne andre Matrix-brukere basert på e-post og telefonnummer. Hvis du godtar å dele adresseboken din for dette formålet, vennligst gi tilgang til neste popup.</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} trenger tillatelse for å få tilgang til kameraet og mikrofonen for å utføre videosamtaler.
+    <string name="permissions_rationale_msg_contacts">${app_name} kan sjekke adresseboken din for å finne andre Matrix-brukere basert på e-post og telefonnummer. Hvis du godtar å dele adresseboken din for dette formålet, vennligst gi tilgang til neste popup.</string>
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} trenger tillatelse for å få tilgang til kameraet og mikrofonen for å utføre videosamtaler.
 \n
 \nTillat tilgang til de neste popup-vinduene for å kunne ringe.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nTillat tilgang i neste popup for å kunne ringe."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} trenger tillatelse for å få tilgang til mikrofonen din for å utføre lydanrop.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} trenger tillatelse for å få tilgang til mikrofonen din for å utføre lydanrop.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nTillat tilgang i neste popup for å kunne ringe."</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} trenger tillatelse for å få tilgang til kameraet ditt for å ta bilder og videosamtaler.</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} trenger tillatelse for å få tilgang til bilde- og videobiblioteket ditt for å sende og lagre vedlegg.
+    <string name="permissions_rationale_msg_camera">${app_name} trenger tillatelse for å få tilgang til kameraet ditt for å ta bilder og videosamtaler.</string>
+    <string name="permissions_rationale_msg_storage">${app_name} trenger tillatelse for å få tilgang til bilde- og videobiblioteket ditt for å sende og lagre vedlegg.
 \n
 \nTillat tilgang i neste popup for å kunne sende filer fra telefonen din.</string>
     <string name="media_picker_cannot_record_video">Kan ikke ta opp video</string>
@@ -1128,7 +1128,7 @@
     <string name="settings_call_ringtone_title">Ringetone for innkommende samtaler</string>
     <string name="settings_call_ringtone_use_default_stun_sum">Vil bruke %s som assistanse når hjemmeserveren din ikke tilbyr en (IP-adressen din blir delt under en samtale)</string>
     <string name="settings_call_ringtone_use_default_stun">Tillat reservehjelpsserver</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Bruk standard ${app_name}-ringetone for innkommende anrop</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Bruk standard ${app_name}-ringetone for innkommende anrop</string>
     <string name="settings_call_show_confirmation_dialog_summary">Be om bekreftelse før du starter en samtale</string>
     <string name="settings_call_show_confirmation_dialog_title">Forhindre utilsiktet samtale</string>
     <string name="room_info_room_topic">Romemne</string>
@@ -1138,7 +1138,7 @@
         <item quantity="other">%d medlemskapsendringer</item>
     </plurals>
     <string name="groups_list">Gruppeliste</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Start ${app_name} på en annen enhet som kan dekryptere meldingen, slik at den kan sende nøklene til denne økten.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Start ${app_name} på en annen enhet som kan dekryptere meldingen, slik at den kan sende nøklene til denne økten.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Forespørsel sendt</string>
     <string name="e2e_re_request_encryption_key_sent">Nøkkelforespørsel sendt.</string>
     <string name="login_error_ssl_peer_unverified">SSL Feil: Denne partnerns identitet har ikke blitt verifisert.</string>
@@ -1149,7 +1149,7 @@
     <string name="action_unpublish">Fjern publiseringen</string>
     <string name="action_add">Legg til</string>
     <string name="start_chatting">Begynn å chatte</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nDenne feilen er utenfor kontroll av ${app_name}, og ifølge Google indikerer denne feilen at enheten har for mange apper registrert hos FCM. Feilen oppstår bare i tilfeller der det er ekstremt mange apper, så det bør ikke påvirke gjennomsnittsbrukeren.</string>
     <string name="room_event_action_report_prompt_ignore_user">Vil du skjule alle meldinger fra denne brukeren\?
 \n
@@ -1337,7 +1337,7 @@
     <string name="soft_logout_clear_data_dialog_submit">Slett data</string>
     <string name="devices_other_devices">Andre økter</string>
     <string name="rageshake_detected">Riste oppdaget!</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} kan krasje oftere når en uventet feil oppstår</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} kan krasje oftere når en uventet feil oppstår</string>
     <string name="create_room_alias_hint">Romadresse</string>
     <string name="create_room_alias_already_in_use">Denne adressen er allerede i bruk</string>
     <string name="create_room_alias_empty">Oppgi romadresse</string>
@@ -1391,7 +1391,7 @@
     <string name="settings_account_data">Kontodata</string>
     <string name="share_confirm_room">Vil du sende dette vedlegget til %1$s\?</string>
     <string name="delete_event_dialog_reason_checkbox">Inkluder en grunn</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="new_session">Ny pålogging. Var dette deg\?</string>
     <string name="new_session_review">Trykk for å se gjennom og bekrefte</string>
     <string name="verify_new_session_notice">Bruk denne økten til å bekrefte den nye, og gi den tilgang til krypterte meldinger.</string>
@@ -1430,7 +1430,7 @@
     <string name="upgrade_security">Krypteringsoppgradering tilgjengelig</string>
     <string name="security_prompt_text">Bekreft deg selv og andre for å sikre chattene dine</string>
     <string name="settings_security_prevent_screenshots_title">Forhindre skjermbilder av applikasjonen</string>
-    <string name="template_use_latest_app">Bruk det nyeste ${app_name} på de andre enhetene dine:</string>
+    <string name="use_latest_app">Bruk det nyeste ${app_name} på de andre enhetene dine:</string>
     <string name="bad_passphrase_key_reset_all_action">Har du glemt eller mistet alle gjenopprettingsalternativene\? Tilbakestill alt</string>
     <string name="secure_backup_reset_all">Tilbakestill alt</string>
     <string name="secure_backup_reset_all_no_other_devices">Gjør dette bare hvis du ikke har noen annen enhet du kan bekrefte denne enheten med.</string>
@@ -1446,7 +1446,7 @@
     <string name="error_empty_field_choose_user_name">Velg et brukernavn.</string>
     <string name="error_empty_field_choose_password">Velg passord.</string>
     <string name="add_people">Legg til personer</string>
-    <string name="template_invite_friends_rich_title">🔐️ Bli med meg på ${app_name}</string>
+    <string name="invite_friends_rich_title">🔐️ Bli med meg på ${app_name}</string>
     <string name="invitation_sent_to_one_user">Invitasjon sendt til %1$s</string>
     <string name="not_a_valid_qr_code">Det er ikke en gyldig QR-kode for matrix</string>
     <string name="invite_users_to_room_failure">Vi kunne ikke invitere brukere. Kontroller brukerne du vil invitere, og prøv på nytt.</string>
@@ -1456,7 +1456,7 @@
     <string name="user_code_info_text">Del denne koden med folk slik at de kan skanne den for å legge til deg og begynne å chatte.</string>
     <string name="choose_locale_loading_locales">Laster inn tilgjengelige språk…</string>
     <string name="identity_server_error_terms_not_signed">Godta først vilkårene for identitetsserveren i innstillingene.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">For ditt privatliv støtter ${app_name} bare sending av hash-bruker-e-post og telefonnummer.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">For ditt privatliv støtter ${app_name} bare sending av hash-bruker-e-post og telefonnummer.</string>
     <string name="power_level_edit_title">Sett rolle</string>
     <string name="a11y_open_chat">Åpne chat</string>
     <string name="add_from_phone_book">Legg til fra telefonboken min</string>
@@ -1473,10 +1473,10 @@
     <string name="call_transfer_title">Overfør</string>
     <string name="call_transfer_failure">Det oppstod en feil under overføring av samtalen</string>
     <string name="call_transfer_users_tab_title">Brukere</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} krever at du oppgir legitimasjonen din for å utføre denne handlingen.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} krever at du oppgir legitimasjonen din for å utføre denne handlingen.</string>
     <string name="attachment_remaining_time_minutes">%1$dm %2$ds</string>
     <string name="startup_notification_fdroid_battery_optim_title">Bakgrunnsforbindelse</string>
-    <string name="template_startup_notification_privacy_message">${app_name} kan kjøre i bakgrunnen for å administrere varslene dine sikkert og privat. Dette kan påvirke batteriforbruket.</string>
+    <string name="startup_notification_privacy_message">${app_name} kan kjøre i bakgrunnen for å administrere varslene dine sikkert og privat. Dette kan påvirke batteriforbruket.</string>
     <string name="reset_secure_backup_warning">Dette vil erstatte din nåværende nøkkel eller frase.</string>
     <string name="reset_secure_backup_title">Generer en ny sikkerhetsnøkkel eller sett en ny sikkerhetsfrase for din eksisterende sikkerhetskopi.</string>
     <string name="settings_secure_backup_section_info">Beskytt deg mot å miste tilgang til krypterte meldinger og data ved å sikkerhetskopiere krypteringsnøkler på serveren din.</string>
@@ -1514,7 +1514,7 @@
     <string name="settings_notification_privacy_fcm">• Meldinger sendes via Firebase Cloud Messaging</string>
     <string name="settings_notification_privacy_need_permission">Appen trenger tillatelse for å kjøre i bakgrunnen</string>
     <string name="settings_troubleshoot_test_battery_failed">Hvis en bruker lar en enhet være frakoblet og stasjonær i en periode, mens skjermen er slått av, går enheten i Døsemodus. Dette forhindrer apper i å få tilgang til nettverket og avviser jobber, synkroniseringer og standardalarmer.</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} påvirkes ikke av batterioptimalisering.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} påvirkes ikke av batterioptimalisering.</string>
     <string name="settings_troubleshoot_test_notification_notification_clicked">Meldingen er klikket!</string>
     <string name="settings_troubleshoot_test_notification_notice">Klikk på varselet. Hvis du ikke ser varselet, må du sjekke systeminnstillingene.</string>
     <string name="settings_troubleshoot_test_notification_title">Varslingsvisning</string>
@@ -1549,7 +1549,7 @@
     <string name="system_theme">System standard</string>
     <string name="search_banned_user_hint">Filtrer utestengte brukere</string>
     <string name="room_permissions_modify_widgets">Endre widgets</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Aktiver analyse for å hjelpe med å forbedre ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Aktiver analyse for å hjelpe med å forbedre ${app_name}.</string>
     <string name="startup_notification_privacy_title">Varselpersonvern</string>
     <string name="settings_show_avatar_display_name_changes_messages_summary">Inkluderer avatar- og visningsnavnendringer.</string>
     <string name="settings_show_avatar_display_name_changes_messages">Vis kontohendelser</string>
@@ -1576,9 +1576,9 @@
     <string name="settings_set_sync_timeout">Tidsavbrudd for synkroniseringsforespørsel</string>
     <string name="settings_enable_background_sync">Aktiver bakgrunnssynkronisering</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Du vil ikke bli varslet om innkommende meldinger når appen er i bakgrunnen.</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} vil synkroniseres i bakgrunnen med jevne mellomrom på presis tid (konfigurerbar).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} vil synkroniseres i bakgrunnen med jevne mellomrom på presis tid (konfigurerbar).
 \nDette vil påvirke radio og batteribruk, det vises en permanent melding om at ${app_name} lytter etter hendelser.</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} synkroniseres i bakgrunnen på en måte som bevarer enhetens begrensede ressurser (batteri).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} synkroniseres i bakgrunnen på en måte som bevarer enhetens begrensede ressurser (batteri).
 \nAvhengig av enhetens ressurstilstand, kan synkroniseringen bli utsatt av operativsystemet.</string>
     <string name="settings_messages_in_group_chat">Msgs i gruppechatter</string>
     <string name="settings_containing_my_user_name">Msgs som inneholder brukernavnet mitt</string>

--- a/vector/src/main/res/values-nl/strings.xml
+++ b/vector/src/main/res/values-nl/strings.xml
@@ -173,7 +173,7 @@
     <string name="local_address_book_header">Lokale contactenlijst</string>
     <string name="matrix_only_filter">Alleen Matrix-contacten</string>
     <string name="no_conversation_placeholder">Geen gesprekken</string>
-    <string name="template_no_contact_access_placeholder">U heeft ${app_name} geen toegang tot uw lokale contacten gegeven</string>
+    <string name="no_contact_access_placeholder">U heeft ${app_name} geen toegang tot uw lokale contacten gegeven</string>
     <string name="no_result_placeholder">Geen resultaten</string>
     <string name="rooms_header">Gesprekken</string>
     <string name="rooms_directory_header">Gesprekscatalogus</string>
@@ -300,22 +300,22 @@
     <string name="media_picker_both_capture_title">Een afbeelding of video maken"</string>
     <string name="media_picker_cannot_record_video">Kan geen video opnemen"</string>
     <string name="permissions_rationale_popup_title">Informatie</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} heeft toegang nodig tot uw mediabestanden om bijlagen te verzenden en op te slaan.
+    <string name="permissions_rationale_msg_storage">${app_name} heeft toegang nodig tot uw mediabestanden om bijlagen te verzenden en op te slaan.
 \n
 \nVerleen toegang op de volgende pop-up om bestanden vanaf uw telefoon te sturen.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} heeft toegang nodig tot uw camera om foto’s en video-oproepen te maken.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} heeft toegang nodig tot uw camera om foto’s en video-oproepen te maken.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nVerleen toegang op de volgende pop-up om de oproep te maken."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} heeft toegang nodig tot uw microfoon om spraakoproepen te maken.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} heeft toegang nodig tot uw microfoon om spraakoproepen te maken.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nVerleen toegang op de volgende pop-up om de oproep te maken."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} heeft toegang nodig tot uw camera en microfoon om video-oproepen te maken.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} heeft toegang nodig tot uw camera en microfoon om video-oproepen te maken.
 \n
 \nVerleen toegang op de volgende pop-ups om de oproep te maken.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} kan uw adresboek benaderen om andere Matrix-gebruikers te vinden aan de hand van hun e-mailadressen en telefoonnummers. Als u het goed vindt om uw adresboek hiervoor te delen, verleen dan toegang op de volgende pop-up.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} kan uw adresboek gebruiken om andere Matrix-gebruikers te vinden aan de hand van hun e-mailadressen en telefoonnummers.
+    <string name="permissions_rationale_msg_contacts">${app_name} kan uw adresboek benaderen om andere Matrix-gebruikers te vinden aan de hand van hun e-mailadressen en telefoonnummers. Als u het goed vindt om uw adresboek hiervoor te delen, verleen dan toegang op de volgende pop-up.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} kan uw adresboek gebruiken om andere Matrix-gebruikers te vinden aan de hand van hun e-mailadressen en telefoonnummers.
 \n 
 \nWilt u uw adresboek hiervoor delen\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Sorry. De actie is niet toegepast vanwege ontbrekende rechten</string>
@@ -795,12 +795,12 @@
     <string name="settings_deactivate_account_section">Account deactiveren</string>
     <string name="settings_deactivate_my_account">Mijn account deactiveren</string>
     <string name="startup_notification_privacy_title">Meldingsprivacy</string>
-    <string name="template_startup_notification_privacy_message">${app_name} kan op de achtergrond werken om uw meldingen veilig en privé te beheren. Dit beïnvloedt mogelijk het accuverbruik.</string>
+    <string name="startup_notification_privacy_message">${app_name} kan op de achtergrond werken om uw meldingen veilig en privé te beheren. Dit beïnvloedt mogelijk het accuverbruik.</string>
     <string name="startup_notification_privacy_button_grant">Toestemming verlenen</string>
     <string name="startup_notification_privacy_button_other">Kies een andere optie</string>
     <string name="settings_opt_in_of_analytics">Statistische gegevens (analytics) versturen</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} verzamelt anonieme statistische gegevens (analytics) om het voor ons mogelijk te maken om de app te verbeteren.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Schakel statistische gegevens in om ons te helpen bij het verbeteren van ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} verzamelt anonieme statistische gegevens (analytics) om het voor ons mogelijk te maken om de app te verbeteren.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Schakel statistische gegevens in om ons te helpen bij het verbeteren van ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Ja, ik wil helpen!</string>
     <string name="widget_integration_missing_parameter">Er ontbreekt een vereiste parameter.</string>
     <string name="widget_integration_invalid_parameter">Er is een parameter ongeldig.</string>
@@ -821,7 +821,7 @@
     <string name="e2e_re_request_encryption_key">Beveiligingssleutels van uw sessies <u>opnieuw aanvragen</u>.</string>
     <string name="e2e_re_request_encryption_key_sent">Sleutelaanvraag verstuurd.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Aanvraag verstuurd</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Start ${app_name} op een ander apparaat dat het bericht kan ontsleutelen, zodat het de sleutels naar deze sessie kan sturen.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Start ${app_name} op een ander apparaat dat het bericht kan ontsleutelen, zodat het de sleutels naar deze sessie kan sturen.</string>
     <string name="lock_screen_hint">Typ hier…</string>
     <string name="action_clear">Wissen</string>
     <string name="option_send_voice">Spraakbericht versturen</string>
@@ -901,7 +901,7 @@
     <string name="action_accept">Aanvaarden</string>
     <string name="auth_accept_policies">Gelieve het beleid van deze thuisserver te lezen en aanvaarden:</string>
     <string name="settings_call_category">Oproepen</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Gebruik de standaardbeltoon van ${app_name} voor inkomende oproepen</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Gebruik de standaardbeltoon van ${app_name} voor inkomende oproepen</string>
     <string name="settings_call_ringtone_title">Beltoon voor inkomende oproepen</string>
     <string name="settings_call_ringtone_dialog_title">Selecteer beltoon voor oproepen:</string>
     <string name="room_participants_action_remove">Eruit sturen</string>
@@ -963,7 +963,7 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Inschakelen</string>
     <string name="settings_troubleshoot_test_device_settings_title">Sessie-instellingen.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Meldingen zijn ingeschakeld voor deze sessie.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Meldingen zijn niet ingeschakeld voor deze sessie.
+    <string name="settings_troubleshoot_test_device_settings_failed">Meldingen zijn niet ingeschakeld voor deze sessie.
 \nGelieve de ${app_name}-instellingen te controleren.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Inschakelen</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Aangepaste instellingen.</string>
@@ -973,7 +973,7 @@
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Instellingen controleren</string>
     <string name="settings_troubleshoot_test_play_services_title">Play-diensten controleren</string>
     <string name="settings_troubleshoot_test_play_services_success">De APK van Google Play Services is beschikbaar en up-to-date.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} maakt gebruikt van Google Play Services om pushberichten af te leveren, maar dit lijkt niet juist geconfigureerd te zijn:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} maakt gebruikt van Google Play Services om pushberichten af te leveren, maar dit lijkt niet juist geconfigureerd te zijn:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Play-diensten herstellen</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase-bewijs</string>
@@ -981,11 +981,11 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">Het FCM-bewijs is niet opgehaald:
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nDeze fout is onafhankelijk van ${app_name}. Volgens Google betekent deze fout dat het apparaat te veel apps heeft geregistreerd met FCM. De fout treedt enkel op ingeval er een enorm aantal apps is, dus zou dit de gemiddelde gebruiker niet mogen hinderen.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nDeze fout is onafhankelijk van ${app_name}. Ze kan verschillende oorzaken hebben. Misschien werkt het als u het later opnieuw probeert. U kunt ook controleren of het gegevensverbruik van Google Play Services niet wordt beperkt in de systeeminstellingen, of dat de klok van uw apparaat wel juist staat, of dat het misschien aan een aangepaste ROM ligt.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nDeze fout is onafhankelijk van ${app_name}. Er is geen Google-account verbonden met de telefoon. Open het accountbeheer en voeg er een Google-account toe.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Account toevoegen</string>
     <string name="settings_troubleshoot_test_token_registration_title">Bewijsregistratie</string>
@@ -997,17 +997,17 @@
     <string name="settings_troubleshoot_test_service_restart_failed">Dienst is niet herstart</string>
     <string name="settings_troubleshoot_test_service_boot_title">Starten bij opstarten van apparaat</string>
     <string name="settings_troubleshoot_test_service_boot_success">De dienst zal starten wanneer het apparaat wordt herstart.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">De dienst zal niet starten wanneer het apparaat wordt herstart en u zult geen meldingen ontvangen tot u ${app_name} hebt geopend.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">De dienst zal niet starten wanneer het apparaat wordt herstart en u zult geen meldingen ontvangen tot u ${app_name} hebt geopend.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Starten bij opstarten inschakelen</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Achtergrondbeperkingen controleren</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Achtergrondbeperkingen zijn uitgeschakeld voor ${app_name}. Deze test dient uitgevoerd te worden met een mobiele verbinding (geen wifi).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Achtergrondbeperkingen zijn uitgeschakeld voor ${app_name}. Deze test dient uitgevoerd te worden met een mobiele verbinding (geen wifi).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Achtergrondbeperkingen zijn ingeschakeld voor ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Achtergrondbeperkingen zijn ingeschakeld voor ${app_name}.
 \nAl wat de app probeert te doen zal in de achtergrond hevig beperkt worden; dit kan het correct functioneren van meldingen beïnvloeden.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Beperkingen uitschakelen</string>
     <string name="settings_troubleshoot_test_battery_title">Accuoptimalisatie</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} wordt niet beperkt door accuoptimalisatie.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} wordt niet beperkt door accuoptimalisatie.</string>
     <string name="settings_troubleshoot_test_battery_failed">Als een gebruiker een apparaat los van de oplader een tijd laat stilliggen, met het scherm uitgeschakeld, gaat het apparaat in slaapmodus. Dit verhindert apps de toegang tot het netwerk, en stelt hun taken, synchronisaties en standaardalarmen uit.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Optimalisatie negeren</string>
     <string name="settings_notification_privacy_no_background_sync">De app heeft <b>geen</b> verbinding met de thuisserver nodig in de achtergrond, dit zou het gebruik van de batterij moeten verlagen</string>
@@ -1019,7 +1019,7 @@
     <string name="settings_send_message_with_enter">Berichten versturen met Enter</string>
     <string name="settings_send_message_with_enter_summary">De Enter-knop van het toetsenbord zal berichten versturen in plaats van een regeleinde in te voegen</string>
     <string name="startup_notification_fdroid_battery_optim_title">Achtergrondverbinding</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} heeft een achtergrondverbinding met lage impact nodig om betrouwbare meldingen te kunnen hebben.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} heeft een achtergrondverbinding met lage impact nodig om betrouwbare meldingen te kunnen hebben.
 \nOp het volgende scherm zult u gevraagd worden om ${app_name} toestemming te verlenen om altijd in de achtergrond te kunnen draaien, gelieve deze toestemming te verlenen.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Toestemming verlenen</string>
     <string name="settings_data_save_mode_summary">Databesparingsmodus past een specifieke filter toe zodat aanwezigheidsupdates en typmeldingen weggefilterd worden.</string>
@@ -1079,7 +1079,7 @@
     <string name="passphrase_passphrase_does_not_match">Wachtwoorden komen niet overeen</string>
     <string name="passphrase_empty_error_message">Voer een wachtwoord in</string>
     <string name="passphrase_passphrase_too_weak">Wachtwoord is te zwak</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Verwijder het wachtwoord als u wilt dat ${app_name} een herstelsleutel genereert.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Verwijder het wachtwoord als u wilt dat ${app_name} een herstelsleutel genereert.</string>
     <string name="keys_backup_no_session_error">Geen Matrix-sessie beschikbaar</string>
     <string name="keys_backup_setup_step1_title">Verlies nooit uw versleutelde berichten</string>
     <string name="keys_backup_setup_step1_description">Berichten in versleutelde gesprekken worden beveiligd met end-to-end-versleuteling. Enkel de ontvanger(s) en u hebben de sleutels om deze berichten te lezen.
@@ -1185,7 +1185,7 @@
     <string name="keys_backup_info_title_signature">Ondertekening</string>
     <string name="autodiscover_invalid_response">Ongeldig thuisserverontdekkingsantwoord</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Serveropties automatisch aanvullen</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} heeft een aangepaste serverconfiguratie gedetecteerd voor uw gebruikers-ID-domein ‘%1$s’:
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} heeft een aangepaste serverconfiguratie gedetecteerd voor uw gebruikers-ID-domein ‘%1$s’:
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Configuratie gebruiken</string>
     <string name="error_jitsi_not_supported_on_old_device">Sorry, vergadergesprekken met Jitsi worden nog niet ondersteund op oudere apparaten (met een Android-versie lager dan 6.0)</string>
@@ -1261,13 +1261,13 @@
     <string name="settings_call_ringtone_use_default_stun_sum">Zal %s gebruiken om te assisteren in het geval dat uw thuisserver er niet over beschikt (uw IP-adres zal tijdens een oproep gedeeld worden)</string>
     <string name="invite_no_identity_server_error">Voeg een identiteitsserver toe in de instellingen om dit te doen.</string>
     <string name="settings_add_3pid_confirm_password_title">Bevestig uw wachtwoord</string>
-    <string name="template_settings_add_3pid_flow_not_supported">U kunt dit niet doen vanaf de mobiele ${app_name}</string>
+    <string name="settings_add_3pid_flow_not_supported">U kunt dit niet doen vanaf de mobiele ${app_name}</string>
     <string name="settings_background_fdroid_sync_mode">Synchroniseren op de achtergrond</string>
     <string name="settings_background_fdroid_sync_mode_battery">Geoptimaliseerd voor batterij</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} zal op een batterijzuinige manier synchroniseren op de achtergrond.
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} zal op een batterijzuinige manier synchroniseren op de achtergrond.
 \nAfhankelijk van de staat van uw apparaat kan het besturingssysteem de synchronisatie uitstellen.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Geoptimaliseerd voor snelheid</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} zal periodiek op de achtergrond synchroniseren (configureerbaar).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} zal periodiek op de achtergrond synchroniseren (configureerbaar).
 \nDit heeft een negatieve impact op uw batterij- en datagebruik. Er zal een melding getoond worden ter informatie.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Geen achtergrondssynchronisatie</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">U zal geen melding van berichten ontvangen als de app zich in de achtergrond bevindt.</string>
@@ -1350,7 +1350,7 @@
     <string name="please_wait">Even wachten…</string>
     <string name="group_all_communities">Alle Gemeenschappen</string>
     <string name="room_preview_no_preview">Dit gesprek kan niet worden voorvertoond</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">De voorvertoning van wereld-leesbare gesprekken zijn nog niet ondersteund in ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">De voorvertoning van wereld-leesbare gesprekken zijn nog niet ondersteund in ${app_name}</string>
     <string name="fab_menu_create_room">Gesprekken</string>
     <string name="fab_menu_create_chat">Directe Berichten</string>
     <string name="create_room_title">Nieuw Gesprek</string>
@@ -1892,7 +1892,7 @@
     <string name="call_select_sound_device">Geluidsapparaat Selecteren</string>
     <string name="call_failed_no_connection_description">Kan geen realtime verbinding tot stand brengen.
 \nVraag de beheerder van uw thuisserver om een TURN-server te configureren om gesprekken betrouwbaar te laten werken.</string>
-    <string name="template_call_failed_no_connection">${app_name} Oproep Mislukt</string>
+    <string name="call_failed_no_connection">${app_name} Oproep Mislukt</string>
     <string name="hs_client_url">Thuisserver API URL</string>
     <string name="send_bug_report_include_key_share_history">Sleutel deelverzoekgeschiedenis verzenden</string>
     <string name="settings_room_directory_show_all_rooms_summary">Alle gesprekken in de lijst tonen, waaronder gesprekken met expliciete inhoud.</string>
@@ -1976,7 +1976,7 @@
     <string name="room_list_quick_actions_favorite_add">Toevoegen aan favorieten</string>
     <string name="room_list_quick_actions_notifications_all_noisy">Alle berichten (luidruchtig)</string>
     <string name="no_network_indicator">Er is momenteel geen netwerkverbinding</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} heeft toestemming nodig om uw E2E-sleutels op schijf op te slaan.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} heeft toestemming nodig om uw E2E-sleutels op schijf op te slaan.
 \n
 \nGeef toegang in de volgende pop-up om uw sleutels handmatig te kunnen exporteren.</string>
     <string name="content_reported_as_inappropriate_content">Deze inhoud is als ongepast gerapporteerd.
@@ -2126,7 +2126,7 @@
     <string name="send_suggestion">Doe een suggestie</string>
     <string name="preference_system_settings">Systeem instellingen</string>
     <string name="preference_versions">Versies</string>
-    <string name="template_preference_help_summary">Hulp bij het gebruik van ${app_name}</string>
+    <string name="preference_help_summary">Hulp bij het gebruik van ${app_name}</string>
     <string name="preference_help_title">Hulp en ondersteuning</string>
     <string name="preference_help">Hulp</string>
     <string name="preference_root_legals">Juridisch</string>
@@ -2232,14 +2232,14 @@
     <string name="legals_no_policy_provided">Deze server biedt geen beleid.</string>
     <string name="legals_third_party_notices">Bibliotheken van derden</string>
     <string name="legals_identity_server_title">Uw identiteitsserverbeleid</string>
-    <string name="template_legals_application_title">${app_name} beleid</string>
+    <string name="legals_application_title">${app_name} beleid</string>
     <string name="analytics_opt_in_list_item_2">We delen <b>geen</b> informatie met derden</string>
     <string name="analytics_opt_in_list_item_1">We registreren of profileren <b>geen</b> accountgegevens</string>
     <string name="analytics_opt_in_content_link">hier</string>
-    <string name="template_analytics_opt_in_content">Help ons problemen te identificeren en ${app_name} te verbeteren door anonieme gebruiksgegevens te delen. Om inzicht te krijgen in hoe mensen meerdere apparaten gebruiken, genereren we een willekeurige identificatie die door uw apparaten wordt gedeeld.
+    <string name="analytics_opt_in_content">Help ons problemen te identificeren en ${app_name} te verbeteren door anonieme gebruiksgegevens te delen. Om inzicht te krijgen in hoe mensen meerdere apparaten gebruiken, genereren we een willekeurige identificatie die door uw apparaten wordt gedeeld.
 \n
 \nU kunt al onze voorwaarden %s lezen.</string>
-    <string name="template_analytics_opt_in_title">Help ${app_name} verbeteren</string>
+    <string name="analytics_opt_in_title">Help ${app_name} verbeteren</string>
     <string name="reset_secure_backup_warning">Dit zal uw huidige sleutel of zin vervangen.</string>
     <string name="reset_secure_backup_title">Genereer een nieuwe beveiligingssleutel of stel een nieuwe beveiligingszin in voor uw bestaande back-up.</string>
     <string name="settings_secure_backup_section_info">Bescherm uzelf tegen verlies van toegang tot versleutelde berichten en gegevens door een back-up te maken van versleutelingssleutels op uw server.</string>
@@ -2357,7 +2357,7 @@
     <string name="a11y_import_key_from_file">Sleutel importeren uit bestand</string>
     <string name="a11y_open_widget">Widgets openen</string>
     <string name="authentication_error">Authenticatie mislukt</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} vereist dat u uw inloggegevens invoert om deze actie uit te voeren.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} vereist dat u uw inloggegevens invoert om deze actie uit te voeren.</string>
     <string name="re_authentication_activity_title">Opnieuw authenticatie nodig</string>
     <string name="call_slide_to_end_conference">Schuif om het gesprek te beëindigen</string>
     <string name="call_transfer_unknown_person">Onbekend persoon</string>
@@ -2416,13 +2416,13 @@
     <string name="auth_pin_confirm_to_disable_title">Bevestig pincode om pincode uit te schakelen</string>
     <string name="settings_security_pin_code_change_pin_summary">Wijzig uw huidige pincode</string>
     <string name="settings_security_pin_code_change_pin_title">Verander pincode</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Elke keer dat u ${app_name} opent, is een pincode vereist.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Pincode is vereist na 2 minuten ${app_name} niet te hebben gebruikt.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Elke keer dat u ${app_name} opent, is een pincode vereist.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Pincode is vereist na 2 minuten ${app_name} niet te hebben gebruikt.</string>
     <string name="settings_security_pin_code_grace_period_title">Pincode vereist na 2 minuten</string>
     <string name="settings_security_pin_code_notifications_summary_off">Geef alleen het aantal ongelezen berichten weer in een eenvoudige melding.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Toon details zoals kamernamen en berichtinhoud.</string>
     <string name="settings_security_pin_code_notifications_title">Inhoud in meldingen weergeven</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">Pincode is de enige manier om ${app_name} te ontgrendelen.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">Pincode is de enige manier om ${app_name} te ontgrendelen.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Schakel apparaatspecifieke biometrische gegevens in, zoals vingerafdrukken en gezichtsherkenning.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Biometrische gegevens inschakelen</string>
     <string name="settings_security_pin_code_summary">Als u uw pincode opnieuw wilt instellen, tikt u op Pincode vergeten om uit te loggen en opnieuw in te stellen.</string>
@@ -2492,11 +2492,11 @@
     <string name="identity_server_user_consent_not_provided">De toestemming van de gebruiker is niet gegeven.</string>
     <string name="identity_server_error_no_current_binding_error">Er is geen huidige associatie met dit id.</string>
     <string name="identity_server_error_binding_error">De associatie heeft gefaald.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Voor uw privacy ondersteunt ${app_name} alleen het verzenden van gehashte e-mailadressen en telefoonnummers van gebruikers.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Voor uw privacy ondersteunt ${app_name} alleen het verzenden van gehashte e-mailadressen en telefoonnummers van gebruikers.</string>
     <string name="identity_server_error_terms_not_signed">Accepteer eerst de voorwaarden van de identiteitsserver in de instellingen.</string>
     <string name="identity_server_error_no_identity_server_configured">Configureer eerst een identiteitsserver.</string>
     <string name="identity_server_error_outdated_home_server">Deze operatie is niet mogelijk. De thuisserver is verouderd.</string>
-    <string name="template_identity_server_error_outdated_identity_server">Deze identiteitsserver is verouderd. ${app_name} ondersteunt alleen API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Deze identiteitsserver is verouderd. ${app_name} ondersteunt alleen API V2.</string>
     <string name="disconnect_identity_server_dialog_content">Verbinding met identiteitsserver %s verbreken\?</string>
     <string name="open_terms_of">Open voorwaarden van %s</string>
     <string name="choose_locale_loading_locales">Beschikbare talen laden…</string>
@@ -2513,8 +2513,8 @@
     <string name="not_a_valid_qr_code">Het is geen geldige matrix QR-code</string>
     <string name="invitations_sent_to_two_users">Uitnodigingen verzonden naar %1$s en %2$s</string>
     <string name="invitation_sent_to_one_user">Uitnodiging verzonden naar %1$s</string>
-    <string name="template_invite_friends_rich_title">🔐️ Doe mee met ${app_name}</string>
-    <string name="template_invite_friends_text">Hé, praat met me op ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Doe mee met ${app_name}</string>
+    <string name="invite_friends_text">Hé, praat met me op ${app_name}: %s</string>
     <string name="invite_friends">Nodig vrienden uit</string>
     <string name="add_people">Mensen toevoegen</string>
     <string name="create_room_dm_failure">We kunnen je DM niet maken. Controleer de gebruikers die u wilt uitnodigen en probeer het opnieuw.</string>
@@ -2553,13 +2553,13 @@
     <string name="enter_secret_storage_passphrase_or_key">Gebruik uw %1$s of gebruik uw %2$s om door te gaan.</string>
     <string name="command_description_discard_session_not_handled">Alleen ondersteund in versleutelde kamers</string>
     <string name="command_description_discard_session">Dwingt dat de huidige uitgaande groepssessie in een versleutelde kamer wordt weggegooid</string>
-    <string name="template_use_latest_app">Gebruik de nieuwste ${app_name} op uw andere apparaten:</string>
+    <string name="use_latest_app">Gebruik de nieuwste ${app_name} op uw andere apparaten:</string>
     <string name="or_other_mx_capable_client">of een andere Matrix client die kruislingsondetekenen ondersteunt</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
-    <string name="template_use_other_session_content_description">Gebruik de nieuwste ${app_name} op uw andere apparaten, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} voor Android of een andere Matrix-client die geschikt is voor kruislingsondertekenen</string>
+    <string name="use_other_session_content_description">Gebruik de nieuwste ${app_name} op uw andere apparaten, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} voor Android of een andere Matrix-client die geschikt is voor kruislingsondertekenen</string>
     <string name="change_password_summary">Stel een nieuw accountwachtwoord in…</string>
     <string name="error_saving_media_file">Kan mediabestand niet opslaan</string>
     <string name="error_adding_media_file_to_gallery">Kan geen mediabestand aan de Galerij toevoegen</string>
@@ -2654,7 +2654,7 @@
     <string name="new_session">Nieuwe login. Was u dit\?</string>
     <string name="e2e_use_keybackup">Ontgrendel de geschiedenis van versleutelde berichten</string>
     <string name="settings_export_trail">Exportcontrole</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Sleutels zijn al up-to-date!</string>
     <string name="event_redacted_by_admin_reason_with_reason">Gebeurtenis gemodereerd door kamer beheerder, reden: %1$s</string>
     <string name="event_redacted_by_user_reason_with_reason">Gebeurtenis verwijderd door gebruiker, reden: %1$s</string>
@@ -2730,9 +2730,9 @@
     <string name="command_description_rainbow">Stuurt het gegeven bericht gekleurd als een regenboog</string>
     <string name="verify_cannot_cross_sign">Deze sessie kan deze verificatie niet delen met uw andere sessies.
 \nDe verificatie wordt lokaal opgeslagen en gedeeld in een toekomstige versie van de app.</string>
-    <string name="template_rendering_event_error_exception">${app_name} heeft een probleem ondervonden bij het weergeven van de inhoud van het gebeurtenis met id \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} verwerkt geen bericht van het type \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} verwerkt geen gebeurtenissen van het type \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} heeft een probleem ondervonden bij het weergeven van de inhoud van het gebeurtenis met id \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} verwerkt geen bericht van het type \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} verwerkt geen gebeurtenissen van het type \'%1$s\'</string>
     <string name="room_member_jump_to_read_receipt">Ga naar ontvangstbewijs lezen</string>
     <string name="room_member_open_or_create_dm">Direct bericht</string>
     <string name="room_member_power_level_custom_in">Aangepast (%1$d) in %2$s</string>
@@ -2792,14 +2792,14 @@
     <string name="command_description_shrug">Voegt ¯\\_(ツ)_/¯ toe aan een bericht in platte tekst</string>
     <string name="settings_developer_mode_show_info_on_screen_summary">Toon wat nuttige informatie om te helpen bij het debuggen van de applicatie</string>
     <string name="settings_developer_mode_show_info_on_screen_title">Toon debug-informatie op het scherm</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} kan vaker crashen als er een onverwachte fout optreedt</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} kan vaker crashen als er een onverwachte fout optreedt</string>
     <string name="autocomplete_limited_results">Laat alleen de eerste resultaten zien, typ meer letters…</string>
     <string name="settings_rageshake_detection_threshold_summary">Schud je telefoon om de detectiedrempel te testen</string>
     <string name="settings_developer_mode_summary">De ontwikkelaarsmodus activeert verborgen functies en kan de applicatie ook minder stabiel maken. Alleen voor ontwikkelaars!</string>
     <string name="settings_show_devices_list">Bekijk al mijn sessies</string>
     <string name="bug_report_error_too_short">De beschrijving is te kort</string>
     <string name="permalink_malformed">Uw matrix.to link is onjuist opgemaakt</string>
-    <string name="template_soft_logout_sso_not_same_user_error">De huidige sessie is voor gebruiker %1$s en u geeft inloggegevens op voor gebruiker %2$s. Dit wordt niet ondersteund door ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">De huidige sessie is voor gebruiker %1$s en u geeft inloggegevens op voor gebruiker %2$s. Dit wordt niet ondersteund door ${app_name}.
 \nWis eerst de gegevens en meld u vervolgens opnieuw aan met een ander account.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">U raakt de toegang tot beveiligde berichten kwijt, tenzij u zich aanmeldt om uw versleutelingssleutels te herstellen.</string>
     <string name="soft_logout_clear_data_dialog_content">Alle gegevens wissen die momenteel op dit apparaat zijn opgeslagen\?
@@ -2934,7 +2934,7 @@
     <string name="create_poll_title">Poll maken</string>
     <string name="restart_the_application_to_apply_changes">Start de toepassing opnieuw om de wijziging door te voeren.</string>
     <string name="labs_enable_latex_maths">LaTeX wiskunde inschakelen</string>
-    <string name="template_link_this_email_with_your_account">%s in Instellingen om uitnodigingen rechtstreeks in ${app_name} te ontvangen.</string>
+    <string name="link_this_email_with_your_account">%s in Instellingen om uitnodigingen rechtstreeks in ${app_name} te ontvangen.</string>
     <string name="link_this_email_settings_link">Koppel deze e-mail aan uw account</string>
     <string name="this_invite_to_this_space_was_sent">Deze uitnodiging voor deze space is verzonden naar %s die niet is gekoppeld aan uw account</string>
     <string name="this_invite_to_this_room_was_sent">Deze uitnodiging voor deze kamer is verzonden naar %s die niet is gekoppeld aan uw account</string>
@@ -3061,8 +3061,8 @@
     <string name="settings_enable_location_sharing_summary">Eenmaal ingeschakeld, kun je je locatie naar elke kamer sturen</string>
     <string name="settings_enable_location_sharing">Locatie delen inschakelen</string>
     <string name="location_share_external">Open met</string>
-    <string name="template_location_not_available_dialog_content">${app_name} kan geen toegang krijgen tot uw locatie. Probeer het later opnieuw.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} heeft geen toegang tot uw locatie</string>
+    <string name="location_not_available_dialog_content">${app_name} kan geen toegang krijgen tot uw locatie. Probeer het later opnieuw.</string>
+    <string name="location_not_available_dialog_title">${app_name} heeft geen toegang tot uw locatie</string>
     <string name="location_share">Deel locatie</string>
     <string name="a11y_location_share_icon">Deel locatie</string>
     <string name="location_activity_title_preview">Locatie</string>

--- a/vector/src/main/res/values-nn/strings.xml
+++ b/vector/src/main/res/values-nn/strings.xml
@@ -148,7 +148,7 @@
     <string name="user_directory_header">Brukarkatalog</string>
     <string name="matrix_only_filter">Berre Matrix-kontaktar</string>
     <string name="no_conversation_placeholder">Ingen samtalar</string>
-    <string name="template_no_contact_access_placeholder">Du gav ikkje ${app_name} tilgang til dei lokale kontaktane dine</string>
+    <string name="no_contact_access_placeholder">Du gav ikkje ${app_name} tilgang til dei lokale kontaktane dine</string>
     <string name="no_result_placeholder">Ingen treff</string>
     <string name="rooms_header">Rom</string>
     <string name="rooms_directory_header">Romkatalog</string>
@@ -262,7 +262,7 @@
     <string name="e2e_re_request_encryption_key"><u>Etterspør på nytt krypteringsnøkklar</u> frå dei andre einingane dine.</string>
     <string name="e2e_re_request_encryption_key_sent">Nøkkelførespurnaden er sendt.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Førespurnaden er send</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Start ${app_name} på ein annan eining som kan dekryptere meldingen, slik at den kan sende nøkklane til denne sesjonen</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Start ${app_name} på ein annan eining som kan dekryptere meldingen, slik at den kan sende nøkklane til denne sesjonen</string>
     <string name="read_receipts_list">Les kvitteringsliste</string>
     <string name="groups_list">Gruppeliste</string>
     <plurals name="membership_changes">
@@ -297,23 +297,23 @@
     <string name="media_picker_both_capture_title">Ta bilete eller video</string>
     <string name="media_picker_cannot_record_video">Kan ikkje spela inn video</string>
     <string name="permissions_rationale_popup_title">Info</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} treng tilgang til bilete- og videobiblioteket for å senda og lagra vedlegg.
+    <string name="permissions_rationale_msg_storage">${app_name} treng tilgang til bilete- og videobiblioteket for å senda og lagra vedlegg.
 \n 
 \nGje tilgang i sprettvindauget som kjem for å senda filer frå mobilen.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} treng tilgang til kameraet ditt for å ta bilete og videosamtalar.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} treng tilgang til kameraet ditt for å ta bilete og videosamtalar.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nVer venleg og gje tilgang på sprettvindauget som kjem for å starta samtalen."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} treng tilgang til mikrofonen din for å utføra talesamtalar.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} treng tilgang til mikrofonen din for å utføra talesamtalar.</string>
     <string name="call_error_ice_failed">Mediaforbindelsen feila</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nGjer vel og gje tilgang på sprettvindauget som kjem for å utføra samtalen."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} treng tilgang til kameraet og mikrofonen din for å utføra videosamtalar.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} treng tilgang til kameraet og mikrofonen din for å utføra videosamtalar.
 \n
 \nGjer vel og gjev tilgang på sprettvindauget som kjem for å utføra samtalen.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} treng tilgang til kontaktliste for å finna andre Matrix-brukarar basert på e-post og telefonnummer. Viss du samtykker til å dele kontaktlista, ver venleg å tillat tilgang på sprettvindauget som kjem på neste skjermbilete.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} treng tilgang til kontaktliste for å finna andre Matrix-brukarar basert på e-post og telefonnummer.
+    <string name="permissions_rationale_msg_contacts">${app_name} treng tilgang til kontaktliste for å finna andre Matrix-brukarar basert på e-post og telefonnummer. Viss du samtykker til å dele kontaktlista, ver venleg å tillat tilgang på sprettvindauget som kjem på neste skjermbilete.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} treng tilgang til kontaktliste for å finna andre Matrix-brukarar basert på e-post og telefonnummer.
 \n
 \nSamtykker du til å dele adresseboka for dette føremålet \?</string>
     <string name="permissions_action_not_performed_missing_permissions">Beklagar. Grunna manglande tilgangar, vart ikkje handlinga utført</string>
@@ -525,13 +525,13 @@
     <string name="settings_deactivate_account_section">Deaktiver konto</string>
     <string name="settings_deactivate_my_account">Deaktiver kontoen min</string>
     <string name="startup_notification_privacy_title">Personvern ved varslingar</string>
-    <string name="template_startup_notification_privacy_message">${app_name} kan køyra i bakgrunnen for å sikkert og privat halda styr på varsla dine (dette kan påverka batteribruk).</string>
+    <string name="startup_notification_privacy_message">${app_name} kan køyra i bakgrunnen for å sikkert og privat halda styr på varsla dine (dette kan påverka batteribruk).</string>
     <string name="startup_notification_privacy_button_grant">Gje tillating</string>
     <string name="startup_notification_privacy_button_other">vel noko anna</string>
     <string name="settings_analytics">Statistikk</string>
     <string name="settings_opt_in_of_analytics">Send statistikkdata</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} samlar anonym statistikk inn for å forbetra applikasjonen.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Ver venleg og skru statistikkinnsamling på for å hjelpa oss med å forbetra ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} samlar anonym statistikk inn for å forbetra applikasjonen.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Ver venleg og skru statistikkinnsamling på for å hjelpa oss med å forbetra ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Ja, eg vil hjelpa til!</string>
     <string name="settings_data_save_mode">Datasparingsmodus</string>
     <string name="devices_details_dialog_title">Informasjon om sesjon</string>
@@ -852,7 +852,7 @@ Meldingssynlegheit på Matrix liknar på epost. At vi gløymer meldingane dine t
     <string name="auth_accept_policies">Venligast sjå over og godta retningslinjene til heimtenaren:</string>
     <string name="login_error_unknown_host">Det gjeng ikkje å nå URL-en, gjer vel og sjå til honom</string>
     <string name="settings_call_category">Oppringingar</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Bruk standard ${app_name}-ringetone for innkommande samtalar</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Bruk standard ${app_name}-ringetone for innkommande samtalar</string>
     <string name="settings_call_ringtone_title">Ringetone for innkommande samtalar</string>
     <string name="settings_call_ringtone_dialog_title">Vel ringetone for samtalar:</string>
     <string name="video_call_in_progress">Ein videosamtale pågår…</string>
@@ -879,7 +879,7 @@ Meldingssynlegheit på Matrix liknar på epost. At vi gløymer meldingane dine t
     <string name="settings_troubleshoot_test_account_settings_quickfix">Skru på</string>
     <string name="settings_troubleshoot_test_device_settings_title">Sesjonsinnstillingar.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Varslingar er aktivert for denne sesjonen.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Varslingar er deaktivert for denne sesjonen.
+    <string name="settings_troubleshoot_test_device_settings_failed">Varslingar er deaktivert for denne sesjonen.
 \nSjekk ${app_name}-innstillingane.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Skru på</string>
     <string name="notification_sync_init">setter opp tenesta</string>
@@ -922,7 +922,7 @@ Meldingssynlegheit på Matrix liknar på epost. At vi gløymer meldingane dine t
     <string name="invite_no_identity_server_error">Legg til ein identitetstenar i innstillingane for å utføre denne handlinga.</string>
     <string name="room_sliding_menu_version_x">Versjon %s</string>
     <string name="settings_add_3pid_confirm_password_title">Stadfest ditt passord</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Denne handlinga kan ikkje utførast frå ${app_name} på mobil</string>
+    <string name="settings_add_3pid_flow_not_supported">Denne handlinga kan ikkje utførast frå ${app_name} på mobil</string>
     <string name="settings_add_3pid_authentication_needed">Authentisering er påkrevd</string>
     <string name="settings_integrations">Integrasjonar</string>
     <string name="settings_integrations_summary">Bruk ein integrasjonshandterar (Integration Manager) for å handtere botar, bruer, tillegg og klistermerkepakker. 
@@ -987,7 +987,7 @@ Meldingssynlegheit på Matrix liknar på epost. At vi gløymer meldingane dine t
     <string name="sound_device_wireless_headset">Trådlaus hovudtelefon</string>
     <string name="sound_device_speaker">Høgtalar</string>
     <string name="call_select_sound_device">Vel eining for lyd</string>
-    <string name="template_call_failed_no_connection">${app_name}-samtalen feila</string>
+    <string name="call_failed_no_connection">${app_name}-samtalen feila</string>
     <string name="no_more_results">Ingen fleire resultat</string>
     <string name="dialog_title_success">Suksess</string>
     <string name="action_add">Legg til</string>

--- a/vector/src/main/res/values-pl/strings.xml
+++ b/vector/src/main/res/values-pl/strings.xml
@@ -148,7 +148,7 @@
     <string name="user_directory_header">Katalog użytkowników</string>
     <string name="matrix_only_filter">Tylko kontakty Matrixa</string>
     <string name="no_conversation_placeholder">Brak rozmów</string>
-    <string name="template_no_contact_access_placeholder">Nie udzieliłeś(-aś) uprawnienia na dostęp do listy kontaktów</string>
+    <string name="no_contact_access_placeholder">Nie udzieliłeś(-aś) uprawnienia na dostęp do listy kontaktów</string>
     <string name="no_result_placeholder">Brak wyników</string>
     <string name="rooms_header">Pokoje</string>
     <string name="rooms_directory_header">Katalog pokojów</string>
@@ -264,11 +264,11 @@
     <string name="media_picker_both_capture_title">Zrób zdjęcie lub nagraj film</string>
     <string name="media_picker_cannot_record_video">Nie można nagrać filmu</string>
     <string name="permissions_rationale_popup_title">Informacja</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} wymaga uprawnienia, aby wysyłać i zapisywać pliki multimedialne.
+    <string name="permissions_rationale_msg_storage">${app_name} wymaga uprawnienia, aby wysyłać i zapisywać pliki multimedialne.
 \n
 \nPrzyznaj dostęp w następnym oknie.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} wymaga uprawnienia, aby wykonywać zdjęcia i nawiązywać połączenia wideo.</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} wymaga uprawnienia, aby przeprowadzić połączenie audio.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} wymaga uprawnienia, aby wykonywać zdjęcia i nawiązywać połączenia wideo.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} wymaga uprawnienia, aby przeprowadzić połączenie audio.</string>
     <string name="permissions_action_not_performed_missing_permissions">Nie można wykonać operacji, ze względu na brak wymaganych uprawnień</string>
     <string name="media_slider_saved">Zapisano</string>
     <string name="media_slider_saved_message">Zapisać do pobranych?</string>
@@ -573,11 +573,11 @@
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nZezwól na dostęp w następnym oknie aby móc wykonać połączenie."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} wymaga dostępu do kamery i mikrofonu, aby przeprowadzać rozmowy wideo.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} wymaga dostępu do kamery i mikrofonu, aby przeprowadzać rozmowy wideo.
 \n
 \nPrzyznaj dostęp w następnym oknie.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} może sprawdzić Twoją książkę adresową, aby znajdywać innych użytkowników Matrixa bazując na ich adresie e-mail i numerze telefonu. Jeśli zgadzasz się na udostępnienie Twojej książki adresowej w tym celu, zezwól na dostęp w następnym okienku.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} wymaga dostępu do kontaktów, aby znajdywać innych użytkowników Matrixa bazując na adresie e-mail i numerze telefonu.
+    <string name="permissions_rationale_msg_contacts">${app_name} może sprawdzić Twoją książkę adresową, aby znajdywać innych użytkowników Matrixa bazując na ich adresie e-mail i numerze telefonu. Jeśli zgadzasz się na udostępnienie Twojej książki adresowej w tym celu, zezwól na dostęp w następnym okienku.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} wymaga dostępu do kontaktów, aby znajdywać innych użytkowników Matrixa bazując na adresie e-mail i numerze telefonu.
 \n
 \nZezwolić ${app_name} na dostęp do kontaktów\?</string>
     <string name="list_members">Lista uczestników</string>
@@ -689,7 +689,7 @@
     <string name="e2e_re_request_encryption_key"><u>Poproś ponownie o klucze szyfrujące</u> z innych Twoich sesji.</string>
     <string name="e2e_re_request_encryption_key_sent">Prośba o klucz wysłana.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Prośba wysłana</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Uruchom proszę ${app_name} na innym urządzeniu, które może odszyfrować wiadomość, aby wysłać klucze do tej sesji.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Uruchom proszę ${app_name} na innym urządzeniu, które może odszyfrować wiadomość, aby wysłać klucze do tej sesji.</string>
     <string name="settings_notification_privacy">Prywatność powiadomień</string>
     <string name="settings_notification_privacy_normal">Standardowa</string>
     <string name="settings_notification_privacy_reduced">Zmniejszona prywatność</string>
@@ -703,12 +703,12 @@
     <string name="settings_deactivate_account_section">Dezaktywuj konto</string>
     <string name="settings_deactivate_my_account">Dezaktywuj moje konto</string>
     <string name="startup_notification_privacy_title">Prywatność powiadomień</string>
-    <string name="template_startup_notification_privacy_message">${app_name} może działać w tle aby bezpiecznie i prywatnie zarządzać Twoimi powiadomieniami. To może mieć wpływ na zużycie baterii.</string>
+    <string name="startup_notification_privacy_message">${app_name} może działać w tle aby bezpiecznie i prywatnie zarządzać Twoimi powiadomieniami. To może mieć wpływ na zużycie baterii.</string>
     <string name="startup_notification_privacy_button_grant">Nadaj uprawnienie</string>
     <string name="startup_notification_privacy_button_other">Wybierz inną opcję</string>
     <string name="settings_opt_in_of_analytics">Wysyłaj dane analityczne</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} zbiera anonimowe informacje które pozwolą ulepszyć aplikację.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Włącz proszę dane analityczne, aby pomóc nam ulepszyć ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} zbiera anonimowe informacje które pozwolą ulepszyć aplikację.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Włącz proszę dane analityczne, aby pomóc nam ulepszyć ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Tak, chcę pomóc!</string>
     <string name="settings_delete_notification_targets_confirmation">Czy na pewno chcesz usunąć ten cel powiadomień?</string>
     <string name="room_settings_room_access_warning">Aby móc stworzyć link do pokoju musi on mieć swój adres.</string>
@@ -929,7 +929,7 @@
     <string name="generic_label_and_value">%1$s: %2$s</string>
     <string name="plus_x">+%d</string>
     <string name="x_plus">%d+</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Użyj domyślnego dzwonka ${app_name} dla przychodzących połączeń</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Użyj domyślnego dzwonka ${app_name} dla przychodzących połączeń</string>
     <string name="call_anyway">Zadzwoń mimo to</string>
     <string name="settings_call_category">Połączenia</string>
     <string name="room_participants_action_remove">Wyrzuć</string>
@@ -966,7 +966,7 @@
 \nSprawdź ustawienia systemowe.</string>
     <string name="settings_troubleshoot_test_account_settings_failed">Powiadomienia są wyłączone dla Twojego konta.
 \nSprawdź ustawienia konta.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Powiadomienia nie są włączone dla tej sesji.
+    <string name="settings_troubleshoot_test_device_settings_failed">Powiadomienia nie są włączone dla tej sesji.
 \nProszę sprawdź ustawienia ${app_name}.</string>
     <string name="account_additional_info">Dodatkowe informacje: %s</string>
     <string name="account_phone_number_error">Wystąpił błąd podczas weryfikowania numeru telefonu.</string>
@@ -1213,13 +1213,13 @@
     <string name="settings_troubleshoot_test_bing_settings_success_with_warn">Niektóre rodzaje wiadomości będą ciche (wygenerują powiadomienie bez dźwięku).</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">Nie udało się wczytać niestandardowych reguł, spróbuj ponowić.</string>
     <string name="settings_troubleshoot_test_play_services_title">Weryfikacja Usług Google</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} używa Usług Google Play do dostarczania wiadomości push. Konfiguracja usług nie wydaje się być prawidłowa:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} używa Usług Google Play do dostarczania wiadomości push. Konfiguracja usług nie wydaje się być prawidłowa:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_success">Otrzymano token FCM:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">Niepowodzenie przy pobieraniu tokena FCM:
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \n${app_name} nie ma wpływu na wystąpienie tego problemu. Na tym urządzeniu nie ma konta Google. Otwórz menadżer kont i dodaj konto Google.</string>
     <string name="settings_troubleshoot_test_token_registration_success">Token FCM pomyślnie zarejestrowany na serwerze domowym.</string>
     <string name="settings_troubleshoot_test_token_registration_failed">Nieudana rejestracja tokena FCM na serwerze domowym:
@@ -1227,7 +1227,7 @@
     <string name="settings_troubleshoot_test_service_restart_success">Usługa została zatrzymana i automatycznie uruchomiona ponownie.</string>
     <string name="settings_troubleshoot_test_service_restart_failed">Usługa nie uruchomiła się ponownie</string>
     <string name="settings_troubleshoot_test_service_boot_success">Usługa zostanie uruchomiona przy starcie urządzenia.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Usługa nie zostanie uruchomiona przy starcie urządzenia, nie otrzymasz żadnych powiadomień, dopóki ${app_name} nie zostanie uruchomiony.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Usługa nie zostanie uruchomiona przy starcie urządzenia, nie otrzymasz żadnych powiadomień, dopóki ${app_name} nie zostanie uruchomiony.</string>
     <string name="sas_security_advise">Dla zwiększenia bezpieczeństwa, zalecamy aby wykonać ten krok osobiście lub przez inne zaufane środki komunikacji.</string>
     <string name="content_reported_content">Treść została zgłoszona.
 \n
@@ -1244,24 +1244,24 @@
     <string name="auth_add_email_and_phone_message_2">Wprowadź adres e-mail, aby możliwe było odzyskiwanie konta. Opcjonalnie użyj adresu e-mail lub numeru telefonu aby móc zostać odkrytym przez znajomych.</string>
     <string name="settings_call_ringtone_use_default_stun">Pozwól na awaryjny serwer wspomagania połączeń</string>
     <string name="settings_call_ringtone_use_default_stun_sum">Użyj %s, gdy Twój serwer domowy takiego nie ofertuje (Twój adres IP będzie udostępniony podczas połączenia)</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nBłąd jest poza kontrolą ${app_name} i nawiązując do Google sygnalizuje on, iż urządzenie posiada zbyt wiele aplikacji zarejestrowanych z FCM. Błąd występuje jedynie w przypadku posiadania skrajnie wielu aplikacji, w związku z czym nie powinno dotknąć to normalnego użytkownika.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nBłąd jest poza kontrolą ${app_name}. Może on występować z wielu powodów. Przypuszczalnie aplikacja powróci do normalnego stanu po spróbowaniu ponownie, chociaż można sprawdzić także w ustawieniach systemu uprawnienia Usług Google Play dotyczące dostępu do sieci, sprawdzić prawidłowość zegaru urządzenia lub też, może być to błąd niestandardowego oprogramowania systemowego.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Aktywuj uruchamianie przy starcie systemu</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Restrykcje dotyczące działania aplikacji w tle są wyłączone dla ${app_name}. Test powinen zostać uruchomiony używając danych komórkowych (bez WIFI).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Restrykcje dotyczące działania aplikacji w tle są wyłączone dla ${app_name}. Test powinen zostać uruchomiony używając danych komórkowych (bez WIFI).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Restrykcje dotyczące działania aplikacji w tle są włączone dla ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Restrykcje dotyczące działania aplikacji w tle są włączone dla ${app_name}.
 \nPraca którą aplikacja próbuje wykonać będzie agresywnie ograniczona podczas działania w tle i może wpłynąć na wyświetlanie powiadomień.
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_battery_success">Na ${app_name} nie ma wpływu Optymalizacja Baterii.</string>
+    <string name="settings_troubleshoot_test_battery_success">Na ${app_name} nie ma wpływu Optymalizacja Baterii.</string>
     <string name="settings_troubleshoot_test_battery_failed">Jeżeli użytkownik pozostawi urządzenie odłączone od zasilania oraz nieużywane przez określony okres, z wyłączonym ekranem, urządzenie przejdzie w tryb Doze. Uniemożliwia to aplikacjom dostęp do sieci i opóźnia ich zadania, synchonizację oraz standardowe alarmy.</string>
     <string name="settings_background_fdroid_sync_mode">Tryb synchronizacji w tle</string>
     <string name="settings_background_fdroid_sync_mode_battery">Zoptymalizowano dla baterii</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} będzie synchronizował się w tle w sposób który oszczędza limitowane zasoby urządzenia (baterię).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} będzie synchronizował się w tle w sposób który oszczędza limitowane zasoby urządzenia (baterię).
 \nW zależności od stanu zasobów urządzenia, synchronizacja może być opóźniania przez system operacyjny.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Zopytmalizowano dla działania w czasie rzeczywistym</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} będzie synchornizował się okresowo o ściśle określonym czasie (konfigurowalne).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} będzie synchornizował się okresowo o ściśle określonym czasie (konfigurowalne).
 \nWpłynie to na użycie baterii i sieci, na panelu powiadomień pozostanie wyświetlone stałe powiadomiene o nasłuchiwaniu zdarzeń.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Brak synchronizacji w tle</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Nie będziesz otrzymywać powiadomień o przychodzących wiadomościach gdy aplikacja będzie działać w tle.</string>
@@ -1278,7 +1278,7 @@
     <string name="settings_send_message_with_enter_summary">Przycisk enter na klawiaturze programowej wyśle wiadomość zamiast wprowadzania łamanania linii</string>
     <string name="settings_discovery_category">Znajdź</string>
     <string name="settings_discovery_manage">Zarządzaj ustawieniami wyszukiwania.</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} potrzebuje utrzymać mało wpływowe połączenie w tle, w celu otrzymywania wiarygodnych powiadomień.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} potrzebuje utrzymać mało wpływowe połączenie w tle, w celu otrzymywania wiarygodnych powiadomień.
 \nNa następnym ekranie zostanie się poproszonym o pozwolenie działania w tle dla ${app_name}, proszę zaakceptować.</string>
     <string name="settings_data_save_mode_summary">Tryb oszczędzania danych użyje filtra szczegółowego, w związku z czym aktualizacje o obecności i powiadomienia o pisaniu zostaną przefiltrowane.</string>
     <string name="settings_media">Media</string>
@@ -1322,7 +1322,7 @@
     <string name="widget_integration_review_terms">Aby kontynuować, musisz zaakceptować Warunki użytkowania dla tej usługi.</string>
     <string name="no_valid_google_play_services_apk">Nie znaleziono prawidłowej aplikacji Usługi Google Play. Powiadomienia mogą nie działać prawidłowo.</string>
     <string name="passphrase_passphrase_too_weak">Hasło jest zbyt słabe</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Proszę usunąć hasło, jeżeli chcesz aby ${app_name} wygenerował klucz odzyskiwania.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Proszę usunąć hasło, jeżeli chcesz aby ${app_name} wygenerował klucz odzyskiwania.</string>
     <string name="keys_backup_no_session_error">Brak dostępnych sesji Matrix</string>
     <string name="keys_backup_setup_step1_title">Nie utrać zaszyfrowanych wiadomości</string>
     <string name="keys_backup_setup_step1_description">Wiadomości w pokojach zaszyfrowanych są bezpieczne dzięki szyfrowaniu end-to-end. Jedynie Ty i Twój odbiorca posiadają klucze dla tych wiadomości.
@@ -1385,7 +1385,7 @@
     </plurals>
     <string name="autodiscover_invalid_response">Nieprawidłowa odpowiedź funkcji autoodkrywania serwera domowego</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Opcje automatycznego uzupełniania serwerów</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} wykryło niestandardową konfigurację serwera dla Twojej domeny userID \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} wykryło niestandardową konfigurację serwera dla Twojej domeny userID \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Użyj Konfiguracji</string>
     <string name="invalid_or_expired_credentials">Zostałeś(-łaś) wylogowana ze względu na nieprawidłowe lub wygasłe dane logowania.</string>
@@ -1397,7 +1397,7 @@
     <string name="sas_view_request_action">Wyświetl żądanie</string>
     <string name="sas_verified_successful_description">Bezpieczne wiadomości od tego użytkownika są zabezpeiczone za pomocą szyfrowania end-to-end i są nie do odczytania przez osoby trzecie.</string>
     <string name="call_failed_no_ice_title">Połączenie nie powiodło się z powodu niewłaściwie skonfigurowanego serwera</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Nie możesz tego zrobić z mobilnej aplikacji ${app_name}</string>
+    <string name="settings_add_3pid_flow_not_supported">Nie możesz tego zrobić z mobilnej aplikacji ${app_name}</string>
     <string name="settings_troubleshoot_test_bing_settings_failed">Niektóre powiadomienia są wyłączone w osobistej konfiguracji.</string>
     <string name="settings_troubleshoot_test_play_services_success">Usługi Google Play są aktualne.</string>
     <string name="settings_troubleshoot_test_service_restart_title">Automatycznie uruchom ponownie usługę powiadomień</string>
@@ -1422,7 +1422,7 @@
     <string name="room_list_people_empty_body">Twoje rozmowy bezpośrednie będą wyświetlane tutaj. Naciśnij przycisk + żeby rozpocząć nową.</string>
     <string name="room_list_rooms_empty_body">Twoje pokoje będą wyświetlane tutaj. Naciśnij przycisk +żeby znaleźć istniejące bądź utworzyć nowy.</string>
     <string name="malformed_message">Nieprawidłowe zdarzenie, nie można wyświetlić</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Podgląd globalnego, publicznego pokoju nie jest wciąż wspierany w ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Podgląd globalnego, publicznego pokoju nie jest wciąż wspierany w ${app_name}</string>
     <string name="keys_backup_unable_to_get_trust_info">Wystąpił błąd podczas otrzymywania zaufanych informacji</string>
     <string name="keys_backup_unable_to_get_keys_backup_data">Wystąpił błąd podczas uzyskiwania danych kluczy kopii zapasowej</string>
     <string name="import_e2e_keys_from_file">Importowanie kluczy E2E z pliku \"%1$s\".</string>
@@ -1492,7 +1492,7 @@
     <string name="content_reported_as_inappropriate_content">Zawartość została zgłoszona jako niewłaściwa.
 \n
 \nJeżeli nie chcesz widzieć treści od tego użytkownika, możesz go zablokować aby ukryć jego wiadomości.</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} potrzebuje uprawnień aby zapisywać klucze E2E na dysku.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} potrzebuje uprawnień aby zapisywać klucze E2E na dysku.
 \n
 \nPozwól na dostęp w następnym oknie aby móc eksportować klucze ręcznie.</string>
     <string name="room_list_quick_actions_leave">Opuść pokój</string>
@@ -1627,7 +1627,7 @@
 \nZaloguj się ponownie aby uzyskać dostęp do danych konta i wiadomości.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Utracisz dostęp do zaszyfrowanych wiadomości do czasu, aż zalogujesz się aby odzyskać Twoje klucze szyfrujące.</string>
     <string name="soft_logout_clear_data_dialog_submit">Wyczyść dane</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Aktualna sesja jest dla użytkownika %1$s, podajesz natomiast dane dla użytkownika %2$s. Nie jest to wspierane przez ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">Aktualna sesja jest dla użytkownika %1$s, podajesz natomiast dane dla użytkownika %2$s. Nie jest to wspierane przez ${app_name}.
 \nNa początku usuń dane, następnie zaloguj ponownie na innym koncie.</string>
     <string name="permalink_malformed">Link matrix.to został zdeformowany</string>
     <string name="bug_report_error_too_short">Opis zbyt krótki</string>
@@ -1641,7 +1641,7 @@
     <string name="devices_other_devices">Inne sesje</string>
     <string name="autocomplete_limited_results">Wyświetlanie jedynie początkowych wyników, wprowadź więcej znaków…</string>
     <string name="settings_developer_mode_fail_fast_title">Bezproblemowy</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} może zawieszać się częściej gdy napotka na niespodziewany błąd</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} może zawieszać się częściej gdy napotka na niespodziewany błąd</string>
     <string name="command_description_shrug">Preparuje ¯\\_(ツ)_/¯ dla zwykłej wiadomości tekstowej</string>
     <string name="create_room_encryption_title">Aktywuj szyfrowanie</string>
     <string name="create_room_encryption_description">Odkąd zostanie włączone, szyfrowanie nie może zostać wyłączone.</string>
@@ -1706,9 +1706,9 @@
     <string name="room_member_power_level_moderator_in">Moderator w %1$s</string>
     <string name="room_member_power_level_custom_in">Niestandardowy (%1$d) w %2$s</string>
     <string name="room_member_jump_to_read_receipt">Przeskocz do znacznika odczytania</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} nie obsługuje wydarzeń typu \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} nie obsługuje wiadomości typu \'%1$s\'</string>
-    <string name="template_rendering_event_error_exception">${app_name} napotkał problem przy wyświetlaniu zawartości wydarzenia z ID \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} nie obsługuje wydarzeń typu \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} nie obsługuje wiadomości typu \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} napotkał problem przy wyświetlaniu zawartości wydarzenia z ID \'%1$s\'</string>
     <string name="unignore">Nie ignoruj</string>
     <string name="verify_cannot_cross_sign">Sesja nie jest w stanie podzielić się weryfikacją z innymi sesjami.
 \nWeryfikacja zostanie zapisana lokalnie i udostępniona w przyszłych wersjach aplikacji.</string>
@@ -1833,7 +1833,7 @@
     <string name="room_profile_section_more_uploads">Przesłane pliki</string>
     <string name="settings_key_requests">Prośby o klucze</string>
     <string name="e2e_use_keybackup">Odblokuj historię zaszyfrowanych wiadomości</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="refresh">Odśwież</string>
     <string name="verify_new_session_notice">Użyj tej sesji do weryfikacji nowej, nadając jej dostęp do zaszyfrowanych wiadomości.</string>
     <string name="verify_new_session_was_not_me">To nie ja</string>
@@ -1902,10 +1902,10 @@
     <string name="identity_server_set_default_submit">Użyj %1$s</string>
     <string name="enter_secret_storage_passphrase_or_key">Użyj %1$s albo %2$s aby kontynuować.</string>
     <string name="command_description_discard_session_not_handled">Dostępne tylko w pokojach szyfrowanych</string>
-    <string name="template_use_latest_app">Skorzystaj z najnowszych aplikacji ${app_name} na innych urządzeniach:</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="use_latest_app">Skorzystaj z najnowszych aplikacji ${app_name} na innych urządzeniach:</string>
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
     <string name="change_password_summary">Ustaw nowe hasło do konta…</string>
     <string name="error_saving_media_file">Nie można zapisać pliku multimediów</string>
@@ -2272,7 +2272,7 @@
     <string name="room_participants_power_level_demote_warning_title">Czy chcesz się zdegradować\?</string>
     <string name="permissions_denied_add_contact">Zezwól na dostęp do Twoich kontaktów.</string>
     <string name="call_select_sound_device">Wybierz urządzenie dźwiękowe</string>
-    <string name="template_call_failed_no_connection">Połączenie ${app_name} nieudane</string>
+    <string name="call_failed_no_connection">Połączenie ${app_name} nieudane</string>
     <string name="call_notification_reject">Odrzuć</string>
     <string name="start_chatting">Rozpocznij konwersację</string>
     <string name="matrix_to_card_title">Łącze Matrix</string>
@@ -2288,13 +2288,13 @@
     <string name="auth_pin_confirm_to_disable_title">Potwierdź PIN aby zablokować kod PIN</string>
     <string name="settings_security_pin_code_change_pin_summary">Zmień swój bieżący kod PIN</string>
     <string name="settings_security_pin_code_change_pin_title">Zmień kod PIN</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Kod PIN jest wymagany za każdym razem kiedy otwierasz ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Kod PIN jest wymagany po dwóch minutach nieużywania ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Kod PIN jest wymagany za każdym razem kiedy otwierasz ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Kod PIN jest wymagany po dwóch minutach nieużywania ${app_name}.</string>
     <string name="settings_security_pin_code_grace_period_title">Wymagaj kodu PIN po upływie dwóch minut</string>
     <string name="settings_security_pin_code_notifications_summary_off">Wyświetlaj tylko liczbę nieprzeczytanych wiadomości w prostym powiadomieniu.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Pokazuj szczegóły takie jak nazwa pokoju lub treść wiadomości.</string>
     <string name="settings_security_pin_code_notifications_title">Pokazuj treść w powiadomieniach</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">Kod PIN jest jedynym sposobem na odblokowanie ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">Kod PIN jest jedynym sposobem na odblokowanie ${app_name}.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Włącz specyficzne dla urządzenia funkcje biometryczne takie jak czytnik odcisków palców bądź rozpoznawanie twarzy.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Włącz biometrię</string>
     <string name="settings_security_pin_code_summary">Jeżeli chcesz zresetować kod PIN, naciśnij Zapomnij kod PIN aby wylogować i zresetować.</string>
@@ -2324,11 +2324,11 @@
     <string name="identity_server_user_consent_not_provided">Użytkownik nie udzielił zgody.</string>
     <string name="identity_server_error_no_current_binding_error">Obecnie brak powiązania z tym identyfikatorem.</string>
     <string name="identity_server_error_binding_error">Powiązanie nieudane.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">W trosce o Twoją prywatność, ${app_name} obsługuje jedynie wysłanie skrótów (hash) adresów e-mail oraz numerów telefonu.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">W trosce o Twoją prywatność, ${app_name} obsługuje jedynie wysłanie skrótów (hash) adresów e-mail oraz numerów telefonu.</string>
     <string name="identity_server_error_terms_not_signed">Zaakceptuj najpierw reguły serwera tożsamości w ustawieniach.</string>
     <string name="identity_server_error_no_identity_server_configured">Najpierw skonfiguruj serwer tożsamości.</string>
     <string name="identity_server_error_outdated_home_server">Ta operacja nie jest możliwa. Ten serwer domowy jest przestarzały.</string>
-    <string name="template_identity_server_error_outdated_identity_server">Ten serwer tożsamości jest przestarzały. ${app_name} obsługuje jedynie API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Ten serwer tożsamości jest przestarzały. ${app_name} obsługuje jedynie API V2.</string>
     <string name="disconnect_identity_server_dialog_content">Rozłączyć z serwerem tożsamości %s\?</string>
     <string name="open_terms_of">Otwórz warunki %s</string>
     <string name="choose_locale_loading_locales">Ładowanie dostępnych języków…</string>
@@ -2348,8 +2348,8 @@
     <string name="not_a_valid_qr_code">To nie jest prawidłowy kod QR Matrix</string>
     <string name="invitations_sent_to_two_users">Zaproszenia wysłane do %1$s i %2$s</string>
     <string name="invitation_sent_to_one_user">Zaproszenie wysłane do %1$s</string>
-    <string name="template_invite_friends_rich_title">🔐️ Dołącz do mnie na ${app_name}</string>
-    <string name="template_invite_friends_text">Cześć, pogadaj ze mną na ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Dołącz do mnie na ${app_name}</string>
+    <string name="invite_friends_text">Cześć, pogadaj ze mną na ${app_name}: %s</string>
     <string name="invite_friends">Zaproś przyjaciół</string>
     <string name="invite_users_to_room_title">Zaproś użytkowników</string>
     <string name="inviting_users_to_room">Zapraszanie użytkowników…</string>
@@ -2477,7 +2477,7 @@
     <string name="notice_room_server_acl_updated_was_banned">• Serwery pasujące do %s zostały usunięte z listy zablokowanych.</string>
     <string name="notice_room_server_acl_updated_banned">• Serwery pasujące do %s są teraz zablokowane.</string>
     <string name="room_displayname_3_members">%1$s, %2$s i %3$s</string>
-    <string name="template_link_this_email_with_your_account">%s w Ustawieniach, aby otrzymywać zaproszenia bezpośrednio w ${app_name}.</string>
+    <string name="link_this_email_with_your_account">%s w Ustawieniach, aby otrzymywać zaproszenia bezpośrednio w ${app_name}.</string>
     <string name="room_permissions_change_topic">Zmiana tematu</string>
     <string name="room_permissions_upgrade_the_space">Aktualizacja Przestrzeni</string>
     <string name="room_permissions_upgrade_the_room">Aktualizacja pokoju</string>
@@ -2906,7 +2906,7 @@
     <string name="command_confetti">Wysyła wiadomość z konfetti</string>
     <string name="enter_secret_storage_input_key">Wybierz swój klucz odzyskiwania, wpisz go ręcznie lub wklej ze schowka</string>
     <string name="use_recovery_key">Użyj Klucza Odzyskiwania</string>
-    <string name="template_use_other_session_content_description">Użyj najnowszej wersji ${app_name} na innych urządzeniach, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} dla Androida, oraz innych wspieranych klientów protokołu Matrix</string>
+    <string name="use_other_session_content_description">Użyj najnowszej wersji ${app_name} na innych urządzeniach, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} dla Androida, oraz innych wspieranych klientów protokołu Matrix</string>
     <string name="bootstrap_migration_use_recovery_key">użyj swojego klucza odzyskiwania Klucza Kopii Zapasowej</string>
     <string name="bootstrap_progress_storing_in_sss">Zapisywanie sekretu klucza kopii zapasowej w SSSS</string>
     <string name="bootstrap_progress_generating_ssss">Generowania klucza SSSS z hasła</string>
@@ -3007,7 +3007,7 @@
     <string name="a11y_open_widget">Otwórz widżety</string>
     <string name="a11y_screenshot">Zrzut ekranu</string>
     <string name="authentication_error">Uwierzytelnianie nieudane</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} wymaga podania Twoich danych do wykonania tej czynności.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} wymaga podania Twoich danych do wykonania tej czynności.</string>
     <string name="call_transfer_transfer_to_title">Przekaż do %1$s</string>
     <string name="create_poll_empty_question_error">Pytanie nie może być puste</string>
     <string name="create_poll_button">UTWÓRZ ANKIETĘ</string>
@@ -3043,10 +3043,10 @@
     <string name="analytics_opt_in_list_item_2"><b>Nie udostępniamy</b> informacji podmiotom trzecim</string>
     <string name="analytics_opt_in_list_item_1"><b> Nie zbieramy i nie profilujemy </b> danych użytkownika</string>
     <string name="analytics_opt_in_content_link">tutaj</string>
-    <string name="template_analytics_opt_in_content">Pomóż nam znaleźć błędy i ulepszyć ${app_name} poprzez udostępnianie anonimowych danych użytkowania. Aby lepiej zrozumieć jak użytkownicy wykorzystują wiele urządzeń wygenerujemy losowy identyfikator dzielony pomiędzy Twoimi urządzeniami.
+    <string name="analytics_opt_in_content">Pomóż nam znaleźć błędy i ulepszyć ${app_name} poprzez udostępnianie anonimowych danych użytkowania. Aby lepiej zrozumieć jak użytkownicy wykorzystują wiele urządzeń wygenerujemy losowy identyfikator dzielony pomiędzy Twoimi urządzeniami.
 \n
 \nWięcej informacji %s.</string>
-    <string name="template_analytics_opt_in_title">Pomóż usprawnić ${app_name}</string>
+    <string name="analytics_opt_in_title">Pomóż usprawnić ${app_name}</string>
     <string name="action_not_now">Nie teraz</string>
     <string name="action_enable">Włącz</string>
     <plurals name="notice_room_aliases_removed_by_you">
@@ -3061,7 +3061,7 @@
     <string name="ftue_auth_carousel_control_title">Ty jesteś w kontroli.</string>
     <string name="ftue_auth_carousel_secure_title">Przejmij swoje konwersacje.</string>
     <string name="identity_server_consent_dialog_content_3">By odkryć istniejące kontakty, musisz najpierw przesłać swoje dane kontaktowe (adresy e-mail i numer telefonu) do serwera tożsamości. Przed wysłaniem Twoje dane zostaną zaszyfrowane w celu zachowania prywatności.</string>
-    <string name="template_preference_help_summary">Uzyskaj pomoc w korzystaniu z ${app_name}</string>
+    <string name="preference_help_summary">Uzyskaj pomoc w korzystaniu z ${app_name}</string>
     <string name="room_error_access_unauthorized">Nie masz uprawnień by dołączyć do tego pokoju</string>
     <string name="dev_tools_form_hint_type">Typ</string>
     <string name="a11y_presence_offline">Niedostępny</string>

--- a/vector/src/main/res/values-pt-rBR/strings.xml
+++ b/vector/src/main/res/values-pt-rBR/strings.xml
@@ -329,7 +329,7 @@
     <string name="local_address_book_header">Agenda de endereços local</string>
     <string name="matrix_only_filter">Contatos de Matrix somente</string>
     <string name="no_conversation_placeholder">Nenhuma conversa</string>
-    <string name="template_no_contact_access_placeholder">Você não permitiu que ${app_name} acesse seus contatos locais</string>
+    <string name="no_contact_access_placeholder">Você não permitiu que ${app_name} acesse seus contatos locais</string>
     <string name="no_result_placeholder">Nenhum resultado</string>
     <string name="rooms_header">Salas</string>
     <string name="rooms_directory_header">Diretório de salas</string>
@@ -456,22 +456,22 @@
     <string name="media_picker_both_capture_title">Tirar uma foto ou um vídeo</string>
     <string name="media_picker_cannot_record_video">Não é possível gravar vídeo</string>
     <string name="permissions_rationale_popup_title">Informação</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} precisa de permissão para acessar sua biblioteca de fotos e vídeos para enviar e salvar anexos.
+    <string name="permissions_rationale_msg_storage">${app_name} precisa de permissão para acessar sua biblioteca de fotos e vídeos para enviar e salvar anexos.
 \n
 \nPor favor permita acesso no próximo pop-up para ser capaz de enviar arquivos do seu celular.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} precisa de permissão para acessar sua câmera para tirar fotos e chamadas de vídeo.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} precisa de permissão para acessar sua câmera para tirar fotos e chamadas de vídeo.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nPor favor permita acesso no próximo pop-up para ser capaz de fazer a chamada."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} precisa de permissão para acessar seu microfone para performar chamadas de áudio.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} precisa de permissão para acessar seu microfone para performar chamadas de áudio.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nPor favor permita acesso no próximo pop-up para ser capaz de fazer a chamada."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} precisa de permissão para acessar sua câmera e seu microfone para performar chamadas de vídeo.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} precisa de permissão para acessar sua câmera e seu microfone para performar chamadas de vídeo.
 \n
 \nPor favor permita acesso no próximo pop-up para ser capaz de fazer a chamada.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} pode checar seu livro de endereços para achar outras(os) usuárias(os) de Matrix baseado em seus email e números de telefone. Se você concorda em compartilhar seu livro de endereços para este propósito, por favor permita acesso no próximo pop-up.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} pode checar seu livro de endereços para encontrar outras(os) usuásias(os) de Matrix baseado em seus emails e números de telefone.
+    <string name="permissions_rationale_msg_contacts">${app_name} pode checar seu livro de endereços para achar outras(os) usuárias(os) de Matrix baseado em seus email e números de telefone. Se você concorda em compartilhar seu livro de endereços para este propósito, por favor permita acesso no próximo pop-up.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} pode checar seu livro de endereços para encontrar outras(os) usuásias(os) de Matrix baseado em seus emails e números de telefone.
 \n
 \nVocê concorda em compartilhar seu livro de endereços para este propósito\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Desculpe. Ação não performada, devido a permissões faltando</string>
@@ -955,7 +955,7 @@
     <string name="e2e_re_request_encryption_key">Re-requisitar chaves de encriptação de suas outras sessões.</string>
     <string name="e2e_re_request_encryption_key_sent">Requisição de chave enviada.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Requisição enviada</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Por favor lance ${app_name} num outro dispositivo que possa decriptar a mensagem para que ele possa enviar as chaves para esta sessão.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Por favor lance ${app_name} num outro dispositivo que possa decriptar a mensagem para que ele possa enviar as chaves para esta sessão.</string>
     <plurals name="format_time_s">
         <item quantity="one">%ds</item>
         <item quantity="other">%ds</item>
@@ -993,12 +993,12 @@
     <string name="settings_deactivate_account_section">Desativar conta</string>
     <string name="settings_deactivate_my_account">Desativar minha conta</string>
     <string name="startup_notification_privacy_title">Privacidade de Notificação</string>
-    <string name="template_startup_notification_privacy_message">${app_name} pode rodar no background para gerenciar suas notificações seguramente e privadamente. Isto pode afetar uso de bateria.</string>
+    <string name="startup_notification_privacy_message">${app_name} pode rodar no background para gerenciar suas notificações seguramente e privadamente. Isto pode afetar uso de bateria.</string>
     <string name="startup_notification_privacy_button_grant">Conceder permissão</string>
     <string name="startup_notification_privacy_button_other">Escolher uma outra opção</string>
     <string name="settings_opt_in_of_analytics">Enviar dados de analítica</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} coleta analítica anônima para nos permitir melhorar o aplicativo.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Por favor habilite analítica para nos ajudar a melhorar ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} coleta analítica anônima para nos permitir melhorar o aplicativo.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Por favor habilite analítica para nos ajudar a melhorar ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Sim, eu quero ajudar!</string>
     <string name="settings_without_flair">Você não é atualmente um membro de quaisquer comunidades.</string>
     <string name="lock_screen_hint">Digite aqui…</string>
@@ -1057,7 +1057,7 @@
     <string name="dialog_title_error">Erro</string>
     <string name="auth_accept_policies">Por favor revise e aceite as políticas deste servidorcasa:</string>
     <string name="settings_call_category">Chamadas</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Usar toque default de ${app_name} para chamadas entrantes</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Usar toque default de ${app_name} para chamadas entrantes</string>
     <string name="settings_call_ringtone_title">Toque de chamada entrante</string>
     <string name="settings_call_ringtone_dialog_title">Selecionar toque para chamadas:</string>
     <string name="reason_hint">Razão</string>
@@ -1082,12 +1082,12 @@
     <string name="settings_troubleshoot_test_device_settings_title">Configurações de Sessão.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Notificações estão habilitadas para esta sessão.</string>
     <string name="room_participants_action_remove">Expulsar</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Notificações não estão habilitadas para esta sessão.
+    <string name="settings_troubleshoot_test_device_settings_failed">Notificações não estão habilitadas para esta sessão.
 \nPor favor cheque as configurações de ${app_name}.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Habilitar</string>
     <string name="settings_troubleshoot_test_play_services_title">Checagem de Play Services</string>
     <string name="settings_troubleshoot_test_play_services_success">APK de Google Play Services está disponível e atualizado.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} usa Google Play Services para entregar mensagens push mas não parece estar configurado corretamente:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} usa Google Play Services para entregar mensagens push mas não parece estar configurado corretamente:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Consertar Play Services</string>
     <string name="settings_troubleshoot_test_fcm_title">Token de Firebase</string>
@@ -1104,11 +1104,11 @@
     <string name="settings_troubleshoot_test_service_restart_failed">Serviço falhou para recomeçar</string>
     <string name="settings_troubleshoot_test_service_boot_title">Começar em boot</string>
     <string name="settings_troubleshoot_test_service_boot_success">Serviço vai começar quando o dispositivo for reiniciado.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">O serviço não vai começar quando o dispositivo for recomeçado, você não vai receber notificações até que ${app_name} tenha sido aberto uma vez.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">O serviço não vai começar quando o dispositivo for recomeçado, você não vai receber notificações até que ${app_name} tenha sido aberto uma vez.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Habilitar Começar em boot</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Checar restrições de background</string>
     <string name="settings_troubleshoot_test_battery_title">Otimização de Bateria</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} não é afetado por Otimização de Bateria.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} não é afetado por Otimização de Bateria.</string>
     <string name="settings_troubleshoot_test_service_restart_title">Auto-Reinício de Serviço de Notificações</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Desabilitar restrições</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignorar Otimização</string>
@@ -1122,11 +1122,11 @@
     <string name="settings_show_avatar_display_name_changes_messages">Mostrar eventos de conta</string>
     <string name="settings_show_avatar_display_name_changes_messages_summary">Inclui mudanças de avatar e nome de exibição.</string>
     <string name="startup_notification_fdroid_battery_optim_title">Conexão no Background</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} precisa manter uma conexão no background de baixo impacto a fim de ter notificações confiáveis.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} precisa manter uma conexão no background de baixo impacto a fim de ter notificações confiáveis.
 \nNa próxima tela você vai ser instigado a permitir ${app_name} sempre rodar em background, por favor aceite.</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Restrições de background estão desabilitadas para ${app_name}. Este teste devia ser rodado usando dados móveis (sem Wi-Fi).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Restrições de background estão desabilitadas para ${app_name}. Este teste devia ser rodado usando dados móveis (sem Wi-Fi).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Restrições de background estão habilitadas para ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Restrições de background estão habilitadas para ${app_name}.
 \nTrabalho que o app tenta fazer vai ser agressivamente restringido enquando ele está no background, e isto poderia afetar notificações.
 \n%1$s</string>
     <string name="settings_send_markdown">Formatação markdown</string>
@@ -1185,16 +1185,16 @@
     <string name="settings_troubleshoot_test_bing_settings_failed">Algumas notificações estão desabilitadas em suas configurações personalizadas.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">Falha para carregar regras personalizadas, por favor retente.</string>
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Checar Configurações</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nEste erro está fora de controle de ${app_name} e de acordo com Google, este erro indica que o dispositivo tem apps demais registrados com FCM. O erro somente ocorre em casos onde há números extremos de apps, então isso não devia afetar a/o usuária(o) média(o).</string>
     <string name="action_ignore">Ignorar</string>
     <string name="auth_login_sso">Fazer sign-in com sign-on único</string>
     <string name="login_error_unknown_host">Este URL não é alcançável, por favor cheque-o</string>
     <string name="login_error_ssl_handshake">Seu dispositivo está usando um protocolo de segurança TLS desatualizado, vulnerável a ataque, para sua segurança você não vai ser capaz de se conectar</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nEste erro está fora de controle de ${app_name}. Isto pode ocorrer por várias razões. Talvez vai funcionar se você retentar mais tarde, você também pode checar que Google Play Service não está restrito em uso de dados nas configurações de sistema, ou que o relógio do seu dispositivo está correto, ou ele pode acontecem em ROM personalizada.</string>
     <string name="notification_sync_init">Inicializando serviço</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nEste erro está fora de controle de ${app_name}. Não há uma conta de Google no celular. Por favor abra o gerenciador de contas e adicione uma conta de Google.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Adicionar Conta</string>
     <string name="settings_noisy_notifications_preferences">Configurar Notificações Barulhentas</string>
@@ -1223,7 +1223,7 @@
 \nAlternativamente, você pode tentar usar o servidor público em %2$s, mas isto não vai ser tão confiável, e vai compartilhar seu endereço de IP com esse servidor. Você também pode gerenciar isto em Configurações.</string>
     <string name="call_failed_no_ice_use_alt">Tentar usar %s</string>
     <string name="call_failed_dont_ask_again">Não me pergunte de novo</string>
-    <string name="template_call_failed_no_connection">Chamada ${app_name} Falhou</string>
+    <string name="call_failed_no_connection">Chamada ${app_name} Falhou</string>
     <string name="call_failed_no_connection_description">Falha para estabelecer conexão em tempo real.
 \nPor favor peça ao/à administrador(a) de seu servidorcasa para configurar um servidor TURN a fim que chamadas funcionem confiavelmente.</string>
     <string name="call_select_sound_device">Selecionar Dispositivo de Som</string>
@@ -1271,15 +1271,15 @@
     <string name="room_participants_unban_title">Desbanir usuária(o)</string>
     <string name="room_participants_unban_prompt_msg">Desbanir usuária(o) vai permitir-lhe se juntar à sala de novo.</string>
     <string name="settings_add_3pid_confirm_password_title">Confirme sua senha</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Você não pode fazer isto desde ${app_name} mobile</string>
+    <string name="settings_add_3pid_flow_not_supported">Você não pode fazer isto desde ${app_name} mobile</string>
     <string name="settings_add_3pid_authentication_needed">Autenticação é requerida</string>
     <string name="settings_notification_privacy_no_background_sync">O app <b>não</b> precisa de se conectar ao servidorcasa no background, isto deveria reduzir uso de bateria</string>
     <string name="settings_background_fdroid_sync_mode">Modo Sinc no Background</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimizado para bateria</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} vai sincar em background de maneira que preserva recursos limitados do dispositivo (bateria).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} vai sincar em background de maneira que preserva recursos limitados do dispositivo (bateria).
 \nDependendo do estado de recurso de seu dispositivo, a sinc pode ser adiada pelo sistema operacional.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimizado para tempo real</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} vai sincar em background periodicamente em tempo preciso (configurável).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} vai sincar em background periodicamente em tempo preciso (configurável).
 \nIsto vai impactar uso de rádio e bateria, vai ter uma notificação permanente exibida declarando que ${app_name} está à escuta por eventos.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Sem sinc em background</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Você não vai ser notificada(o) sobre mensagens entrantes quando o app está em background.</string>
@@ -1384,7 +1384,7 @@
     <string name="error_empty_field_enter_user_name">Por favor entre um nome de usuária(o).</string>
     <string name="passphrase_empty_error_message">Por favor entre sua frasepasse</string>
     <string name="passphrase_passphrase_too_weak">Frasepasse é fraca demais</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Por favor delete a frasepasse se quiser que ${app_name} gere uma chave de recuperação.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Por favor delete a frasepasse se quiser que ${app_name} gere uma chave de recuperação.</string>
     <string name="keys_backup_no_session_error">Nenhuma sessão Matrix disponível</string>
     <string name="keys_backup_setup_step1_title">Nunca perca mensagens encriptadas</string>
     <string name="keys_backup_setup_step1_description">Mensagens em salas encriptadas são asseguradas com encriptação ponta-a-ponta. Somente você e a(s)/o(s) recipiente(s) têm as chaves para ler estas mensagens.
@@ -1498,7 +1498,7 @@
     <string name="keys_backup_info_title_algorithm">Algoritmo</string>
     <string name="autodiscover_invalid_response">Resposta de descoberta de servidorcasa inválida</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Autocompletar Opções de Servidor</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} detectou uma configuração de servidor personalizada para seu domínio de userId \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} detectou uma configuração de servidor personalizada para seu domínio de userId \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Usar Config</string>
     <string name="invalid_or_expired_credentials">Você tem sido feito logout devido a credenciais inválidas ou expiradas.</string>
@@ -1576,7 +1576,7 @@
     <string name="please_wait">Por favor espere…</string>
     <string name="group_all_communities">Todas as Comunidades</string>
     <string name="room_preview_no_preview">Esta sala não pode ser previsualizada</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">A previsualização de sala legível pelo mundo não é suportada ainda em ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">A previsualização de sala legível pelo mundo não é suportada ainda em ${app_name}</string>
     <string name="fab_menu_create_room">Salas</string>
     <string name="fab_menu_create_chat">Mensagens Diretas</string>
     <string name="create_room_title">Nova Sala</string>
@@ -1724,7 +1724,7 @@
     <string name="content_reported_as_inappropriate_content">Este conteúdo foi reportado como inapropriado.
 \n
 \nSe você não quer ver mais nada de conteúdo desta(e) usuária(o), você pode ignorá-la(o) para esconder mensagens dela(e).</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} precisa de permissão para salvar suas chaves E2E em disco.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} precisa de permissão para salvar suas chaves E2E em disco.
 \n
 \nPor favor permita acesso no próximo pop-up para ser capaz de exportar suas chaves manualmente.</string>
     <string name="no_network_indicator">Não há nenhuma conexão de rede no momento</string>
@@ -1881,7 +1881,7 @@
 \nFaça signin de novo para acessar os dados e mensagens de sua conta.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Você vai perder acesso a mensagens seguras a menos que você faça signin para recuperar suas chaves de encriptação.</string>
     <string name="soft_logout_clear_data_dialog_submit">Limpar dados</string>
-    <string name="template_soft_logout_sso_not_same_user_error">A sessão atual é para usuária(o) %1$s e você provê credenciais para usuária(o) %2$s. Isto não é suportado por ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">A sessão atual é para usuária(o) %1$s e você provê credenciais para usuária(o) %2$s. Isto não é suportado por ${app_name}.
 \nPor favor primeiro limpe dados, então faça signin de novo em uma outra conta.</string>
     <string name="permalink_malformed">Seu link matrix.to foi malformado</string>
     <string name="bug_report_error_too_short">A descrição é curta demais</string>
@@ -1899,7 +1899,7 @@
     <string name="devices_other_devices">Outras sessões</string>
     <string name="autocomplete_limited_results">Mostrando somente os primeiros resultados, digite mais letras…</string>
     <string name="settings_developer_mode_fail_fast_title">Rápida-falha</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} pode crashar com mais frequência quando um erro inesperado ocorre</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} pode crashar com mais frequência quando um erro inesperado ocorre</string>
     <string name="command_description_shrug">Prepende ¯\\_(ツ)_/¯ a uma mensagem de texto puro</string>
     <string name="create_room_encryption_title">Habilitar encriptação</string>
     <string name="create_room_encryption_description">Uma vez habilitada, encriptação não poder ser desabilitada.</string>
@@ -1973,9 +1973,9 @@
     <string name="room_member_power_level_default_in">Default em %1$s</string>
     <string name="room_member_power_level_custom_in">Personalizado (%1$d) em %2$s</string>
     <string name="room_member_jump_to_read_receipt">Pular para recibo de leitura</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} não lida com eventos de tipo \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} não lida com mensagens de tipo \'%1$s\'</string>
-    <string name="template_rendering_event_error_exception">${app_name} encontrou um problema ao render conteúdo de evento com id \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} não lida com eventos de tipo \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} não lida com mensagens de tipo \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} encontrou um problema ao render conteúdo de evento com id \'%1$s\'</string>
     <string name="unignore">Designorar</string>
     <string name="verify_cannot_cross_sign">Esta sessão é incapaz de compartilhar essa verificação com suas outras sessões.
 \nA confirmação vai ser salvada localmente e compartilhada numa versão futura do app.</string>
@@ -2062,7 +2062,7 @@
     <string name="event_redacted_by_user_reason_with_reason">Evento deletado por usuária(o), razão: %1$s</string>
     <string name="event_redacted_by_admin_reason_with_reason">Evento moderado por admin de sala, razão: %1$s</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Chaves já estão atualizadas!</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">Requisições de Chave</string>
     <string name="e2e_use_keybackup">Destrancar histórico de mensagens encriptadas</string>
     <string name="refresh">Recarregar</string>
@@ -2171,13 +2171,13 @@
     <string name="error_adding_media_file_to_gallery">Não foi possível adicionar arquivo de mídia à Galeria</string>
     <string name="error_saving_media_file">Não foi possível salvar arquivo de mídia</string>
     <string name="change_password_summary">Definir uma nova senha de conta…</string>
-    <string name="template_use_other_session_content_description">Use o ${app_name} mais recente em seus outros dispositivos, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} para Android, ou um outro cliente Matrix capaz de assinatura cruzada</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="use_other_session_content_description">Use o ${app_name} mais recente em seus outros dispositivos, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} para Android, ou um outro cliente Matrix capaz de assinatura cruzada</string>
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
     <string name="or_other_mx_capable_client">ou um outro cliente Matrix capaz de assinatura cruzada</string>
-    <string name="template_use_latest_app">Use o ${app_name} mais recente em seus outros dispositivos:</string>
+    <string name="use_latest_app">Use o ${app_name} mais recente em seus outros dispositivos:</string>
     <string name="command_description_discard_session">Força a atual sessão de grupo de saída em uma sala encriptada a ser descartada</string>
     <string name="command_description_discard_session_not_handled">Somente suportado em salas encriptadas</string>
     <string name="enter_secret_storage_passphrase_or_key">Use sua %1$s ou %2$s para continuar.</string>
@@ -2218,11 +2218,11 @@
     <string name="choose_locale_loading_locales">Carregando línguas disponíveis…</string>
     <string name="open_terms_of">Abrir termos de %s</string>
     <string name="disconnect_identity_server_dialog_content">Desconectar-se do servidor de identidade %s\?</string>
-    <string name="template_identity_server_error_outdated_identity_server">Este servidor de identidade está desatualizado. ${app_name} suporta somente API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Este servidor de identidade está desatualizado. ${app_name} suporta somente API V2.</string>
     <string name="identity_server_error_outdated_home_server">Esta operação não é possível. O servidorcasa está desatualizado.</string>
     <string name="identity_server_error_no_identity_server_configured">Por favor primeiro configure um servidor de identidade.</string>
     <string name="identity_server_error_terms_not_signed">Por favor primeiro aceite os termos do servidor de identidade nas configurações.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Para sua privacidade, ${app_name} somente suporta enviar emails e números de telefone de usuária(o) hashados.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Para sua privacidade, ${app_name} somente suporta enviar emails e números de telefone de usuária(o) hashados.</string>
     <string name="identity_server_error_binding_error">A associação tem falhado.</string>
     <string name="identity_server_error_no_current_binding_error">Não há nenhuma associação atual com este identificador.</string>
     <string name="identity_server_set_default_notice">Seu servidorcasa (%1$s) propõe usar %2$s para seu servidor de identidade</string>
@@ -2351,13 +2351,13 @@
     <string name="delete_account_data_warning">Deletar os dados de conta de tipo %1$s\?
 \n
 \nUse com caução, pode levar a comportamento inesperado.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Código PIN é requerido toda vez que você abre ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Código PIN é requerido depois de 2 minutos de não usar ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Código PIN é requerido toda vez que você abre ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Código PIN é requerido depois de 2 minutos de não usar ${app_name}.</string>
     <string name="settings_security_pin_code_grace_period_title">Requerer PIN depois de 2 minutos</string>
     <string name="settings_security_pin_code_notifications_summary_off">Somente mostrar número de mensagens não-lidas em uma notificação simples.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Mostrar detalhes como nomes de salas e conteúdo de mensagens.</string>
     <string name="settings_security_pin_code_notifications_title">Mostrar conteúdo em notificações</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">Código PIN é a única maneira de destrancar ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">Código PIN é a única maneira de destrancar ${app_name}.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Habilitar biometria específica de dispositivo, como impressões digitais e reconhecimento de face.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Habilitar biometria</string>
     <string name="settings_security_application_protection_screen_title">Configurar a proteção</string>
@@ -2436,8 +2436,8 @@
     <string name="user_code_share">Compartilhar meu código</string>
     <string name="user_code_scan">Scannar um QR code</string>
     <string name="not_a_valid_qr_code">Não é um QR code matrix válido</string>
-    <string name="template_invite_friends_rich_title">🔐️ Junte-se a mim em ${app_name}</string>
-    <string name="template_invite_friends_text">Hey, fale comigo em ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Junte-se a mim em ${app_name}</string>
+    <string name="invite_friends_text">Hey, fale comigo em ${app_name}: %s</string>
     <string name="invite_friends">Convidar amigas(os)</string>
     <string name="add_people">Adicionar pessoas</string>
     <string name="topic_prefix">"Tópico: "</string>
@@ -2545,7 +2545,7 @@
     <string name="room_participants_leave_private_warning">Esta sala não é pública. Você não vai ser capaz de se rejuntar sem um convite.</string>
     <string name="system_theme">Default de Sistema</string>
     <string name="authentication_error">Falha para autenticar</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} requer que você entre suas credenciais para performar esta ação.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} requer que você entre suas credenciais para performar esta ação.</string>
     <string name="re_authentication_activity_title">Re-Autenticação Necessitada</string>
     <string name="error_unauthorized">Não autorizada(o), credenciais de autenticação válidas faltando</string>
     <string name="call_transfer_users_tab_title">Usuárias(os)</string>
@@ -2859,7 +2859,7 @@
     <string name="settings_notification_other">Outras</string>
     <string name="settings_notification_mentions_and_keywords">Menções e Palavrachaves</string>
     <string name="settings_notification_default">Notificações Default</string>
-    <string name="template_link_this_email_with_your_account">%s em Configurações para receber convites diretamente em ${app_name}.</string>
+    <string name="link_this_email_with_your_account">%s em Configurações para receber convites diretamente em ${app_name}.</string>
     <string name="link_this_email_settings_link">Linkar este email com sua conta</string>
     <string name="this_invite_to_this_space_was_sent">Este convite para este espaço foi enviado para %s que não está associado com sua conta</string>
     <string name="this_invite_to_this_room_was_sent">Este convite para esta sala foi enviado para %s que não está associado com sua conta</string>
@@ -3021,18 +3021,18 @@
         <item quantity="other">%1$d votos</item>
     </plurals>
     <string name="preference_versions">Versões</string>
-    <string name="template_preference_help_summary">Conseguir ajuda com uso de ${app_name}</string>
+    <string name="preference_help_summary">Conseguir ajuda com uso de ${app_name}</string>
     <string name="preference_root_legals">Jurídicos</string>
     <string name="legals_no_policy_provided">Este servidor não provê nenhuma política.</string>
     <string name="legals_third_party_notices">Bibliotecas de terceiros</string>
     <string name="legals_identity_server_title">A política de seu servidor de identidade</string>
     <string name="legals_home_server_title">A política de seu servidorcasa</string>
-    <string name="template_legals_application_title">Política de ${app_name}</string>
+    <string name="legals_application_title">Política de ${app_name}</string>
     <string name="analytics_opt_in_list_item_1">Nós <b>não</b> gravamos ou perfilamos quaisquer dados de conta</string>
-    <string name="template_analytics_opt_in_content">Ajude-nos a identificar problemas e melhorar ${app_name} ao compartilhar dados de uso anônimos. Para entender como pessoas usam seus múltiplos dispositivos, nós vamos gerar um identificador aleatório, compartilhado por seus dispositivos.
+    <string name="analytics_opt_in_content">Ajude-nos a identificar problemas e melhorar ${app_name} ao compartilhar dados de uso anônimos. Para entender como pessoas usam seus múltiplos dispositivos, nós vamos gerar um identificador aleatório, compartilhado por seus dispositivos.
 \n
 \nVocê pode ler todos os nossos termos %s.</string>
-    <string name="template_analytics_opt_in_title">Ajude a melhorar ${app_name}</string>
+    <string name="analytics_opt_in_title">Ajude a melhorar ${app_name}</string>
     <string name="preference_system_settings">Configurações de sistema</string>
     <string name="preference_help_title">Ajuda e suporte</string>
     <string name="preference_help">Ajuda</string>
@@ -3061,8 +3061,8 @@
     <string name="settings_enable_location_sharing_summary">Uma vez habilitada você vai ser capaz de enviar sua localização a qualquer sala</string>
     <string name="settings_enable_location_sharing">Habilitar compartilhamento de localização</string>
     <string name="location_share_external">Abrir com</string>
-    <string name="template_location_not_available_dialog_content">${app_name} não pôde acessar sua localização. Por favor tente de novo mais tarde.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} não pôde acessar sua localização</string>
+    <string name="location_not_available_dialog_content">${app_name} não pôde acessar sua localização. Por favor tente de novo mais tarde.</string>
+    <string name="location_not_available_dialog_title">${app_name} não pôde acessar sua localização</string>
     <string name="location_share">Compartilhar localização</string>
     <string name="a11y_location_share_icon">Compartilhar localização</string>
     <string name="location_activity_title_preview">Localização</string>

--- a/vector/src/main/res/values-pt/strings.xml
+++ b/vector/src/main/res/values-pt/strings.xml
@@ -118,7 +118,7 @@
     <string name="local_address_book_header">Lista de endereços local</string>
     <string name="matrix_only_filter">Apenas contactos do Matrix</string>
     <string name="no_conversation_placeholder">Não há conversas</string>
-    <string name="template_no_contact_access_placeholder">Não permitiu ao ${app_name} aceder aos seus contactos locais</string>
+    <string name="no_contact_access_placeholder">Não permitiu ao ${app_name} aceder aos seus contactos locais</string>
     <string name="no_result_placeholder">Sem resultados</string>
     <string name="rooms_header">Salas</string>
     <string name="rooms_directory_header">Lista de salas</string>
@@ -245,24 +245,24 @@ A sessão foi terminada em todos os dispositivos e não receberá mais notifica�
     <string name="media_picker_both_capture_title">Tirar fotografia ou gravar um vídeo</string>
     <string name="media_picker_cannot_record_video">Não foi possível gravar vídeo</string>
     <string name="permissions_rationale_popup_title">Informação</string>
-    <string name="template_permissions_rationale_msg_storage">O ${app_name} necessita de permissão para aceder ao seu armazenamento de fotos e vídeos para poder enviar e guardar anexos.
+    <string name="permissions_rationale_msg_storage">O ${app_name} necessita de permissão para aceder ao seu armazenamento de fotos e vídeos para poder enviar e guardar anexos.
 
 Permita o acesso na próxima janela para poder enviar ficheiros a partir do seu telefone.</string>
-    <string name="template_permissions_rationale_msg_camera">O ${app_name} necessita de permissão para aceder à sua câmara para poder tirar fotos e fazer chamadas de vídeo.</string>
+    <string name="permissions_rationale_msg_camera">O ${app_name} necessita de permissão para aceder à sua câmara para poder tirar fotos e fazer chamadas de vídeo.</string>
     <string name="permissions_rationale_msg_camera_explanation">
 
 Por favor, permita o acesso na próxima janela para poder realizar a chamada.</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} necessita de permissão para aceder ao seu microfone para realizar chamadas de áudio.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} necessita de permissão para aceder ao seu microfone para realizar chamadas de áudio.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">
 
 Por favor, permita acesso na próxima janela para poder efetuar a chamada.</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} necessita de permissão para aceder à sua câmara e ao seu microfone para realizar chamadas de vídeo.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} necessita de permissão para aceder à sua câmara e ao seu microfone para realizar chamadas de vídeo.
 
 Por favor, permita o acesso na próxima janela para poder efetuar a chamada.</string>
-    <string name="template_permissions_rationale_msg_contacts">O ${app_name} necessita de permissão para aceder à sua lista de contactos para encontrar outros utilizadores Matrix a partir dos seus e-mails e números de telefone.
+    <string name="permissions_rationale_msg_contacts">O ${app_name} necessita de permissão para aceder à sua lista de contactos para encontrar outros utilizadores Matrix a partir dos seus e-mails e números de telefone.
 
 Por favor, permita o acesso na próxima janela para poder encontrar utilizadores na sua lista de contactos que podem ser contactados pelo ${app_name}.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">O ${app_name} necessita de permissão para aceder à sua lista de contactos para encontrar outros utilizadores Matrix a partir dos seus endereços de email e números de telefone.
+    <string name="permissions_msg_contacts_warning_other_androids">O ${app_name} necessita de permissão para aceder à sua lista de contactos para encontrar outros utilizadores Matrix a partir dos seus endereços de email e números de telefone.
 
 Permitir ao ${app_name} aceder aos seus contactos?</string>
     <string name="permissions_action_not_performed_missing_permissions">Desculpe… A ação não foi realizada, por falta de permissões</string>
@@ -644,7 +644,7 @@ Adicionar alguns agora?</string>
     <string name="e2e_re_request_encryption_key"><u>Pedir de novo as chaves criptográficas</u> aos seus outros dispositivos.</string>
     <string name="e2e_re_request_encryption_key_sent">Pedido de chaves enviado.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Pedido enviado</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Por favor abra o ${app_name} num dispositivo que consiga decifrar a mensagem, para que esse dispositivo possa enviar as chaves para este dispositivo.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Por favor abra o ${app_name} num dispositivo que consiga decifrar a mensagem, para que esse dispositivo possa enviar as chaves para este dispositivo.</string>
     <string name="groups_list">Lista de Grupos</string>
     <plurals name="membership_changes">
         <item quantity="one">%d mudança de adesão</item>
@@ -725,13 +725,13 @@ Adicionar alguns agora?</string>
     <string name="settings_deactivate_account_section">Desactivar a conta</string>
     <string name="settings_deactivate_my_account">Desactivar a minha conta</string>
     <string name="startup_notification_privacy_title">Privacidade das Notificações</string>
-    <string name="template_startup_notification_privacy_message">O ${app_name} pode executar em segundo plano para gerir as notificações de forma segura e confidencial (isso poderá afectar a utilização da bateria).</string>
+    <string name="startup_notification_privacy_message">O ${app_name} pode executar em segundo plano para gerir as notificações de forma segura e confidencial (isso poderá afectar a utilização da bateria).</string>
     <string name="startup_notification_privacy_button_grant">Conceder permissão</string>
     <string name="startup_notification_privacy_button_other">Escolha outra opção</string>
     <string name="settings_analytics">Estatísticas de uso</string>
     <string name="settings_opt_in_of_analytics">Enviar dados de análise de estatísticas</string>
-    <string name="template_settings_opt_in_of_analytics_summary">O ${app_name} recolhe dados anónimos de análise de estatísticas para ajudar a melhorar a aplicação.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Por favor, permita o envio de dados de análise para ajudar-nos a melhorar o ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">O ${app_name} recolhe dados anónimos de análise de estatísticas para ajudar a melhorar a aplicação.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Por favor, permita o envio de dados de análise para ajudar-nos a melhorar o ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Sim, quero ajudar!</string>
     <string name="settings_flair">Insígnias</string>
     <string name="settings_without_flair">Você não faz, actualmente, parte de qualquer comunidade.</string>
@@ -900,7 +900,7 @@ A visibilidade das mensagens no Matrix é parecida com a dos emails. O nosso esq
     <string name="keys_backup_settings_delete_confirm_title">Apagar Backup</string>
     <string name="auth_accept_policies">Por favor veja e aceite, apolice para este servidor</string>
     <string name="settings_call_category">Chamadas</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Usar toque padrão para chamadas recebidas</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Usar toque padrão para chamadas recebidas</string>
     <string name="settings_call_ringtone_title">Toque para chamadas recebidas</string>
     <string name="settings_call_ringtone_dialog_title">Selecione toque para chamadas:</string>
     <string name="video_call_in_progress">Chamada de Vídeo em Progresso…</string>
@@ -923,7 +923,7 @@ Se faz favor verifique configurações de conta</string>
     <string name="settings_troubleshoot_test_account_settings_quickfix">Activar</string>
     <string name="settings_troubleshoot_test_device_settings_title">Configurações de aparelho</string>
     <string name="settings_troubleshoot_test_device_settings_success">Notificações estão activadas para este aparelho</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Notificações estão desactivadas para este aparelho
+    <string name="settings_troubleshoot_test_device_settings_failed">Notificações estão desactivadas para este aparelho
 Por favor, verifique configurações de aplicação</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Activar</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Configurações personalizadas</string>
@@ -941,7 +941,7 @@ Por favor, verifique configurações de aplicação</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Verificar restriçoes de histórico</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Desactivar restricções</string>
     <string name="settings_troubleshoot_test_battery_title">Optimização de bateria</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} não é afectado por Optimização de bateria</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} não é afectado por Optimização de bateria</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignorar Optimização</string>
     <string name="settings_noisy_notifications_preferences">Configurar Notificações de ruido</string>
     <string name="settings_call_notifications_preferences">Configurar Notificações de chamadas</string>
@@ -949,6 +949,6 @@ Por favor, verifique configurações de aplicação</string>
     <string name="settings_system_preferences_summary">Escolha cor de LED, vibração, som…</string>
     <string name="notification_sync_init">A iniciar o serviço</string>
     <string name="title_activity_verify_device">Verificar sessão</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} irá sincronizar em fundo periodicamente em tempo preciso (configurável).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} irá sincronizar em fundo periodicamente em tempo preciso (configurável).
 \nIsto terá impacto na utilização do rádio e da bateria, será exibida uma notificação permanente declarando que ${app_name} está à escuta dos eventos.</string>
 </resources>

--- a/vector/src/main/res/values-ru/strings.xml
+++ b/vector/src/main/res/values-ru/strings.xml
@@ -345,7 +345,7 @@
     <string name="local_address_book_header">Локальные контакты</string>
     <string name="matrix_only_filter">Только Matrix контакты</string>
     <string name="no_conversation_placeholder">Нет диалогов</string>
-    <string name="template_no_contact_access_placeholder">Вы не дали доступ ${app_name} к внутренним контактам</string>
+    <string name="no_contact_access_placeholder">Вы не дали доступ ${app_name} к внутренним контактам</string>
     <string name="no_result_placeholder">Нет результатов</string>
     <string name="rooms_header">Комнаты</string>
     <string name="rooms_directory_header">Каталог комнат</string>
@@ -474,18 +474,18 @@
     <string name="media_picker_both_capture_title">Снять фото или видео"</string>
     <string name="media_picker_cannot_record_video">Не удалось записать видео"</string>
     <string name="permissions_rationale_popup_title">Информация</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} нуждается в разрешении на доступ к вашей фото-и видеотеке для отправки и сохранения вложений.
+    <string name="permissions_rationale_msg_storage">${app_name} нуждается в разрешении на доступ к вашей фото-и видеотеке для отправки и сохранения вложений.
 \n
 \nПожалуйста, разрешите доступ в следующем всплывающем окне, чтобы иметь возможность отправлять файлы с вашего устройства.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} необходимы разрешения на доступ к вашей камере, чтобы делать фото и совершать видеозвонки.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} необходимы разрешения на доступ к вашей камере, чтобы делать фото и совершать видеозвонки.</string>
     <string name="permissions_rationale_msg_camera_explanation">\n\nПожалуйста разрешите доступ в следующем окне, чтобы иметь возможность совершать звонки.</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} необходимы разрешения на доступ к микрофону, чтобы выполнять звонки.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} необходимы разрешения на доступ к микрофону, чтобы выполнять звонки.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">\n\nПожалуйста разрешите доступ в следующем окне, чтобы иметь возможность совершать звонки.</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} необходимы разрешения на доступ к камере и микрофону для видеовызовов.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} необходимы разрешения на доступ к камере и микрофону для видеовызовов.
 \n
 \nПожалуйста дайте разрешение в следующем окне для звонка.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} может проверить вашу адресную книгу, чтобы найти других пользователей Matrix по их электронной почте и номерам телефонов. Если вы согласны поделиться своей адресной книгой для этой цели, пожалуйста, откройте доступ на следующем всплывающем окне.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} может проверить Вашу адресную книгу, чтобы найти других пользователей сети по email или телефонному номеру.
+    <string name="permissions_rationale_msg_contacts">${app_name} может проверить вашу адресную книгу, чтобы найти других пользователей Matrix по их электронной почте и номерам телефонов. Если вы согласны поделиться своей адресной книгой для этой цели, пожалуйста, откройте доступ на следующем всплывающем окне.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} может проверить Вашу адресную книгу, чтобы найти других пользователей сети по email или телефонному номеру.
 \n
 \nСогласны ли вы поделиться своей адресной книгой для этой цели\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Извините. Действие не выполнено из-за отсутствия на него разрешений</string>
@@ -976,7 +976,7 @@
     <string name="settings_notification_privacy_nosecure_message_content">• Уведомления содержат <b>метаданные и данные сообщения</b></string>
     <string name="settings_notification_privacy_message_content_not_shown">• Уведомления <b>не будут показывать содержимое сообщения</b></string>
     <string name="startup_notification_privacy_title">Конфиденциальность уведомлений</string>
-    <string name="template_startup_notification_privacy_message">${app_name} может работать в фоновом режиме для управления конфиденциальностью и безопасностью ваших уведомлений. Это может повлиять на время работы от батареи.</string>
+    <string name="startup_notification_privacy_message">${app_name} может работать в фоновом режиме для управления конфиденциальностью и безопасностью ваших уведомлений. Это может повлиять на время работы от батареи.</string>
     <string name="startup_notification_privacy_button_grant">Предоставить разрешение</string>
     <string name="startup_notification_privacy_button_other">Выбрать другой вариант</string>
     <string name="settings_notification_privacy_reduced">Ограниченная конфиденциальность</string>
@@ -989,8 +989,8 @@
     <string name="settings_deactivate_account_section">Деактивация аккаунта</string>
     <string name="settings_deactivate_my_account">Деактивировать мой аккаунт</string>
     <string name="settings_opt_in_of_analytics">Отправка аналитических данных</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} собирает анонимную аналитику для улучшения приложения.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Пожалуйста, включите аналитику, чтобы помочь нам улучшить ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} собирает анонимную аналитику для улучшения приложения.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Пожалуйста, включите аналитику, чтобы помочь нам улучшить ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Да, я хочу помочь!</string>
     <string name="widget_integration_missing_parameter">Обязательный параметр отсутствует.</string>
     <string name="widget_integration_invalid_parameter">Параметр недействителен.</string>
@@ -1012,7 +1012,7 @@
     <string name="e2e_re_request_encryption_key">Перезапросить ключи шифрования у других ваших сессий.</string>
     <string name="e2e_re_request_encryption_key_sent">Отправлен запрос ключа.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Запрос отправлен</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Запустите ${app_name} на другом устройстве, которое может расшифровать сообщение, для отправки ключа на эту сессию.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Запустите ${app_name} на другом устройстве, которое может расшифровать сообщение, для отправки ключа на эту сессию.</string>
     <string name="lock_screen_hint">Введите здесь…</string>
     <string name="option_send_voice">Отправить голосовое сообщение</string>
     <string name="go_on_with">продолжить с…</string>
@@ -1115,7 +1115,7 @@
     <string name="settings_password">Пароль</string>
     <string name="auth_accept_policies">Пожалуйста, ознакомьтесь и примите правила этого домашнего сервера:</string>
     <string name="settings_call_category">Вызовы</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Использовать стандартную мелодию ${app_name} для входящих звонков</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Использовать стандартную мелодию ${app_name} для входящих звонков</string>
     <string name="settings_call_ringtone_title">Мелодия входящего вызова</string>
     <string name="settings_call_ringtone_dialog_title">Выберите мелодию звонка:</string>
     <string name="video_call_in_progress">Идёт видеозвонок …</string>
@@ -1155,12 +1155,12 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Включить</string>
     <string name="settings_troubleshoot_test_device_settings_title">Настройки сессии.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Уведомления включены для этой сессии.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Уведомления не включено для этой сессии.
+    <string name="settings_troubleshoot_test_device_settings_failed">Уведомления не включено для этой сессии.
 \nПожалуйста, проверьте настройки ${app_name}.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Включить</string>
     <string name="settings_troubleshoot_test_play_services_title">Проверка сервисов Play</string>
     <string name="settings_troubleshoot_test_play_services_success">APK Google Play сервисов доступен и обновлён.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} использует сервисы Google Play для доставки push-сообщений, но не похоже что он настроен правильно:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} использует сервисы Google Play для доставки push-сообщений, но не похоже что он настроен правильно:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Исправить сервисы Play</string>
     <string name="settings_troubleshoot_test_fcm_title">Токен Firebase</string>
@@ -1177,17 +1177,17 @@
     <string name="settings_troubleshoot_test_service_restart_failed">Не удалось перезапустить службу</string>
     <string name="settings_troubleshoot_test_service_boot_title">Запуск при загрузке</string>
     <string name="settings_troubleshoot_test_service_boot_success">Служба будет запущена после перезапуска устройства.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">При перезагрузке устройства служба не будет запущена , вы не будете получать уведомления, пока ${app_name} не будет открыт один раз.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">При перезагрузке устройства служба не будет запущена , вы не будете получать уведомления, пока ${app_name} не будет открыт один раз.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Включить запуск при загрузке</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Проверьте фоновые ограничения</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Фоновые ограничения отключены для ${app_name}. Этот тест должен быть запущен с использованием мобильных данных (без WIFI).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Фоновые ограничения отключены для ${app_name}. Этот тест должен быть запущен с использованием мобильных данных (без WIFI).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Фоновые ограничения включены для ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Фоновые ограничения включены для ${app_name}.
 \nРабота приложения будет жестко ограничена, пока оно находится в фоновом режиме, и это может повлиять на уведомления. 
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Отключить ограничения</string>
     <string name="settings_troubleshoot_test_battery_title">Оптимизация батареи</string>
-    <string name="template_settings_troubleshoot_test_battery_success">Оптимизация батареи не влияет на ${app_name}.</string>
+    <string name="settings_troubleshoot_test_battery_success">Оптимизация батареи не влияет на ${app_name}.</string>
     <string name="settings_troubleshoot_test_battery_failed">Если пользователь оставляет устройство в отключенном от сети и в неподвижном состоянии в течение некоторого времени при выключенном экране, устройство переходит в режим Doze. Это предотвращает доступ приложений к сети и откладывает выполнение заданий, синхронизацию и передачу стандартных аварийных сигналов.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Игнорировать оптимизацию</string>
     <string name="settings_inline_url_preview_summary">Предпросмотр ссылок в чате, когда ваш домашний сервер поддерживает эту функцию.</string>
@@ -1198,7 +1198,7 @@
     <string name="settings_show_join_leave_messages">Показывать события о вступлении/выходе</string>
     <string name="settings_show_avatar_display_name_changes_messages">Показывать события аккаунта</string>
     <string name="settings_show_avatar_display_name_changes_messages_summary">Включает изменения аватара и отображаемого имени.</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">Необходимо минимизировать влияние на фоновое соединение для надёжности уведомлений.
+    <string name="startup_notification_fdroid_battery_optim_message">Необходимо минимизировать влияние на фоновое соединение для надёжности уведомлений.
 \nНа следующем экране вам будет предложено разрешить ${app_name} всегда работать в фоновом режиме, пожалуйста, согласитесь.</string>
     <string name="settings_labs_native_camera_summary">Использовать системную камеру вместо камеры Element.</string>
     <string name="settings_info_area_show">Показать информацию</string>
@@ -1230,7 +1230,7 @@
     <string name="notification_silent">Беззвучный</string>
     <string name="passphrase_empty_error_message">Пожалуйста, введите парольную фразу</string>
     <string name="passphrase_passphrase_too_weak">Парольная фраза слишком простая</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Пожалуйста, удалите парольную фразу, если хотите, чтобы ${app_name} сгенерировал ключ восстановления.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Пожалуйста, удалите парольную фразу, если хотите, чтобы ${app_name} сгенерировал ключ восстановления.</string>
     <string name="keys_backup_no_session_error">Matrix сессия недоступна</string>
     <string name="keys_backup_setup_step1_title">Никогда не теряйте зашифрованных сообщений</string>
     <string name="keys_backup_setup_step1_description">Сообщения в зашифрованных комнатах защищены сквозным шифрованием. Ключи для прочтения этих сообщений есть только у вас и получателя(ей).
@@ -1297,11 +1297,11 @@
     <string name="recovery_key_export_saved_as_warning">Ключ восстановления был сохранен в \'%s\'. 
 \n
 \nПредупреждение: этот файл может быть удален при удалении приложения.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nЭта ошибка вне контроля ${app_name}. На телефоне нет учетной записи Google. Пожалуйста, добавьте аккаунт Google.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nЭта ошибка вне контроля ${app_name}. Причины могут быть разными. Возможно, это будет работать, если вы повторите попытку позже, вы также можете проверить, что службы Google Play не ограничены в использовании данных в настройках системы, или что часы вашего устройства установлены правильно, или это может произойти на модифицированных прошивках.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nЭта ошибка вне контроля ${app_name}, и, по словам Google, эта ошибка означает, что на устройстве слишком много приложений, зарегистрированных в FCM. Ошибка возникает только в тех случаях, когда существует огромное количество приложений, поэтому она не должна влиять на обычного пользователя.</string>
     <string name="sign_out_bottom_sheet_warning_no_backup">Ваши зашифрованные сообщения будут потеряны, если выйдете сейчас</string>
     <string name="sign_out_bottom_sheet_warning_backing_up">Выполняется резервное копирование ключа. Если выйти сейчас, Вы потеряете доступ к Вашим зашифрованным сообщениям.</string>
@@ -1413,7 +1413,7 @@
     <string name="ignore_request_short_label">Игнорировать</string>
     <string name="autodiscover_invalid_response">Ошибка отклика сервера</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Дополнить параметры сервера</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} обнаружил пользовательскую конфигурацию сервера для вашего userID домена\"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} обнаружил пользовательскую конфигурацию сервера для вашего userID домена\"%1$s\":
 \n%2$s</string>
     <string name="sas_verify_title">Проверьте, сравнив короткую текстовую строку.</string>
     <string name="sas_security_advise">Для обеспечения максимальной безопасности мы рекомендуем делать это лично или использовать другие надежные средства связи.</string>
@@ -1527,7 +1527,7 @@
     <string name="send_suggestion_sent">Спасибо, предложение было успешно отправлено</string>
     <string name="send_suggestion_failed">Не удалось отправить предложение (%s)</string>
     <string name="settings_labs_show_hidden_events_in_timeline">Показать скрытые события в ленте сообщений</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Предварительный просмотр открытой комнаты в ${app_name} пока не поддерживается</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Предварительный просмотр открытой комнаты в ${app_name} пока не поддерживается</string>
     <string name="bottom_action_people_x">Диалоги</string>
     <string name="send_file_step_idle">Ждите…</string>
     <string name="send_file_step_encrypting_thumbnail">Шифрование миниатюры…</string>
@@ -1589,9 +1589,9 @@
     <string name="settings_call_ringtone_use_default_stun_sum">Будет использовать %s в качестве помощника, если ваш домашний сервер не предлагает его (ваш IP-адрес будет доступен во время разговора)</string>
     <string name="invite_no_identity_server_error">Добавьте сервер обнаружения в свои настройки, чтобы выполнить это действие.</string>
     <string name="settings_background_fdroid_sync_mode">Режим фоновой синхронизации</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} будет синхронизироваться в фоновом режиме таким образом, чтобы сохранить ограниченные ресурсы устройства (батарея).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} будет синхронизироваться в фоновом режиме таким образом, чтобы сохранить ограниченные ресурсы устройства (батарея).
 \nВ зависимости от состояния ресурса вашего устройства, синхронизация может быть отложена операционной системой.</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} будет синхронизироваться в фоновом режиме периодически в точное время (настраивается).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} будет синхронизироваться в фоновом режиме периодически в точное время (настраивается).
 \nЭто повлияет на использование радио и батареи, появится постоянное уведомление о том, что ${app_name} прислушивается к событиям.</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Вы не будете уведомлены о входящих сообщениях, когда приложение находится в фоновом режиме.</string>
     <string name="settings_set_workmanager_delay_summary">%s
@@ -1638,7 +1638,7 @@
     <string name="room_widget_open_in_browser">Открыть в браузере</string>
     <string name="room_widget_permission_widget_id">ID виджета</string>
     <string name="room_widget_resource_grant_permission">Позволить</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Вы это не можете делать на мобильном ${app_name}</string>
+    <string name="settings_add_3pid_flow_not_supported">Вы это не можете делать на мобильном ${app_name}</string>
     <string name="room_widget_permission_added_by">Этот виджет был добавлен:</string>
     <string name="room_widget_permission_theme">Ваша тема</string>
     <string name="room_widget_permission_room_id">ID комнаты</string>
@@ -1802,7 +1802,7 @@
 \nВойдите заново, чтобы получить доступ к данным своей учётной записи и сообщениям.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Вы потеряете доступ к защищённым сообщениям, если не войдёте в систему для восстановления ключей шифрования.</string>
     <string name="soft_logout_clear_data_dialog_submit">Очистить данные</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Текущая сессия предназначена для пользователя %1$s, а вы предоставляете учётные данные для пользователя %2$s. Это не поддерживается в ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">Текущая сессия предназначена для пользователя %1$s, а вы предоставляете учётные данные для пользователя %2$s. Это не поддерживается в ${app_name}.
 \nПожалуйста, сначала очистите данные, а затем снова войдите под другим аккаунтом.</string>
     <string name="permalink_malformed">Ваша ссылка на matrix.to была испорчена</string>
     <string name="bug_report_error_too_short">Описание слишком короткое</string>
@@ -1907,7 +1907,7 @@
     <string name="a11y_close_keys_backup_banner">Закрыть окно резервного копирования ключей</string>
     <string name="one_user_read">%s прочитано</string>
     <string name="error_handling_incoming_share">Не удалось обработать данные</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} требуются права для сохранения ваших ключей сквозного шифрования на диск.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} требуются права для сохранения ваших ключей сквозного шифрования на диск.
 \n
 \nПожалуйста, разрешите доступ в следующем всплывающем окне, чтобы экспортировать ключи вручную.</string>
     <string name="no_network_indicator">Сейчас нет подключения к сети</string>
@@ -1916,7 +1916,7 @@
     <string name="action_copy">Копировать</string>
     <string name="dialog_title_success">Удачно</string>
     <string name="bottom_action_notification">Уведомления</string>
-    <string name="template_call_failed_no_connection">Звонок не состоялся</string>
+    <string name="call_failed_no_connection">Звонок не состоялся</string>
     <string name="call_failed_no_connection_description">Не удалось установить соединение реального времени.
 \nПопросите администратора вашего сервера настроить сервер TURN, чтобы звонки работали надёжно.</string>
     <string name="call_select_sound_device">Выберите звуковое устройство</string>
@@ -2015,7 +2015,7 @@
     <string name="rageshake_detected">Обнаружено потрясение!</string>
     <string name="autocomplete_limited_results">Показываем только первые результаты, наберите больше букв…</string>
     <string name="settings_developer_mode_fail_fast_title">Раннее падение</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} может падать чаще, когда происходит непредвиденная ошибка</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} может падать чаще, когда происходит непредвиденная ошибка</string>
     <string name="command_description_shrug">Добавляет смайл ¯\\_(ツ)_/¯ в начало сообщения</string>
     <string name="create_room_encryption_description">После включения шифрования его нельзя отключить.</string>
     <string name="login_error_threepid_denied">Ваш почтовый домен не имеет права регистрироваться на этом сервере</string>
@@ -2071,9 +2071,9 @@
     <string name="room_member_power_level_default_in">По умолчанию в %1$s</string>
     <string name="room_member_power_level_custom_in">Пользовательский (%1$d) в %2$s</string>
     <string name="room_member_jump_to_read_receipt">Перейти к последнему прочтённому им сообщению</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} не обрабатывает события типа \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} не обрабатывает сообщения типа \'%1$s\'</string>
-    <string name="template_rendering_event_error_exception">${app_name} столкнулся с проблемой при отображении содержимого события с идентификатором \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} не обрабатывает события типа \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} не обрабатывает сообщения типа \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} столкнулся с проблемой при отображении содержимого события с идентификатором \'%1$s\'</string>
     <string name="unignore">Перестать игнорировать</string>
     <string name="verify_cannot_cross_sign">Эта сессия не может поделиться подтверждением с другими сессиями.
 \nПодтверждение будет сохранено локально и отправится в будущей версии приложения.</string>
@@ -2129,8 +2129,8 @@
     <string name="settings_messages_at_room">Сообщения, содержащие @room</string>
     <string name="settings_troubleshoot_title">Отладка</string>
     <string name="settings_notification_advanced_summary">Настройки важности уведомлений для событий</string>
-    <string name="template_use_other_session_content_description">Используйте последнюю версию ${app_name} на других ваших устройствах, веб-клиент ${app_name}, ${app_name} для ПК, ${app_name} для iOS, ${app_name} для Android или другой клиент Matrix, поддерживающий перекрестную подпись</string>
-    <string name="template_use_latest_app">Используйте последнюю версию ${app_name} на других ваших устройствах:</string>
+    <string name="use_other_session_content_description">Используйте последнюю версию ${app_name} на других ваших устройствах, веб-клиент ${app_name}, ${app_name} для ПК, ${app_name} для iOS, ${app_name} для Android или другой клиент Matrix, поддерживающий перекрестную подпись</string>
+    <string name="use_latest_app">Используйте последнюю версию ${app_name} на других ваших устройствах:</string>
     <string name="verify_this_session">Подтвердите новую сессию вашей учетной записи: %1$s</string>
     <string name="settings_setup_secure_backup">Настроить безопасное резервное копирование</string>
     <string name="bottom_sheet_setup_secure_backup_title">Безопасное резервное копирование</string>
@@ -2173,7 +2173,7 @@
     <string name="event_redacted_by_user_reason_with_reason">Событие удалено пользователем, Причина: %1$s</string>
     <string name="event_redacted_by_admin_reason_with_reason">Событие модерируется администратором комнаты, Причина: %1$s</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Ключи успешно обновлены!</string>
-    <string name="template_login_default_session_public_name">${app_name} для Android</string>
+    <string name="login_default_session_public_name">${app_name} для Android</string>
     <string name="refresh">Обновить</string>
     <string name="new_session">Новый вход в вашу учётную запись. Это были Вы\?</string>
     <string name="new_session_review">Нажмите, чтобы просмотреть и проверить</string>
@@ -2246,9 +2246,9 @@
     <string name="media_file_added_to_gallery">Медиафайл добавлен в галерею</string>
     <string name="error_adding_media_file_to_gallery">Не удалось добавить медиафайл в галерею</string>
     <string name="error_saving_media_file">Не удалось сохранить медиафайл</string>
-    <string name="template_app_desktop_web">Веб-${app_name}
+    <string name="app_desktop_web">Веб-${app_name}
 \n${app_name} для ПК</string>
-    <string name="template_app_ios_android">${app_name} для iOS
+    <string name="app_ios_android">${app_name} для iOS
 \n${app_name} для Android</string>
     <string name="or_other_mx_capable_client">или другой клиент Matrix поддерживающий перекрестную подпись</string>
     <string name="command_description_discard_session">Принудительно отбрасывает текущую групповую сессию для отправки сообщений в зашифрованную комнату</string>
@@ -2285,11 +2285,11 @@
     <string name="choose_locale_loading_locales">Загрузка доступных языков…</string>
     <string name="open_terms_of">Посмотреть условия %s</string>
     <string name="disconnect_identity_server_dialog_content">Отключиться от сервера идентификации %s\?</string>
-    <string name="template_identity_server_error_outdated_identity_server">Этот сервер идентификации устарел. ${app_name} поддерживает только API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Этот сервер идентификации устарел. ${app_name} поддерживает только API V2.</string>
     <string name="identity_server_error_outdated_home_server">Эта операция невозможна. Домашний сервер устарел.</string>
     <string name="identity_server_error_no_identity_server_configured">Пожалуйста, настройте сначала сервер идентификации.</string>
     <string name="identity_server_error_terms_not_signed">Пожалуйста, примите сначала условия сервера идентификации в настройках.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Для вашей приватности, ${app_name} поддерживает отправку адреса электронной почты и номера телефона только в хэшированном виде.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Для вашей приватности, ${app_name} поддерживает отправку адреса электронной почты и номера телефона только в хэшированном виде.</string>
     <string name="identity_server_error_binding_error">Привязка не удалась.</string>
     <string name="identity_server_error_no_current_binding_error">Текущая взаимосвязь с этим идентификатором отсутствует.</string>
     <string name="identity_server_set_default_notice">Ваш домашний сервер (%1$s) предлагает использовать %2$s для вашего сервера обнаружения</string>
@@ -2419,13 +2419,13 @@
     <string name="delete_account_data_warning">Удалить данные учетной записи типа %1$s\?
 \n
 \nИспользуйте с осторожностью, это может привести к неожиданному поведению.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">ПИН-код потребуется каждый раз, когда вы откроете ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">ПИН-код потребуется через 2 минуты неиспользования ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">ПИН-код потребуется каждый раз, когда вы откроете ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">ПИН-код потребуется через 2 минуты неиспользования ${app_name}.</string>
     <string name="settings_security_pin_code_grace_period_title">Требовать PIN-код через 2 минуты</string>
     <string name="settings_security_pin_code_notifications_summary_off">Отображать только количество непрочитанных сообщений в простом уведомлении.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Показывать подробности, такие как названия комнат и содержание сообщений.</string>
     <string name="settings_security_pin_code_notifications_title">Показывать содержимое в уведомлениях</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">PIN-код - единственный способ разблокировать ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">PIN-код - единственный способ разблокировать ${app_name}.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Включить биометрические данные устройства, такие как отпечатки пальцев и распознавание лиц.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Включить биометрию</string>
     <string name="settings_security_application_protection_screen_title">Настроить защиту</string>
@@ -2503,8 +2503,8 @@
     <string name="user_code_share">Поделиться моим кодом</string>
     <string name="user_code_scan">Сканировать QR-код</string>
     <string name="not_a_valid_qr_code">Это недействительный QR-код matrix</string>
-    <string name="template_invite_friends_rich_title">🔐️ Присоединяйтесь ко мне в ${app_name}</string>
-    <string name="template_invite_friends_text">Привет, поговори со мной в ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Присоединяйтесь ко мне в ${app_name}</string>
+    <string name="invite_friends_text">Привет, поговори со мной в ${app_name}: %s</string>
     <string name="invite_friends">Пригласить друзей</string>
     <string name="add_people">Добавить людей</string>
     <string name="topic_prefix">"Тема: "</string>
@@ -2617,7 +2617,7 @@
     <string name="room_participants_leave_private_warning">Эта комната не публичная. Вы не сможете повторно присоединиться без приглашения.</string>
     <string name="system_theme">Системная тема</string>
     <string name="authentication_error">Не удалось пройти аутентификацию</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} требует от вас ввести свои учетные данные для выполнения этого действия.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} требует от вас ввести свои учетные данные для выполнения этого действия.</string>
     <string name="re_authentication_activity_title">Требуется повторная аутентификация</string>
     <string name="failed_to_initialize_cross_signing">Не удалось настроить перекрестную подпись</string>
     <string name="call_only_active">Активный звонок (%1$s)</string>
@@ -2945,7 +2945,7 @@
     <string name="settings_notification_mentions_and_keywords">Упоминания и ключевые слова</string>
     <string name="settings_notification_default">Уведомления по умолчанию</string>
     <string name="denied_permission_voice_message">Чтобы отправлять голосовые сообщения, предоставьте разрешение на Микрофон.</string>
-    <string name="template_link_this_email_with_your_account">%s в настройках, чтобы получать приглашения непосредственно в ${app_name}.</string>
+    <string name="link_this_email_with_your_account">%s в настройках, чтобы получать приглашения непосредственно в ${app_name}.</string>
     <string name="link_this_email_settings_link">Свяжите этот адрес электронной почты с вашей учетной записью</string>
     <string name="this_invite_to_this_room_was_sent">Приглашение в эту комнату было отправлено на %s, который не связан с вашей учетной записью</string>
     <string name="this_invite_to_this_space_was_sent">Приглашение в это пространство было отправлено на %s, который не связан с вашей учетной записью</string>
@@ -3068,8 +3068,8 @@
     <string name="settings_enable_location_sharing_summary">После включения вы сможете отправить свое местоположение в любую комнату</string>
     <string name="settings_enable_location_sharing">Включить отправку местоположения</string>
     <string name="location_share_external">Открыть с помощью</string>
-    <string name="template_location_not_available_dialog_content">${app_name} не смог получить доступ к вашему местоположению. Пожалуйста, повторите попытку позже.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} не смог получить доступ к вашему местоположению</string>
+    <string name="location_not_available_dialog_content">${app_name} не смог получить доступ к вашему местоположению. Пожалуйста, повторите попытку позже.</string>
+    <string name="location_not_available_dialog_title">${app_name} не смог получить доступ к вашему местоположению</string>
     <string name="location_share">Поделиться местоположением</string>
     <string name="a11y_location_share_icon">Поделиться местоположением</string>
     <string name="location_activity_title_preview">Местоположение</string>
@@ -3160,7 +3160,7 @@
     <string name="settings_discovery_consent_notice_off_2">Ваши контакты приватны. Чтобы обнаружить пользователей из ваших контактов, нам необходимо ваше разрешение на отправку контактной информации на ваш сервер обнаружения.</string>
     <string name="preference_system_settings">Системные настройки</string>
     <string name="preference_versions">Версии</string>
-    <string name="template_preference_help_summary">Получите помощь в использовании ${app_name}</string>
+    <string name="preference_help_summary">Получите помощь в использовании ${app_name}</string>
     <string name="preference_help_title">Помощь и поддержка</string>
     <string name="preference_help">Помощь</string>
     <string name="preference_root_legals">Правовые положения</string>
@@ -3168,15 +3168,15 @@
     <string name="legals_third_party_notices">Сторонние библиотеки</string>
     <string name="legals_identity_server_title">Политика вашего сервера опознавания</string>
     <string name="legals_home_server_title">Политика вашего домашнего сервера</string>
-    <string name="template_legals_application_title">Политика ${app_name}</string>
+    <string name="legals_application_title">Политика ${app_name}</string>
     <string name="analytics_opt_in_list_item_3">Вы можете отключить это в любое время в настройках</string>
     <string name="analytics_opt_in_list_item_2">Мы <b>не</b> передаем информацию третьим лицам</string>
     <string name="analytics_opt_in_list_item_1">Мы <b>не</b> записываем и <b>не</b> профилируем любые данные учетной записи</string>
     <string name="analytics_opt_in_content_link">тут</string>
-    <string name="template_analytics_opt_in_content">Помогите нам выявить проблемы и улучшить ${app_name}, поделившись анонимными данными об использовании. Чтобы понять, как люди используют несколько устройств, мы сгенерируем случайный идентификатор, общий для всех ваших устройств.
+    <string name="analytics_opt_in_content">Помогите нам выявить проблемы и улучшить ${app_name}, поделившись анонимными данными об использовании. Чтобы понять, как люди используют несколько устройств, мы сгенерируем случайный идентификатор, общий для всех ваших устройств.
 \n
 \nВы можете ознакомиться со всеми нашими условиями %s.</string>
-    <string name="template_analytics_opt_in_title">Помогите улучшить ${app_name}</string>
+    <string name="analytics_opt_in_title">Помогите улучшить ${app_name}</string>
     <string name="shortcut_disabled_reason_sign_out">Сессия завершена!</string>
     <string name="shortcut_disabled_reason_room_left">Комната покинута!</string>
     <string name="room_unsupported_e2e_algorithm_as_admin">Шифрование неправильно настроено, поэтому вы не можете отправлять сообщения. Нажмите, чтобы открыть настройки.</string>

--- a/vector/src/main/res/values-sk/strings.xml
+++ b/vector/src/main/res/values-sk/strings.xml
@@ -280,7 +280,7 @@
     <string name="user_directory_header">Adresár používateľov</string>
     <string name="matrix_only_filter">Len Matrix kontakty</string>
     <string name="no_conversation_placeholder">Žiadne konverzácie</string>
-    <string name="template_no_contact_access_placeholder">Aplikácii ${app_name} ste nepovolili prístup k lokálnym kontaktom</string>
+    <string name="no_contact_access_placeholder">Aplikácii ${app_name} ste nepovolili prístup k lokálnym kontaktom</string>
     <string name="no_result_placeholder">Žiadne výsledky</string>
     <string name="rooms_header">Miestnosti</string>
     <string name="rooms_directory_header">Adresár miestností</string>
@@ -409,22 +409,22 @@
     <string name="media_picker_both_capture_title">Odfotiť obrázok alebo video</string>
     <string name="media_picker_cannot_record_video">Nie je možné nahrať video</string>
     <string name="permissions_rationale_popup_title">Informácia</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} potrebuje povolenie na prístup k vašej knižnici fotografií a videí, aby mohla posielať a ukladať prílohy.
+    <string name="permissions_rationale_msg_storage">${app_name} potrebuje povolenie na prístup k vašej knižnici fotografií a videí, aby mohla posielať a ukladať prílohy.
 \n
 \nPovoľte prístup v ďalšom vyskakovacom okne, aby ste mohli odosielať súbory z telefónu.</string>
-    <string name="template_permissions_rationale_msg_camera">Aby ste mohli fotiť obrázky a videá a tiež uskutočňovať video hovory, ${app_name} potrebuje prístup k fotoaparátu.</string>
+    <string name="permissions_rationale_msg_camera">Aby ste mohli fotiť obrázky a videá a tiež uskutočňovať video hovory, ${app_name} potrebuje prístup k fotoaparátu.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nProsím, povoľte prístup na nasledujúcej obrazovke, aby ste mohli uskutočniť hovor."</string>
-    <string name="template_permissions_rationale_msg_record_audio">Aby ste mohli uskutočňovať audio hovory, ${app_name} potrebuje prístup k mikrofónu vašeho zariadenia.</string>
+    <string name="permissions_rationale_msg_record_audio">Aby ste mohli uskutočňovať audio hovory, ${app_name} potrebuje prístup k mikrofónu vašeho zariadenia.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nProsím, povoľte prístup na nasledujúcej obrazovke, aby ste mohli uskutočniť hovor."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} potrebuje povolenie na prístup k vašej kamere a mikrofónu na uskutočňovanie videohovorov.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} potrebuje povolenie na prístup k vašej kamere a mikrofónu na uskutočňovanie videohovorov.
 \n
 \nPovoľte prístup v ďalších vyskakovacích oknách, aby ste mohli uskutočniť hovor.</string>
-    <string name="template_permissions_rationale_msg_contacts">Aby ste mohli na Matrixe nájsť vašich známych podľa telefónneho čísla alebo emailovej adresy, ${app_name} potrebuje prístup k vašim kontaktom. Ak si prajete zdieľať váš zoznam kontaktov za týmto účelom, prosím, povoľte prístup na nasledujúcej obrazovke.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} môže skontrolovať váš adresár a nájsť ostatných používateľov Matrixu na základe ich e-mailov a telefónnych čísel.
+    <string name="permissions_rationale_msg_contacts">Aby ste mohli na Matrixe nájsť vašich známych podľa telefónneho čísla alebo emailovej adresy, ${app_name} potrebuje prístup k vašim kontaktom. Ak si prajete zdieľať váš zoznam kontaktov za týmto účelom, prosím, povoľte prístup na nasledujúcej obrazovke.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} môže skontrolovať váš adresár a nájsť ostatných používateľov Matrixu na základe ich e-mailov a telefónnych čísel.
 \n
 \nSúhlasíte so zdieľaním svojho adresára na tento účel\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Prepáčte, akcia nebola vykonaná kvôli chýbajúcim oprávneniam</string>
@@ -899,7 +899,7 @@
     <string name="settings_notification_privacy_nosecure_message_content">• Oznámenia obsahujú <b>meta údaje aj obsah správy</b></string>
     <string name="settings_notification_privacy_message_content_not_shown">• Súčasťou oznámení <b>nebude zobrazený obsah správ</b></string>
     <string name="startup_notification_privacy_title">Súkromie oznámení</string>
-    <string name="template_startup_notification_privacy_message">${app_name} môže fungovať na pozadí aby spracovával vaše upozornenia bezpečne a v súkromí. Môže to ovplyvniť využitie batérie.</string>
+    <string name="startup_notification_privacy_message">${app_name} môže fungovať na pozadí aby spracovával vaše upozornenia bezpečne a v súkromí. Môže to ovplyvniť využitie batérie.</string>
     <string name="startup_notification_privacy_button_grant">Udeliť oprávnenie</string>
     <string name="startup_notification_privacy_button_other">Vyberte inú voľbu</string>
     <string name="title_activity_choose_sticker">Odoslať nálepku</string>
@@ -910,8 +910,8 @@
     <string name="settings_deactivate_account_section">Deaktivovať účet</string>
     <string name="settings_deactivate_my_account">Deaktivovať môj účet</string>
     <string name="settings_opt_in_of_analytics">Odosielať analytické údaje</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} zbiera anonymné analytické údaje, čo nám umožňuje aplikáciu ďalej zlepšovať.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Prosím povoľte odosielanie analytických údajov a pomôžte nám tak vylepšovať ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} zbiera anonymné analytické údaje, čo nám umožňuje aplikáciu ďalej zlepšovať.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Prosím povoľte odosielanie analytických údajov a pomôžte nám tak vylepšovať ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Áno, chcem pomôcť!</string>
     <string name="widget_integration_missing_parameter">Chýba zadanie povinného argumentu.</string>
     <string name="widget_integration_invalid_parameter">Argument nie je správny.</string>
@@ -934,7 +934,7 @@
     <string name="e2e_re_request_encryption_key_dialog_title">Žiadosť odoslaná</string>
     <string name="lock_screen_hint">Píšte sem…</string>
     <string name="e2e_re_request_encryption_key">Znovu požiadať o šifrovacie kľúče z vašich ostatných relácií.</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Spustite prosím ${názov_aplikácie} na inom zariadení, ktoré dokáže dešifrovať správu, aby mohlo poslať kľúče do tejto relácie.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Spustite prosím ${názov_aplikácie} na inom zariadení, ktoré dokáže dešifrovať správu, aby mohlo poslať kľúče do tejto relácie.</string>
     <string name="option_send_voice">Odoslať hlasovú správu</string>
     <string name="go_on_with">Pokračovať v aplikácii…</string>
     <string name="error_no_external_application_found">Nebola nájdená žiadna vhodná aplikácia na dokončenie tejto akcie.</string>
@@ -1037,7 +1037,7 @@
     <string name="action_accept">Prijať</string>
     <string name="auth_accept_policies">Prosím prečítajte si a odsúhlaste zmluvné podmienky tohoto domovského servera:</string>
     <string name="settings_call_category">Hovory</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Použiť predvolené zvonenie ${app_name} pre prichádzajúce hovory</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Použiť predvolené zvonenie ${app_name} pre prichádzajúce hovory</string>
     <string name="settings_call_ringtone_title">Zvonenie pre prichádzajúci hovor</string>
     <string name="settings_call_ringtone_dialog_title">Vyberte zvonenie pre prichádzajúce hovory:</string>
     <string name="video_call_in_progress">Prebiehajúci video hovor…</string>
@@ -1062,12 +1062,12 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Povoliť</string>
     <string name="settings_troubleshoot_test_device_settings_title">Nastavenia relácií.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Oznámenia sú povolené pre túto reláciu.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Oznámenia nie sú povolené pre túto reláciu.
+    <string name="settings_troubleshoot_test_device_settings_failed">Oznámenia nie sú povolené pre túto reláciu.
 \nProsím, skontrolujte nastavenia ${app_name}u.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Povoliť</string>
     <string name="settings_troubleshoot_test_play_services_title">Kontrola aplikácii Služby Google Play</string>
     <string name="settings_troubleshoot_test_play_services_success">Aplikácia Služby Google Play je k dispozícii a aktualizovaná.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} používa aplikáciu Služby Google Play na doručovanie oznámení. No zdá sa, že táto nie je správne nakonfigurovaná:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} používa aplikáciu Služby Google Play na doručovanie oznámení. No zdá sa, že táto nie je správne nakonfigurovaná:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Opraviť Služby Play</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase Token</string>
@@ -1084,17 +1084,17 @@
     <string name="settings_troubleshoot_test_service_restart_failed">Službu sa nepodarilo reštartovať</string>
     <string name="settings_troubleshoot_test_service_boot_title">Spustenie po zapnutí</string>
     <string name="settings_troubleshoot_test_service_boot_success">Služba sa automaticky spustí po reštarte zariadenia.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Služba sa automaticky nespustí po reštarte zariadenia a nedostanete po reštarte žiadne oznámenia, kým nespustíte ${app_name} aspoň raz.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Služba sa automaticky nespustí po reštarte zariadenia a nedostanete po reštarte žiadne oznámenia, kým nespustíte ${app_name} aspoň raz.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Povoliť spustenie služby po reštarte</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Kontrola obmedzenia spustenia na pozadí</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Obmedzenie spustenia na pozadí nie je aktívne pre ${app_name}. Tento test je potrebné spustiť cez mobilné dáta (nie cez wifi). 
+    <string name="settings_troubleshoot_test_bg_restricted_success">Obmedzenie spustenia na pozadí nie je aktívne pre ${app_name}. Tento test je potrebné spustiť cez mobilné dáta (nie cez wifi).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Pre ${app_name} sú povolené obmedzenia na pozadí.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Pre ${app_name} sú povolené obmedzenia na pozadí.
 \nPráca, ktorú sa aplikácia pokúsi vykonať, bude agresívne obmedzená, keď je na pozadí, čo môže ovplyvniť oznámenia.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Deaktivovať obmedzenia</string>
     <string name="settings_troubleshoot_test_battery_title">Optimalizácia batérie</string>
-    <string name="template_settings_troubleshoot_test_battery_success">Chod ${app_name} nie je ovplyvnený nastavením optimalizácie batérie.</string>
+    <string name="settings_troubleshoot_test_battery_success">Chod ${app_name} nie je ovplyvnený nastavením optimalizácie batérie.</string>
     <string name="settings_troubleshoot_test_battery_failed">Ak používateľ nechá zariadenie na určitý čas odpojené od siete a nehybné s vypnutou obrazovkou, zariadenie prejde do režimu Doze. Tým sa aplikáciám zabráni v prístupe k sieti a oddialia sa ich úlohy, synchronizácia a štandardné alarmy.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignorovať optimalizáciu</string>
     <string name="settings_inline_url_preview_summary">Zobraziť náhľady odkazov v konverzáciách (ak sú podporované domovským serverom).</string>
@@ -1109,7 +1109,7 @@
     <string name="settings_show_avatar_display_name_changes_messages">Zobrazovať udalosti účtu</string>
     <string name="settings_show_avatar_display_name_changes_messages_summary">Zahŕňa zmeny zobrazovaného mena a obrázka v profile.</string>
     <string name="startup_notification_fdroid_battery_optim_title">Pripojenie na pozadí</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} potrebuje na pozadí udržovať aktívne nenáročné spojenie, aby spoľahlivo fungovali oznámenia. 
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} potrebuje na pozadí udržovať aktívne nenáročné spojenie, aby spoľahlivo fungovali oznámenia.
 \nNa ďalšej obrazovke budete vyzvaní, aby ste povolili aplikácii ${názov_aplikácie}, aby sa vždy spúšťala na pozadí, prosím, prijmite.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Udeliť oprávnenie</string>
     <string name="account_email_error">Pri pokuse overiť vašu emailovú adresu sa vyskytla chyba.</string>
@@ -1152,11 +1152,11 @@
     <string name="settings_troubleshoot_test_bing_settings_failed">Niektoré oznámenia máte zakázané v rozšírených nastaveniach.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">Nepodarilo sa načítať pravidlá oznámení. Prosím, skúste znovu.</string>
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Skontrolovať nastavenia</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nNa zariadení máte množstvo aplikácií zaregistrovaných na doručovanie okamžitých oznámení cez služby Google play. Konfigurácia ${app_name} nemá vplyv na výskyt tejto chyby. Podľa Google sa môže vyskytovať len pri veľmi vysokom počte nainštalovaných aplikácií. Bežní používatelia by týmto nemali byť postihnutí.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nKonfigurácia ${app_name} nemá vplyv na zobrazenie tejto chyby. Táto chyba sa môže zobraziť z niekoľkých dôvodov. Uistite sa že máte správne nastavený systémový čas a že ste v nastaveniach systému aplikácii služby Google play neobmedzili používanie prístupu na internet. Chyba sa tiež môže zobrazovať na vlastných zostaveniach (ROM), alebo sa chyba môže samovoľne prestať zobrazovať neskôr.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nV zariadení nemáte nastavený účet Google. Prosím, pridajte si účet cez správcu účtov. Konfigurácia ${app_name} nemá vplyv na zobrazenie tejto chyby.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Pridať účet</string>
     <string name="settings_notification_privacy_no_background_sync">Aplikácia sa <b>nemusí</b> pripájať k domovskému serveru, keď beží na pozadí, čo môže predĺžiť výdrž batérie</string>
@@ -1232,7 +1232,7 @@
     <string name="action_copy">Kopírovať</string>
     <string name="dialog_title_success">Úspešné</string>
     <string name="bottom_action_notification">Oznámenia</string>
-    <string name="template_call_failed_no_connection">${app_name} hovor zlyhal</string>
+    <string name="call_failed_no_connection">${app_name} hovor zlyhal</string>
     <string name="call_failed_no_connection_description">Nepodarilo sa uskutočniť spojenie v reálnom čase.
 \nProsím, požiadajte správcu domovského servera, aby správne nastavil server turn na zaistenie čo najspoľahlivejšej prevádzky hovorov.</string>
     <string name="call_select_sound_device">Vybrať zvukové zariadenie</string>
@@ -1276,14 +1276,14 @@
     <string name="room_participants_unban_title">Povoliť používateľovi vstupovať</string>
     <string name="room_participants_unban_prompt_msg">Povolením používateľovi vstupovať zaistíte, aby sa používateľ mohol vrátiť do miestnosti.</string>
     <string name="settings_add_3pid_confirm_password_title">Potvrdiť vaše heslo</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Toto nie je možné urobiť cez mobilnú aplikáciu ${app_name}</string>
+    <string name="settings_add_3pid_flow_not_supported">Toto nie je možné urobiť cez mobilnú aplikáciu ${app_name}</string>
     <string name="settings_add_3pid_authentication_needed">Je požadované overenie</string>
     <string name="settings_background_fdroid_sync_mode">Režim synchronizácie na pozadí</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimalizovaný na využívanie batérie</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} sa bude synchronizovať na pozadí s cieľom ušetriť limitované zdroje (batériu).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} sa bude synchronizovať na pozadí s cieľom ušetriť limitované zdroje (batériu).
 \nV závislosti od kapacity prostriedkov zariadenia môže byť synchronizácia odložená operačným systémom na neskôr.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimalizovaný na používanie v reálnom čase</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} sa bude pravidelne synchronizovať na pozadí v presne stanovenom čase (nastaviteľné).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} sa bude pravidelne synchronizovať na pozadí v presne stanovenom čase (nastaviteľné).
 \nBude to mať vplyv na používanie rádia a batérie, bude sa zobrazovať trvalé oznámenie, že ${app_name} počúva udalosti.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Žiadna synchronizácia na pozadí</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Nebudete dostávať oznámenia o prichádzajúcich správach, keď aplikácia pracuje na pozadí.</string>
@@ -1367,7 +1367,7 @@
     <string name="ignore_request_short_label">Ignorovať</string>
     <string name="passphrase_empty_error_message">Zadajte prosím prístupovú frázu</string>
     <string name="passphrase_passphrase_too_weak">Prístupová fráza je príliš slabá</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Ak chcete, aby ${app_name} vygeneroval kľúč na obnovenie, odstráňte prístupovú frázu.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Ak chcete, aby ${app_name} vygeneroval kľúč na obnovenie, odstráňte prístupovú frázu.</string>
     <string name="keys_backup_no_session_error">Nie je dostupná žiadna relácia Matrix</string>
     <string name="keys_backup_setup_step1_title">Nikdy nepríďte o šifrované správy</string>
     <string name="keys_backup_setup_step1_description">Správy v šifrovaných miestnostiach sú zabezpečené end-to-end šifrovaním. Kľúče na čítanie týchto správ máte len vy a príjemca (príjemcovia).
@@ -1485,7 +1485,7 @@
     <string name="keys_backup_info_title_signature">Podpis</string>
     <string name="autodiscover_invalid_response">Neplatná odpoveď pri zisťovaní domovského servera</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Automaticky doplniť možnosti servera</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} zistil vlastné nastavenie servera pre vaše ID používateľa a doménu \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} zistil vlastné nastavenie servera pre vaše ID používateľa a doménu \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Použiť nastavenia</string>
     <string name="invalid_or_expired_credentials">Boli ste odhlásení, pretože vaše prihlasovacie údaje vypršali alebo nie sú viac platné.</string>
@@ -1563,7 +1563,7 @@
     <string name="please_wait">Prosím čakajte…</string>
     <string name="group_all_communities">Všetky komunity</string>
     <string name="room_preview_no_preview">Nie je možné zobraziť náhľad tejto miestnosti</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Nazeranie do verejných miestností nie je zatiaľ podporované</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Nazeranie do verejných miestností nie je zatiaľ podporované</string>
     <string name="fab_menu_create_room">Miestnosti</string>
     <string name="fab_menu_create_chat">Priame konverzácie</string>
     <string name="create_room_title">Nová miestnosť</string>
@@ -1947,7 +1947,7 @@
     <string name="settings_category_room_directory">Adresár miestností</string>
     <string name="disclaimer_positive_button">DOZVEDIEŤ SA VIAC</string>
     <string name="disclaimer_negative_button">ROZUMIEM</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="notice_room_server_acl_updated_no_change">Žiadna zmena.</string>
     <string name="dev_tools_event_content_hint">Obsah udalosti</string>
     <string name="dev_tools_edit_content">Upraviť obsah</string>
@@ -2216,8 +2216,8 @@
     <string name="location_activity_title_preview">Poloha</string>
     <string name="a11y_location_share_icon">Zdieľať polohu</string>
     <string name="location_share">Zdieľať polohu</string>
-    <string name="template_location_not_available_dialog_title">${app_name} nemohol získať prístup k vašej polohe</string>
-    <string name="template_location_not_available_dialog_content">${app_name} nemohol získať prístup k vašej polohe. Skúste to prosím neskôr.</string>
+    <string name="location_not_available_dialog_title">${app_name} nemohol získať prístup k vašej polohe</string>
+    <string name="location_not_available_dialog_content">${app_name} nemohol získať prístup k vašej polohe. Skúste to prosím neskôr.</string>
     <string name="location_share_external">Otvoriť s</string>
     <string name="settings_enable_location_sharing">Povoliť zdieľanie polohy</string>
     <string name="settings_enable_location_sharing_summary">Po zapnutí tejto funkcie budete môcť odoslať svoju polohu do ľubovoľnej miestnosti</string>
@@ -2387,7 +2387,7 @@
     <string name="error_unauthorized">Neautorizované, chýbajúce platné poverenia na overenie</string>
     <string name="legals_identity_server_title">Pravidlá a zásady vášho servera totožností</string>
     <string name="legals_home_server_title">Pravidlá a zásady vášho domovského servera</string>
-    <string name="template_legals_application_title">${app_name} pravidlá</string>
+    <string name="legals_application_title">${app_name} pravidlá</string>
     <string name="settings_messages_by_bot">Správy od bota</string>
     <string name="settings_encrypted_group_messages">Šifrované skupinové správy</string>
     <string name="settings_encrypted_direct_messages">Šifrované priame správy</string>
@@ -2463,7 +2463,7 @@
     <string name="a13n_qr_code_description">Obrázok QR kódu</string>
     <string name="a11y_create_direct_message_by_qr_code">Vytvorte novú priamu konverzáciu naskenovaním QR kódu</string>
     <string name="add_by_qr_code">Pridať pomocou QR kódu</string>
-    <string name="template_link_this_email_with_your_account">%s v Nastaveniach na prijímanie pozvánok priamo v ${app_name}e.</string>
+    <string name="link_this_email_with_your_account">%s v Nastaveniach na prijímanie pozvánok priamo v ${app_name}e.</string>
     <string name="this_invite_to_this_space_was_sent">Táto pozvánka do tohto priestoru bola odoslaná na adresu %s, ktorá nie je spojená s vaším účtom</string>
     <string name="this_invite_to_this_room_was_sent">Táto pozvánka do tejto miestnosti bola odoslaná na adresu %s, ktorá nie je spojená s vaším účtom</string>
     <string name="upgrade_room_for_restricted_no_param">Každý, kto sa nachádza v nadradenom priestore, bude môcť túto miestnosť nájsť a pripojiť sa k nej - nie je potrebné každého ručne pozývať. V nastaveniach miestnosti to budete môcť kedykoľvek zmeniť.</string>
@@ -2482,7 +2482,7 @@
     <string name="invite_people_to_your_space">Pozvite ľudí do svojho priestoru</string>
     <string name="three_pid_revoke_invite_dialog_content">Odvolať pozvánku do %1$s\?</string>
     <string name="invite_users_to_room_failure">Používateľov sme nemohli pozvať. Skontrolujte používateľov, ktorých chcete pozvať, a skúste to znova.</string>
-    <string name="template_invite_friends_text">Ahoj, ozvi sa mi na ${app_name}: %s</string>
+    <string name="invite_friends_text">Ahoj, ozvi sa mi na ${app_name}: %s</string>
     <string name="create_room_dm_failure">Nemohli sme vytvoriť vašu priamu správu. Skontrolujte používateľov, ktorých chcete pozvať, a skúste to znova.</string>
     <string name="notice_crypto_unable_to_decrypt_friendly_desc">Kvôli end-to-end šifrovaniu sa môže stať, že budete musieť chvíľu počkať, kým vám od niekoho príde správa, pretože vám neboli správne odoslané šifrovacie kľúče.</string>
     <string name="direct_room_encryption_enabled_tile_description">Správy v tejto miestnosti sú šifrované od vás až k príjemcovi.</string>
@@ -2508,7 +2508,7 @@
     <string name="bootstrap_migration_with_passphrase_helper_with_link">Nepoznáte svoju prístupovú frázu pre zálohovanie kľúčov, môžete %s.</string>
     <string name="verify_user_sas_emoji_help_text">Overte tohto používateľa potvrdením, že sa na jeho obrazovke zobrazujú nasledujúce jedinečné emotikony v rovnakom poradí.</string>
     <string name="settings_developer_mode_show_info_on_screen_summary">Zobrazenie niektorých užitočných informácií na pomoc pri ladení aplikácie</string>
-    <string name="template_preference_help_summary">Získajte pomoc s používaním aplikácie ${app_name}</string>
+    <string name="preference_help_summary">Získajte pomoc s používaním aplikácie ${app_name}</string>
     <string name="all_rooms_youre_in_will_be_shown_in_home">Všetky miestnosti, v ktorých sa nachádzate, sa zobrazia v časti Domov.</string>
     <string name="preference_show_all_rooms_in_home">Zobraziť všetky miestnosti v časti Domov</string>
     <string name="settings_troubleshoot_title">Riešenie problémov</string>
@@ -2609,8 +2609,8 @@
 \nAk nechcete nastaviť Heslo správy, vygenerujte namiesto toho Kľúč správy.</string>
     <string name="set_recovery_passphrase">Nastaviť %s</string>
     <string name="verification_cannot_access_other_session">Použite prístupovú frázu na obnovenie alebo kľúč</string>
-    <string name="template_use_latest_app">Použite najnovšiu aplikáciu ${app_name} na svojich ostatných zariadeniach:</string>
-    <string name="template_use_other_session_content_description">Použite najnovšiu aplikáciu ${app_name} na svojich ostatných zariadeniach, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} pre Android alebo iného klienta Matrix podporujúceho krížové podpisovanie</string>
+    <string name="use_latest_app">Použite najnovšiu aplikáciu ${app_name} na svojich ostatných zariadeniach:</string>
+    <string name="use_other_session_content_description">Použite najnovšiu aplikáciu ${app_name} na svojich ostatných zariadeniach, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} pre Android alebo iného klienta Matrix podporujúceho krížové podpisovanie</string>
     <string name="verification_use_passphrase">Ak nemáte prístup k existujúcej relácii</string>
     <string name="verification_open_other_to_verify">Použite existujúcu reláciu na overenie tejto relácie, čím jej udelíte prístup k zašifrovaným správam.</string>
     <string name="analytics_opt_in_list_item_3">Túto funkciu môžete kedykoľvek vypnúť v nastaveniach</string>
@@ -2625,10 +2625,10 @@
     <string name="analytics_opt_in_list_item_1"><b>Nezaznamenávame ani neprofilujeme</b> žiadne údaje o účte</string>
     <string name="confirm_your_identity_quad_s">Potvrďte svoju totožnosť overením tohto prihlasovacieho mena, čím mu udelíte prístup k zašifrovaným správam.</string>
     <string name="confirm_your_identity">Potvrďte svoju totožnosť overením tohto prihlásenia z jednej z vašich ďalších relácií, čím jej udelíte prístup k zašifrovaným správam.</string>
-    <string name="template_analytics_opt_in_content">Pomôžte nám identifikovať problémy a zlepšiť ${app_name} zdieľaním anonymných údajov o používaní. Aby sme pochopili, ako ľudia používajú viacero zariadení, vygenerujeme náhodný identifikátor, ktorý zdieľajú vaše zariadenia.
+    <string name="analytics_opt_in_content">Pomôžte nám identifikovať problémy a zlepšiť ${app_name} zdieľaním anonymných údajov o používaní. Aby sme pochopili, ako ľudia používajú viacero zariadení, vygenerujeme náhodný identifikátor, ktorý zdieľajú vaše zariadenia.
 \n
 \nMôžete si prečítať všetky naše podmienky %s.</string>
-    <string name="template_analytics_opt_in_title">Pomôžte zlepšiť ${app_name}</string>
+    <string name="analytics_opt_in_title">Pomôžte zlepšiť ${app_name}</string>
     <string name="call_tap_to_return">%1$s Ťuknite pre návrat</string>
     <string name="call_one_active">Aktívny hovor (%1$s) ·</string>
     <plurals name="call_active_status">
@@ -2683,11 +2683,11 @@
     <string name="identity_server_set_alternative_notice">Prípadne môžete zadať akúkoľvek inú adresu URL servera totožností</string>
     <string name="identity_server_set_default_notice">Váš domovský server (%1$s) navrhuje použiť %2$s pre váš server totožností</string>
     <string name="identity_server_user_consent_not_provided">Súhlas používateľa nebol poskytnutý.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Pre vaše súkromie ${app_name} podporuje iba odosielanie zahašovaných e-mailov a telefónnych čísel používateľov.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Pre vaše súkromie ${app_name} podporuje iba odosielanie zahašovaných e-mailov a telefónnych čísel používateľov.</string>
     <string name="identity_server_error_terms_not_signed">Najprv prosím prijmite podmienky servera totožností v nastaveniach.</string>
     <string name="identity_server_error_no_identity_server_configured">Najprv prosím nastavte server totožností.</string>
     <string name="identity_server_error_outdated_home_server">Táto operácia nie je možná. Domovský server je zastaraný.</string>
-    <string name="template_identity_server_error_outdated_identity_server">Tento server identity je zastaraný. ${app_name} podporuje iba API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Tento server identity je zastaraný. ${app_name} podporuje iba API V2.</string>
     <string name="disconnect_identity_server_dialog_content">Odpojiť sa od servera totožností %s\?</string>
     <string name="user_code_info_text">Zdieľajte tento kód s ľuďmi, aby si vás mohli naskenovať, pridať a začať konverzovať.</string>
     <string name="user_code_my_code">Môj kód</string>
@@ -2698,7 +2698,7 @@
     </plurals>
     <string name="invitations_sent_to_two_users">Pozvánky odoslané používateľovi %1$s a %2$s</string>
     <string name="invitation_sent_to_one_user">Pozvánka odoslaná používateľovi %1$s</string>
-    <string name="template_invite_friends_rich_title">🔐️ Pridajte sa ku mne na ${app_name}</string>
+    <string name="invite_friends_rich_title">🔐️ Pridajte sa ku mne na ${app_name}</string>
     <string name="external_link_confirmation_message">Odkaz %1$s vás presmeruje na inú stránku: %2$s.
 \n
 \nSte si istí, že chcete pokračovať\?</string>
@@ -2731,9 +2731,9 @@
     <string name="command_description_discard_session_not_handled">Podporované len v zašifrovaných miestnostiach</string>
     <string name="command_description_discard_session">Vynúti zrušenie aktuálnej relácie odchádzajúcej skupiny v zašifrovanej miestnosti</string>
     <string name="or_other_mx_capable_client">alebo iného klienta Matrix, ktorý dokáže krížovo podpisovať</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
     <string name="error_saving_media_file">Nepodarilo sa uložiť mediálny súbor</string>
     <string name="bootstrap_progress_checking_backup_with_info">Kontrola kľúča na zálohovanie (%s)</string>
@@ -2831,7 +2831,7 @@
     <string name="settings_rageshake_detection_threshold_summary">Zatraste telefónom a otestujte prah detekcie</string>
     <string name="settings_rageshake_detection_threshold">Prahová hodnota detekcie</string>
     <string name="permalink_malformed">Váš odkaz matrix.to bol nesprávne vytvorený</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Aktuálna relácia je pre používateľa %1$s a vy ste zadali poverenia pre používateľa %2$s. Toto nie je podporované aplikáciou ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">Aktuálna relácia je pre používateľa %1$s a vy ste zadali poverenia pre používateľa %2$s. Toto nie je podporované aplikáciou ${app_name}.
 \nNajprv vymažte údaje a potom sa znovu prihláste na inom účte.</string>
     <string name="login_reset_password_on">Obnoviť heslo na %1$s</string>
     <string name="login_registration_not_supported">Aplikácia nie je schopná vytvoriť konto na tomto domovskom serveri.
@@ -2847,7 +2847,7 @@
     <string name="room_list_quick_actions_low_priority_remove">Odobrať z nízkej priority</string>
     <string name="room_list_quick_actions_low_priority_add">Pridať k nízkej priorite</string>
     <string name="no_network_indicator">Momentálne nie je k dispozícii žiadne sieťové pripojenie</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} potrebuje povolenie na uloženie vašich šifrovacích kľúčov na disk.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} potrebuje povolenie na uloženie vašich šifrovacích kľúčov na disk.
 \n
 \nPovoľte prístup v ďalšom kontextovom okne, aby ste mohli svoje kľúče exportovať ručne.</string>
     <string name="enter_secret_storage_passphrase_or_key">Na pokračovanie použite %1$s alebo %2$s.</string>
@@ -2887,10 +2887,10 @@
     <string name="settings_security_prevent_screenshots_title">Zabrániť snímkam obrazovky aplikácie</string>
     <string name="auth_pin_confirm_to_disable_title">Potvrďte kód PIN, ak chcete deaktivovať kód PIN</string>
     <string name="settings_security_pin_code_change_pin_summary">Zmeňte svoj aktuálny kód PIN</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">PIN kód sa vyžaduje pri každom otvorení aplikácie ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">PIN kód sa vyžaduje po 2 minútach nepoužívania ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">PIN kód sa vyžaduje pri každom otvorení aplikácie ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">PIN kód sa vyžaduje po 2 minútach nepoužívania ${app_name}.</string>
     <string name="settings_security_pin_code_grace_period_title">Vyžadovať PIN po 2 minútach</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">PIN kód je jediný spôsob, ako odomknúť ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">PIN kód je jediný spôsob, ako odomknúť ${app_name}.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Povoliť biometriu špecifickú pre zariadenie, ako sú odtlačky prstov a rozpoznávanie tváre.</string>
     <string name="settings_security_pin_code_summary">Ak chcete vynulovať kód PIN, ťuknite na položku Zabudnutý kód PIN, čím sa odhlásite a vynulujete ho.</string>
     <string name="auth_pin_reset_content">Ak chcete obnoviť kód PIN, musíte sa znovu prihlásiť a vytvoriť nový.</string>
@@ -2907,7 +2907,7 @@
     <string name="finish_setting_up_discovery">Dokončiť nastavenie objavovania.</string>
     <string name="settings_discovery_consent_action_give_consent">Udeliť súhlas</string>
     <string name="settings_discovery_consent_action_revoke">Odvolať môj súhlas</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} vyžaduje, aby ste na vykonanie tejto akcie zadali svoje poverenia.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} vyžaduje, aby ste na vykonanie tejto akcie zadali svoje poverenia.</string>
     <string name="event_status_a11y_delete_all">Odstrániť všetky neúspešné správy</string>
     <string name="event_status_failed_messages_warning">Správy sa nepodarilo odoslať</string>
     <string name="event_status_delete_all_failed_dialog_title">Vymazať neodoslané správy</string>
@@ -3107,8 +3107,8 @@
     <string name="dev_tools_form_hint_event_content">Obsah udalosti</string>
     <string name="dev_tools_error_no_content">Žiadny obsah</string>
     <string name="dev_tools_success_event">Udalosť odoslaná!</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} nespracováva správy typu \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} nespracováva udalosti typu \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} nespracováva správy typu \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} nespracováva udalosti typu \'%1$s\'</string>
     <string name="search_hint_room_name">Hľadať názov</string>
     <string name="feedback_failed">Spätnú väzbu sa nepodarilo odoslať (%s)</string>
     <string name="settings_developer_mode_show_info_on_screen_title">Zobraziť informácie o ladení chýb na obrazovke</string>
@@ -3148,10 +3148,10 @@
     <string name="bootstrap_info_text">Zabezpečte a odomknite zašifrované správy a dôveryhodnosť pomocou %s.</string>
     <string name="event_redacted_by_user_reason_with_reason">Udalosť vymazaná používateľom, dôvod: %1$s</string>
     <string name="delete_event_dialog_reason_hint">Dôvod úpravy</string>
-    <string name="template_rendering_event_error_exception">${app_name} sa stretol s problémom pri vykresľovaní obsahu udalosti s id \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} sa stretol s problémom pri vykresľovaní obsahu udalosti s id \'%1$s\'</string>
     <string name="you">Vy</string>
     <string name="sent_a_reaction">Reagoval/a s: %s</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} môže padať častejšie, keď sa vyskytne neočakávaná chyba</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} môže padať častejšie, keď sa vyskytne neočakávaná chyba</string>
     <string name="login_server_url_form_common_notice">Zadajte adresu servera, ktorý chcete použiť</string>
     <string name="report_content_custom">Vlastné hlásenie…</string>
     <string name="report_content_inappropriate">Je to nevhodné</string>

--- a/vector/src/main/res/values-sq/strings.xml
+++ b/vector/src/main/res/values-sq/strings.xml
@@ -862,7 +862,7 @@
     <string name="ongoing_conference_call_video">Video</string>
     <string name="missing_permissions_to_start_conf_call">Ju duhen leje për ftesa, që të nisni një konferencë në këtë dhomë</string>
     <string name="bottom_action_favourites">Të parapëlqyer</string>
-    <string name="template_no_contact_access_placeholder">S’e lejuat ${app_name}-in të hyjë në kontaktet tuaja vendore</string>
+    <string name="no_contact_access_placeholder">S’e lejuat ${app_name}-in të hyjë në kontaktet tuaja vendore</string>
     <string name="send_bug_report_description">Ju lutemi, përshkruajeni të metën. Ç’po bënit? Ç’prisnit të ndodhte? Ç’ndodhi në fakt?</string>
     <string name="send_bug_report_alert_message">Duket se po përplasni telefonin nga inati. Do të donit të hapej skena për njoftim të metash?</string>
     <string name="send_bug_report_app_crashed">Herën e fundit aplikacioni u vithis. Do të donit të hapej skena e raportimit të vithisjeve?</string>
@@ -877,7 +877,7 @@
     <string name="auth_reset_password_success_message">Fjalëkalimi juaj u ricaktua.
 \n
 \nËshtë bërë dalja juaj nga llogaria në krejt sesionet dhe s’do të merrni më njoftime push. Për riaktivizim të njoftimeve, ribëni hyrjen në çdo pajisje.</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Ju lutemi, niseni ${app_name}-in në një tjetër pajisje që mund të shfshehtëzojë mesazhin, që kështu të mund të dërgojë kyçet te ky sesion.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Ju lutemi, niseni ${app_name}-in në një tjetër pajisje që mund të shfshehtëzojë mesazhin, që kështu të mund të dërgojë kyçet te ky sesion.</string>
     <string name="call_error_ice_failed">Lidhja e Medias Dështoi</string>
     <string name="media_picker_cannot_record_video">S’regjistrohet dot video</string>
     <string name="room_preview_unlinked_email_warning">Kjo ftesë i qe dërguar %s, që s’është i përshoqëruar me këtë llogari.
@@ -945,22 +945,22 @@
     <string name="call_connected">U bë lidhja e thirrjes</string>
     <string name="call_connecting">Po bëhet lidhja e thirrjes…</string>
     <string name="call_error_user_not_responding">Ana e largët dështoi të përgjigjet.</string>
-    <string name="template_permissions_rationale_msg_storage">Për të dërguar dhe ruajtur bashkëngjitje, ${app_name}-i lyp leje të përdorë mediatekën tuaj.
+    <string name="permissions_rationale_msg_storage">Për të dërguar dhe ruajtur bashkëngjitje, ${app_name}-i lyp leje të përdorë mediatekën tuaj.
 \n
 \nJu lutemi, lejoni përdorimin, që nga flluska pasuese, që të jetë në gjendje të dërgojë kartela që nga telefoni juaj.</string>
-    <string name="template_permissions_rationale_msg_camera">Për të bërë foto dhe thirrje video, ${app_name}-i lyp leje të përdorë kamerën tuaj.</string>
+    <string name="permissions_rationale_msg_camera">Për të bërë foto dhe thirrje video, ${app_name}-i lyp leje të përdorë kamerën tuaj.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nJu lutemi, lejoni përdorimin, që nga flluska pasuese, që të jetë në gjendje të bëjë thirrjen."</string>
-    <string name="template_permissions_rationale_msg_record_audio">Për të kryer thirrje audio, ${app_name}-i lyp leje të përdorë mikrofonin tuaj.</string>
+    <string name="permissions_rationale_msg_record_audio">Për të kryer thirrje audio, ${app_name}-i lyp leje të përdorë mikrofonin tuaj.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nJu lutemi, lejoni përdorimin, që nga flluska pasuese, që të jetë në gjendje të bëjë thirrjen."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">Për të kryer thirrje video, ${app_name}-i lyp leje të përdorë kamerën dhe mikrofonin tuaj.
+    <string name="permissions_rationale_msg_camera_and_audio">Për të kryer thirrje video, ${app_name}-i lyp leje të përdorë kamerën dhe mikrofonin tuaj.
 \n
 \nJu lutemi, lejoni përdorimin, që nga flluskat pasuese, që të jetë në gjendje të bëjë thirrjen.</string>
-    <string name="template_permissions_rationale_msg_contacts">Për të gjetur përdorues të tjerë Matrix, bazuar në email-et apo numrat e tyre të telefonit, ${app_name}-i mund të kërkojë në librin tuaj të adresave. Nëse jeni dakord të lejohet hyrja në librin tuaj të adresave për këtë qëllim, ju lutemi, lejojeni hyrjen gjatë flluskës pasuese.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">Për të gjetur përdorues të tjerë Matrix, bazuar në email-et apo numrat e tyre të telefonit, ${app_name}-i mund të kërkojë në librin tuaj të adresave.
+    <string name="permissions_rationale_msg_contacts">Për të gjetur përdorues të tjerë Matrix, bazuar në email-et apo numrat e tyre të telefonit, ${app_name}-i mund të kërkojë në librin tuaj të adresave. Nëse jeni dakord të lejohet hyrja në librin tuaj të adresave për këtë qëllim, ju lutemi, lejojeni hyrjen gjatë flluskës pasuese.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">Për të gjetur përdorues të tjerë Matrix, bazuar në email-et apo numrat e tyre të telefonit, ${app_name}-i mund të kërkojë në librin tuaj të adresave.
 \n 
 \nJeni dakord të lejohet hyrja në librin tuaj të adresave për këtë qëllim\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Na ndjeni. Veprimi nuk u krye, për shkak lejesh që mungojnë</string>
@@ -1049,9 +1049,9 @@
     <string name="settings_send_typing_notifs_summary">Lejojuni përdoruesve të tjerë të dinë se po shtypni.</string>
     <string name="settings_send_markdown_summary">Formatojini mesazhet duke përdorur sintaksën Markdown përpara se të dërgohen. Kjo lejon formatim të thelluar, f.v., përdorimi i yllthit për ta shfaqur tekstin me të pjerrëta.</string>
     <string name="settings_show_join_leave_messages_summary">Nuk prek ftesat, heqjet dhe dëbimet.</string>
-    <string name="template_startup_notification_privacy_message">${app_name}-i mund të xhirojë në prapaskenë që të administrojë njoftimet tuaja në rrugë të sigurt dhe privatisht. Kjo mund të ndikojë në harxhimin e baterisë.</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name}-i grumbullon të dhëna analitike anonime që të na lejojë ta përmirësojmë aplikacionin.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Ju lutemi, aktivizoni analizat që të na ndihmoni të përmirësojmë ${app_name}-in.</string>
+    <string name="startup_notification_privacy_message">${app_name}-i mund të xhirojë në prapaskenë që të administrojë njoftimet tuaja në rrugë të sigurt dhe privatisht. Kjo mund të ndikojë në harxhimin e baterisë.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name}-i grumbullon të dhëna analitike anonime që të na lejojë ta përmirësojmë aplikacionin.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Ju lutemi, aktivizoni analizat që të na ndihmoni të përmirësojmë ${app_name}-in.</string>
     <string name="settings_unignore_user">Të shfaqen krejt mesazhet prej %s\?
 \n
 \nKini parasysh që ky veprim do të sjellë rinisjen e aplikacionit dhe mund të hajë ca kohë.</string>
@@ -1078,7 +1078,7 @@
     <string name="option_send_sticker">Dërgoni një ngjitës</string>
     <string name="go_on_with">vazhdoni me…</string>
     <string name="settings_call_category">Thirrje</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Për thirrje ardhëse përdor zilen parazgjedhje të ${app_name}-it</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Për thirrje ardhëse përdor zilen parazgjedhje të ${app_name}-it</string>
     <string name="settings_call_ringtone_title">Zile thirrjesh ardhëse</string>
     <string name="settings_call_ringtone_dialog_title">Përzgjidhni zile për thirrjet:</string>
     <string name="room_settings_no_flair">Kjo dhomë nuk shfaq simbole për ndonjë bashkësi</string>
@@ -1106,12 +1106,12 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Aktivizoje</string>
     <string name="settings_troubleshoot_test_device_settings_title">Rregullime Sesioni.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Njoftimet janë të aktivizuara për këtë sesion.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Nuk janë aktivizuar njoftimet për këtë sesion.
+    <string name="settings_troubleshoot_test_device_settings_failed">Nuk janë aktivizuar njoftimet për këtë sesion.
 \nJu lutemi, kontrolloni rregullimet e ${app_name}-it.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Aktivizoje</string>
     <string name="settings_troubleshoot_test_play_services_title">Kontroll pë Play Services</string>
     <string name="settings_troubleshoot_test_play_services_success">APK-ja për Google Play Services është e pranishme dhe e përditësuar.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name}-i përdor Google Play Services për të dorëzuar mesazhe push, por s’duket të jetë formësuar saktë:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name}-i përdor Google Play Services për të dorëzuar mesazhe push, por s’duket të jetë formësuar saktë:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Ndreqni Play Services</string>
     <string name="settings_troubleshoot_test_fcm_title">Token Firebase</string>
@@ -1128,21 +1128,21 @@
     <string name="settings_troubleshoot_test_service_restart_failed">S’u arrit të rinisej shërbimi</string>
     <string name="settings_troubleshoot_test_service_boot_title">Nise gjatë nisjes së sistemit</string>
     <string name="settings_troubleshoot_test_service_boot_success">Shërbimi do të niset kur të riniset pajisja.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Shërbimi s’do të niset kur të riniset pajisja, s’do të merrni njoftime derisa ${app_name}-i të jetë hapur një herë.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Shërbimi s’do të niset kur të riniset pajisja, s’do të merrni njoftime derisa ${app_name}-i të jetë hapur një herë.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Aktivizo Nisje gjatë nisjes së sistemit</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Kontrollo kufizime prapaskene</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Kufizimet për në prapaskenë janë të çaktivizuar për ${app_name}-in. Ky test duhet të xhirojë duke përdorur të dhëna rrjeti celular (jo WIFI).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Kufizimet për në prapaskenë janë të çaktivizuar për ${app_name}-in. Ky test duhet të xhirojë duke përdorur të dhëna rrjeti celular (jo WIFI).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Kufizimet për në prapaskenë janë të aktivizuara për ${app_name}-in.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Kufizimet për në prapaskenë janë të aktivizuara për ${app_name}-in.
 \nPuna që aplikacioni rreket të bëjë do të kufizohet në mënyrë agresive, teksa gjendet në prapaskenë, dhe kjo mund të prekë njoftimet.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Çaktivizoji kufizimet</string>
     <string name="settings_troubleshoot_test_battery_title">Optimizim Baterie</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name}-i nuk preket nga Optimizime Baterie.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name}-i nuk preket nga Optimizime Baterie.</string>
     <string name="settings_troubleshoot_test_battery_failed">Nëse një përdorues e lë një pajisje jo në prizë dhe të palëvizshme për një periudhë, me ekranin të fikur, pajisja kalon nën mënyrën Dremitje. Kjo u parandalon aplikimeve të hyjnë në rrjet dhe shtyn për më vonë punët e tyre, njëkohësimet dhe alarmet standarde.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Shpërfille Optimizimin</string>
     <string name="startup_notification_fdroid_battery_optim_title">Lidhje Në Prapaskenë</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">Për t’ju dhënë njoftime të qëndrueshme, ${app_name}-i lyp të mbajë në prapaskenë një lidhje me pak ndikim.
+    <string name="startup_notification_fdroid_battery_optim_message">Për t’ju dhënë njoftime të qëndrueshme, ${app_name}-i lyp të mbajë në prapaskenë një lidhje me pak ndikim.
 \nNë skenën pasuese do t’ju kërkohet të lejoni ${app_name}-in të xhirojë në prapaskenë, ju lutemi, pranojeni.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Akordojini leje</string>
     <string name="account_email_error">Ndodhi një gabim teksa verifikohej adresa juaj email.</string>
@@ -1162,11 +1162,11 @@
     <string name="settings_troubleshoot_test_bing_settings_failed">Disa njoftime janë të çaktivizuara te rregullimet tuaja vetjake.</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">S’u arrit të ngarkohen rregulla vetjakë, ju lutemi, riprovoni.</string>
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Kontrolloni Rregullimet</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nKy gabim është jashtë kontrollit të ${app_name}-it dhe, sipas Google-it, ky gabim është shenjë se pajisja ka shumë aplikacione të regjistruar me FCM. Gabimi ndodh vetëm në raste kur ka një numër të skajshëm aplikacionesh, ndaj nuk duhet të prekë përdoruesin mesatar.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nKy gabim është jashtë kontrollit të ${app_name}-it. Mund të ndodhë për disa arsye. Ndoshta do të funksionojë, nëse riprovoni më vonë, mund të kontrolloni edhe nëse për Google Play Service s’ka kufizime lidhur me përdorimin e të dhënave, te rregullimet e sistemit, ose se ora e pajisjes suaj është e saktë, ose mund të ndodhë në ROM të përshtatur.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nKy gabim është jashtë kontrollit të ${app_name}-it. S’ka llogari Google te telefoni. Ju lutemi, hapni përgjegjësin e llogarive dhe shtoni një llogari Google.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Shtoni Llogari</string>
     <string name="settings_noisy_notifications_preferences">Formësoni Njoftime të Zhurmshme</string>
@@ -1178,7 +1178,7 @@
     <string name="notification_silent">Të heshtur</string>
     <string name="passphrase_empty_error_message">Ju lutemi, jepni një frazëkalim</string>
     <string name="passphrase_passphrase_too_weak">Frazëkalimi është shumë i dobët</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Ju lutemi, fshini frazëkalimin, nëse doni që ${app_name}-i të prodhojë një kyç rimarrjesh.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Ju lutemi, fshini frazëkalimin, nëse doni që ${app_name}-i të prodhojë një kyç rimarrjesh.</string>
     <string name="keys_backup_no_session_error">S’ka sesione Matrix të gatshëm</string>
     <string name="keys_backup_setup_step1_title">Mos humbni kurrë mesazhe të fshehtëzuar</string>
     <string name="keys_backup_setup_step1_description">Mesazhet në dhoma të fshehtëzuara sigurohen me fshehtëzim skaj-më-skaj. Vetëm ju dhe marrësi(t) keni kyçet për leximin e këtyre mesazheve.
@@ -1308,7 +1308,7 @@
     <string name="new_recovery_method_popup_was_me">Unë qeshë</string>
     <string name="autodiscover_invalid_response">Përgjigje e pavlefshme zbulimi shërbyesi Home</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Mundësi Vetëplotësimi Shërbyesi</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name}-i pikasi një formësim shërbyesi të përshtatur për përkatësinë tuaj userId \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name}-i pikasi një formësim shërbyesi të përshtatur për përkatësinë tuaj userId \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Përdor Formësim</string>
     <string name="notification_sync_init">Po gatitet shërbimi</string>
@@ -1422,7 +1422,7 @@
     <string name="please_wait">Ju lutemi, pritni…</string>
     <string name="group_all_communities">Krejt Bashkësitë</string>
     <string name="room_preview_no_preview">Kjo dhomë s’mund të parashihet</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Paraparja e dhomave të lexueshme nga bota nuk mbulohet ende në ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Paraparja e dhomave të lexueshme nga bota nuk mbulohet ende në ${app_name}</string>
     <string name="fab_menu_create_room">Dhoma</string>
     <string name="fab_menu_create_chat">Mesazhe të Drejtpërdrejtë</string>
     <string name="create_room_title">Dhomë e Re</string>
@@ -1514,10 +1514,10 @@
     <string name="invite_no_identity_server_error">Që të kryhet ky veprim, shtoni një shërbyes identitetesh, që nga rregullimet tuaja.</string>
     <string name="settings_background_fdroid_sync_mode">Mënyrë Njëkohësimi Në Prapaskenë</string>
     <string name="settings_background_fdroid_sync_mode_battery">E optimizuar për baterinë</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name}-i do të bëjë njëkohësim në prapaskenë, në një mënyrë që kursen burimet e kufizuara të pajisjes (baterinë).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name}-i do të bëjë njëkohësim në prapaskenë, në një mënyrë që kursen burimet e kufizuara të pajisjes (baterinë).
 \nNë varësi të gjendjes së burimeve tuaja, njëkohësimi mund të shtyhet për më vonë nga sistemi operativ.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">I optimizuar për kohë të njëmendtë</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name}0-i do të bëjë njëkohësim në prapaskenë periodikisht në një kohë të caktuar (e formësueshme).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name}0-i do të bëjë njëkohësim në prapaskenë periodikisht në një kohë të caktuar (e formësueshme).
 \nKjo do të ketë ndikim mbi përdorimin e baterisë dhe të transmetimit, do të shfaqet një njoftim i pandërprerë që pohon se ${app_name}-i po përgjon për akte.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Pa njëkohësim në prapraskenë</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">S’do të njoftoheni për mesazhe ardhës, kur aplikacioni gjendet në prapaskenë.</string>
@@ -1601,12 +1601,12 @@
     <string name="content_reported_as_inappropriate_content">Kjo lëndë është raportuar si e papërshtatshme. 
 \n 
 \nNëse s’doni të shihni më lëndë nga ky përdorues, mund ta shpërfillni, që të fshihen mesazhet e tij.</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name}-i lyp leje për të ruajtur kyçet tuaj E2E në disk.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name}-i lyp leje për të ruajtur kyçet tuaj E2E në disk.
 \n
 \nJu lutemi, lejoni, te flluska pasuese, hyrje për të qenë e mundur të eksportohen kyçet tuaj dorazi.</string>
     <string name="no_network_indicator">Tani për tani s’la lidhje rrjeti</string>
     <string name="settings_add_3pid_confirm_password_title">Ripohoni fjalëkalimin tuaj</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Këtë s’e bëni dot që nga ${app_name} për celular</string>
+    <string name="settings_add_3pid_flow_not_supported">Këtë s’e bëni dot që nga ${app_name} për celular</string>
     <string name="settings_add_3pid_authentication_needed">Lypset mirëfilltësim</string>
     <string name="settings_integrations">Integrime</string>
     <string name="settings_integrations_summary">Përdorni një përgjegjës integrimesh që të administroni robotë, ura, widget-e dhe paketa ngjitësish.
@@ -1774,7 +1774,7 @@
 \nQë të mund të hyni te të dhëna të llogarisë tuaj dhe te mesazhe, bëni sërish hyrjen.</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Do të humbni hyrje te mesazhe të sigurt, veç në hyfshi për të rimarrë kyçet tuaj të fshehtëzimit.</string>
     <string name="soft_logout_clear_data_dialog_submit">Spastro të dhënat</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Sesioni i tanishëm është për përdoruesin %1$s dhe ju jepni kredenciale për përdoruesin %2$s. Kjo nuk mbulohet nga ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">Sesioni i tanishëm është për përdoruesin %1$s dhe ju jepni kredenciale për përdoruesin %2$s. Kjo nuk mbulohet nga ${app_name}.
 \nJu lutemi, së pari spastroni të dhëna, mandej hyni sërish në një tjetër llogari.</string>
     <string name="permalink_malformed">Lidhja juaj matrix.to është e keqformuar</string>
     <string name="bug_report_error_too_short">Përshkrimi është shumë i shkurtër</string>
@@ -1793,7 +1793,7 @@
     <string name="devices_current_device">Sesioni i tanishëm</string>
     <string name="devices_other_devices">Shfaq sesione të tjera</string>
     <string name="autocomplete_limited_results">Po shfaqen vetëm përfundimet e para, shtypni më shumë shkronja…</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} mund të vithiset më shpesh, kur ndodh një gabim i papritur</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} mund të vithiset më shpesh, kur ndodh një gabim i papritur</string>
     <string name="settings_call_ringtone_use_default_stun">Lejoni shërbyes rrugëzgjidhje asistimi thirrjesh</string>
     <string name="command_description_shrug">Parashtoji ¯\\_(ツ)_/¯ një mesazhi tekst të thjeshtë</string>
     <string name="create_room_encryption_title">Aktivizoni fshehtëzim</string>
@@ -1907,9 +1907,9 @@
     <string name="verification_request_alert_description">Për siguri ekstra, verifikojeni %s duke parë kontrolluar në të dy pajisjet tuaja një kod njëpërdorimsh.
 \n
 \nPër sigurinë maksimale, bëjeni këtë ju vetë.</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} nuk trajton akte të llojit \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} nuk trajton mesazhe të llojit \'%1$s\'</string>
-    <string name="template_rendering_event_error_exception">${app_name} ndeshi një problem kur vizatohej lëndë e aktit me ID \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} nuk trajton akte të llojit \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} nuk trajton mesazhe të llojit \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} ndeshi një problem kur vizatohej lëndë e aktit me ID \'%1$s\'</string>
     <string name="verify_cannot_cross_sign">Ky sesion s’është në gjendje të ndajë këtë verifikim me sesionet tuaj të tjerë.
 \nVerifikimi do të ruhet lokalisht dhe do të ndahet nën një version të ardhshëm të aplikacionit.</string>
     <string name="verification_request_notice">Për të qenë i sigurt, verifikoni %s duke kontrolluar një kod njëpërdorimsh.</string>
@@ -1953,7 +1953,7 @@
     <string name="event_redacted_by_user_reason_with_reason">Veprimtari e fshirë nga përdorues, arsye: %1$s</string>
     <string name="event_redacted_by_admin_reason_with_reason">Veprimtari e moderuar nga përgjegjësi i dhomës, arsye: %1$s</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Kyçet janë tashmë të përditësuar!</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">Kërkesa Kyçi</string>
     <string name="e2e_use_keybackup">Shkyçni historik mesazhesh të fshehtëzuar</string>
     <string name="refresh">Rifreskoje</string>
@@ -2054,13 +2054,13 @@
     <string name="media_file_added_to_gallery">Te Galeria u shtua kartelë media</string>
     <string name="error_adding_media_file_to_gallery">S’u shtua dot kartelë media te Galeria</string>
     <string name="change_password_summary">Caktoni një fjalëkalim të ri llogarie…</string>
-    <string name="template_use_other_session_content_description">Përdorni ${app_name}-in më të ri në pajisjet tuaja të tjera, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} për Android, ose një tjetër klient Matrix të aftë për &lt;em&gt;cross-signing&lt;/em</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="use_other_session_content_description">Përdorni ${app_name}-in më të ri në pajisjet tuaja të tjera, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} për Android, ose një tjetër klient Matrix të aftë për &lt;em&gt;cross-signing&lt;/em</string>
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
     <string name="or_other_mx_capable_client">ose një tjetër klient Matrix i aftë për &lt;em&gt;cross-signing&lt;/em</string>
-    <string name="template_use_latest_app">Përdorni ${app_name}-in më të ri në pajisjet tuaja të tjera:</string>
+    <string name="use_latest_app">Përdorni ${app_name}-in më të ri në pajisjet tuaja të tjera:</string>
     <string name="command_description_discard_session_not_handled">Mbulohet vetëm për dhoma të fshehtëzuara</string>
     <string name="enter_secret_storage_passphrase_or_key">Përdorni %1$s tuaj ose përdorni %2$s tuaj që të vazhdohet.</string>
     <string name="use_recovery_key">Përdorni Kyçin Rimarrjesh</string>
@@ -2120,7 +2120,7 @@
     <string name="choose_locale_other_locales_title">Gjuhë të tjera të gatshme</string>
     <string name="choose_locale_loading_locales">Po ngarkohen gjuhë të gatshme…</string>
     <string name="disconnect_identity_server_dialog_content">Të bëhet shkëputja prej shërbyesit tuaj të identitetit %s\?</string>
-    <string name="template_identity_server_error_outdated_identity_server">Ky shërbyes identitetesh është i vjetruar. ${app_name} mbulon vetëm API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Ky shërbyes identitetesh është i vjetruar. ${app_name} mbulon vetëm API V2.</string>
     <string name="identity_server_error_outdated_home_server">Ky veprim s’është i mundshëm. Shërbyesi Home është i vjetruar.</string>
     <string name="identity_server_error_no_identity_server_configured">Ju lutemi, së pari formësoni një shërbyes identitetesh.</string>
     <string name="identity_server_error_terms_not_signed">Ju lutemi, së pari pranoni te rregullimet termat e shërbyesit të identiteteve.</string>
@@ -2151,7 +2151,7 @@
     <string name="action_copy">Kopjoje</string>
     <string name="dialog_title_success">Sukses</string>
     <string name="bottom_action_notification">Njoftime</string>
-    <string name="template_call_failed_no_connection">Thirrja ${app_name} Dështoi</string>
+    <string name="call_failed_no_connection">Thirrja ${app_name} Dështoi</string>
     <string name="call_failed_no_connection_description">S’u arrit të vendosej lidhje e atypëratyshme.
 \nQë thirrjet të punojnë mirë, ju lutemi, kërkojini përgjegjësit të shërbyesit tuaj Home të formësojë një shërbyes TURN.</string>
     <string name="call_select_sound_device">Përzgjidhni Pajisje Zëri</string>
@@ -2266,7 +2266,7 @@
     <string name="auth_invalid_login_deactivated_account">Kjo llogari është çaktivizuar.</string>
     <string name="error_saving_media_file">S’u ruajt dot kartelë media</string>
     <string name="confirm_your_identity_quad_s">Ripohoni identitetin tuaj duke verifikuar këto kredenciale hyrjeje, duke i akorduar hyrje te mesazhe të fshehtëzuar.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Për privatësinë tuaj, ${app_name}-i mbulon vetëm dërgim email-esh dhe numrash telefoni përdoruesi të koduar.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Për privatësinë tuaj, ${app_name}-i mbulon vetëm dërgim email-esh dhe numrash telefoni përdoruesi të koduar.</string>
     <string name="power_level_edit_title">Caktoni rol</string>
     <string name="power_level_title">Rol</string>
     <string name="a11y_open_chat">Hapni fjalosje</string>
@@ -2339,13 +2339,13 @@
     <string name="error_opening_banned_room">S’mund të hapet një dhomë prej të cilës jeni dëbuar.</string>
     <string name="room_error_not_found">S’gjendet dot kjo dhomë. Sigurohuni që ekziston.</string>
     <string name="universal_link_malformed">Lidhja qe e keqformësuar</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Kodi PIN kërkohet doemos sa herë që hapni ${app_name}-in.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Kodi PIN kërkohet doemos pas 2 minutash mospërdorimi të ${app_name}-it.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Kodi PIN kërkohet doemos sa herë që hapni ${app_name}-in.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Kodi PIN kërkohet doemos pas 2 minutash mospërdorimi të ${app_name}-it.</string>
     <string name="settings_security_pin_code_grace_period_title">Kërkoje doemos PIN-in pas 2 minutash</string>
     <string name="settings_security_pin_code_notifications_summary_off">Shfaq vetëm numrin e mesazheve të palexuar, në një njoftim të thjeshtë.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Shfaq hollësi, të tilla si emra dhomash dhe lëndë mesazhesh.</string>
     <string name="settings_security_pin_code_notifications_title">Shfaq lëndë në njoftime</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">Kodi PIN është rruga e vetme për të shkyçur ${app_name}-in.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">Kodi PIN është rruga e vetme për të shkyçur ${app_name}-in.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Aktivizoni të dhëna biometrike specifike për pajisjen, bie fjala, shenja gishtash dhe njohje fytyre.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Aktivizo të dhëna biometrike</string>
     <string name="settings_security_application_protection_screen_title">Formësoni mbrojtjen</string>
@@ -2418,8 +2418,8 @@
     <string name="user_code_share">Ndaje kodin tim me të tjerët</string>
     <string name="user_code_scan">Skanoni një kod QR</string>
     <string name="not_a_valid_qr_code">S’është kod QR Matrix i vlefshëm</string>
-    <string name="template_invite_friends_rich_title">Takohuni me mua në ${app_name}</string>
-    <string name="template_invite_friends_text">Hej, bisedoni me mua në ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">Takohuni me mua në ${app_name}</string>
+    <string name="invite_friends_text">Hej, bisedoni me mua në ${app_name}: %s</string>
     <string name="invite_friends">Ftoni shokë</string>
     <string name="add_people">Shtoni persona</string>
     <string name="topic_prefix">"Temë: "</string>
@@ -2495,7 +2495,7 @@
     <string name="action_unpublish">Hiqi botimin</string>
     <string name="action_add">Shto</string>
     <string name="authentication_error">S’u arrit të bëhej mirëfilltësimi</string>
-    <string name="template_re_authentication_default_confirm_text">Që të kryejë këtë veprim, ${app_name}-i lyp dhënien prej jush të kredencialeve tuaja.</string>
+    <string name="re_authentication_default_confirm_text">Që të kryejë këtë veprim, ${app_name}-i lyp dhënien prej jush të kredencialeve tuaja.</string>
     <string name="re_authentication_activity_title">Lypset Rimirëfilltësim</string>
     <string name="call_transfer_users_tab_title">Përdorues</string>
     <string name="call_transfer_failure">Ndodhi një gabim teksa shpërngulej thirrja</string>
@@ -2849,7 +2849,7 @@
     <string name="settings_notification_other">Tjetër</string>
     <string name="settings_notification_mentions_and_keywords">Përmendje dhe Fjalëkyçe</string>
     <string name="settings_notification_default">Njoftime Parazgjedhje</string>
-    <string name="template_link_this_email_with_your_account">%s te Rregullimet, që të merrni ftesa drejt e në ${app_name}.</string>
+    <string name="link_this_email_with_your_account">%s te Rregullimet, që të merrni ftesa drejt e në ${app_name}.</string>
     <string name="link_this_email_settings_link">Lidheni këtë email me llogarinë tuaj</string>
     <string name="this_invite_to_this_space_was_sent">Kjo ftesë për te kjo hapësirë u dërgua te %s që s’është i përshoqëruar me llogarinë tuaj</string>
     <string name="this_invite_to_this_room_was_sent">Kjo ftesë për te kjo dhomë qe dërguar për %s që s’është i përshoqëruar me llogarinë tuaj</string>
@@ -3006,7 +3006,7 @@
     <string name="attachment_type_poll">Pyetësor</string>
     <string name="preference_system_settings">Rregullime sistemi</string>
     <string name="preference_versions">Versione</string>
-    <string name="template_preference_help_summary">Merrni ndihmë për përdorimin e ${app_name}-it</string>
+    <string name="preference_help_summary">Merrni ndihmë për përdorimin e ${app_name}-it</string>
     <string name="preference_help_title">Ndihmë dhe asistencë</string>
     <string name="preference_help">Ndihmë</string>
     <string name="preference_root_legals">Ligjore</string>
@@ -3014,15 +3014,15 @@
     <string name="legals_third_party_notices">Biblioteka prej palësh të treta</string>
     <string name="legals_identity_server_title">Rregulla të shërbyesit tuaj të identiteteve</string>
     <string name="legals_home_server_title">Rregulla të shërbyesit tuaj Home</string>
-    <string name="template_legals_application_title">Rregulla për ${app_name}</string>
+    <string name="legals_application_title">Rregulla për ${app_name}</string>
     <string name="analytics_opt_in_list_item_3">Këtë mund të çaktivizoni në çfarëdo kohe, që nga rregullimet</string>
     <string name="analytics_opt_in_list_item_2"><b>Nuk</b> u japin hollësi palëve të treta</string>
     <string name="analytics_opt_in_list_item_1"><b>Nuk</b> regjistrojmë ose profilizojmë ndonjë të dhënë llogarie</string>
     <string name="analytics_opt_in_content_link">këtu</string>
-    <string name="template_analytics_opt_in_content">Ndihmonani të identifikojmë probleme dhe të përmirësojmë ${app_name}-in, duke ndarë me ne të dhëna anonime përdorimi. Për të kuptuar se si i përdorin njerëzit disa pajisje njëherësh, do të prodhojmë një identifikues kuturu, të përbashkët për pajisjet tuaja.
+    <string name="analytics_opt_in_content">Ndihmonani të identifikojmë probleme dhe të përmirësojmë ${app_name}-in, duke ndarë me ne të dhëna anonime përdorimi. Për të kuptuar se si i përdorin njerëzit disa pajisje njëherësh, do të prodhojmë një identifikues kuturu, të përbashkët për pajisjet tuaja.
 \n
 \nMund të lexoni krejt kushtet tona %s.</string>
-    <string name="template_analytics_opt_in_title">Ndihmoni të përmirësohet ${app_name}-in</string>
+    <string name="analytics_opt_in_title">Ndihmoni të përmirësohet ${app_name}-in</string>
     <string name="action_enable">Aktivizoje</string>
     <plurals name="poll_total_vote_count_before_ended_and_not_voted">
         <item quantity="one">%1$d votë e hedhur. Votoni, që të shihni përfundimet</item>
@@ -3063,8 +3063,8 @@
     <string name="labs_render_locations_in_timeline">Trego vendndodhje përdoruesi në rrjedhën kohore</string>
     <string name="settings_enable_location_sharing_summary">Pasi të aktivizohet, do të jeni në gjendje të dërgoni vendndodhjen tuaj në çfarëdo dhome</string>
     <string name="location_share_external">Hape me</string>
-    <string name="template_location_not_available_dialog_content">${app_name} s’njohu dot vendndodhjen tuaj. Ju lutemi, riprovoni më vonë.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} s’mësoi dot vendndodhjen tuaj</string>
+    <string name="location_not_available_dialog_content">${app_name} s’njohu dot vendndodhjen tuaj. Ju lutemi, riprovoni më vonë.</string>
+    <string name="location_not_available_dialog_title">${app_name} s’mësoi dot vendndodhjen tuaj</string>
     <string name="edit_poll_button">PËRPUNONI ANKETIMIN</string>
     <string name="edit_poll_title">Përpunoni anketimin</string>
     <string name="poll_no_votes_cast">S’janë hedhur vota</string>

--- a/vector/src/main/res/values-sr/strings.xml
+++ b/vector/src/main/res/values-sr/strings.xml
@@ -418,7 +418,7 @@
     </plurals>
     <string name="no_public_room_placeholder">Нема доступних јавних соба</string>
     <string name="no_more_results">Нема више резултата</string>
-    <string name="template_no_contact_access_placeholder">Нисте доволили да Елемент приступи вашим контактима</string>
+    <string name="no_contact_access_placeholder">Нисте доволили да Елемент приступи вашим контактима</string>
     <string name="no_conversation_placeholder">Нема разговора</string>
     <string name="system_alerts_header">Системска упозорења</string>
     <string name="bottom_action_groups">Заједнице</string>
@@ -472,7 +472,7 @@
     <string name="settings_call_ringtone_dialog_title">Одабери мелодију за позиве:</string>
     <string name="settings_call_ringtone_title">Мелодија долазног позива</string>
     <string name="settings_call_ringtone_use_default_stun">Дозволи сервер за повратни позив</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Користити звоно од ${app_name} за долазне позиве</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Користити звоно од ${app_name} за долазне позиве</string>
     <string name="settings_call_show_confirmation_dialog_summary">Затражити потврду пре него што се започнете позив</string>
     <string name="settings_call_show_confirmation_dialog_title">Спречити случајни позив</string>
     <string name="settings_call_category">Позиви</string>
@@ -564,7 +564,7 @@
     <string name="sound_device_speaker">Звучници</string>
     <string name="sound_device_phone">Телефон</string>
     <string name="call_select_sound_device">Изаберите звучни уређај</string>
-    <string name="template_call_failed_no_connection">${app_name} Позив није успео</string>
+    <string name="call_failed_no_connection">${app_name} Позив није успео</string>
     <string name="call_failed_dont_ask_again">Не питај ме више</string>
     <string name="call_failed_no_ice_use_alt">Пробајте да користите %s</string>
     <string name="call_failed_no_ice_title">Позив није успео због погрешне конфигурације сервера</string>

--- a/vector/src/main/res/values-sv/strings.xml
+++ b/vector/src/main/res/values-sv/strings.xml
@@ -378,7 +378,7 @@
     <string name="user_directory_header">Användarkatalog</string>
     <string name="matrix_only_filter">Bara Matrix-kontakter</string>
     <string name="no_conversation_placeholder">Inga konversationer</string>
-    <string name="template_no_contact_access_placeholder">Du gav inte ${app_name} tillgång till dina lokala kontakter</string>
+    <string name="no_contact_access_placeholder">Du gav inte ${app_name} tillgång till dina lokala kontakter</string>
     <string name="no_result_placeholder">Inga resultat</string>
     <string name="people_no_identity_server">Ingen identitetsserver konfigurerad.</string>
     <string name="rooms_header">Rum</string>
@@ -513,7 +513,7 @@
     <string name="e2e_re_request_encryption_key">Efterfråga krypteringsnycklarna igen från dina andra sessioner.</string>
     <string name="e2e_re_request_encryption_key_sent">Nyckelförfrågan har skickats.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Förfrågan har skickats</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Vänligen öppna ${app_name} på en annan enhet som kan dekryptera meddelandet så att den kan skicka nycklarna till den här sessionen.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Vänligen öppna ${app_name} på en annan enhet som kan dekryptera meddelandet så att den kan skicka nycklarna till den här sessionen.</string>
     <string name="read_receipts_list">Läsindikationslista</string>
     <string name="groups_list">Grupplista</string>
     <plurals name="membership_changes">
@@ -534,7 +534,7 @@
     <string name="room_info_room_name">Rumsnamn</string>
     <string name="room_info_room_topic">Rumsämne</string>
     <string name="settings_call_category">Samtal</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Använd förvald ${app_name}-ringsignal för inkommande samtal</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Använd förvald ${app_name}-ringsignal för inkommande samtal</string>
     <string name="settings_call_ringtone_use_default_stun">Tillåt reservassistansserver för samtal</string>
     <string name="settings_call_ringtone_use_default_stun_sum">Kommer att använda %s som reserv när din hemserver inte erbjuder en (din IP-adress kommer att delas under samtalet)</string>
     <string name="settings_call_ringtone_title">Ringsignal för inkommande samtal</string>
@@ -556,22 +556,22 @@
     <string name="media_picker_both_capture_title">Ta en bild eller en video</string>
     <string name="media_picker_cannot_record_video">Kan inte spela in video</string>
     <string name="permissions_rationale_popup_title">Information</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} behöver tillstånd att komma åt ditt foto- och videobibliotek för att skicka och spara bilagor.
+    <string name="permissions_rationale_msg_storage">${app_name} behöver tillstånd att komma åt ditt foto- och videobibliotek för att skicka och spara bilagor.
 \n 
 \nVänligen ge tillstånd i nästa popup för att kunna skicka filer från din telefon.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} behöver tillstånd att komma åt din kamera för att kunna ta bilder och hålla videosamtal.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} behöver tillstånd att komma åt din kamera för att kunna ta bilder och hålla videosamtal.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nVänligen ge åtkomst i nästa popup för att kunna utföra samtalet."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} behöver tillstånd att komma åt din mikrofon för hålla röstsamtal.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} behöver tillstånd att komma åt din mikrofon för hålla röstsamtal.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nVänligen ge åtkomst i nästa popup för att kunna utföra samtalet."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} behöver tillstånd att komma åt din kamera och mikrofon för att kunna utföra videosamtal.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} behöver tillstånd att komma åt din kamera och mikrofon för att kunna utföra videosamtal.
 \n 
 \nVänligen ge tillstånd i nästa popup för att kunna utföra samtalet.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} kan kolla i din adressbok för att hitta andra Matrixanvändare baserat på deras e-postadresser och telefonnummer. Om du går med på att dela din adressbok för detta ändamål, vänligen ge tillstånd i nästa popup.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} kan kolla i din adressbok för att hitta andra Matrixanvändare baserat på deras e-postadresser och telefonnummer.
+    <string name="permissions_rationale_msg_contacts">${app_name} kan kolla i din adressbok för att hitta andra Matrixanvändare baserat på deras e-postadresser och telefonnummer. Om du går med på att dela din adressbok för detta ändamål, vänligen ge tillstånd i nästa popup.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} kan kolla i din adressbok för att hitta andra Matrixanvändare baserat på deras e-postadresser och telefonnummer.
 \n
 \nVill du dela din adressbok för detta ändamål\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Tyvärr. Handlingen utfördes inte på grund av saknade rättigheter</string>
@@ -791,13 +791,13 @@
     <string name="settings_troubleshoot_test_account_settings_failed">Aviseringar är inaktiverade för ditt konto.
 \nVänligen kolla kontoinställningarna.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Aviseringar är aktiverade för den här sessionen.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Aviseringar är inaktiverade för den här sessionen.
+    <string name="settings_troubleshoot_test_device_settings_failed">Aviseringar är inaktiverade för den här sessionen.
 \nVänligen kolla ${app_name}inställningarna.</string>
     <string name="settings_troubleshoot_test_bing_settings_success_with_warn">Observera att vissa meddelandetyper är satta till tyst (kommer att producera aviseringar utan ljud).</string>
     <string name="settings_troubleshoot_test_bing_settings_failed">Vissa aviseringar är inaktiverade i dina anpassade inställningar.</string>
     <string name="settings_troubleshoot_test_service_restart_title">Automatisk omstart av aviseringstjänsten</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Tjänsten kommer inte att starta när enheten startas om, så du kommer inte att få aviseringar förrens ${app_name} har öppnats en gång.</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Bakgrundsbegränsningar är aktiverade för ${app_name}.
+    <string name="settings_troubleshoot_test_service_boot_failed">Tjänsten kommer inte att starta när enheten startas om, så du kommer inte att få aviseringar förrens ${app_name} har öppnats en gång.</string>
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Bakgrundsbegränsningar är aktiverade för ${app_name}.
 \nSaker som appen försöker göra kommer att kraftigt begränsas när appen är bakgrunden, och detta kan påverka aviseringar.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_battery_failed">Om en användare lämnar sin enhet urkopplad och stilla en längre tid, med skärmen av, så går enheten in i Doze-läget. Detta hindrar appar från att komma åt nätverket och skjuter upp deras uppgifter, synkroniseringar och standardlarm.</string>
@@ -816,7 +816,7 @@
     <string name="settings_containing_my_user_name">Meddelanden innehållande mitt användarnamn</string>
     <string name="settings_messages_in_one_to_one">Meddelanden i direktchattar</string>
     <string name="settings_messages_in_group_chat">Meddelanden i gruppchattar</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} kommer att synka i bakgrunden periodiskt vid precisa tider (konfigurerbart).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} kommer att synka i bakgrunden periodiskt vid precisa tider (konfigurerbart).
 \nDetta kommer att påverka data- och batterianvändning, och det kommer att visas en permanent avisering som säger att ${app_name} lyssnar efter händelser.</string>
     <string name="settings_version">Version</string>
     <string name="settings_olm_version">olm-version</string>
@@ -837,8 +837,8 @@
     <string name="settings_discovery_category">Upptäckbarhet</string>
     <string name="settings_discovery_manage">Hantera dina upptäckbarhetsinställningar.</string>
     <string name="startup_notification_privacy_title">Aviseringssekretess</string>
-    <string name="template_startup_notification_privacy_message">${app_name} kan köra i bakgrunden för att hantera dina aviseringar säkert och privat. Detta kan påverka batteritiden.</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} behöver hålla en bakgrundsanslutning med låg påverkan för att ha pålitliga aviseringar.
+    <string name="startup_notification_privacy_message">${app_name} kan köra i bakgrunden för att hantera dina aviseringar säkert och privat. Detta kan påverka batteritiden.</string>
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} behöver hålla en bakgrundsanslutning med låg påverkan för att ha pålitliga aviseringar.
 \nPå nästa skärm kommer du att frågas om du vill tillåta att ${app_name} alltid körs i bakgrunden, vänligen acceptera.</string>
     <string name="settings_logged_in">Inloggad som</string>
     <string name="settings_home_server">Hemserver</string>
@@ -980,7 +980,7 @@
 \nLogga in igen för att komma åt din kontodata och dina meddelanden.</string>
     <string name="settings_advanced_settings">Avancerade inställningar</string>
     <string name="autocomplete_limited_results">Visar endast de första resultaten, skriv mer…</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} kan krascha mer när ett oväntat fel inträffar</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} kan krascha mer när ett oväntat fel inträffar</string>
     <string name="create_room_encryption_description">Efter aktivering så kan kryptering inte avaktiveras.</string>
     <string name="login_error_threepid_denied">Din e-postdomän är inte auktoriserad för att registrera på den här servern</string>
     <string name="room_profile_not_encrypted_subtitle">Meddelanden i det här rummet är inte totalsträckskrypterade.</string>
@@ -1029,7 +1029,7 @@
     </plurals>
     <string name="invite_users_to_room_failure">Vi kunde inte bjuda in användarna. Vänligen kolla användarna du vill bjuda in och försök igen.</string>
     <string name="disconnect_identity_server_dialog_content">Koppla bort från identitetsservern %s\?</string>
-    <string name="template_identity_server_error_outdated_identity_server">Den här identitetsservern är utdaterat. ${app_name} stöder endast API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Den här identitetsservern är utdaterat. ${app_name} stöder endast API V2.</string>
     <string name="identity_server_error_no_identity_server_configured">Vänligen konfigurera en identitetsserver.</string>
     <string name="identity_server_error_terms_not_signed">Vänligen acceptera först identitetsserverns användarvillkor i inställningarna.</string>
     <string name="identity_server_set_default_notice">Din hemserver (%1$s) föreslår att du använder %2$s som din identitetsserver</string>
@@ -1165,7 +1165,7 @@
     <string name="sent_an_audio_file">Ljud</string>
     <string name="sent_a_file">Fil</string>
     <string name="send_a_sticker">Dekal</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} hanterar inte meddelanden av typen \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} hanterar inte meddelanden av typen \'%1$s\'</string>
     <string name="command_description_rainbow">Skickar det valda meddelandet I regnbågsfärger</string>
     <string name="settings_category_composer">Meddelanderedigering</string>
     <string name="message_key">Meddelandenyckel</string>
@@ -1202,7 +1202,7 @@
     <string name="cannot_call_yourself_with_invite">Du kan inte ringa ett samtal till dig själv, vänta tills deltagare accepterar inbjudan</string>
     <string name="failed_to_add_widget">Misslyckades att lägga till widget</string>
     <string name="failed_to_remove_widget">Misslyckades att ta bort widget</string>
-    <string name="template_call_failed_no_connection">${app_name}samtal misslyckades</string>
+    <string name="call_failed_no_connection">${app_name}samtal misslyckades</string>
     <string name="call_failed_no_connection_description">Misslyckades att upprätta en realtidsuppkoppling.
 \nVänligen be administratören för din hemserver att konfigurera en TURN-server för att samtal ska fungera pålitligt.</string>
     <string name="call_select_sound_device">Välj ljudenhet</string>
@@ -1297,7 +1297,7 @@
     <string name="room_sliding_menu_copyright">Upphovsrätt</string>
     <string name="room_sliding_menu_privacy_policy">Integritetspolicy</string>
     <string name="settings_phone_number">Telefon</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Du kan inte göra detta från ${app_name} på mobilen</string>
+    <string name="settings_add_3pid_flow_not_supported">Du kan inte göra detta från ${app_name} på mobilen</string>
     <string name="settings_add_3pid_authentication_needed">Autentisering krävs</string>
     <string name="settings_troubleshoot_diagnostic">Diagnostik för felsökning</string>
     <string name="settings_troubleshoot_diagnostic_run_button_title">Kör tester</string>
@@ -1307,7 +1307,7 @@
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">Misslyckades att ladda anpassade regler, vänligen försök igen.</string>
     <string name="settings_troubleshoot_test_play_services_title">Kolla Play-tjänster</string>
     <string name="settings_troubleshoot_test_play_services_success">APK:n Google Play-tjänster är tillgänglig och uppdaterad.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} använder Google Play-tjänster för att skicka pushmeddelanden, men den verkar inte vara korrekt konfigurerad:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} använder Google Play-tjänster för att skicka pushmeddelanden, men den verkar inte vara korrekt konfigurerad:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Fixa Play-tjänster</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase-token</string>
@@ -1315,11 +1315,11 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">Misslyckades att hämta FCM-token:
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nDet här felet är ur ${app_name}s kontroll, och enligt Google indikerar det här felet att den här enheten har för många appar registrerade med FCM. Felet händer endast i fall då extremt många appar är installerade, så det bör inte påverka normala användare.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nDet här felet är ur ${app_name}s kontroll. Det kan hända av flera anledningar. Det kanske funkar om du försöker igen senare, du kan kolla så att Google Play-tjänster inte är databegränsad i systeminställningarna, eller att enhetens klocka går rätt, eller så kan det hända på en alternativ ROM.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nDet här felet är ur ${app_name}s kontroll. Det finns inget Google-konto på telefonen. Vänligen öppna kontohanteraren och lägg till ett Google-konto.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Lägg till konto</string>
     <string name="settings_troubleshoot_test_token_registration_title">Token-registrering</string>
@@ -1332,11 +1332,11 @@
     <string name="settings_troubleshoot_test_service_boot_success">Tjänsten kommer att startas när enheten startas om.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Aktivera start på boot</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Kolla bakgrundsrestriktioner</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Bakgrundsrestriktioner är inaktiverade för ${app_name}. Detta test bör köras med mobildata (inte Wi-Fi).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Bakgrundsrestriktioner är inaktiverade för ${app_name}. Detta test bör köras med mobildata (inte Wi-Fi).
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Inaktivera restriktioner</string>
     <string name="settings_troubleshoot_test_battery_title">Batterioptimering</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} påverkas inte av batterioptimering.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} påverkas inte av batterioptimering.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignorera optimering</string>
     <string name="settings_notification_privacy_reduced">Reducerad sekretess</string>
     <string name="settings_notification_privacy_need_permission">Den här appen behöver behörighet att köra i bakgrunden</string>
@@ -1461,7 +1461,7 @@
         <item quantity="one">%1$s, %2$s och %3$d annan har läst</item>
         <item quantity="other">%1$s, %2$s och %3$d andra har läst</item>
     </plurals>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} behöver behörighet för att spara dina nycklar för totalsträckskryptering i lagringen.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} behöver behörighet för att spara dina nycklar för totalsträckskryptering i lagringen.
 \n
 \nVänligen ge tillstånd i nästa popup för att kunna manuellt exportera dina nycklar.</string>
     <string name="no_ignored_users">Du ignorerar inga användare</string>
@@ -1477,7 +1477,7 @@
     <string name="soft_logout_clear_data_notice">Varning: Din personliga data (inklusive krypteringsnycklar) lagras fortfarande på den här enheten.
 \n
 \nRensa den om du inte ska använda den här enheten längre, eller vill logga in på ett annat konto.</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Den nuvarande sessionen är för användaren %1$s och du försedde uppgifter för användaren %2$s. Detta stöds inte av ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">Den nuvarande sessionen är för användaren %1$s och du försedde uppgifter för användaren %2$s. Detta stöds inte av ${app_name}.
 \nVänligen rensa först data, och logga sen in på ett annat konto.</string>
     <string name="settings_show_devices_list">Se alla mina sessioner</string>
     <string name="settings_developer_mode">Utvecklarläge</string>
@@ -1547,16 +1547,16 @@
     <string name="bootstrap_migration_backup_recovery_key">Återställningsnyckel för säkerhetskopiering</string>
     <string name="settings_security_prevent_screenshots_title">Förhindra skärmdumpar av appen</string>
     <string name="settings_security_prevent_screenshots_summary">Att aktivera den här inställningen lägger till FLAG_SECURE till alla aktiviteter. Starta om appen för att inställningen ska få effekt.</string>
-    <string name="template_use_other_session_content_description">Använd senaste ${app_name} på dina andra enheter; ${app_name} Web, ${app_name} iOS, ${app_name} för Android, eller annan Matrixklient som stöder korssignering</string>
+    <string name="use_other_session_content_description">Använd senaste ${app_name} på dina andra enheter; ${app_name} Web, ${app_name} iOS, ${app_name} för Android, eller annan Matrixklient som stöder korssignering</string>
     <string name="or_other_mx_capable_client">eller en annan Matrixklient som städer korssignering</string>
-    <string name="template_use_latest_app">Använd senaste ${app_name} på dina andra enheter:</string>
+    <string name="use_latest_app">Använd senaste ${app_name} på dina andra enheter:</string>
     <string name="command_description_discard_session">Tvingar den nuvarande utgående gruppsessionen i ett krypterat rum att kasseras</string>
     <string name="keys_backup_recovery_key_error_decrypt">Säkerhetskopian kunde inte avkrypteras med den här återställningsnyckeln: vänligen verifiera att du skrev in rätt återställningsnyckel.</string>
     <string name="settings_setup_secure_backup">Sätt upp säker säkerhetskopiering</string>
     <string name="bottom_sheet_setup_secure_backup_title">Säker säkerhetskopiering</string>
     <string name="bottom_sheet_setup_secure_backup_submit">Sätt upp</string>
     <string name="bottom_sheet_setup_secure_backup_security_phrase_subtitle">Skriv in en hemlig fras endast du känner till, och generera en nyckel för säkerhetskopiering.</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} kommer att synka i bakgrunden på ett sätt som sparar på enhetens begränsade resurser (batteri).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} kommer att synka i bakgrunden på ett sätt som sparar på enhetens begränsade resurser (batteri).
 \nBeroende på din enhets resurser, så kan synkroniseringen bli uppskjuten av operativsystemet.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimerad för realtid</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Ingen bakgrundssynk</string>
@@ -1587,8 +1587,8 @@
     <string name="startup_notification_fdroid_battery_optim_button_grant">Ge behörighet</string>
     <string name="settings_analytics">Statistik</string>
     <string name="settings_opt_in_of_analytics">Skicka statistikdata</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} samlar in anonym statistik för att låta oss förbättra appen.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Vänligen aktivera statistik för att hjälpa oss att förbättra ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} samlar in anonym statistik för att låta oss förbättra appen.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Vänligen aktivera statistik för att hjälpa oss att förbättra ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Ja, jag vill hjälpa till!</string>
     <string name="settings_data_save_mode">Databesparingsläge</string>
     <string name="devices_details_id_title">ID</string>
@@ -1827,7 +1827,7 @@
     <string name="passphrase_passphrase_does_not_match">Lösenfrasen matchar inte</string>
     <string name="passphrase_empty_error_message">Vänligen skriv en lösenfras</string>
     <string name="passphrase_passphrase_too_weak">Lösenfrasen är för svag</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Vänligen radera lösenfrasen om du vill att ${app_name} ska generera en återställningsnyckel.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Vänligen radera lösenfrasen om du vill att ${app_name} ska generera en återställningsnyckel.</string>
     <string name="keys_backup_setup_step2_button_title">Sätt lösenfras</string>
     <string name="keys_backup_setup_creating_backup">Skapar säkerhetskopia</string>
     <string name="keys_backup_setup_step3_success_title">Framgång !</string>
@@ -1870,7 +1870,7 @@
     </plurals>
     <string name="keys_backup_info_title_signature">Signatur</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Autokomplettera serveralternativ</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} detekterade en anpassad serverkonfiguration för din användar-ID-domän \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} detekterade en anpassad serverkonfiguration för din användar-ID-domän \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Använd konfig</string>
     <string name="sas_verify_title">Verifiera genom att jämföra en kort textsträng.</string>
@@ -1920,7 +1920,7 @@
     <string name="action_change">Ändra</string>
     <string name="please_wait">Vänligen vänta…</string>
     <string name="room_preview_no_preview">Det här rummet kan inte förhandsgranskas</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Förhandsgranskning av världsläsbara rum stöds inte än av ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Förhandsgranskning av världsläsbara rum stöds inte än av ${app_name}</string>
     <string name="create_room_title">Nytt rum</string>
     <string name="create_room_action_create">SKAPA</string>
     <string name="create_room_name_hint">Namn</string>
@@ -2137,8 +2137,8 @@
     <string name="room_member_power_level_default_in">Standardbehörig i %1$s</string>
     <string name="room_member_power_level_custom_in">Anpassad (%1$d) i %2$s</string>
     <string name="room_member_jump_to_read_receipt">Hoppa till läskvitto</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} hanterar inte händelser av typen \'%1$s\'</string>
-    <string name="template_rendering_event_error_exception">${app_name} stötte på ett fel vid rendering av innehållet i händelsen med id \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} hanterar inte händelser av typen \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} stötte på ett fel vid rendering av innehållet i händelsen med id \'%1$s\'</string>
     <string name="unignore">Avignorera</string>
     <string name="command_description_rainbow_emote">Skickar den givna emoten i regnbågsfärg</string>
     <string name="call_notification_answer">Godkänn</string>
@@ -2185,7 +2185,7 @@
     <string name="event_redacted_by_user_reason_with_reason">Händelsen raderades av användaren, anledning: %1$s</string>
     <string name="event_redacted_by_admin_reason_with_reason">Händelsen modererades av rumsadministratören. Anledning: %1$s</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Nycklarna är redan uppdaterade!</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="refresh">Ladda om</string>
     <string name="new_session">Ny inloggning. Var det du\?</string>
     <string name="new_session_review">Tryck för att granska och verifiera</string>
@@ -2237,9 +2237,9 @@
     <string name="bootstrap_progress_generating_ssss_recovery">Generar SSSS-nyckel baserat på återställningsnyckel</string>
     <string name="bootstrap_progress_storing_in_sss">Lagrar hemlighet för nyckelsäkerhetskopiering i SSSS</string>
     <string name="new_session_review_with_info">%1$s (%2$s)</string>
-    <string name="template_app_desktop_web">${app_name} Webb
+    <string name="app_desktop_web">${app_name} Webb
 \n${app_name} Skrivbord</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
     <string name="enter_secret_storage_passphrase_or_key">Använd din %1$s eller %2$s för att fortsätta.</string>
     <string name="use_recovery_key">Använd återställningsnyckel</string>
@@ -2264,7 +2264,7 @@
     <string name="invitations_sent_to_two_users">Inbjudan skickad till %1$s och %2$s</string>
     <string name="open_terms_of">Öppna villkor för %s</string>
     <string name="identity_server_error_outdated_home_server">Den här operationen är inte möjlig. Hemservern är utdaterad.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">För ditt privatlivs skull stöder ${app_name} bara att skicka hashade e-postadresser och telefonnummer.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">För ditt privatlivs skull stöder ${app_name} bara att skicka hashade e-postadresser och telefonnummer.</string>
     <string name="identity_server_error_binding_error">Associationen har misslyckats.</string>
     <string name="identity_server_error_no_current_binding_error">Det finns ingen nuvarande association med den här identifieraren.</string>
     <string name="identity_server_set_default_submit">Använd %1$s</string>
@@ -2352,13 +2352,13 @@
 \n
 \nAnvänd varsamt, det kan leda till oväntat beteende.</string>
     <string name="secure_backup_reset_no_history">så kommer du att börja om utan historik, meddelanden, betrodda enheter eller betrodda användare</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">PIN-kod krävs varje gång du öppnar ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">PIN-kod krävs efter att du inte har använt ${app_name} på 2 minuter.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">PIN-kod krävs varje gång du öppnar ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">PIN-kod krävs efter att du inte har använt ${app_name} på 2 minuter.</string>
     <string name="settings_security_pin_code_grace_period_title">Kräv PIN-kod efter 2 minuter</string>
     <string name="settings_security_pin_code_notifications_summary_off">Visa bara antal olästa meddelanden i en enkel avisering.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Visa detaljer som rumsnamn och meddelandeinnehåll.</string>
     <string name="settings_security_pin_code_notifications_title">Visa innehåll i aviseringar</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">PIN-kod är det enda sättet att låsa upp ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">PIN-kod är det enda sättet att låsa upp ${app_name}.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Aktivera enhetsspecifik biometri, som fingeravtryck och ansiktsigenkänning.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Aktivera biometri</string>
     <string name="settings_security_application_protection_screen_title">Ställ in skydd</string>
@@ -2438,8 +2438,8 @@
     <string name="user_code_share">Dela min kod</string>
     <string name="user_code_scan">Skanna en QR-kod</string>
     <string name="not_a_valid_qr_code">Det är inte en giltig Matrix-QR-kod</string>
-    <string name="template_invite_friends_rich_title">🔐️ Gå med mig i ${app_name}</string>
-    <string name="template_invite_friends_text">Hallå, prata med mig i ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Gå med mig i ${app_name}</string>
+    <string name="invite_friends_text">Hallå, prata med mig i ${app_name}: %s</string>
     <string name="invite_friends">Bjud in vänner</string>
     <string name="add_people">Lägg till personer</string>
     <string name="topic_prefix">"Ämne: "</string>
@@ -2545,7 +2545,7 @@
     <string name="room_participants_leave_private_warning">Det är rummet är inte offentligt. Du kommer inte kunna gå med igen utan en inbjudan.</string>
     <string name="system_theme">Systemets förval</string>
     <string name="authentication_error">Misslyckades att autentisera</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} kräver att du anger dina autentiseringsuppgifter innan du gör det här.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} kräver att du anger dina autentiseringsuppgifter innan du gör det här.</string>
     <string name="re_authentication_activity_title">Omautentisering krävs</string>
     <string name="failed_to_initialize_cross_signing">Mislyckades att ställa in korssignering</string>
     <string name="error_unauthorized">Obehörig, saknar giltiga autentiseringsuppgifter</string>
@@ -2859,7 +2859,7 @@
     <string name="hs_client_url">Hemserver-API-URL</string>
     <string name="missing_permissions_title">Saknar behörighet</string>
     <string name="denied_permission_voice_message">För att skicka röstmeddelanden, vänligen ge mikrofonåtkomst.</string>
-    <string name="template_link_this_email_with_your_account">%s i inställningar för att ta emot inbjudningar direkt i ${app_name}.</string>
+    <string name="link_this_email_with_your_account">%s i inställningar för att ta emot inbjudningar direkt i ${app_name}.</string>
     <string name="link_this_email_settings_link">Länka den här e-postadressen med ditt konto</string>
     <string name="this_invite_to_this_space_was_sent">Denna inbjudan till det här utrymmet skickades till %s, vilket inte är associerat med ditt konto</string>
     <string name="this_invite_to_this_room_was_sent">Denna inbjudan till det här rummet skickades till %s, vilket inte är associerat med ditt konto</string>
@@ -2999,10 +2999,10 @@
     <string name="analytics_opt_in_list_item_2">Vi delar <b>inte</b> information med tredje parter</string>
     <string name="analytics_opt_in_list_item_1">Vi spelar <b>inte</b> in eller profilerar någon kontodata</string>
     <string name="analytics_opt_in_content_link">här</string>
-    <string name="template_analytics_opt_in_content">Hjälp oss att identifiera problem och förbättra ${app_name} genom att dela anonym användningsdata. För att förstå hur personer använder multipla enheter så generar vi en slumpmässig identifierare som delas mellan dina enheter.
+    <string name="analytics_opt_in_content">Hjälp oss att identifiera problem och förbättra ${app_name} genom att dela anonym användningsdata. För att förstå hur personer använder multipla enheter så generar vi en slumpmässig identifierare som delas mellan dina enheter.
 \n
 \nDu kan läsa alla våra villkor %s.</string>
-    <string name="template_analytics_opt_in_title">Hjälp att förbättra ${app_name}</string>
+    <string name="analytics_opt_in_title">Hjälp att förbättra ${app_name}</string>
     <string name="action_enable">Aktivera</string>
     <string name="delete_poll_dialog_content">Är du säker på att du vill ta bort den här omröstningen\? Du kommer inte kunna få tillbaka den när den har tagits bort.</string>
     <string name="delete_poll_dialog_title">Ta bort omröstning</string>
@@ -3027,14 +3027,14 @@
     </plurals>
     <string name="preference_system_settings">Systeminställningar</string>
     <string name="preference_versions">Versioner</string>
-    <string name="template_preference_help_summary">Få hjälp med att använda ${app_name}</string>
+    <string name="preference_help_summary">Få hjälp med att använda ${app_name}</string>
     <string name="preference_help_title">Hjälp och support</string>
     <string name="preference_help">Hjälp</string>
     <string name="preference_root_legals">Legalt</string>
     <string name="legals_no_policy_provided">Den här servern förser ingen policy.</string>
     <string name="legals_third_party_notices">Tredjepartsbibliotek</string>
     <string name="legals_identity_server_title">Din identitetsservers policy</string>
-    <string name="template_legals_application_title">${app_name}s policy</string>
+    <string name="legals_application_title">${app_name}s policy</string>
     <string name="legals_home_server_title">Din hemservers policy</string>
     <plurals name="poll_total_vote_count_before_ended_and_not_voted">
         <item quantity="one">%1$d röst avgiven. Rösta för att se resultatet</item>
@@ -3061,8 +3061,8 @@
     <string name="settings_enable_location_sharing_summary">När det har aktiverats så kan du skicka din plats till vilket rum som helst</string>
     <string name="settings_enable_location_sharing">Aktivera platsdelning</string>
     <string name="location_share_external">Öppna med</string>
-    <string name="template_location_not_available_dialog_content">${app_name} kunde inte komma åt din plats. Försök igen senare.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} kunde inte komma åt din plats</string>
+    <string name="location_not_available_dialog_content">${app_name} kunde inte komma åt din plats. Försök igen senare.</string>
+    <string name="location_not_available_dialog_title">${app_name} kunde inte komma åt din plats</string>
     <string name="location_share">Dela plats</string>
     <string name="a11y_location_share_icon">Dela plats</string>
     <string name="location_activity_title_preview">Plats</string>

--- a/vector/src/main/res/values-te/strings.xml
+++ b/vector/src/main/res/values-te/strings.xml
@@ -115,7 +115,7 @@
     <string name="local_address_book_header">స్థానిక చిరునామా పుస్తకం</string>
     <string name="matrix_only_filter">మ్యాట్రిక్స్ పరిచయాలు మాత్రమే</string>
     <string name="no_conversation_placeholder">సంభాషణలు లేవు</string>
-    <string name="template_no_contact_access_placeholder">మీరు మీ స్థానిక పరిచయాలను యాక్సెస్ చేయడానికి రియోట్ను అనుమతించలేదు</string>
+    <string name="no_contact_access_placeholder">మీరు మీ స్థానిక పరిచయాలను యాక్సెస్ చేయడానికి రియోట్ను అనుమతించలేదు</string>
     <string name="no_result_placeholder">ఫలితాలు లేవు</string>
 
     <string name="rooms_header">గదులు</string>
@@ -243,8 +243,8 @@
     <string name="media_picker_cannot_record_video">వీడియో రికార్డ్ చేయలేరు</string>
 
     <string name="permissions_rationale_popup_title">సమాచారం</string>
-    <string name="template_permissions_rationale_msg_camera">చిత్రాలను మరియు వీడియో కాల్లను తీయడానికి మీ కెమెరాను ప్రాప్తి చేయడానికి ${app_name}కు అనుమతి అవసరం.</string>
-    <string name="template_permissions_rationale_msg_record_audio">ఆడియో కాల్లను చేయడానికి మీ మైక్రోఫోన్ను ప్రాప్యత చేయడానికి ${app_name}కు అనుమతి అవసరం.</string>
+    <string name="permissions_rationale_msg_camera">చిత్రాలను మరియు వీడియో కాల్లను తీయడానికి మీ కెమెరాను ప్రాప్తి చేయడానికి ${app_name}కు అనుమతి అవసరం.</string>
+    <string name="permissions_rationale_msg_record_audio">ఆడియో కాల్లను చేయడానికి మీ మైక్రోఫోన్ను ప్రాప్యత చేయడానికి ${app_name}కు అనుమతి అవసరం.</string>
     <string name="permissions_action_not_performed_missing_permissions">క్షమించాలి… ఆమోదించని అనుమతుల కారణంగా చర్య చేయలేదు</string>
 
     <string name="media_slider_saved">దాయబడినది</string>
@@ -534,7 +534,7 @@
     <string name="login_error_login_email_not_yet">ఇంకా నొక్కని ఇ-తపాలా లింగక</string>
 
     <string name="call_error_camera_init_failed">కెమెరాను ప్రారంభించడం సాధ్యపడదు</string>
-    <string name="template_permissions_rationale_msg_storage">అటాచ్మెంట్లు పంపడానికి మరియు సేవ్ చేయడానికి మీ ఫోటో మరియు వీడియో లైబ్రరీని ప్రాప్తి చేయడానికి కలతకు అనుమతి అవసరం.
+    <string name="permissions_rationale_msg_storage">అటాచ్మెంట్లు పంపడానికి మరియు సేవ్ చేయడానికి మీ ఫోటో మరియు వీడియో లైబ్రరీని ప్రాప్తి చేయడానికి కలతకు అనుమతి అవసరం.
 \n
 \nదయచేసి మీ ఫోన్ నుండి ఫైల్లను పంపగల తదుపరి పాప్-అప్లో ప్రాప్యతను అనుమతించండి.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
@@ -543,7 +543,7 @@
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nదయచేసి కాల్ చేయడానికి వీలుగా తదుపరి పాప్-అప్లో ప్రాప్యతను అనుమతించండి."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">"మీ కెమెరాను మరియు మీ శబ్ద ప్రసారిణి సాంగత్యం చేయడానికి రియోట్కు అనుమతి అవసరం.
+    <string name="permissions_rationale_msg_camera_and_audio">"మీ కెమెరాను మరియు మీ శబ్ద ప్రసారిణి సాంగత్యం చేయడానికి రియోట్కు అనుమతి అవసరం.
 \n
 \nదయచేసి   పిలుపు చేయడానికి వీలుగా తదుపరి పాప్-అప్ల్లో ప్రాప్యతను అనుమతించండి."</string>
     <string name="action_preview">ప్రత్యేక ప్రదర్శన</string>

--- a/vector/src/main/res/values-th/strings.xml
+++ b/vector/src/main/res/values-th/strings.xml
@@ -42,7 +42,7 @@
     <string name="bottom_action_groups">ชุมชน</string>
     <string name="invitations_header">คำเชิญ</string>
     <string name="system_alerts_header">การแจ้งเตือนจากระบบ</string>
-    <string name="template_no_contact_access_placeholder">คุณไม่ได้อนุญาตให้ ${app_name} เข้าถึงรายชื่อผู้ติดต่อในเครื่อง</string>
+    <string name="no_contact_access_placeholder">คุณไม่ได้อนุญาตให้ ${app_name} เข้าถึงรายชื่อผู้ติดต่อในเครื่อง</string>
     <string name="no_result_placeholder">ไม่มีผลลัพธ์</string>
     <string name="no_room_placeholder">ไม่มีห้อง</string>
     <plurals name="public_room_nb_users">

--- a/vector/src/main/res/values-tr/strings.xml
+++ b/vector/src/main/res/values-tr/strings.xml
@@ -85,7 +85,7 @@
     <string name="user_directory_header">Kullanıcı sözlüğü</string>
     <string name="matrix_only_filter">Sadece Matrix kullanıcıları</string>
     <string name="no_conversation_placeholder">Konuşma yok</string>
-    <string name="template_no_contact_access_placeholder">${app_name}\'in yerel rehbere erişmesine izin vermediniz</string>
+    <string name="no_contact_access_placeholder">${app_name}\'in yerel rehbere erişmesine izin vermediniz</string>
     <string name="no_result_placeholder">Sonuç bulunamadı</string>
     <string name="rooms_header">Odalar</string>
     <string name="rooms_directory_header">Odalar dizini</string>
@@ -244,7 +244,7 @@
     <string name="e2e_re_request_encryption_key">Diğer oturumlardan <u>şifreleme anahtarlarını tekrar iste</u>.</string>
     <string name="e2e_re_request_encryption_key_sent">Anahtar isteği gönderildi.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">İstek gönderildi</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">${app_name}\'i mesajları çözebilen farklı bir cihazda açarsanız ordan anahtarları bu oturuma gönderebilirsiniz.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">${app_name}\'i mesajları çözebilen farklı bir cihazda açarsanız ordan anahtarları bu oturuma gönderebilirsiniz.</string>
     <string name="read_receipts_list">Makbuz Listesini Oku</string>
     <string name="groups_list">Grup Listesi</string>
     <plurals name="membership_changes">
@@ -265,7 +265,7 @@
     <string name="room_info_room_name">Oda adı</string>
     <string name="room_info_room_topic">Oda konusu</string>
     <string name="settings_call_category">Aramalar</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Gelen aramalar için varsayılan ${app_name} zil sesini kullan</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Gelen aramalar için varsayılan ${app_name} zil sesini kullan</string>
     <string name="settings_call_ringtone_title">Gelen arama zil sesi</string>
     <string name="settings_call_ringtone_dialog_title">Aramalar için zil sesi seç:</string>
     <string name="call">Arama</string>
@@ -285,22 +285,22 @@
     <string name="media_picker_both_capture_title">Fotoğraf ya da video çek</string>
     <string name="media_picker_cannot_record_video">Video kaydedilemiyor</string>
     <string name="permissions_rationale_popup_title">Bilgilendirme</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name}\'in ekleri göndermek ya da kaydetmek için galeriye erişmeye ihtiyacı var.
+    <string name="permissions_rationale_msg_storage">${app_name}\'in ekleri göndermek ya da kaydetmek için galeriye erişmeye ihtiyacı var.
 \n
 \nLütfen çıkacak ekranda telefonunuzdan dosya gönderebilmesine izin verin.</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name}\'in fotoğraf ya da video çekmek için kameraya erişmeye ihtiyacı var.</string>
+    <string name="permissions_rationale_msg_camera">${app_name}\'in fotoğraf ya da video çekmek için kameraya erişmeye ihtiyacı var.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nLütfen çıkacak ekranda kamera erişimine izin verin."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name}\'in sesli arama yapması için mikrofonunuza erişmeye ihtiyacı var.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name}\'in sesli arama yapması için mikrofonunuza erişmeye ihtiyacı var.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nLütfen çıkacak ekranda mikrofon erişimine izin verin."</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name}\'in görüntülü arama yapması için kameranıza ve mikrofonunuza erişmeye ihtiyacı var.
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name}\'in görüntülü arama yapması için kameranıza ve mikrofonunuza erişmeye ihtiyacı var.
 \n
 \nLütfen çıkacak ekranda kamera ve mikrofon erişimine izin verin.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} e-posta ve telefon numaralarına göre diğer Matrix kullanıcılarını bulmak için rehberinizi kontrol edebilir. Eğer bu nedenle rehberinizi paylaşmak istiyorsanız, lütfen açılan ekranda erişime izin verin.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name}\'in e-posta ve telefon numaralarına göre diğer Matrix kullanıcılarını bulmak için rehberinizi kontrol edebilir.
+    <string name="permissions_rationale_msg_contacts">${app_name} e-posta ve telefon numaralarına göre diğer Matrix kullanıcılarını bulmak için rehberinizi kontrol edebilir. Eğer bu nedenle rehberinizi paylaşmak istiyorsanız, lütfen açılan ekranda erişime izin verin.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name}\'in e-posta ve telefon numaralarına göre diğer Matrix kullanıcılarını bulmak için rehberinizi kontrol edebilir.
 \n 
 \nRehberinizi bu sebeple paylaşmayı kabul ediyor musunuz\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Üzgünüz. İsteğiniz, yetersiz izinlerden dolayı gerçekleştirilemedi</string>
@@ -503,7 +503,7 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">Etkinleştir</string>
     <string name="settings_troubleshoot_test_device_settings_title">Oturum Ayarları</string>
     <string name="settings_troubleshoot_test_device_settings_success">Bildirimler bu oturum için etkinleştirilmiş.</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Bildirimler bu oturum için etkin değil.
+    <string name="settings_troubleshoot_test_device_settings_failed">Bildirimler bu oturum için etkin değil.
 \nLütfen ${app_name} ayarlarını gözden geçirin.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Etkinleştir</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Özel Ayarlar</string>
@@ -513,7 +513,7 @@
     <string name="settings_troubleshoot_test_bing_settings_quickfix">Ayarları Gözden Geçir</string>
     <string name="settings_troubleshoot_test_play_services_title">Play Hizmetlerini Gözden Geçir</string>
     <string name="settings_troubleshoot_test_play_services_success">Google Play Hizmetleri APK\'sı kullanılabilir ve güncel.</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} bildirimleri göndermek için Google Play Hizmetleri kullanır, ancak düzgün ayarlanmış görünmüyor:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} bildirimleri göndermek için Google Play Hizmetleri kullanır, ancak düzgün ayarlanmış görünmüyor:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Google Play Hizmetlerini Düzelt</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase Belirteci</string>
@@ -521,11 +521,11 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">FCM belirtecini alırken hata meydana geldi:
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nBu hata ${app_name}\'in kontrolü dışında Google\'a bağlı ve cihazın çok fazla FCM ile kayıtlı uygulaması olduğunu belirtiyor. Bu hata sadece çok fazla uygulama kullanıldığı zaman olur ve genelde ortalama kullanıcıyı etkilemez.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nBu hata ${app_name}\'in kontrolü dışında ve birçok nedene bağlı olabilir. Belki sonra denediğin zaman çalışır. Ayrıca Google Play Hizmetlerinin veri kullanımı konusunda sistem ayarlarında kısıtlanmamış ya da cihaz saatinin doğru olduğundan emin olun, bu hata özel ROM\'larda meydana gelebiliyor.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nBu hata ${app_name}\'in kontrolü dışında. Telefonda hiç Google hesabı yok. Lütfen hesap yöneticisini açın ve bir tane Google hesabı ekleyin.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Hesap ekle</string>
     <string name="settings_troubleshoot_test_token_registration_title">Belirteç Kayıtı</string>
@@ -537,17 +537,17 @@
     <string name="settings_troubleshoot_test_service_restart_failed">Hizmet yeniden başlatılamadı</string>
     <string name="settings_troubleshoot_test_service_boot_title">Açılışta başlat</string>
     <string name="settings_troubleshoot_test_service_boot_success">Hizmet cihaz yeniden başlatıldığında çalıştırılacak.</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Hizmet cihaz yeniden başlatılınca çalıştırılmayacak, ${app_name}\'i açana kadar bildirimleri almakyacaksın.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Hizmet cihaz yeniden başlatılınca çalıştırılmayacak, ${app_name}\'i açana kadar bildirimleri almakyacaksın.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Açılışta başlatı etkinleştir</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Arka plan kısıtlamalarını gözden geçir</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Arka plan kısıtlamaları ${app_name} için devre dışı. Bu test mobil veri kullanacak (WIFI değil).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Arka plan kısıtlamaları ${app_name} için devre dışı. Bu test mobil veri kullanacak (WIFI değil).
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Arka plan kısıtlamaları ${app_name} için etkinleştirilmiş.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Arka plan kısıtlamaları ${app_name} için etkinleştirilmiş.
 \nUygulamanın arka planda iken yapmaya çalıştığı şeyler agresif bir biçimde kısıtlanacak ve bu bildirimleri de etkileyebilir.
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Kısıtlamaları devre dışı bırak</string>
     <string name="settings_troubleshoot_test_battery_title">Pil Optimizasyonu</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} Pil Optimizasyonundan etkilenmedi.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} Pil Optimizasyonundan etkilenmedi.</string>
     <string name="settings_troubleshoot_test_battery_failed">Eğer kullanıcı cihazını prize bağlanmamış sabit ve ekranı kapalı bir şekilde bir süre bırakırsa cihaz Derin uyku moduna geçer. Bu uygulamaların internete erişmesini engeller ve yapılacak işlerini, senkronizasyolarını, alarmını erteler.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Optimizasyonu Göz ardı et</string>
     <string name="settings_notification_privacy_normal">Normal</string>
@@ -621,17 +621,17 @@
     <string name="settings_deactivate_account_section">Hesabı devre dışı bırak</string>
     <string name="settings_deactivate_my_account">Hesabımı devre dışı bırak</string>
     <string name="startup_notification_privacy_title">Bildirim Gizliliği</string>
-    <string name="template_startup_notification_privacy_message">${app_name} bildirimlerinizi güvenli ve gizli bir şekilde yönetmek için arka planda çalışır. Bu pil kullanımını etkileyebilir.</string>
+    <string name="startup_notification_privacy_message">${app_name} bildirimlerinizi güvenli ve gizli bir şekilde yönetmek için arka planda çalışır. Bu pil kullanımını etkileyebilir.</string>
     <string name="startup_notification_privacy_button_grant">İzin ver</string>
     <string name="startup_notification_privacy_button_other">Farklı bir seçenek seç</string>
     <string name="startup_notification_fdroid_battery_optim_title">Arka plan Bağlantısı</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} güvenilir bildirimlere sahip olmak için düşük arka plan bağlatısı yapmaya ihtiyaç duyar.
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} güvenilir bildirimlere sahip olmak için düşük arka plan bağlatısı yapmaya ihtiyaç duyar.
 \nÇıkacak ekranda ${app_name}\'in arka planda sürekli çalışması için izin istenecek, lütfen kabul edin.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">İzin ver</string>
     <string name="settings_analytics">Analitik</string>
     <string name="settings_opt_in_of_analytics">Analitik verilerini gönder</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} uygulamayı geliştirmemiz için anonim analitik veriler toplar.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Lütfen ${app_name}\'i geliştirebilmemiz için analitikleri etkinleştirin.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} uygulamayı geliştirmemiz için anonim analitik veriler toplar.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Lütfen ${app_name}\'i geliştirebilmemiz için analitikleri etkinleştirin.</string>
     <string name="settings_opt_in_of_analytics_ok">Evet, yardım etmek istiyorum!</string>
     <string name="settings_data_save_mode">Veri kaydetme modu</string>
     <string name="settings_data_save_mode_summary">Veri kaydetme modu belirli filtreler uygular bu sayede ilerideki güncellemeler ve yazıyor bildirimleri filtrelenir.</string>
@@ -955,7 +955,7 @@
     <string name="passphrase_passphrase_does_not_match">Parolalar uyuşmuyor</string>
     <string name="passphrase_empty_error_message">Lütfen bir parola girin</string>
     <string name="passphrase_passphrase_too_weak">Parola çok zayıf</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Eğer ${app_name}\'in kurtarma anahtarı oluşturmasını istiyorsanız lütfen parolayı silin.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Eğer ${app_name}\'in kurtarma anahtarı oluşturmasını istiyorsanız lütfen parolayı silin.</string>
     <string name="keys_backup_no_session_error">Matrix oturumu müsait değil</string>
     <string name="keys_backup_setup_step1_title">Şifrelenmiş mesajları asla kaybetme</string>
     <string name="keys_backup_setup_step1_description">Şifrelenmiş odalarda mesajlar uçtan-uca şifreleme ile korunur. Sadece sen ve makbuzcular bu mesajları okumak için anahtara sahip.
@@ -1071,10 +1071,10 @@
     <string name="settings_call_ringtone_use_default_stun_sum">Ana sunucunuz bir tane sunmadığında %sas assist kullanacaktır (arama sırasında IP adresiniz paylaşılacaktır)</string>
     <string name="invite_no_identity_server_error">Bu eylemi gerçekleştirebilmek için ayarlarınızdan bir kimlik sunucusu ekleyin.</string>
     <string name="settings_add_3pid_confirm_password_title">Şifreni doğrula</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name}, cihazın sınırlı kaynaklarını (pil) koruyacak şekilde arka planda senkronize olur.
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name}, cihazın sınırlı kaynaklarını (pil) koruyacak şekilde arka planda senkronize olur.
 \nCihazınızın kaynak durumuna bağlı olarak, senkronizasyon işletim sistemi tarafından ertelenebilir.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Gerçek zamanlı için optimize</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} periyodik olarak belirli bir zamanda (ayarlanabilir) arka planda senkronize olur.
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} periyodik olarak belirli bir zamanda (ayarlanabilir) arka planda senkronize olur.
 \nBu pil ve radyo kullanımını etkileyecek ve ${app_name}\'in olayları dinlediğini belirten kalıcı bir bildirim gösterecektir.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Arka plan senkronizasyonu yok</string>
     <string name="settings_set_workmanager_delay">Tercih Edilen Senkronize Aralığı</string>
@@ -1157,7 +1157,7 @@
     <string name="keys_backup_settings_checking_backup_state">Yedek durumu kontrol ediliyor</string>
     <string name="autodiscover_invalid_response">Geçersiz anasunucu keşif cevabı</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Sunucu Ayarlarını Otomatik Doldur</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} userld alan adı için özel sunucu yapılandırması buldu \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} userld alan adı için özel sunucu yapılandırması buldu \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Yapılandırmayı kullan</string>
     <string name="invalid_or_expired_credentials">Geçersiz ya da süresi dolmuş girdilerden dolayı çıkış yaptınız.</string>
@@ -1232,7 +1232,7 @@
     <string name="please_wait">Lütfen bekleyin…</string>
     <string name="group_all_communities">Tüm Topluluklar</string>
     <string name="room_preview_no_preview">Bu oda ön izlenemez</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">${app_name} henüz herkese açık odaları ön izlemeyi desteklemiyor</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">${app_name} henüz herkese açık odaları ön izlemeyi desteklemiyor</string>
     <string name="fab_menu_create_room">Odalar</string>
     <string name="fab_menu_create_chat">Doğrudan Mesajlar</string>
     <string name="create_room_title">Yeni Oda</string>
@@ -1246,7 +1246,7 @@
     <string name="keys_backup_unable_to_get_keys_backup_data">Anahtar yedek verileri alınırken hata oluştu</string>
     <string name="login_error_no_homeserver_found">Bu geçerli bir Matrix sunucu adresi değil</string>
     <string name="login_error_homeserver_not_found">Bu URL ile ev-sunucusuna erişilemiyor, lütfen kontrol edin</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Bunu ${app_name} mobil ile yapamazsınız</string>
+    <string name="settings_add_3pid_flow_not_supported">Bunu ${app_name} mobil ile yapamazsınız</string>
     <string name="settings_add_3pid_authentication_needed">Kimlik doğrulama gereklidir</string>
     <string name="settings_background_fdroid_sync_mode">Arka plan Senkronizasyon Modu (Deneysel)</string>
     <string name="settings_background_fdroid_sync_mode_battery">Batarya için optimize edildi</string>
@@ -1258,7 +1258,7 @@
     <string name="action_copy">Kopyala</string>
     <string name="dialog_title_success">Başarılı</string>
     <string name="bottom_action_notification">Bildirimler</string>
-    <string name="template_call_failed_no_connection">${app_name} Araması Başarısız Oldu</string>
+    <string name="call_failed_no_connection">${app_name} Araması Başarısız Oldu</string>
     <string name="call_failed_no_connection_description">Eş zamanlı bağlantı kurulamadı.
 \nAramaların hatasız çalışması için snucunuzun yöneticisinden TURN sunucusu ayarlamasını rica edin.</string>
     <string name="call_select_sound_device">Ses Cihazı Seç</string>
@@ -2069,15 +2069,15 @@
     <string name="legals_third_party_notices">Üçüncü taraf kitaplıkları</string>
     <string name="legals_identity_server_title">Kimlik sunucusu politikanız</string>
     <string name="legals_home_server_title">Ana sunucu politikanız</string>
-    <string name="template_legals_application_title">${app_name} politikası</string>
+    <string name="legals_application_title">${app_name} politikası</string>
     <string name="analytics_opt_in_list_item_3">Bunu istediğiniz zaman ayarlardan kapatabilirsiniz</string>
     <string name="analytics_opt_in_list_item_2">Bilgileri üçüncü taraflarla <b>paylaşmayız</b></string>
     <string name="analytics_opt_in_list_item_1">Herhangi bir hesap verisini <b>kaydetmiyoruz</b></string>
     <string name="analytics_opt_in_content_link">burada</string>
-    <string name="template_analytics_opt_in_content">Anonim kullanım verilerini paylaşarak sorunları belirlememize ve ${app_name}\'i iyileştirmemize yardımcı olun. İnsanların birden fazla cihazı nasıl kullandığını anlamak için, cihazlarınız tarafından paylaşılan rastgele bir tanımlayıcı oluşturacağız.
+    <string name="analytics_opt_in_content">Anonim kullanım verilerini paylaşarak sorunları belirlememize ve ${app_name}\'i iyileştirmemize yardımcı olun. İnsanların birden fazla cihazı nasıl kullandığını anlamak için, cihazlarınız tarafından paylaşılan rastgele bir tanımlayıcı oluşturacağız.
 \n
 \n Tüm şartlarımızı %s okuyabilirsiniz.</string>
-    <string name="template_analytics_opt_in_title">Öğeyi iyileştirmeye yardımcı olun</string>
+    <string name="analytics_opt_in_title">Öğeyi iyileştirmeye yardımcı olun</string>
     <string name="settings_mentions_and_keywords_encryption_notice">Mobil cihazlarda şifreli odalarda bahsedilenler ve anahtar kelimeler için bildirim almayacaksınız.</string>
     <string name="settings_room_upgrades">Oda yükseltmeleri</string>
     <string name="settings_messages_by_bot">Bot tarafından gönderilen mesajlar</string>
@@ -2166,7 +2166,7 @@
     <string name="command_description_shrug">Düz metin mesajının başına ¯\\_(ツ)_/¯ ekler</string>
     <string name="settings_developer_mode_show_info_on_screen_summary">Uygulamada hata ayıklamaya yardımcı olacak bazı yararlı bilgiler gösterin</string>
     <string name="settings_developer_mode_show_info_on_screen_title">Hata ayıklama bilgilerini ekranda göster</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name}, beklenmeyen bir hata oluştuğunda daha sık çökebilir</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name}, beklenmeyen bir hata oluştuğunda daha sık çökebilir</string>
     <string name="settings_developer_mode_fail_fast_title">Hızlı arıza</string>
     <string name="autocomplete_limited_results">Yalnızca ilk sonuçlar gösteriliyor, daha fazla harf yazın…</string>
     <string name="devices_other_devices">Diğer oturumlar</string>
@@ -2183,7 +2183,7 @@
     <string name="notification_initial_sync">İlk Senkronizasyon…</string>
     <string name="bug_report_error_too_short">Açıklama çok kısa</string>
     <string name="permalink_malformed">matrix.to bağlantınız hatalı biçimlendirilmiş</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Geçerli oturum %1$s kullanıcısı içindir ve %2$s kullanıcısı için kimlik bilgileri sağlarsınız. Bu, ${app_name} tarafından desteklenmez.
+    <string name="soft_logout_sso_not_same_user_error">Geçerli oturum %1$s kullanıcısı içindir ve %2$s kullanıcısı için kimlik bilgileri sağlarsınız. Bu, ${app_name} tarafından desteklenmez.
 \nLütfen önce verileri temizleyin, sonra başka bir hesapta tekrar oturum açın.</string>
     <string name="soft_logout_clear_data_dialog_submit">Verileri temizle</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Şifreleme anahtarlarınızı kurtarmak için oturum açmadığınız sürece güvenli mesajlara erişiminizi kaybedersiniz.</string>
@@ -2234,7 +2234,7 @@
     <string name="spoiler">Spoiler</string>
     <string name="command_description_spoiler">Verilen mesajı spoiler olarak gönderir</string>
     <string name="room_list_quick_actions_notifications_all_noisy">Tüm mesajlar (gürültülü)</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name}, E2E anahtarlarınızı diske kaydetmek için izne ihtiyaç duyuyor.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name}, E2E anahtarlarınızı diske kaydetmek için izne ihtiyaç duyuyor.
 \n
 \n Anahtarlarınızı manuel olarak dışa aktarabilmek için lütfen bir sonraki açılır pencerede erişime izin verin.</string>
     <string name="content_reported_content">Bu içerik rapor edildi.
@@ -2306,7 +2306,7 @@
     <string name="settings_troubleshoot_test_token_registration_quick_fix">Kayıt belirteci</string>
     <string name="preference_system_settings">Sistem ayarları</string>
     <string name="preference_versions">Sürümler</string>
-    <string name="template_preference_help_summary">${app_name}\'i kullanma konusunda yardım alın</string>
+    <string name="preference_help_summary">${app_name}\'i kullanma konusunda yardım alın</string>
     <string name="preference_help_title">Yardım ve Destek</string>
     <string name="preference_help">Yardım</string>
     <string name="preference_root_legals">Yasal</string>

--- a/vector/src/main/res/values-uk/strings.xml
+++ b/vector/src/main/res/values-uk/strings.xml
@@ -243,7 +243,7 @@
     <string name="user_directory_header">Каталог користувачів</string>
     <string name="matrix_only_filter">Лише Matrix-контакти</string>
     <string name="no_conversation_placeholder">Немає бесід</string>
-    <string name="template_no_contact_access_placeholder">Ви не надали ${app_name} доступу до контактів</string>
+    <string name="no_contact_access_placeholder">Ви не надали ${app_name} доступу до контактів</string>
     <string name="no_result_placeholder">Немає результатів</string>
     <string name="rooms_header">Кімнати</string>
     <string name="rooms_directory_header">Каталог кімнат</string>
@@ -367,14 +367,14 @@
     <string name="media_picker_both_capture_title">Зняти світлину чи відео"</string>
     <string name="media_picker_cannot_record_video">Не вдалося записати відео"</string>
     <string name="permissions_rationale_popup_title">Інформація</string>
-    <string name="template_permissions_rationale_msg_storage">Для передачі та збереження вкладень потрібен доступ до медіатеки.\n\nБудь ласка, надайте його у наступному виринаючому вікні, щоб отримати змогу надсилати файли з вашого телефону.</string>
-    <string name="template_permissions_rationale_msg_camera">Для зйомки та відеодзвінків необхідно мати доступ до камери.</string>
+    <string name="permissions_rationale_msg_storage">Для передачі та збереження вкладень потрібен доступ до медіатеки.\n\nБудь ласка, надайте його у наступному виринаючому вікні, щоб отримати змогу надсилати файли з вашого телефону.</string>
+    <string name="permissions_rationale_msg_camera">Для зйомки та відеодзвінків необхідно мати доступ до камери.</string>
     <string name="permissions_rationale_msg_camera_explanation">\n\nБудь ласка, надайте його у наступному виринаючому вікні, щоб мати змогу здійснювати дзвінки.</string>
-    <string name="template_permissions_rationale_msg_record_audio">Для здійснення аудіодзвінків потрібен доступ до мікрофону.</string>
+    <string name="permissions_rationale_msg_record_audio">Для здійснення аудіодзвінків потрібен доступ до мікрофону.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">\n\nБудь ласка, надайте його у наступному виринаючому вікні, щоб мати змогу здійснити дзвінок.</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">Для здійснення відеодзвінків потрібен доступ до камери та мікрофону.\n\nБудь ласка, надайте його у наступних виринаючих вікнах, щоб мати змогу їх здійснити.</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} потребує доступу до ваших контактів, щоб знайти інших користувачів Matrix за їх електронними адресами та номерами телефонів. Якщо ви згодні, надайте його у наступному діалоговому вікні, щоб знати, які з контактів теж використовують ${app_name}.</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} потребує доступу до ваших контактів, щоб знайти інших користувачів Matrix за електронною поштою чи номерами телефонів.
+    <string name="permissions_rationale_msg_camera_and_audio">Для здійснення відеодзвінків потрібен доступ до камери та мікрофону.\n\nБудь ласка, надайте його у наступних виринаючих вікнах, щоб мати змогу їх здійснити.</string>
+    <string name="permissions_rationale_msg_contacts">${app_name} потребує доступу до ваших контактів, щоб знайти інших користувачів Matrix за їх електронними адресами та номерами телефонів. Якщо ви згодні, надайте його у наступному діалоговому вікні, щоб знати, які з контактів теж використовують ${app_name}.</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} потребує доступу до ваших контактів, щоб знайти інших користувачів Matrix за електронною поштою чи номерами телефонів.
 \n
 \nНадати ${app_name} доступ до ваших контактів\?</string>
     <string name="permissions_action_not_performed_missing_permissions">Вибачте.. Дію не виконано через нестачу дозволів</string>
@@ -805,7 +805,7 @@
     <string name="settings_opt_in_of_analytics_ok">Так, я бажаю помогти!</string>
     <string name="settings_flair">Настрій</string>
     <string name="room_settings_room_notifications_title">Сповіщення</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Щоб надіслати ключ на цей пристрій, запустіть ${app_name} на іншому пристрої, що може розшифрувати повідомлення.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Щоб надіслати ключ на цей пристрій, запустіть ${app_name} на іншому пристрої, що може розшифрувати повідомлення.</string>
     <string name="error_no_external_application_found">Вибачте, жодного зовнішнього застосунку не знайдено для виконання цієї дії.</string>
     <string name="option_send_voice">Надіслати голосове повідомлення</string>
     <string name="missing_permissions_error">Ця дія неможлива через відсутність дозволів.</string>
@@ -867,9 +867,9 @@
     <string name="settings_notification_privacy_message_content_not_shown">• Сповіщення <b>не будуть показувати вміст повідомлень</b></string>
     <string name="settings_inline_url_preview">Попередній перегляд посилань</string>
     <string name="settings_preview_media_before_sending">Попередній перегляд медіа перед надсиланням</string>
-    <string name="template_startup_notification_privacy_message">${app_name} може працювати у фоновому режимі для керування безпекою та конфіденційністю ваших сповіщень. Це може вплинути на час роботи батареї.</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} збирає анонімну аналітику, щоб ми могли вдосконалювати цей додаток.</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Будь ласка, увімкніть аналітику, щоб допомагати нам вдосконалювати ${app_name}.</string>
+    <string name="startup_notification_privacy_message">${app_name} може працювати у фоновому режимі для керування безпекою та конфіденційністю ваших сповіщень. Це може вплинути на час роботи батареї.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} збирає анонімну аналітику, щоб ми могли вдосконалювати цей додаток.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Будь ласка, увімкніть аналітику, щоб допомагати нам вдосконалювати ${app_name}.</string>
     <string name="settings_without_flair">Ви наразі не є учасником жодної спільноти.</string>
     <string name="room_settings_no_flair">Ця кімната не показує настрій для спільнот</string>
     <string name="room_settings_add_new_group">Новий ID спільноти (наприклад, +foo:matrix.org)</string>
@@ -1018,7 +1018,7 @@
     <string name="markdown_has_been_enabled">Markdown задіяно.</string>
     <string name="markdown_has_been_disabled">Markdown вимкнено.</string>
     <string name="settings_call_category">Виклики</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Використовувати стандартний рингтон ${app_name} для вхідних викликів</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Використовувати стандартний рингтон ${app_name} для вхідних викликів</string>
     <string name="settings_call_ringtone_title">Мелодія вхідного виклику</string>
     <string name="settings_call_ringtone_dialog_title">Виберіть мелодію викликів:</string>
     <string name="action_accept">Прийняти</string>
@@ -1033,7 +1033,7 @@
     <string name="bottom_action_people_x">Особисті повідомлення</string>
     <string name="room_filtering_footer_create_new_direct_message">Надіслати нове особисте повідомлення</string>
     <string name="command_description_shrug">Додає ¯\\_(ツ)_/¯ перед текстовим повідомленням</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} не підтримує повідомлення типу \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} не підтримує повідомлення типу \'%1$s\'</string>
     <string name="command_description_rainbow">Надсилає повідомлення розмальоване веселково</string>
     <string name="settings_category_composer">Редактор повідомлень</string>
     <string name="command_description_plain">Надсилає повідомлення як текст без інтерпретації його як Markdown</string>
@@ -1144,8 +1144,8 @@
     <string name="settings_phone_numbers">Номери телефонів</string>
     <string name="settings_emails">Електронні адреси</string>
     <string name="room_participants_action_cancel_invite">Скасувати запрошення</string>
-    <string name="template_invite_friends_rich_title">🔐️ Приєднуйтесь до мене в ${app_name}</string>
-    <string name="template_invite_friends_text">Привіт! Спілкуймося в ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Приєднуйтесь до мене в ${app_name}</string>
+    <string name="invite_friends_text">Привіт! Спілкуймося в ${app_name}: %s</string>
     <string name="invite_friends">Запросити друзів</string>
     <string name="group_all_communities">Всі спільноти</string>
     <string name="settings_show_redacted_summary">Показувати заглушку на місці видалених повідомлень</string>
@@ -1163,7 +1163,7 @@
     <string name="uploads_files_subtitle">%1$s о %2$s</string>
     <string name="settings_phone_number_empty">Жодного номера телефону не додано до вашого облікового запису</string>
     <string name="settings_emails_empty">У ваш обліковий запис не додано жодної електронної адреси</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Для вашої приватності ${app_name} підтримує лише надсилання хешованих електронних адрес користувачів та номера телефону.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Для вашої приватності ${app_name} підтримує лише надсилання хешованих електронних адрес користувачів та номера телефону.</string>
     <string name="settings_discovery_consent_notice_off">Ви не погодилися надіслати електронні адреси та телефонні номери на цей сервер ідентифікації для виявлення інших користувачів із ваших контактів.</string>
     <string name="settings_discovery_consent_notice_on">Ви погодилися надіслати електронні адреси та телефонні номери на цей сервер ідентифікації для виявлення інших користувачів із ваших контактів.</string>
     <string name="identity_server_consent_dialog_title">Надіслати електронні адреси та номери телефонів</string>
@@ -1184,7 +1184,7 @@
     <string name="settings_troubleshoot_test_bing_settings_success_with_warn">Зверніть увагу, що для деяких типів повідомлень встановлено беззвучність (беззвучні сповіщення).</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Власні налаштування.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Увімкнути</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Сповіщення не ввімкнено для цього сеансу.
+    <string name="settings_troubleshoot_test_device_settings_failed">Сповіщення не ввімкнено для цього сеансу.
 \nПеревірте налаштування ${app_name}.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Сповіщення ввімкнено для цього сеансу.</string>
     <string name="settings_troubleshoot_test_device_settings_title">Налаштування сеансу.</string>
@@ -1222,7 +1222,7 @@
     <string name="settings_discovery_category">Виявність</string>
     <string name="call_failed_no_connection_description">Не вдалося встановити зв’язок у режимі реального часу.
 \nПопросіть адміністратора вашого домашнього сервера налаштувати сервер TURN для надійної роботи викликів.</string>
-    <string name="template_call_failed_no_connection">${app_name} не вдалося здійснити виклик</string>
+    <string name="call_failed_no_connection">${app_name} не вдалося здійснити виклик</string>
     <string name="call_failed_no_ice_description">Попросіть адміністратора вашого домашнього сервера (%1$s) налаштувати сервер TURN для надійної роботи дзвінків.
 \n
 \nЯк варіант, ви можете спробувати використати загальнодоступний сервер на рівні %2$s, але це буде не так надійно й він надаватиме вашу IP-адресу цьому серверу. Ви також можете керувати цим у налаштуваннях.</string>
@@ -1287,7 +1287,7 @@
 \nБезпечно створюйте резервні копії ключів, щоб не втратити їх.</string>
     <string name="keys_backup_setup_step1_title">Ніколи не втрачайте зашифровані повідомлення</string>
     <string name="keys_backup_no_session_error">Немає доступного сеансу Matrix</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Видаліть парольну фразу, якщо хочете, щоб ${app_name} створив ключ відновлення.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Видаліть парольну фразу, якщо хочете, щоб ${app_name} створив ключ відновлення.</string>
     <string name="passphrase_passphrase_too_weak">Парольна фраза занадто слабка</string>
     <string name="passphrase_empty_error_message">Введіть парольну фразу</string>
     <string name="no_valid_google_play_services_apk">Не знайдено дійсного файлу .apk сервісів Google Play. Сповіщення можуть працювати неправильно.</string>
@@ -1424,7 +1424,7 @@
     <string name="settings_integration_allow">Дозволити інтеграції</string>
     <string name="settings_data_save_mode_summary">Режим збереження даних застосовує певний фільтр, тому оновлення присутності та сповіщення про введення фільтруються.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Надати дозвіл</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">Для отримання надійних сповіщень ${app_name} повинен підтримувати з’єднання у фоновому режимі з незначним споживанням даних.
+    <string name="startup_notification_fdroid_battery_optim_message">Для отримання надійних сповіщень ${app_name} повинен підтримувати з’єднання у фоновому режимі з незначним споживанням даних.
 \nНа наступному екрані вам буде запропоновано дозволити ${app_name} завжди працювати у фоновому режимі, погодьтеся.</string>
     <string name="startup_notification_fdroid_battery_optim_title">Фонове з’єднання</string>
     <string name="reset_secure_backup_warning">Це замінить ваш поточний ключ або фразу.</string>
@@ -1453,27 +1453,27 @@
     <string name="settings_background_sync_update_error">Не вдалося оновити налаштування.</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">Ви не отримуватимете сповіщення про вхідні повідомлення, коли програма перебуває у фоновому режимі.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">Немає фонової синхронізації</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} періодично синхронізуватиметься у фоновому режимі в певний час (налаштовується).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} періодично синхронізуватиметься у фоновому режимі в певний час (налаштовується).
 \nЦе вплине на використання радіо та акумулятора, з’явиться постійне сповіщення про те, що ${app_name} очікує на події.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Оптимізовано для реального часу</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} синхронізується у фоновому режимі так, щоб зберегти обмежені ресурси пристрою (акумулятор).
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} синхронізується у фоновому режимі так, щоб зберегти обмежені ресурси пристрою (акумулятор).
 \nЗалежно від стану ресурсів вашого пристрою, синхронізацію може бути відкладено операційною системою.</string>
     <string name="settings_background_fdroid_sync_mode_battery">Оптимізовано для батареї</string>
     <string name="settings_background_fdroid_sync_mode">Режим фонової синхронізації</string>
     <string name="settings_notification_privacy_no_background_sync">Застосунки <b>не</b> потребують з\'єднання з homeserver у фоновому режимі, це має скоротити споживання батареї</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Нехтувати оптимізацією</string>
     <string name="settings_troubleshoot_test_battery_failed">Якщо користувач залишає пристрій від\'єднаним та нерухомим впродовж певного часу з вимкненим екраном, пристрій переходить у режим сну. Це запобігає доступу застосунків до мережі та відкладає їхні завдання, синхронізацію та стандартні попередження.</string>
-    <string name="template_settings_troubleshoot_test_battery_success">Оптимізація акумулятора не впливає на ${app_name}.</string>
+    <string name="settings_troubleshoot_test_battery_success">Оптимізація акумулятора не впливає на ${app_name}.</string>
     <string name="settings_troubleshoot_test_battery_title">Оптимізація акумулятора</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Вимкнути обмеження</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Фонові обмеження ввімкнено для ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Фонові обмеження ввімкнено для ${app_name}.
 \nРобота, яку намагається виконати застосунок, буде агресивно обмежена, доки вона перебуває у фоновому режимі й це може вплинути на сповіщення.
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Фонові обмеження для ${app_name} вимкнено. Цю перевірку варто виконувати з використанням мобільних даних (без Wi-Fi).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Фонові обмеження для ${app_name} вимкнено. Цю перевірку варто виконувати з використанням мобільних даних (без Wi-Fi).
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Перевірте фонові обмеження</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Увімкніть Запуск під час завантаження</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Служба не запуститься під час перезавантаження пристрою, ви не отримуватимете сповіщень, доки ${app_name} не буде відкрито.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Служба не запуститься під час перезавантаження пристрою, ви не отримуватимете сповіщень, доки ${app_name} не буде відкрито.</string>
     <string name="settings_troubleshoot_test_service_boot_success">Служба запуститься після перезапуску пристрою.</string>
     <string name="settings_troubleshoot_test_service_boot_title">Запускати під час завантаження</string>
     <string name="settings_troubleshoot_test_service_restart_failed">Помилка перезапуску служби</string>
@@ -1492,11 +1492,11 @@
     <string name="settings_troubleshoot_test_token_registration_success">Токен FCM успішно зареєстровано на homeserver.</string>
     <string name="settings_troubleshoot_test_token_registration_title">Реєстрація токена</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Додати обліковий запис</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \nЦя помилка не підконтрольна ${app_name}. На телефоні немає облікового запису Google. Відкрийте менеджер облікових записів і додайте обліковий запис Google.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \nЦя помилка не підконтрольна ${app_name}. Це може статися з кількох причин. Можливо все запрацює, якщо ви спробуєте пізніше, ви також можете перевірити, чи не обмежено використання даних для служби Google Play в налаштуваннях системи, чи правильний годинник вашого пристрою, або це може статися в користувацькому ROM.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \nЦя помилка не підконтрольна ${app_name} й за даними Google, вона вказує на те, що на пристрої зареєстровано забагато програм у FCM. Помилка виникає лише у випадках, коли встановлено надзвичайно багато застосунків, тому вона не повинна впливати на звичайного користувача.</string>
     <string name="settings_troubleshoot_test_fcm_failed">Не вдалося отримати токен FCM:
 \n%1$s</string>
@@ -1504,7 +1504,7 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_title">Токен Firebase</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Виправити служби Play</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} використовує сервіси Google Play для доставлення push-сповіщень, але, схоже, його налаштовано неправильно:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} використовує сервіси Google Play для доставлення push-сповіщень, але, схоже, його налаштовано неправильно:
 \n%1$s</string>
     <string name="open_settings">Відкрити Налаштування</string>
     <string name="settings_troubleshoot_test_system_settings_failed">Сповіщення вимкнено в налаштуваннях системи.
@@ -1516,7 +1516,7 @@
     <string name="error_threepid_auth_failed">Переконайтеся, що ви натиснули посилання в електронному листі, який ми надіслали вам.</string>
     <string name="settings_remove_three_pid_confirmation_content">Вилучити %s\?</string>
     <string name="settings_add_3pid_authentication_needed">Потрібна автентифікація</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Це неможливо зробити за допомогою ${app_name} mobile</string>
+    <string name="settings_add_3pid_flow_not_supported">Це неможливо зробити за допомогою ${app_name} mobile</string>
     <string name="settings_add_3pid_confirm_password_title">Підтвердити пароль</string>
     <string name="search_banned_user_hint">Фільтрувати заблокованих користувачів</string>
     <string name="room_participants_unban_prompt_msg">Скасування блокування користувача дозволить їм знову приєднатися до кімнати.</string>
@@ -1584,10 +1584,10 @@
     <string name="auth_pin_reset_content">Щоб відновити PIN-код, потрібно буде повторно ввійти в систему та створити новий.</string>
     <string name="settings_security_pin_code_title">Увімкнути PIN-код</string>
     <string name="settings_security_pin_code_summary">Якщо хочете відновити PIN-код, торкніться «Забули PIN-код», щоб вийти та відновити.</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">PIN-код — єдиний спосіб розблокувати ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">PIN-код — єдиний спосіб розблокувати ${app_name}.</string>
     <string name="settings_security_pin_code_grace_period_title">Вимагати PIN-код через 2 хвилини</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">PIN-код вимагається після 2 хвилин не використання ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">PIN-код потрібно вводити за кожного відкриття ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">PIN-код вимагається після 2 хвилин не використання ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">PIN-код потрібно вводити за кожного відкриття ${app_name}.</string>
     <string name="settings_security_pin_code_change_pin_title">Змінити PIN-код</string>
     <string name="settings_security_pin_code_change_pin_summary">Зміна поточного PIN-коду</string>
     <string name="auth_pin_confirm_to_disable_title">Підтвердьте PIN-код, щоб вимкнути його</string>
@@ -1606,7 +1606,7 @@
     <string name="settings_active_sessions_show_all">Показати всі сеанси</string>
     <string name="authentication_error">Помилка автентифікації</string>
     <string name="re_authentication_activity_title">Потрібна повторна автентифікація</string>
-    <string name="template_re_authentication_default_confirm_text">Для виконання цієї дії ${app_name} вимагає ввести свої облікові дані.</string>
+    <string name="re_authentication_default_confirm_text">Для виконання цієї дії ${app_name} вимагає ввести свої облікові дані.</string>
     <string name="verify_cancel_self_verification_from_trusted">Якщо скасувати, ви не зможете читати зашифровані повідомлення на новому пристрої, а інші користувачі не довірятимуть йому</string>
     <string name="verify_cancel_self_verification_from_untrusted">Якщо скасувати, ви не зможете читати зашифровані повідомлення на цьому пристрої, а інші користувачі не довірятимуть йому</string>
     <string name="settings_active_sessions_manage">Керування сеансами</string>
@@ -1755,8 +1755,8 @@
     <string name="use_file">Використати файл</string>
     <string name="verification_cannot_access_other_session">Скористатись парольною фразою відновлення або ключем</string>
     <string name="keys_backup_restore_with_passphrase">Скористатись відновлювальними парольною фразою або ключем</string>
-    <string name="template_use_other_session_content_description">Використовуйте найостаннішій ${app_name} на ваших інших пристроях, ${app_name} Web, ${app_name} для комп\'ютерів, ${app_name} iOS, ${app_name} для Android, або будь-який інший, здатний до перехресного підписування, Matrix-клієнт</string>
-    <string name="template_use_latest_app">Використовуйте найостаннішій ${app_name} на ваших інших пристроях:</string>
+    <string name="use_other_session_content_description">Використовуйте найостаннішій ${app_name} на ваших інших пристроях, ${app_name} Web, ${app_name} для комп\'ютерів, ${app_name} iOS, ${app_name} для Android, або будь-який інший, здатний до перехресного підписування, Matrix-клієнт</string>
+    <string name="use_latest_app">Використовуйте найостаннішій ${app_name} на ваших інших пристроях:</string>
     <string name="verification_use_passphrase">Якщо ви не можете доступитись до чинного сеансу</string>
     <string name="verification_open_other_to_verify">Використайте чинний сеанс, щоб звірити цей сеанс, таким чином надавши йому доступ до зашифрованих повідомлень.</string>
     <string name="confirm_your_identity_quad_s">Підтвердьте вашу тотожність, звіривши цей вхід та надавши йому доступ до зашифрованих повідомлень.</string>
@@ -1889,7 +1889,7 @@
     <string name="identity_server_set_default_notice">Ваш домашній сервер (%1$s) пропонує використовувати %2$s як ваш сервер ідентифікації</string>
     <string name="identity_server_error_terms_not_signed">Спочатку погодьтесь з умовами користування сервером ідентифікації в налаштуваннях.</string>
     <string name="identity_server_error_no_identity_server_configured">Спочатку налаштуйте сервер ідентифікації.</string>
-    <string name="template_identity_server_error_outdated_identity_server">Цей сервер ідентифікації є застарілим. ${app_name} підтримує лише API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Цей сервер ідентифікації є застарілим. ${app_name} підтримує лише API V2.</string>
     <string name="disconnect_identity_server_dialog_content">Від\'єднатись від сервера ідентифікації %s\?</string>
     <string name="settings_agree_to_terms">Погодьтесь з умовами використання сервера ідентифікації (%s), щоб дозволити вашу виявність за електронною адресою та номером телефону.</string>
     <string name="no_ignored_users">Ви не нехтуєте жодних користувачів</string>
@@ -1960,7 +1960,7 @@
     <string name="settings_server_version">Версія сервера</string>
     <string name="settings_server_name">Назва сервера</string>
     <string name="change_password_summary">Встановити новий пароль облікового запису…</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Попередній перегляд відкритих кімнат поки що не підтримується в ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Попередній перегляд відкритих кімнат поки що не підтримується в ${app_name}</string>
     <string name="edited_suffix">(відредаговано)</string>
     <string name="last_edited_info_message">Востаннє відредаговано %1$s %2$s</string>
     <string name="call_tile_ended">Цей виклик було завершено</string>
@@ -2062,7 +2062,7 @@
     <string name="create_room_in_progress">Створення кімнати…</string>
     <string name="creating_direct_room">Створення кімнати…</string>
     <string name="settings_hs_admin_e2e_disabled">Адміністратор вашого сервера вимкнув автоматичне наскрізне шифрування для приватних кімнат та особистих повідомлень.</string>
-    <string name="template_link_this_email_with_your_account">%s у налаштуваннях, щоб отримувати запрошення безпосередньо в ${app_name}.</string>
+    <string name="link_this_email_with_your_account">%s у налаштуваннях, щоб отримувати запрошення безпосередньо в ${app_name}.</string>
     <string name="settings_encrypted_direct_messages">Зашифровані особисті повідомлення</string>
     <string name="settings_messages_direct_messages">Особисті повідомлення</string>
     <string name="recovery_key_empty_error_message">Введіть ключ відновлення</string>
@@ -2460,7 +2460,7 @@
     <string name="sas_verify_title">Звірити, порівнявши короткий текстовий рядок.</string>
     <string name="invalid_or_expired_credentials">Ви вийшли з облікового запису через хибні або застарілі облікові дані.</string>
     <string name="autodiscover_well_known_autofill_confirm">Використати конфігурацію</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} виявив користувацьку конфігурацію сервера для вашого userID домену «%1$s»:
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} виявив користувацьку конфігурацію сервера для вашого userID домену «%1$s»:
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Параметри сервера автозаповнення</string>
     <plurals name="keys_backup_info_keys_backing_up">
@@ -2490,7 +2490,7 @@
     <string name="search_in_my_contacts">Шукати у моїх контактах</string>
     <string name="phone_book_title">Телефонна книга</string>
     <string name="crypto_utd">Не вдалося розшифрувати</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} потребує дозволу, щоб зберегти ваші ключі E2E на диск.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} потребує дозволу, щоб зберегти ваші ключі E2E на диск.
 \n
 \nДозвольте доступ у наступному спливному вікні, щоб могти експортувати ключі власноруч.</string>
     <string name="a11y_close_keys_backup_banner">Закрити нагадування про резервне копіювання ключів</string>
@@ -2675,7 +2675,7 @@
     <string name="settings_server_room_versions">Версії кімнати 👓</string>
     <string name="verification_request_start_notice">Для безпеки зробіть це особисто або скористайтеся іншим способом зв\'язку.</string>
     <string name="verification_request_notice">Для власної безпеки, перевірте %s звіривши одноразовий код.</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} не обробляє події типу «%1$s»</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} не обробляє події типу «%1$s»</string>
     <string name="verify_by_emoji_title">Перевірка за допомогою емоджі</string>
     <string name="verification_verify_device_manually">Перевірити власноруч</string>
     <string name="verification_sent">Запит перевірки надіслано</string>
@@ -2685,7 +2685,7 @@
     <string name="create_room_disable_federation_title">Заборонити будь-кому, хто не є учасником %s, будь-коли приєднуватися до цієї кімнати</string>
     <string name="settings_developer_mode_show_info_on_screen_summary">Показати корисні дані для зневадження застосунку</string>
     <string name="settings_developer_mode_show_info_on_screen_title">Показати дані зневадження на екрані</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} може частіше виходити з ладу, коли виникає несподівана помилка</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} може частіше виходити з ладу, коли виникає несподівана помилка</string>
     <string name="settings_developer_mode_fail_fast_title">Швидкий збій</string>
     <string name="autocomplete_limited_results">Показано лише перші результати, введіть більше букв…</string>
     <string name="permalink_malformed">Ваше посилання matrix.to неправильне</string>
@@ -2703,7 +2703,7 @@
     <string name="enter_secret_storage_passphrase_warning">Попередження:</string>
     <string name="delete_event_dialog_title">Підтвердити вилучення</string>
     <string name="settings_key_requests">Запити ключів</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="a11y_start_camera">Увімкнути камеру</string>
     <string name="a11y_stop_camera">Вимкнути камеру</string>
     <string name="add_people">Додати людей</string>
@@ -2716,9 +2716,9 @@
     <string name="failed_to_initialize_cross_signing">Не вдалося налаштувати перехресне підписування</string>
     <string name="cross_signing_verify_by_text">Звірити власноруч за допомогою тексту</string>
     <string name="failed_to_access_secure_storage">Не вдалося отримати доступ до безпечного сховища</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
-    <string name="template_app_desktop_web">${app_name} для переглядача
+    <string name="app_desktop_web">${app_name} для переглядача
 \n${app_name} для ПК</string>
     <string name="error_saving_media_file">Не вдалося зберегти медіафайл</string>
     <string name="error_adding_media_file_to_gallery">Не вдалося додати медіафайл до галереї</string>
@@ -2996,7 +2996,7 @@
 \nКористуйтеся обачно. Це може призвести до несподіваних наслідків.</string>
     <string name="verification_conclusion_ok_notice">Повідомлення з цим користувачем наскрізно шифровані й не можуть бути прочитані сторонніми.</string>
     <string name="verification_code_notice">Порівняйте цей код з показаним на екрані іншого користувача кодом.</string>
-    <string name="template_rendering_event_error_exception">${app_name} зіткнувся з проблемою показу вмісту події з ID «%1$s»</string>
+    <string name="rendering_event_error_exception">${app_name} зіткнувся з проблемою показу вмісту події з ID «%1$s»</string>
     <string name="room_member_jump_to_read_receipt">Перейти до останнього прочитаного</string>
     <string name="soft_logout_clear_data_dialog_content">Очистити всі дані, збережені на цьому пристрої\?
 \nУвійдіть знову, щоб отримати доступ до даних свого облікового запису й повідомлень.</string>
@@ -3087,7 +3087,7 @@
 \nНайбезпечніше зробити це вживу.</string>
     <string name="verify_user_sas_emoji_help_text">Звірте користувача, підтвердивши, що ваші екрани показують такі унікальні емодзі в однаковому порядку.</string>
     <string name="create_room_disable_federation_description">Можете ввімкнути це, якщо в кімнаті співпрацюватимуть лише внутрішні команди на вашому домашньому сервері. Цього більше не можна буде змінити.</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Цей сеанс — користувача %1$s, а ви надаєте облікові дані користувача %2$s. Це не підтримується в ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">Цей сеанс — користувача %1$s, а ви надаєте облікові дані користувача %2$s. Це не підтримується в ${app_name}.
 \nБудь ласка, спершу очистіть дані, а тоді ввійдіть в інший обліковий запис.</string>
     <plurals name="poll_total_vote_count_before_ended_and_not_voted">
         <item quantity="one">%1$d голос. Проголосуйте, щоб побачити результати</item>
@@ -3124,7 +3124,7 @@
     </plurals>
     <string name="preference_system_settings">Системні налаштування</string>
     <string name="preference_versions">Версії</string>
-    <string name="template_preference_help_summary">Отримати допомогу в використанні ${app_name}</string>
+    <string name="preference_help_summary">Отримати допомогу в використанні ${app_name}</string>
     <string name="preference_help_title">Довідка й підтримка</string>
     <string name="preference_help">Довідка</string>
     <string name="preference_root_legals">Правові положення</string>
@@ -3132,15 +3132,15 @@
     <string name="legals_third_party_notices">Сторонні бібліотеки</string>
     <string name="legals_identity_server_title">Політика вашого сервера ідентифікації</string>
     <string name="legals_home_server_title">Політика вашого домашнього сервера</string>
-    <string name="template_legals_application_title">Політика ${app_name}</string>
+    <string name="legals_application_title">Політика ${app_name}</string>
     <string name="analytics_opt_in_list_item_3">Можете вимкнути це коли завгодно в налаштуваннях</string>
     <string name="analytics_opt_in_list_item_2">Ми <b>не</b> передаємо даних стороннім особам</string>
     <string name="analytics_opt_in_list_item_1">Ми <b>не</b> записуємо й <b>не</b> аналізуємо жодних даних облікового запису</string>
     <string name="analytics_opt_in_content_link">тут</string>
-    <string name="template_analytics_opt_in_content">Допомагайте нам визначати проблеми й удосконалювати ${app_name}, надсилаючи анонімні дані про використання. Щоб розуміти, як люди використовують кілька пристроїв, ми створимо спільний для ваших пристроїв випадковий ідентифікатор.
+    <string name="analytics_opt_in_content">Допомагайте нам визначати проблеми й удосконалювати ${app_name}, надсилаючи анонімні дані про використання. Щоб розуміти, як люди використовують кілька пристроїв, ми створимо спільний для ваших пристроїв випадковий ідентифікатор.
 \n
 \nМожете прочитати всі наші умови %s.</string>
-    <string name="template_analytics_opt_in_title">Допоможіть покращити ${app_name}</string>
+    <string name="analytics_opt_in_title">Допоможіть покращити ${app_name}</string>
     <string name="action_enable">Увімкнути</string>
     <string name="restart_the_application_to_apply_changes">Перезапустіть застосунок, щоб зміни набули чинності.</string>
     <string name="labs_enable_latex_maths">Увімкнути підтримку LaTeX</string>
@@ -3163,8 +3163,8 @@
     <string name="settings_enable_location_sharing_summary">Після увімкнення ви зможете надіслати своє місцеперебування до будь-якої кімнати</string>
     <string name="settings_enable_location_sharing">Увімкнути надсилання місцеперебування</string>
     <string name="location_share_external">Відкрити за допомогою</string>
-    <string name="template_location_not_available_dialog_content">${app_name} не може отримати доступ до вашого місцеперебування. Спробуйте пізніше.</string>
-    <string name="template_location_not_available_dialog_title">${app_name} не може отримати доступ до вашого місцеперебування</string>
+    <string name="location_not_available_dialog_content">${app_name} не може отримати доступ до вашого місцеперебування. Спробуйте пізніше.</string>
+    <string name="location_not_available_dialog_title">${app_name} не може отримати доступ до вашого місцеперебування</string>
     <string name="location_share">Поділитися місцеперебуванням</string>
     <string name="a11y_location_share_icon">Поділитися місцеперебуванням</string>
     <string name="location_activity_title_preview">Місцеперебування</string>

--- a/vector/src/main/res/values-vi/strings.xml
+++ b/vector/src/main/res/values-vi/strings.xml
@@ -22,7 +22,7 @@
     <string name="action_ignore">Bỏ qua</string>
     <string name="conference_call_in_progress">Đã có một cuộc hội thoại đang diễn ra!</string>
     <string name="no_result_placeholder">Không có kết quả nào</string>
-    <string name="template_no_contact_access_placeholder">Bạn chưa cho phép ${app_name} truy cập danh bạ của bạn</string>
+    <string name="no_contact_access_placeholder">Bạn chưa cho phép ${app_name} truy cập danh bạ của bạn</string>
     <string name="no_conversation_placeholder">Không có cuộc trò chuyện nào</string>
     <string name="matrix_only_filter">Chỉ những liên hệ Matrix</string>
     <string name="user_directory_header">Danh sách người dùng</string>
@@ -206,7 +206,7 @@
     <string name="sound_device_speaker">Loa</string>
     <string name="sound_device_phone">Điện thoại</string>
     <string name="call_select_sound_device">Chọn thiết bị âm thanh</string>
-    <string name="template_call_failed_no_connection">Cuộc gọi ${app_name} thất bại</string>
+    <string name="call_failed_no_connection">Cuộc gọi ${app_name} thất bại</string>
     <string name="call_failed_dont_ask_again">Đừng hỏi lại tôi</string>
     <string name="call_failed_no_ice_use_alt">Hãy thử dùng %s</string>
     <string name="call_failed_no_ice_description">Vui lòng yêu cầu quản trị viên của máy chủ nhà của bạn (%1$s) thiết lập một máy chủ TURN để các cuộc gọi có thể hoạt động một cách đáng tin cậy.
@@ -254,7 +254,7 @@
     <string name="call">Gọi</string>
     <string name="settings_call_ringtone_dialog_title">Chọn nhạc chuông:</string>
     <string name="settings_call_ringtone_title">Nhạc chuông cho cuộc gọi đến</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">Dùng nhạc chuông mặc định cho cuộc gọi đến</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Dùng nhạc chuông mặc định cho cuộc gọi đến</string>
     <string name="settings_call_show_confirmation_dialog_summary">Yêu cầu xác nhận trước khi gọi</string>
     <string name="settings_call_show_confirmation_dialog_title">Tránh gọi nhầm</string>
     <string name="room_info_room_topic">Chủ đề của phòng</string>
@@ -284,7 +284,7 @@
     <string name="notice_room_server_acl_updated_allowed">• Những máy chủ khớp với %s bây giờ sẽ được cho phép.</string>
     <string name="notice_room_server_acl_updated_was_banned">• Những máy chủ khớp với %s đã được xoá khỏi danh sách cấm.</string>
     <string name="notice_room_server_acl_updated_banned">• Những máy chủ khớp với %s bây giờ sẽ bị cấm.</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} yêu cầu bạn nhập thông tin của bạn để thực hiện hành động này.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} yêu cầu bạn nhập thông tin của bạn để thực hiện hành động này.</string>
     <string name="re_authentication_activity_title">Cần xác thực lại</string>
     <string name="call_transfer_users_tab_title">Người dùng</string>
     <string name="call_transfer_failure">Đã xảy ra lỗi khi đang chuyển cuộc gọi</string>
@@ -595,22 +595,22 @@
     <string name="permissions_denied_add_contact">Cho phép quyền truy cập danh bạ của bạn.</string>
     <string name="permissions_denied_qr_code">Để quét mã QR, bạn cần cho phép quyền truy cập máy ảnh.</string>
     <string name="permissions_action_not_performed_missing_permissions">Xin lỗi. Hành động không được thực hiện do thiếu quyền</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} có thể kiểm tra sổ địa chỉ của bạn để tìm những người dùng Matrix khác dựa trên email và số điện thoại của họ.
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} có thể kiểm tra sổ địa chỉ của bạn để tìm những người dùng Matrix khác dựa trên email và số điện thoại của họ.
 \n
 \nBạn có đồng ý chia sẻ sổ địa chỉ của bạn vì mục đích này không\?</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} có thể kiểm tra sổ địa chỉ của bạn để tìm những người dùng Matrix khác dựa trên email và số điện thoại của họ. Nếu bạn đồng ý chia sẻ sổ địa chỉ vì mục đích này, vui lòng cho phép quyền truy cập trên cửa sổ popup tiếp theo.</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} cần quyền truy cập máy ảnh và micro của bạn để thực hiện các cuộc gọi video.
+    <string name="permissions_rationale_msg_contacts">${app_name} có thể kiểm tra sổ địa chỉ của bạn để tìm những người dùng Matrix khác dựa trên email và số điện thoại của họ. Nếu bạn đồng ý chia sẻ sổ địa chỉ vì mục đích này, vui lòng cho phép quyền truy cập trên cửa sổ popup tiếp theo.</string>
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} cần quyền truy cập máy ảnh và micro của bạn để thực hiện các cuộc gọi video.
 \n
 \nVui lòng cho phép quyền truy cập trên các cửa sổ popup tiếp theo để có thể thực hiện cuộc gọi.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \nVui lòng cho phép quyền truy cập trên cửa sổ popup tiếp theo để có thể thực hiện cuộc gọi."</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} cần quyền truy cập micro của bạn để thực hiện các cuộc gọi âm thanh.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} cần quyền truy cập micro của bạn để thực hiện các cuộc gọi âm thanh.</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \nVui lòng cho phép quyền truy cập trên cửa sổ popup tiếp theo để có thể thực hiện cuộc gọi."</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} cần quyền truy cập máy ảnh để chụp ảnh và thực hiện các cuộc gọi video.</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} cần quyền truy cập thư viện ảnh và video của bạn để gửi và lưu các tệp đính kèm.
+    <string name="permissions_rationale_msg_camera">${app_name} cần quyền truy cập máy ảnh để chụp ảnh và thực hiện các cuộc gọi video.</string>
+    <string name="permissions_rationale_msg_storage">${app_name} cần quyền truy cập thư viện ảnh và video của bạn để gửi và lưu các tệp đính kèm.
 \n
 \nVui lòng cho phép quyền truy cập trên cửa sổ popup tiếp theo để có thể gửi các tệp từ điện thoại của bạn.</string>
     <string name="permissions_rationale_popup_title">Thông tin</string>
@@ -651,7 +651,7 @@
     </plurals>
     <string name="groups_list">Danh sách nhóm</string>
     <string name="read_receipts_list">Danh sách xác nhận đã đọc</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Vui lòng khởi chạy ${app_name} trên một thiết bị khác mà có thể giải mã tin nhắn để nó có thể gửi các mã khoá vào phiên làm việc này.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Vui lòng khởi chạy ${app_name} trên một thiết bị khác mà có thể giải mã tin nhắn để nó có thể gửi các mã khoá vào phiên làm việc này.</string>
     <string name="e2e_re_request_encryption_key_dialog_title">Đã gửi yêu cầu</string>
     <string name="e2e_re_request_encryption_key_sent">Đã gửi yêu cầu mã khoá.</string>
     <string name="e2e_re_request_encryption_key">Yêu cầu lại các mã khoá mã hoá từ các phiên làm việc khác của bạn.</string>
@@ -886,7 +886,7 @@
     <string name="settings_notification_privacy_reduced">Rút gọn Riêng tư</string>
     <string name="settings_notification_privacy_normal">Bình thường</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Bỏ qua trình tối ưu pin</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} không bị ảnh hưởng bởi Trình tối ưu pin.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} không bị ảnh hưởng bởi Trình tối ưu pin.</string>
     <string name="settings_troubleshoot_test_battery_title">Tối ưu pin</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Hủy các giới hạn</string>
     <string name="deactivate_account_title">Hủy tài khoản</string>
@@ -1038,7 +1038,7 @@
     <string name="room_list_quick_actions_notifications_all_noisy">Tất cả tin nhắn (ầm ĩ)</string>
     <string name="message_ignore_user">Lơ người dùng</string>
     <string name="no_network_indicator">Hiện không có kết nối mạng</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} cần được cấp quyền để lưu khóa bảo mật E2E keys trên bộ nhớ.
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} cần được cấp quyền để lưu khóa bảo mật E2E keys trên bộ nhớ.
 \n
 \nVui lòng cấp quyền để App có thể xuất khẩu khóa bảo mật.</string>
     <string name="content_reported_as_inappropriate_content">Nội dung này bị báo cáo không phù hợp.
@@ -1209,8 +1209,8 @@
     <string name="devices_details_dialog_title">Thông tin phiên</string>
     <string name="settings_data_save_mode">Chế độ tiết kiệm dữ liệu</string>
     <string name="settings_opt_in_of_analytics_ok">Có, Tôi muốn giúp!</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">Cho phép lấy dữ liệu phân tích để giúp cải thiện ${app_name}.</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} thu thập dữ liệu khuyết danh để giúp chúng tôi cải thiện app.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Cho phép lấy dữ liệu phân tích để giúp cải thiện ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} thu thập dữ liệu khuyết danh để giúp chúng tôi cải thiện app.</string>
     <string name="settings_opt_in_of_analytics">Gửi dữ liệu phân tích</string>
     <string name="settings_analytics">Phân tích</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Cấp quyền</string>
@@ -1359,7 +1359,7 @@
     <string name="login_server_text">Giống như email, tài khoản cần có nhà riêng, dù bạn có thể nói chuyện với bất kỳ ai</string>
     <string name="settings_troubleshoot_test_bing_settings_title">Thiết lập tùy chỉnh.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Khả dụng</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Thông báo không được bật cho phiên này.
+    <string name="settings_troubleshoot_test_device_settings_failed">Thông báo không được bật cho phiên này.
 \nVui lòng kiểm tra trong thiết lập ứng dụng ${app_name}.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Thông báo được bật cho phiên này.</string>
     <string name="settings_troubleshoot_test_device_settings_title">Thiết lập phiên.</string>
@@ -1391,7 +1391,7 @@
     <string name="settings_emails_empty">Không có địa chỉ email nào trong tài khoản của bạn</string>
     <string name="settings_emails">Địa chỉ email</string>
     <string name="settings_add_3pid_authentication_needed">Yêu cầu đăng nhập</string>
-    <string name="template_settings_add_3pid_flow_not_supported">Bạn không thể làm việc này từ ứng dụng ${app_name}</string>
+    <string name="settings_add_3pid_flow_not_supported">Bạn không thể làm việc này từ ứng dụng ${app_name}</string>
     <string name="settings_add_3pid_confirm_password_title">Xác nhận mật khẩu</string>
     <string name="settings_app_info_link_summary">Hiển thị thông tin ứng dụng trong thiết lập hệ thống.</string>
     <string name="settings_app_info_link_title">Thông tin ứng dụng</string>
@@ -1536,25 +1536,25 @@
     <string name="account_email_validation_error">Không thể hoàn thành xác nhận email. Vui lòng kiểm tra email của bạn và bấm vào đường liên kết trong đó. Một khi đã xong, bấm tiếp tục.</string>
     <string name="account_email_validation_message">Vui lòng kiểm tra email và bấm vào liên kết trong đó. Một khi xong, bấm tiếp tục.</string>
     <string name="settings_data_save_mode_summary">Chế độ tiết kiệm dữ liệu sẽ dừng việc đưa ra các thông báo đang có mặt và đang gõ.</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} cần phải giữ kết nối mạng liên tục dưới nền để đạt hiệu quả thông báo cao nhất:
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} cần phải giữ kết nối mạng liên tục dưới nền để đạt hiệu quả thông báo cao nhất:
 \nỞ màn hình tiếp theo ban sẽ được hỏi để cho phép ${app_name} hoạt động liên tục dưới nền, hãy nhấn cho phép.</string>
-    <string name="template_startup_notification_privacy_message">${app_name} sẽ chạy dưới nền để quản lý các thông báo của bạn một cách chính xác và riêng tư. Điều này sẽ có thể ảnh hưởng đến thời lượng pin.</string>
+    <string name="startup_notification_privacy_message">${app_name} sẽ chạy dưới nền để quản lý các thông báo của bạn một cách chính xác và riêng tư. Điều này sẽ có thể ảnh hưởng đến thời lượng pin.</string>
     <string name="startup_notification_privacy_title">Thông báo riêng tư</string>
     <string name="settings_integrations_summary">Sử dụng trình quản lý chung để quản lý bot, các cầu nối, widget và các gói nhãn dán.
 \nTrình quản lý chung sẽ nhận được dữ liệu hiệu chỉnh, và sẽ có thể điều chỉnh các widget, gửi lời mời vào phòng và thiết lập các mốc quyền lợi theo ý bạn.</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} sẽ đồng bộ hóa dưới nền trong một khoảng thời gian nhất định (có thể điều chỉnh thời gian).
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} sẽ đồng bộ hóa dưới nền trong một khoảng thời gian nhất định (có thể điều chỉnh thời gian).
 \nViệc này sẽ làm ảnh hưởng tới khả năng thu phát và sử dụng pin, sẽ xuất hiện một thông báo cho biết lúc nào ${app_name} đang hoạt động.</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} sẽ đồng bộ dưới nền và sẽ sử dụng các tài nguyên như pin một cách tiết kiệm.
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} sẽ đồng bộ dưới nền và sẽ sử dụng các tài nguyên như pin một cách tiết kiệm.
 \nTùy vào các tài nguyên có sẵn trên thiết bị, việc đồng bộ hóa có thể sẽ bị ngăn cản bởi hệ điều hành.</string>
     <string name="settings_troubleshoot_test_battery_failed">Nếu người dùng để thiết bị đã tháo sạc và đang chờ trong khoảng thời gian, với màn hình tắt, thiết bị sẽ khởi động chế độ Doze. Việc này ngăn cản các ứng dụng sử dụng mạng và dừng lại các hoạt động đồng bộ hóa, kể cả các báo thức.</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Giới hạn dưới nền đã được bật cho ${app_name}.
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Giới hạn dưới nền đã được bật cho ${app_name}.
 \nCác hoạt động của ứng dụng sẽ bị giới hạn nặng nề khi chạy dưới nền, điều này có thể ảnh hưởng đến cách thông báo của ứng dụng.
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Các giới hạn dưới nền đã được tắt cho ${app_name}. Bài kiểm tra này sẽ được chạy khi sử dụng dữ liệu di động (không Wi-Fi).
+    <string name="settings_troubleshoot_test_bg_restricted_success">Các giới hạn dưới nền đã được tắt cho ${app_name}. Bài kiểm tra này sẽ được chạy khi sử dụng dữ liệu di động (không Wi-Fi).
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">Kiểm tra giới hạn dưới nền</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Bật khởi động cùng hệ thống</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">Dịch vụ sẽ không khởi động sau khi thiết bị đã khởi động lại, bạn sẽ không nhận được bất kỳ thông báo nào cho tới khi ${app_name} được mở một lần.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">Dịch vụ sẽ không khởi động sau khi thiết bị đã khởi động lại, bạn sẽ không nhận được bất kỳ thông báo nào cho tới khi ${app_name} được mở một lần.</string>
     <string name="settings_troubleshoot_test_service_boot_success">Dịch vụ sẽ bắt đầu ngay khi thiết bị được khởi động lại.</string>
     <string name="settings_troubleshoot_test_service_boot_title">Khởi động cùng hệ thống</string>
     <string name="settings_troubleshoot_test_service_restart_failed">Dịch vụ không thể khởi động</string>
@@ -1573,11 +1573,11 @@
     <string name="settings_troubleshoot_test_token_registration_success">Đăng ký token FCM thành công tới máy chủ.</string>
     <string name="settings_troubleshoot_test_token_registration_title">Đăng ký token</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Thêm tài khoản</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s
 \nLỗi này đã vượt khỏi tầm kiểm soát của ${app_name}. Không phát hiện thấy tài khoản Google trên thiết bị. Vui lòng thêm một tài khoản.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s
 \nLỗi này đã vượt ra khỏi tầm kiểm soát của ${app_name}. Nó có thể xảy ra vì vài lý do. Có thể nó sẽ hoạt động nếu bạn thử lại sau, bạn cũng có thể kiểm rằng các dịch vụ của Google Play không bị giới hạn quyền sử dụng data trong cài đặt hệ thống, hoặc đồng hồ trên thiết bị của bạn bị sai, hoặc là do bản ROM custom của bạn.</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s
 \nLỗi này đã vượt ra khỏi tầm kiểm soát của ${app_name} và theo như Google thông báo, lỗi này chỉ ra rằng thiết bị đã có quá nhiều ứng dụng được đăng ký với FCM. Lỗi này chỉ xảy ra khi có quá nhiều ứng dụng hoạt động, vì vậy có thể sẽ không ảnh hưởng đến trải nghiệm người dùng cơ bản.</string>
     <string name="settings_troubleshoot_test_fcm_failed">Lấy token FCM thất bại:
 \n%1$s</string>
@@ -1585,7 +1585,7 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_title">Token Firebase</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Sửa dịch vụ của Google Play</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} sử dụng Dịch vụ của Google Play nhằm đưa ra cái thông báo đẩy nhưng có vẻ nó đã không được căn chỉnh đúng cách:
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} sử dụng Dịch vụ của Google Play nhằm đưa ra cái thông báo đẩy nhưng có vẻ nó đã không được căn chỉnh đúng cách:
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_success">Dịch vụ của Google Play APK đang hoạt động và đã được nâng cấp lên phiên bản mới nhất.</string>
     <string name="settings_troubleshoot_test_play_services_title">Kiểm tra dịch vụ của Google Play</string>
@@ -1704,7 +1704,7 @@
     <string name="create_poll_question_hint">Câu hỏi hoặc chủ đề</string>
     <string name="create_poll_question_title">Câu hỏi hoặc chủ đề thăm dò ý kiến</string>
     <string name="create_poll_title">Tạo Cuộc thăm dò ý kiến</string>
-    <string name="template_link_this_email_with_your_account">%s trong Cài đặt để nhận lời mời trực tiếp trong ${app_name}.</string>
+    <string name="link_this_email_with_your_account">%s trong Cài đặt để nhận lời mời trực tiếp trong ${app_name}.</string>
     <string name="link_this_email_settings_link">Liên kết email này với tài khoản của bạn</string>
     <string name="this_invite_to_this_space_was_sent">Lời mời này đến Space này đã được gửi đến %s không được liên kết với tài khoản của bạn</string>
     <string name="this_invite_to_this_room_was_sent">Lời mời này đến phòng này đã được gửi đến %s không được liên kết với tài khoản của bạn</string>
@@ -1887,13 +1887,13 @@
     <string name="auth_pin_confirm_to_disable_title">Xác nhận mã PIN để vô hiệu hóa MÃ PIN</string>
     <string name="settings_security_pin_code_change_pin_summary">Thay đổi mã PIN hiện tại của bạn</string>
     <string name="settings_security_pin_code_change_pin_title">Thay đổi mã PIN</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">Mã PIN được yêu cầu mỗi khi bạn mở ${app_name}.</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">Mã PIN được yêu cầu sau 2 phút không sử dụng ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">Mã PIN được yêu cầu mỗi khi bạn mở ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">Mã PIN được yêu cầu sau 2 phút không sử dụng ${app_name}.</string>
     <string name="settings_security_pin_code_grace_period_title">Yêu cầu mã PIN sau 2 phút</string>
     <string name="settings_security_pin_code_notifications_summary_off">Chỉ hiển thị số lượng tin nhắn chưa đọc trong một thông báo đơn giản.</string>
     <string name="settings_security_pin_code_notifications_summary_on">Hiển thị chi tiết như tên phòng và nội dung tin nhắn.</string>
     <string name="settings_security_pin_code_notifications_title">Hiện nội dung trong thông báo</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">Mã PIN là cách duy nhất để mở khóa ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">Mã PIN là cách duy nhất để mở khóa ${app_name}.</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Bật sinh trắc học cụ thể của thiết bị, như dấu vân tay và nhận dạng khuôn mặt.</string>
     <string name="settings_security_pin_code_use_biometrics_title">Bật sinh trắc học</string>
     <string name="settings_security_pin_code_summary">Nếu bạn muốn đặt lại mã PIN của mình, hãy nhấp vào quên mã PIN để đăng nhập và đặt lại.</string>
@@ -1962,11 +1962,11 @@
     <string name="identity_server_user_consent_not_provided">Sự đồng ý của người dùng chưa được cung cấp.</string>
     <string name="identity_server_error_no_current_binding_error">Không có mối liên hệ hiện tại với mã định danh này.</string>
     <string name="identity_server_error_binding_error">Sự kết hợp đã thất bại.</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">Đối với quyền riêng tư của bạn, ${app_name} chỉ hỗ trợ gửi email và số điện thoại của người dùng băm.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">Đối với quyền riêng tư của bạn, ${app_name} chỉ hỗ trợ gửi email và số điện thoại của người dùng băm.</string>
     <string name="identity_server_error_terms_not_signed">Trước tiên, vui lòng chấp nhận các điều khoản của máy chủ nhận dạng trong cài đặt.</string>
     <string name="identity_server_error_no_identity_server_configured">Trước tiên, vui lòng cấu hình máy chủ nhận dạng.</string>
     <string name="identity_server_error_outdated_home_server">Hoạt động này là không thể. Homeerver đã lỗi thời.</string>
-    <string name="template_identity_server_error_outdated_identity_server">Máy chủ nhận dạng này đã lỗi thời. ${app_name} chỉ hỗ trợ API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">Máy chủ nhận dạng này đã lỗi thời. ${app_name} chỉ hỗ trợ API V2.</string>
     <string name="disconnect_identity_server_dialog_content">Ngắt kết nối khỏi máy chủ nhận dạng %s\?</string>
     <string name="open_terms_of">Mở các điều khoản của %s</string>
     <string name="choose_locale_loading_locales">Tải các ngôn ngữ có sẵn…</string>
@@ -1980,8 +1980,8 @@
     <string name="not_a_valid_qr_code">Nó không phải là mã QR Matrix hợp lệ</string>
     <string name="invitations_sent_to_two_users">Lời mời được gửi đến %1$s và %2$s</string>
     <string name="invitation_sent_to_one_user">Lời mời được gửi đến %1$s</string>
-    <string name="template_invite_friends_rich_title">🔐️ Tham gia với tôi trên ${app_name}</string>
-    <string name="template_invite_friends_text">Hey, nói chuyện với tôi trên ${app_name}: %s</string>
+    <string name="invite_friends_rich_title">🔐️ Tham gia với tôi trên ${app_name}</string>
+    <string name="invite_friends_text">Hey, nói chuyện với tôi trên ${app_name}: %s</string>
     <string name="invite_friends">Mời bạn bè</string>
     <string name="invite_users_to_room_title">Mời Người dùng</string>
     <string name="inviting_users_to_room">Mời người dùng…</string>
@@ -2023,13 +2023,13 @@
     <string name="enter_secret_storage_passphrase_or_key">Dùng %1$s của bạn hoặc dùng %2$s của bạn để tiếp tục.</string>
     <string name="command_description_discard_session_not_handled">Chỉ được hỗ trợ trong các phòng được mã hóa</string>
     <string name="command_description_discard_session">Buộc nhóm phiên hướng ra hiện tại trong một căn phòng được mã hóa phải bị loại bỏ</string>
-    <string name="template_use_latest_app">Sử dụng ${app_name mới nhất} trên các thiết bị khác của bạn:</string>
+    <string name="use_latest_app">Sử dụng ${app_name mới nhất} trên các thiết bị khác của bạn:</string>
     <string name="or_other_mx_capable_client">hoặc một máy khách Matrix có khả năng xác thực chéo khác</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
-    <string name="template_use_other_session_content_description">Sử dụng ${app_name} mới nhất trên các thiết bị khác của bạn, Web ${app_name}, Máy tính để bàn ${app_name}, ${app_name} iOS, ${app_name} cho Android hoặc một máy khách Matrix có khả năng xác thực chéo khác</string>
+    <string name="use_other_session_content_description">Sử dụng ${app_name} mới nhất trên các thiết bị khác của bạn, Web ${app_name}, Máy tính để bàn ${app_name}, ${app_name} iOS, ${app_name} cho Android hoặc một máy khách Matrix có khả năng xác thực chéo khác</string>
     <string name="change_password_summary">Đặt mật khẩu tài khoản mới…</string>
     <string name="error_saving_media_file">Không thể lưu tệp Media</string>
     <string name="error_adding_media_file_to_gallery">Không thể thêm tệp Media vào Bộ sưu tập</string>
@@ -2163,9 +2163,9 @@
     <string name="verify_cannot_cross_sign">Phiên này không thể chia sẻ xác minh này với các phiên khác của bạn.
 \nViệc xác minh sẽ được lưu cục bộ và chia sẻ trong phiên bản tương lai của ứng dụng.</string>
     <string name="unignore">Hủy bỏ qua</string>
-    <string name="template_rendering_event_error_exception">${app_name} gặp sự cố khi hiển thị nội dung sự kiện với id \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} không xử lý tin nhắn kiểu \'%1$s\'</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} không xử lý các sự kiện thuộc loại \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} gặp sự cố khi hiển thị nội dung sự kiện với id \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} không xử lý tin nhắn kiểu \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} không xử lý các sự kiện thuộc loại \'%1$s\'</string>
     <string name="room_member_jump_to_read_receipt">Nhảy để đọc biên nhận</string>
     <string name="room_member_open_or_create_dm">Tin nhắn trực tiếp</string>
     <string name="room_member_power_level_custom_in">Tùy chỉnh (%1$d) trong %2$s</string>
@@ -2263,7 +2263,7 @@
     <string name="command_description_shrug">Thêm ¯\\_(ツ)_/¯ vào một tin nhắn văn bản thuần túy</string>
     <string name="settings_developer_mode_show_info_on_screen_summary">Hiển thị một số thông tin hữu ích để giúp gỡ lỗi ứng dụng</string>
     <string name="settings_developer_mode_show_info_on_screen_title">Hiện thông tin debug trên màn hình</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} có thể gặp sự cố thường xuyên hơn khi một lỗi bất ngờ xảy ra</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} có thể gặp sự cố thường xuyên hơn khi một lỗi bất ngờ xảy ra</string>
     <string name="settings_developer_mode_fail_fast_title">Thất bại nhanh</string>
     <string name="autocomplete_limited_results">Chỉ hiển thị kết quả đầu tiên, nhập thêm chữ cái</string>
     <string name="devices_other_devices">Các phiên khác</string>
@@ -2280,7 +2280,7 @@
     <string name="notification_initial_sync">Đồng bộ ban đầu…</string>
     <string name="bug_report_error_too_short">Mô tả quá ngắn</string>
     <string name="permalink_malformed">Liên kết matrix.to của bạn bị dị hỏng</string>
-    <string name="template_soft_logout_sso_not_same_user_error">Phiên hiện tại dành cho người dùng %1$s và bạn cung cấp thông tin đăng nhập cho người dùng %2$s. Điều này không được hỗ trợ bởi ${app_name}.
+    <string name="soft_logout_sso_not_same_user_error">Phiên hiện tại dành cho người dùng %1$s và bạn cung cấp thông tin đăng nhập cho người dùng %2$s. Điều này không được hỗ trợ bởi ${app_name}.
 \nTrước tiên, hãy xóa dữ liệu, sau đó đăng nhập lại trên tài khoản khác.</string>
     <string name="soft_logout_clear_data_dialog_submit">Xóa dữ liệu</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">Bạn sẽ mất quyền truy cập vào các tin nhắn an toàn trừ khi bạn đăng nhập để khôi phục khóa mã hóa của mình.</string>
@@ -2428,7 +2428,7 @@
     <string name="room_preview_no_preview_join">Căn phòng này không thể xem trước được. Bạn có muốn tham gia nó không\?</string>
     <string name="room_preview_not_found">Căn phòng này không thể truy cập vào thời điểm này.
 \nHãy thử lại sau, hoặc yêu cầu quản trị viên phòng kiểm tra xem bạn có quyền truy cập hay không.</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">Bản xem trước của phòng có thể đọc được trên thế giới vẫn chưa được hỗ trợ bằng ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">Bản xem trước của phòng có thể đọc được trên thế giới vẫn chưa được hỗ trợ bằng ${app_name}</string>
     <string name="room_preview_no_preview">Phòng này không thể được xem trước</string>
     <string name="group_all_communities">Tất cả Community</string>
     <string name="please_wait">Vui lòng chờ…</string>
@@ -2496,7 +2496,7 @@
     <string name="sas_verify_title">Xác minh bằng cách so sánh một chuỗi văn bản ngắn.</string>
     <string name="invalid_or_expired_credentials">Bạn đã bị đăng xuất do mật khẩu không hợp lệ hoặc hết hạn.</string>
     <string name="autodiscover_well_known_autofill_confirm">Sử dụng cấu hình</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} đã phát hiện cấu hình máy chủ tùy chỉnh cho tên miền userId của bạn \"%1$s\":
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} đã phát hiện cấu hình máy chủ tùy chỉnh cho tên miền userId của bạn \"%1$s\":
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_dialog_title">Tự động hoàn tất các tùy chọn máy chủ</string>
     <string name="autodiscover_invalid_response">Phản hồi khám phá homeserver không hợp lệ</string>
@@ -2644,7 +2644,7 @@
     <string name="e2e_use_keybackup">Mở khóa lịch sử tin nhắn được mã hóa</string>
     <string name="settings_export_trail">Kiểm toán Xuất</string>
     <string name="settings_key_requests">Yêu cầu chìa khóa</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">Chìa khóa đã được cập nhật!</string>
     <string name="event_redacted_by_admin_reason_with_reason">Sự kiện được kiểm duyệt bởi người quản trị phòng, lý do: %1$s</string>
     <string name="event_redacted_by_user_reason_with_reason">Sự kiện bị người dùng xóa, lý do: %1$s</string>
@@ -2698,7 +2698,7 @@
     <string name="settings_server_default_room_version">Phiên bản Mặc định</string>
     <string name="settings_server_room_versions">Phiên bản phòng 👓</string>
     <string name="keys_backup_no_session_error">Không có phiên Matrix sẵn dùng</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Vui lòng xóa cụm mật khẩu nếu bạn muốn ${app_name} để tạo khóa khôi phục.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Vui lòng xóa cụm mật khẩu nếu bạn muốn ${app_name} để tạo khóa khôi phục.</string>
     <string name="passphrase_passphrase_too_weak">Cụm mật khẩu quá yếu</string>
     <string name="passphrase_empty_error_message">Vui lòng nhập cụm mật khẩu</string>
     <string name="passphrase_passphrase_does_not_match">Cụm mật khẩu không khớp</string>
@@ -2906,15 +2906,15 @@
     <string name="legals_third_party_notices">Thư viện bên thứ ba</string>
     <string name="legals_identity_server_title">Chính sách máy chủ xác thực của bạn</string>
     <string name="legals_home_server_title">Chính sách homeerver của bạn</string>
-    <string name="template_legals_application_title">Chính sách ${app_name}</string>
+    <string name="legals_application_title">Chính sách ${app_name}</string>
     <string name="analytics_opt_in_list_item_3">Bạn có thể tắt tính năng này bất cứ lúc nào trong cài đặt</string>
     <string name="analytics_opt_in_list_item_2">Chúng tôi <b>không </b> chia sẻ thông tin với bên thứ ba</string>
     <string name="analytics_opt_in_list_item_1">Chúng tôi <b>không</b> ghi âm hoặc tạo hồ sơ bất kỳ dữ liệu tài khoản nào</string>
     <string name="analytics_opt_in_content_link">ở đây</string>
-    <string name="template_analytics_opt_in_content">Giúp chúng tôi xác định các vấn đề và cải thiện ${app_name} bằng cách chia sẻ dữ liệu sử dụng ẩn danh. Để hiểu cách mọi người sử dụng nhiều thiết bị, chúng tôi sẽ tạo ra một mã định danh ngẫu nhiên, được chia sẻ bởi các thiết bị của bạn.
+    <string name="analytics_opt_in_content">Giúp chúng tôi xác định các vấn đề và cải thiện ${app_name} bằng cách chia sẻ dữ liệu sử dụng ẩn danh. Để hiểu cách mọi người sử dụng nhiều thiết bị, chúng tôi sẽ tạo ra một mã định danh ngẫu nhiên, được chia sẻ bởi các thiết bị của bạn.
 \n
 \nBạn có thể đọc tất cả các thuật ngữ của chúng tôi %s.</string>
-    <string name="template_analytics_opt_in_title">Giúp cải thiện ${app_name}</string>
+    <string name="analytics_opt_in_title">Giúp cải thiện ${app_name}</string>
     <string name="shortcut_disabled_reason_sign_out">Thiết bị đã bị đăng xuất!</string>
     <string name="shortcut_disabled_reason_room_left">Căn phòng đã bị bỏ lại!</string>
     <string name="login_error_homeserver_from_url_not_found_enter_manual">Chọn homeerver</string>
@@ -2962,7 +2962,7 @@
     <string name="settings_troubleshoot_test_token_registration_quick_fix">Token đăng ký</string>
     <string name="preference_system_settings">Cài đặt hệ thống</string>
     <string name="preference_versions">Phiên bản</string>
-    <string name="template_preference_help_summary">Nhận trợ giúp về việc sử dụng ${app_name}</string>
+    <string name="preference_help_summary">Nhận trợ giúp về việc sử dụng ${app_name}</string>
     <string name="preference_help_title">Trợ giúp và hỗ trợ</string>
     <string name="preference_help">Trợ giúp</string>
     <string name="preference_root_legals">Pháp lý</string>

--- a/vector/src/main/res/values-zh-rCN/strings.xml
+++ b/vector/src/main/res/values-zh-rCN/strings.xml
@@ -391,11 +391,11 @@
     <string name="attachment_remaining_time_seconds">%d 秒</string>
     <string name="call_connected">通话已连接</string>
     <string name="call_connecting">通话正在连接…</string>
-    <string name="template_permissions_rationale_msg_storage">为发送或保存附件，${app_name} 需要权限以访问你的图片和视频库。
+    <string name="permissions_rationale_msg_storage">为发送或保存附件，${app_name} 需要权限以访问你的图片和视频库。
 \n
 \n请在接下来的弹出窗口中授权允许访问，以便从此设备中发送文件。</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} 需要权限来访问你的相机，以拍摄照片或进行视频通话。</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} 需要权限以访问你的麦克风来进行语音通话。</string>
+    <string name="permissions_rationale_msg_camera">${app_name} 需要权限来访问你的相机，以拍摄照片或进行视频通话。</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} 需要权限以访问你的麦克风来进行语音通话。</string>
     <string name="room_preview_try_join_an_unknown_room">你试图访问聊天室 %s。你是否愿意加入这个聊天室？</string>
     <string name="room_participants_header_admin_tools">管理工具</string>
     <string name="room_participants_header_direct_chats">私聊</string>
@@ -575,7 +575,7 @@
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \n请在接下来弹出的窗口中授权允许访问。"</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} 需要权限以访问你的摄像机和麦克风来进行视频通话。
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} 需要权限以访问你的摄像机和麦克风来进行视频通话。
 \n
 \n请在接下来的弹出窗口中授权允许访问，以便进行通话。</string>
     <string name="permissions_action_not_performed_missing_permissions">对不起。因为权限不足，操作已取消</string>
@@ -635,8 +635,8 @@
     <string name="send_files_in">发送至</string>
     <string name="read_receipts_list">已读标签清单</string>
     <string name="compression_options">发送为</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} 可以检查你的通讯录，并基于他们的邮箱地址和电话号码，来查找其他 Matrix 用户。若你同意本应用以此目的访问你的通讯录，请在接下来的弹出窗口中授权允许访问。</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} 可以检查你的通讯录，并基于他们的邮箱地址和电话号码，来查找其他 Matrix 用户。
+    <string name="permissions_rationale_msg_contacts">${app_name} 可以检查你的通讯录，并基于他们的邮箱地址和电话号码，来查找其他 Matrix 用户。若你同意本应用以此目的访问你的通讯录，请在接下来的弹出窗口中授权允许访问。</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} 可以检查你的通讯录，并基于他们的邮箱地址和电话号码，来查找其他 Matrix 用户。
 \n
 \n你是否同意本应用以此目的访问你的通讯录\?</string>
     <string name="room_participants_idle">空闲</string>
@@ -690,7 +690,7 @@
     <string name="matrix_only_filter">只显示 Matrix 联系人</string>
     <string name="no_conversation_placeholder">没有对话</string>
     <string name="no_result_placeholder">没有结果</string>
-    <string name="template_no_contact_access_placeholder">你没有授予 ${app_name} 访问本地通讯录的权限</string>
+    <string name="no_contact_access_placeholder">你没有授予 ${app_name} 访问本地通讯录的权限</string>
     <string name="rooms_header">聊天室</string>
     <string name="rooms_directory_header">聊天室目录</string>
     <string name="no_room_placeholder">没有聊天室</string>
@@ -863,7 +863,7 @@
         <item quantity="other">%d 条未读消息</item>
     </plurals>
     <string name="startup_notification_privacy_title">通知隐私</string>
-    <string name="template_startup_notification_privacy_message">${app_name} 可以在后台运行以安全隐密地管理你的通知（这可能会影响电池消耗）。</string>
+    <string name="startup_notification_privacy_message">${app_name} 可以在后台运行以安全隐密地管理你的通知（这可能会影响电池消耗）。</string>
     <string name="startup_notification_privacy_button_grant">获取权限</string>
     <string name="startup_notification_privacy_button_other">选择其他选项</string>
     <string name="settings_notification_privacy_fcm">• 通知通过 Firebase Cloud Messaging 发送</string>
@@ -876,8 +876,8 @@
     <string name="settings_deactivate_account_section">停用账号</string>
     <string name="settings_deactivate_my_account">停用我的账号</string>
     <string name="settings_opt_in_of_analytics">发送统计分析数据</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} 会收集匿名统计数据来帮助我们改进程序。</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">请允许资料分析以帮助我们改进 ${app_name}。</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} 会收集匿名统计数据来帮助我们改进程序。</string>
+    <string name="settings_opt_in_of_analytics_prompt">请允许资料分析以帮助我们改进 ${app_name}。</string>
     <string name="settings_opt_in_of_analytics_ok">是的，我愿意帮助！</string>
     <string name="deactivate_account_title">停用账号</string>
     <string name="deactivate_account_content">这将使你的账号永远不再可用。你将无法登录，也不能使用相同的用户 ID 重新注册。你的账号将退出所有已加入的聊天室，你在身份服务器上的账号信息也会被删除。<b>此操作是不可逆的。</b>
@@ -910,7 +910,7 @@
     <string name="e2e_re_request_encryption_key">从其他设备上 <u>重新请求密钥</u>。</string>
     <string name="e2e_re_request_encryption_key_sent">已发送密钥共享请求。</string>
     <string name="e2e_re_request_encryption_key_dialog_title">已请求</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">请在其他可解密此消息的设备上启动 ${app_name}，以便其将密钥发送至当前设备。</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">请在其他可解密此消息的设备上启动 ${app_name}，以便其将密钥发送至当前设备。</string>
     <string name="lock_screen_hint">在此输入…</string>
     <string name="settings_labs_enable_send_voice">发送语音消息</string>
     <string name="error_empty_field_your_password">请输入你的密码。</string>
@@ -983,7 +983,7 @@
     <string name="dialog_title_error">错误</string>
     <string name="auth_accept_policies">请审阅并接受此主服务器的政策：</string>
     <string name="settings_call_category">通话</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">为来电使用 ${app_name} 的默认铃声</string>
+    <string name="settings_call_ringtone_use_app_ringtone">为来电使用 ${app_name} 的默认铃声</string>
     <string name="settings_call_ringtone_title">来电铃声</string>
     <string name="settings_call_ringtone_dialog_title">请选择来电铃声：</string>
     <string name="room_participants_action_remove">移除</string>
@@ -1008,12 +1008,12 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">启用</string>
     <string name="settings_troubleshoot_test_device_settings_title">设备设置。</string>
     <string name="settings_troubleshoot_test_device_settings_success">已为此设备启用通知。</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">此会话未启用通知。
+    <string name="settings_troubleshoot_test_device_settings_failed">此会话未启用通知。
 \n请检查 ${app_name} 设置。</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">启用</string>
     <string name="settings_troubleshoot_test_play_services_title">Play 服务检查</string>
     <string name="settings_troubleshoot_test_play_services_success">Google Play 服务的 APK 文件可用且为最新版本。</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} 使用 Google Play 服务来推送通知，但它似乎并未正确设置：
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} 使用 Google Play 服务来推送通知，但它似乎并未正确设置：
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">修复 Play 服务</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase 令牌</string>
@@ -1043,7 +1043,7 @@
     <string name="settings_show_avatar_display_name_changes_messages">显示账号变动事件</string>
     <string name="settings_show_avatar_display_name_changes_messages_summary">包括头像与显示名称的变动。</string>
     <string name="startup_notification_fdroid_battery_optim_title">后台连接</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} 需要保持低影响的后台连接，以便获得可靠的通知。
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} 需要保持低影响的后台连接，以便获得可靠的通知。
 \n下一个屏幕中，系统将提示你允许 ${app_name} 始终在后台运行，请点击“允许“。</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">授予权限</string>
     <string name="account_email_error">在验证你的电子邮件地址时发生了一个错误。</string>
@@ -1071,14 +1071,14 @@
     <string name="settings_troubleshoot_test_service_restart_success">服务被停止，并已自动重启。</string>
     <string name="settings_troubleshoot_test_service_restart_failed">服务重启失败</string>
     <string name="settings_troubleshoot_test_service_boot_success">服务将在设备重启后启动。</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">服务不会在设备重启后启动，在你打开 ${app_name} 一次之前你将不会收到消息通知。</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">已禁用对 ${app_name} 的后台限制。此测试应使用移动数据（非Wi-Fi）进行。
+    <string name="settings_troubleshoot_test_service_boot_failed">服务不会在设备重启后启动，在你打开 ${app_name} 一次之前你将不会收到消息通知。</string>
+    <string name="settings_troubleshoot_test_bg_restricted_success">已禁用对 ${app_name} 的后台限制。此测试应使用移动数据（非Wi-Fi）进行。
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">已启用对 ${app_name} 的后台限制。
+    <string name="settings_troubleshoot_test_bg_restricted_failed">已启用对 ${app_name} 的后台限制。
 \n${app_name} 在后台时的工作将被显著地限制，这可能会影响消息通知。
 \n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">关闭后台限制</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} 未被电池优化影响。</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} 未被电池优化影响。</string>
     <string name="settings_troubleshoot_test_battery_failed">如果设备在未充电的情况下关屏静置一段时间，其将进入打盹模式（Doze）。这将阻止应用访问网络并延后其运行、同步、与响铃。</string>
     <string name="settings_troubleshoot_test_battery_quickfix">忽略电池优化</string>
     <string name="encryption_export_notice">请输入用于加密被导出密钥的密语。恢复此备份时，必须输入相同的密语才能导入密钥。</string>
@@ -1110,11 +1110,11 @@
     <string name="settings_troubleshoot_test_bing_settings_failed">有些通知已在你的自定义设置中被禁用。</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">自定义规则加载失败，请重试。</string>
     <string name="settings_troubleshoot_test_bing_settings_quickfix">检查设置</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \n此错误不受 ${app_name} 控制，根据 Google 的说法，此错误表示该设备在 FCM 中注册了太多应用。该错误仅在应用程序数量极多的情况下发生，因此不应影响普通用户。</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \n此错误不受 ${app_name} 控制。它的发生可能有几个原因。也许你稍后重试就有效了，你也可以检查一下 Google Play 服务是否被系统设置限制了数据使用，或者你的设备时钟是否正确，或者可能发生在自定义的 ROM 中。</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \n此错误不受 ${app_name} 控制。此设备上没有登录 Google 账号。请打开账号管理器并添加一个 Google 账号。</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">添加账号</string>
     <string name="settings_noisy_notifications_preferences">设置响铃通知</string>
@@ -1129,7 +1129,7 @@
     <string name="error_empty_field_enter_user_name">请输入一个用户名。</string>
     <string name="passphrase_empty_error_message">请输入密语</string>
     <string name="passphrase_passphrase_too_weak">密语太弱了</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">如果你想要 ${app_name} 生成一个恢复密钥，请删除密语。</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">如果你想要 ${app_name} 生成一个恢复密钥，请删除密语。</string>
     <string name="keys_backup_no_session_error">没有可用的 Matrix 会话</string>
     <string name="keys_backup_setup_step1_title">永不丢失已加密消息</string>
     <string name="keys_backup_setup_step1_description">加密聊天室中的信息会被端对端加密以确保安全。只有你和拥有密钥的接收方可以读取这些信息。
@@ -1241,7 +1241,7 @@
     <string name="passwords_do_not_match">密码不匹配</string>
     <string name="autodiscover_invalid_response">无效的主服务器探测响应</string>
     <string name="autodiscover_well_known_autofill_dialog_title">自动完成服务器选项</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} 侦测到你的 userId 域名 \"%1$s\" 有自定义的服务器设置：
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} 侦测到你的 userId 域名 \"%1$s\" 有自定义的服务器设置：
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">使用设置</string>
     <string name="notification_sync_init">正在初始化服务</string>
@@ -1367,7 +1367,7 @@
     <string name="action_copy">复制</string>
     <string name="dialog_title_success">成功</string>
     <string name="bottom_action_notification">通知</string>
-    <string name="template_call_failed_no_connection">${app_name} 呼叫失败</string>
+    <string name="call_failed_no_connection">${app_name} 呼叫失败</string>
     <string name="call_failed_no_connection_description">无法建立实时连接。
 \n请要求你的主服务器管理员配置 TURN 服务器以使通话可靠工作。</string>
     <string name="call_select_sound_device">选择声音设备</string>
@@ -1408,14 +1408,14 @@
     <string name="room_participants_unban_title">取消封禁用户</string>
     <string name="room_participants_unban_prompt_msg">取消封禁用户将允许他们再次加入聊天室。</string>
     <string name="settings_add_3pid_confirm_password_title">确认你的密码</string>
-    <string name="template_settings_add_3pid_flow_not_supported">你无法在 ${app_name} 移动版中这么做</string>
+    <string name="settings_add_3pid_flow_not_supported">你无法在 ${app_name} 移动版中这么做</string>
     <string name="settings_add_3pid_authentication_needed">需要身份认证</string>
     <string name="settings_background_fdroid_sync_mode">后台同步模式</string>
     <string name="settings_background_fdroid_sync_mode_battery">电池优化</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} 将在后台以保留设备有限资源（电池）的方式同步。
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} 将在后台以保留设备有限资源（电池）的方式同步。
 \n取决于你的设备资源状态，同步可能被操作系统推迟。</string>
     <string name="settings_background_fdroid_sync_mode_real_time">实时优化</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} 将在后台定期准时同步（可配置）。
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} 将在后台定期准时同步（可配置）。
 \n这将影响网络和电池的使用，将显示一个永久通知表明 ${app_name} 正在监听事件。</string>
     <string name="settings_background_fdroid_sync_mode_disabled">无后台同步</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">应用在后台时你不会收到消息通知。</string>
@@ -1518,7 +1518,7 @@
     <string name="malformed_message">格式错误事件，无法显示</string>
     <string name="error_no_network">无网络。请检查你的网络连接。</string>
     <string name="change_room_directory_network">更改网络</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">${app_name} 尚不支持公开聊天室预览</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">${app_name} 尚不支持公开聊天室预览</string>
     <string name="fab_menu_create_chat">私聊消息</string>
     <string name="create_room_title">新聊天室</string>
     <string name="create_room_public_title">公开</string>
@@ -1643,7 +1643,7 @@
     <string name="content_reported_as_inappropriate_content">此内容已报告为不合适。
 \n
 \n如果你不希望再看到此用户的更多内容，你可以忽略他们以隐藏他们的消息。</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} 需要权限以在磁盘上保存你的端对端密钥。
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} 需要权限以在磁盘上保存你的端对端密钥。
 \n
 \n请在接下来的弹出窗口中授权允许访问，以便你手动导出密钥。</string>
     <string name="no_network_indicator">目前没有网络连接</string>
@@ -1795,7 +1795,7 @@
 \n再次登录以访问你的账号数据和消息。</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">除非你登录以恢复加密密钥，否则你将无法访问安全消息。</string>
     <string name="soft_logout_clear_data_dialog_submit">清除数据</string>
-    <string name="template_soft_logout_sso_not_same_user_error">当前会话用于用户 %1$s 而你提供了用户 %2$s 的凭证。${app_name} 不支持此功能。
+    <string name="soft_logout_sso_not_same_user_error">当前会话用于用户 %1$s 而你提供了用户 %2$s 的凭证。${app_name} 不支持此功能。
 \n请先清除数据，然后重新登录另一个账号。</string>
     <string name="permalink_malformed">你的 matrix.to 链接更是不正确</string>
     <string name="bug_report_error_too_short">描述太短</string>
@@ -1813,7 +1813,7 @@
     <string name="devices_other_devices">其他会话</string>
     <string name="autocomplete_limited_results">仅显示第一个结果，请输入更多字符…</string>
     <string name="settings_developer_mode_fail_fast_title">快速失败</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">发生意外错误时，${app_name} 可能更经常崩溃</string>
+    <string name="settings_developer_mode_fail_fast_summary">发生意外错误时，${app_name} 可能更经常崩溃</string>
     <string name="command_description_shrug">在明文消息前添加 ¯\\_(ツ)_/¯</string>
     <string name="create_room_encryption_title">启用加密</string>
     <string name="create_room_encryption_description">加密一经启用，便无法禁用。</string>
@@ -1885,9 +1885,9 @@
     <string name="room_member_power_level_moderator_in">%1$s 的协管员</string>
     <string name="room_member_power_level_default_in">%1$s 默认权限</string>
     <string name="room_member_power_level_custom_in">%2$s 自定义权限 (%1$d)</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} 无法处理类型为 \'%1$s\' 的事件</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} 无法处理类型为 \'%1$s\' 的消息</string>
-    <string name="template_rendering_event_error_exception">${app_name} 在渲染 id 为 \'%1$s\' 的事件内容时遇到了一个问题</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} 无法处理类型为 \'%1$s\' 的事件</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} 无法处理类型为 \'%1$s\' 的消息</string>
+    <string name="rendering_event_error_exception">${app_name} 在渲染 id 为 \'%1$s\' 的事件内容时遇到了一个问题</string>
     <string name="unignore">取消忽略</string>
     <string name="verify_cannot_cross_sign">该会话无法与你的其他会话共享此验证。
 \n验证将保存在本地，并在此应用的未来版本中共享。</string>
@@ -1970,7 +1970,7 @@
     <string name="delete_event_dialog_reason_checkbox">附加理由</string>
     <string name="delete_event_dialog_reason_hint">编辑理由</string>
     <string name="event_redacted_by_user_reason_with_reason">事件被用户删除，理由：%1$s</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">密钥请求</string>
     <string name="e2e_use_keybackup">解锁加密消息历史</string>
     <string name="refresh">刷新</string>
@@ -2086,13 +2086,13 @@
     <string name="error_adding_media_file_to_gallery">无法添加媒体文件到相册</string>
     <string name="error_saving_media_file">无法保存媒体文件</string>
     <string name="change_password_summary">选择新的账号密码…</string>
-    <string name="template_use_other_session_content_description">在你的其他设备上使用最新的${app_name} 网页版、${app_name} 桌面版、${app_name} iOS 版、${app_name} 安卓版，或其他能够交叉签名的 Matrix 客户端</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="use_other_session_content_description">在你的其他设备上使用最新的${app_name} 网页版、${app_name} 桌面版、${app_name} iOS 版、${app_name} 安卓版，或其他能够交叉签名的 Matrix 客户端</string>
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} Desktop</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
     <string name="or_other_mx_capable_client">或其他能够交叉签名的 Matrix 客户端</string>
-    <string name="template_use_latest_app">在你的其他设备上使用最新的 ${app_name}：</string>
+    <string name="use_latest_app">在你的其他设备上使用最新的 ${app_name}：</string>
     <string name="command_description_discard_session">强制丢弃加密聊天室中的当前出站群组会话</string>
     <string name="command_description_discard_session_not_handled">仅在加密聊天室中支持</string>
     <string name="enter_secret_storage_passphrase_or_key">使用你的 %1$s 或使用你的 %2$s 继续。</string>
@@ -2132,11 +2132,11 @@
     <string name="choose_locale_loading_locales">正在载入可用语言…</string>
     <string name="open_terms_of">打开 %s 条款</string>
     <string name="disconnect_identity_server_dialog_content">是否从身份服务器 %s 断开？</string>
-    <string name="template_identity_server_error_outdated_identity_server">身份服务器已过期。${app_name} 仅支持 API V2。</string>
+    <string name="identity_server_error_outdated_identity_server">身份服务器已过期。${app_name} 仅支持 API V2。</string>
     <string name="identity_server_error_outdated_home_server">无法执行此操作。主服务器已过期。</string>
     <string name="identity_server_error_no_identity_server_configured">请先配置身份服务器。</string>
     <string name="identity_server_error_terms_not_signed">请先在设置中接受身份服务器的条款。</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">为了你的隐私，${app_name} 仅支持发送用户电子邮件和电话号码的哈希值。</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">为了你的隐私，${app_name} 仅支持发送用户电子邮件和电话号码的哈希值。</string>
     <string name="identity_server_error_binding_error">关联失败。</string>
     <string name="identity_server_error_no_current_binding_error">当前与此标识符没有关联。</string>
     <string name="identity_server_set_default_notice">你的主服务器（%1$s）建议使用 %2$s 作为你的身份服务器</string>
@@ -2261,13 +2261,13 @@
 \n
 \n小心使用，它可能导致意外行为。</string>
     <string name="universal_link_malformed">链接格式不正确</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">每次打开 ${app_name} 都要求 PIN 码。</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">在 2 分钟未使用 ${app_name} 后要求 PIN 码。</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">每次打开 ${app_name} 都要求 PIN 码。</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">在 2 分钟未使用 ${app_name} 后要求 PIN 码。</string>
     <string name="settings_security_pin_code_grace_period_title">2 分钟后要求 PIN</string>
     <string name="settings_security_pin_code_notifications_summary_off">仅在一个简单通知中显示未读消息内容数量。</string>
     <string name="settings_security_pin_code_notifications_summary_on">显示细节如聊天室名称和消息内容。</string>
     <string name="settings_security_pin_code_notifications_title">在通知中显示内容</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">PIN 码是解锁 ${app_name} 的唯一方式。</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">PIN 码是解锁 ${app_name} 的唯一方式。</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">启用设备特定的生物特征识别，如指纹和面部识别。</string>
     <string name="settings_security_pin_code_use_biometrics_title">启用生物特征识别</string>
     <string name="settings_security_application_protection_screen_title">配置保护</string>
@@ -2623,7 +2623,7 @@
     <string name="a11y_unchecked">未检查</string>
     <string name="a11y_open_widget">开启挂件</string>
     <string name="a11y_screenshot">屏幕截图</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} 要求你输入凭据才能执行此操作。</string>
+    <string name="re_authentication_default_confirm_text">${app_name} 要求你输入凭据才能执行此操作。</string>
     <string name="call_transfer_failure">呼叫转移时发生错误</string>
     <string name="call_transfer_consult_first">先询问</string>
     <plurals name="call_one_active_and_other_paused">
@@ -2642,8 +2642,8 @@
     <string name="share_by_text">通过文字分享</string>
     <string name="settings_security_pin_code_change_pin_summary">更改你当前的 PIN</string>
     <string name="settings_security_pin_code_change_pin_title">更改 PIN</string>
-    <string name="template_invite_friends_rich_title">🔐️ 在 ${app_name} 上加入我的行列</string>
-    <string name="template_invite_friends_text">嗨，和我在 ${app_name} 上聊天吧：%s</string>
+    <string name="invite_friends_rich_title">🔐️ 在 ${app_name} 上加入我的行列</string>
+    <string name="invite_friends_text">嗨，和我在 ${app_name} 上聊天吧：%s</string>
     <string name="send_images_and_video_with_original_size">发送原始大小的媒体</string>
     <plurals name="send_videos_with_original_size">
         <item quantity="other">发送原始大小的视频</item>
@@ -2808,7 +2808,7 @@
     <string name="settings_notification_default">默认通知</string>
     <string name="call_tile_video_active">活跃视频通话</string>
     <string name="call_tile_voice_active">活跃语音通话</string>
-    <string name="template_link_this_email_with_your_account">在 ${app_name} 中直接接收邀请的设置 %s。</string>
+    <string name="link_this_email_with_your_account">在 ${app_name} 中直接接收邀请的设置 %s。</string>
     <string name="link_this_email_settings_link">将此邮箱与您的账户相链接</string>
     <string name="this_invite_to_this_space_was_sent">加入这个空间的邀请被发送至 %s，此邮箱未与您的账户相关联</string>
     <string name="this_invite_to_this_room_was_sent">加入这个聊天室的邀请被发送至 %s，此邮箱未与您的账户相关联</string>
@@ -2963,7 +2963,7 @@
     </plurals>
     <string name="preference_system_settings">系统设置</string>
     <string name="preference_versions">版本</string>
-    <string name="template_preference_help_summary">获取使用 ${app_name} 的帮助</string>
+    <string name="preference_help_summary">获取使用 ${app_name} 的帮助</string>
     <string name="preference_help_title">帮助和支持</string>
     <string name="preference_help">帮助</string>
     <string name="preference_root_legals">法律</string>
@@ -2972,13 +2972,13 @@
     <string name="legals_identity_server_title">你的身份服务器政策</string>
     <string name="analytics_opt_in_list_item_1">我们<b>不</b>记录任何账户数据或绘制任何账户数据的画像</string>
     <string name="legals_home_server_title">你的主服务器政策</string>
-    <string name="template_legals_application_title">${app_name} 政策</string>
+    <string name="legals_application_title">${app_name} 政策</string>
     <string name="analytics_opt_in_list_item_3">你可以随时在设置中关闭它</string>
     <string name="analytics_opt_in_list_item_2">我们<b>不</b>与第三方共享信息</string>
     <string name="analytics_opt_in_content_link">此处</string>
-    <string name="template_analytics_opt_in_content">通过共享匿名使用数据，帮助我们识别问题并改进 ${app_name}。为了理解人们如何使用多台设备，我们将生成一个随机标识符，由您的设备共享。
+    <string name="analytics_opt_in_content">通过共享匿名使用数据，帮助我们识别问题并改进 ${app_name}。为了理解人们如何使用多台设备，我们将生成一个随机标识符，由您的设备共享。
 \n
 \n你可以阅读我们所有的条款 %s。</string>
-    <string name="template_analytics_opt_in_title">帮助改进 ${app_name}</string>
+    <string name="analytics_opt_in_title">帮助改进 ${app_name}</string>
     <string name="action_enable">启用</string>
 </resources>

--- a/vector/src/main/res/values-zh-rTW/strings.xml
+++ b/vector/src/main/res/values-zh-rTW/strings.xml
@@ -335,7 +335,7 @@
     <string name="user_directory_header">使用者目錄</string>
     <string name="matrix_only_filter">僅 Matrix 聯絡人</string>
     <string name="no_conversation_placeholder">沒有對話</string>
-    <string name="template_no_contact_access_placeholder">您沒有允許 ${app_name} 存取裝置上的聯絡資訊</string>
+    <string name="no_contact_access_placeholder">您沒有允許 ${app_name} 存取裝置上的聯絡資訊</string>
     <string name="no_result_placeholder">沒有結果</string>
     <string name="rooms_header">聊天室</string>
     <string name="rooms_directory_header">聊天室目錄</string>
@@ -472,22 +472,22 @@
     <string name="media_picker_both_capture_title">拍照或錄影</string>
     <string name="media_picker_cannot_record_video">無法錄影</string>
     <string name="permissions_rationale_popup_title">資訊</string>
-    <string name="template_permissions_rationale_msg_storage">${app_name} 需要權限來存取你的照片與影片庫，以傳送及儲存附件。
+    <string name="permissions_rationale_msg_storage">${app_name} 需要權限來存取你的照片與影片庫，以傳送及儲存附件。
 \n
 \n請在下個彈跳視窗允許存取，來從手機傳送檔案。</string>
-    <string name="template_permissions_rationale_msg_camera">${app_name} 需要權限存取您的相機，來拍照與視訊通話。</string>
+    <string name="permissions_rationale_msg_camera">${app_name} 需要權限存取您的相機，來拍照與視訊通話。</string>
     <string name="permissions_rationale_msg_camera_explanation">"
 \n
 \n為了要通話，請在下個彈跳視窗中允許存取。"</string>
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} 需要權限來存取麥克風，來撥打語音通話。</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} 需要權限來存取麥克風，來撥打語音通話。</string>
     <string name="permissions_rationale_msg_record_audio_explanation">"
 \n
 \n為了要通話，請在下個彈跳視窗中允許存取。"</string>
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} 需要權限來存取相機及麥克風來撥打視訊通話。
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} 需要權限來存取相機及麥克風來撥打視訊通話。
 \n
 \n為了可以正常使用通話功能，請在下個彈跳視窗中允許存取。</string>
-    <string name="template_permissions_rationale_msg_contacts">${app_name} 可以檢查您的電話簿並以電子郵件與電話號碼為基礎來尋找其他 Matrix 使用者。如果您同意為此用途分享您的電話簿，請在下一個彈出式視窗中允許存取權限。</string>
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} 可以檢查您的電話簿並以電子郵件與電話號碼為基礎來尋找其他 Matrix 使用者。
+    <string name="permissions_rationale_msg_contacts">${app_name} 可以檢查您的電話簿並以電子郵件與電話號碼為基礎來尋找其他 Matrix 使用者。如果您同意為此用途分享您的電話簿，請在下一個彈出式視窗中允許存取權限。</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} 可以檢查您的電話簿並以電子郵件與電話號碼為基礎來尋找其他 Matrix 使用者。
 \n
 \n您同意為此用途分享您的電話簿嗎？</string>
     <string name="permissions_action_not_performed_missing_permissions">抱歉。由於缺少權限，所以無法執行動作</string>
@@ -597,7 +597,7 @@
     <string name="e2e_re_request_encryption_key">從其他工作階段重新請求金鑰。<u>重新請求金鑰</u>。</string>
     <string name="e2e_re_request_encryption_key_sent">已發送金鑰分享請求。</string>
     <string name="e2e_re_request_encryption_key_dialog_title">已發送請求</string>
-    <string name="template_e2e_re_request_encryption_key_dialog_content">請在另一個可以解密訊息的裝置上啟動 ${app_name}，以便它將金鑰發送到此工作階段。</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">請在另一個可以解密訊息的裝置上啟動 ${app_name}，以便它將金鑰發送到此工作階段。</string>
     <string name="ssl_expected_existing_expl">憑證已從以前受信任的更改為不受信任的憑證。伺服器可能已續訂其憑證。請與伺服器管理員聯繫以尋找所需的指紋。</string>
     <string name="ssl_only_accept">僅當伺服器管理員發佈的指紋與上面的指紋匹配時才接受此憑證。</string>
     <string name="room_details_title">聊天室詳情</string>
@@ -708,13 +708,13 @@
     <string name="settings_deactivate_account_section">停用帳號</string>
     <string name="settings_deactivate_my_account">停用我的帳號</string>
     <string name="startup_notification_privacy_title">通知隱私</string>
-    <string name="template_startup_notification_privacy_message">${app_name} 可以在後臺安全隱密地管理通知。這可能會影響電池的使用。</string>
+    <string name="startup_notification_privacy_message">${app_name} 可以在後臺安全隱密地管理通知。這可能會影響電池的使用。</string>
     <string name="startup_notification_privacy_button_grant">獲取權限</string>
     <string name="startup_notification_privacy_button_other">選擇其他選項</string>
     <string name="settings_analytics">傳送分析資料</string>
     <string name="settings_opt_in_of_analytics">傳送分析資料</string>
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} 會收集匿名分析以讓我們可以改進此應用程式。</string>
-    <string name="template_settings_opt_in_of_analytics_prompt">請允許收集匿名分析以讓我們可以改進此應用程式。</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} 會收集匿名分析以讓我們可以改進此應用程式。</string>
+    <string name="settings_opt_in_of_analytics_prompt">請允許收集匿名分析以讓我們可以改進此應用程式。</string>
     <string name="settings_opt_in_of_analytics_ok">是的，我想要協助！</string>
     <string name="settings_data_save_mode">節省流量模式</string>
     <string name="devices_details_dialog_title">工作階段資訊</string>
@@ -1064,7 +1064,7 @@
     <string name="plus_x">+%d</string>
     <string name="x_plus">%d+</string>
     <string name="settings_call_category">通話</string>
-    <string name="template_settings_call_ringtone_use_app_ringtone">為來電使用預設的 ${app_name} 鈴聲</string>
+    <string name="settings_call_ringtone_use_app_ringtone">為來電使用預設的 ${app_name} 鈴聲</string>
     <string name="settings_call_ringtone_title">來電鈴聲</string>
     <string name="settings_call_ringtone_dialog_title">選取通話鈴聲：</string>
     <string name="action_accept">接受</string>
@@ -1088,12 +1088,12 @@
     <string name="settings_troubleshoot_test_account_settings_quickfix">啟用</string>
     <string name="settings_troubleshoot_test_device_settings_title">工作階段設定。</string>
     <string name="settings_troubleshoot_test_device_settings_success">通知已為此工作階段啟用。</string>
-    <string name="template_settings_troubleshoot_test_device_settings_failed">此工作階段未啟用通知。
+    <string name="settings_troubleshoot_test_device_settings_failed">此工作階段未啟用通知。
 \n請檢查 ${app_name} 設定。</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">啟用</string>
     <string name="settings_troubleshoot_test_play_services_title">Play 服務檢查</string>
     <string name="settings_troubleshoot_test_play_services_success">Google Play 服務 APK 可用且已為最新。</string>
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} 使用 Google Play 服務來傳遞推送訊息，但它似乎並未正確設定：
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} 使用 Google Play 服務來傳遞推送訊息，但它似乎並未正確設定：
 \n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">修復 Play 服務</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase 權杖</string>
@@ -1110,21 +1110,21 @@
     <string name="settings_troubleshoot_test_service_restart_failed">服務重新啟動失敗</string>
     <string name="settings_troubleshoot_test_service_boot_title">開機時啟動</string>
     <string name="settings_troubleshoot_test_service_boot_success">服務將會在裝置重新啟動時自行啟動。</string>
-    <string name="template_settings_troubleshoot_test_service_boot_failed">服務不會在裝置重心啟動時自行啟動，您將不能在 ${app_name} 開啟前收到通知。</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">服務不會在裝置重心啟動時自行啟動，您將不能在 ${app_name} 開啟前收到通知。</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">啟用開機時啟動</string>
     <string name="settings_troubleshoot_test_bg_restricted_title">檢查背景限制</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">背景限制已為 ${app_name} 停用。本測試應該使用行動數據執行（不是 WiFi）。
+    <string name="settings_troubleshoot_test_bg_restricted_success">背景限制已為 ${app_name} 停用。本測試應該使用行動數據執行（不是 WiFi）。
 \n%1$s</string>
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">背景限制已為 ${app_name} 啟用。
+    <string name="settings_troubleshoot_test_bg_restricted_failed">背景限制已為 ${app_name} 啟用。
 \n應用程式要在背景執行的工作將被嚴格限制，這可能會影響通知功能。
 \n %1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">停用限制</string>
     <string name="settings_troubleshoot_test_battery_title">電池最佳化</string>
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} 不會被電池最佳化影響。</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} 不會被電池最佳化影響。</string>
     <string name="settings_troubleshoot_test_battery_failed">如果使用者不為裝置充電，並讓其靜置一段時間，且將螢幕關閉，裝置將會進入 Doze 模式。這可能會導致應用程式無法存取網路，並延遲它們的工作、同步與標準警報。</string>
     <string name="settings_troubleshoot_test_battery_quickfix">忽略最佳化</string>
     <string name="startup_notification_fdroid_battery_optim_title">背景連線</string>
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} 需要保持最低影響的背景連線以接收可靠的通知。
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} 需要保持最低影響的背景連線以接收可靠的通知。
 \n在下一個畫面，您必須允許 ${app_name} 總是在背景執行，請接受。</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">授予權限</string>
     <string name="account_email_error">當驗證您的電子郵件地址時遇到錯誤。</string>
@@ -1144,11 +1144,11 @@
     <string name="settings_troubleshoot_test_bing_settings_failed">有一些通知在您的自訂設定中被停用了。</string>
     <string name="settings_troubleshoot_test_bing_settings_failed_to_load_rules">載入自訂規則失敗，請重試。</string>
     <string name="settings_troubleshoot_test_bing_settings_quickfix">檢查設定</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]
 \n這個錯誤並非 ${app_name} 所能控制，而是與 Google 有關，這個錯誤代表裝置註冊了太多使用 FCM 的應用程式。這個錯誤只會發生在有超大量的應用程式的裝置上，所以不應該影響一般的使用者。</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]
 \n這個錯誤並非 ${app_name} 所能控制。可能由多種原因所導致。也可能會在稍後重試時就可以運作，您也可以檢查 Google Play 服務在系統設定中有沒有被限制使用資料，或是您裝置的時鐘是否正確，或是也可能會在自訂的 ROM 上發生。</string>
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]
 \n這個錯誤並非 ${app_name} 所能控制。手機上沒有 Google 帳號。請開啟帳號管理員並新增一個 Google 帳號。</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">新增帳號</string>
     <string name="settings_noisy_notifications_preferences">設定吵鬧的通知</string>
@@ -1160,7 +1160,7 @@
     <string name="notification_silent">安靜</string>
     <string name="passphrase_empty_error_message">請輸入通關密語</string>
     <string name="passphrase_passphrase_too_weak">通關密語太弱了</string>
-    <string name="template_keys_backup_passphrase_not_empty_error_message">如果您想要讓 ${app_name} 生成復原金鑰的話，請刪除通關密語。</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">如果您想要讓 ${app_name} 生成復原金鑰的話，請刪除通關密語。</string>
     <string name="keys_backup_no_session_error">沒有可用的 Matrix 工作階段</string>
     <string name="keys_backup_setup_step1_title">永不遺失已加密的訊息</string>
     <string name="keys_backup_setup_step1_description">在加密聊天室裡的訊息是使用端到端加密。只有您和接收者有金鑰可以閱讀這些訊息。
@@ -1287,7 +1287,7 @@
     <string name="passwords_do_not_match">密碼不符合</string>
     <string name="autodiscover_invalid_response">無效的家伺服器探索回應</string>
     <string name="autodiscover_well_known_autofill_dialog_title">自動完成伺服器選項</string>
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} 偵測到您的 userId 網域「%1$s」有自訂的伺服器設定：
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} 偵測到您的 userId 網域「%1$s」有自訂的伺服器設定：
 \n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">使用設定</string>
     <string name="notification_sync_init">正在初始化服務</string>
@@ -1400,7 +1400,7 @@
     <string name="please_wait">請稍候……</string>
     <string name="group_all_communities">所有社群</string>
     <string name="room_preview_no_preview">無法預覽此聊天室</string>
-    <string name="template_room_preview_world_readable_room_not_supported_yet">${app_name} 尚不支援預覽所有人皆可讀的聊天室</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">${app_name} 尚不支援預覽所有人皆可讀的聊天室</string>
     <string name="fab_menu_create_room">聊天室</string>
     <string name="fab_menu_create_chat">直接訊息</string>
     <string name="create_room_title">新聊天室</string>
@@ -1495,10 +1495,10 @@
     <string name="invite_no_identity_server_error">在您的設定中新增一臺身份識別伺服器以執行此動作。</string>
     <string name="settings_background_fdroid_sync_mode">背景同步模式</string>
     <string name="settings_background_fdroid_sync_mode_battery">為電池最佳化</string>
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} 將會在背景同步以節省裝置的有限資源（電池）。
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} 將會在背景同步以節省裝置的有限資源（電池）。
 \n取決於您裝置的資源狀態，作業系統可能會延遲同步。</string>
     <string name="settings_background_fdroid_sync_mode_real_time">為即時作業最佳化</string>
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} 將會精準地定期在背景同步（可設定）。
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} 將會精準地定期在背景同步（可設定）。
 \n這會影響到網路與電池的使用，並會顯示指出 ${app_name} 正在監聽某事件的永久通知。</string>
     <string name="settings_background_fdroid_sync_mode_disabled">無背景同步</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">當應用程式在背景時，您將不會收到訊息通知。</string>
@@ -1582,12 +1582,12 @@
     <string name="content_reported_as_inappropriate_content">此內容已被回報為不合適。 
 \n 
 \n如果您不想要看到從此使用者而來的更多內容，您可以忽略他們以隱藏他們的訊息。</string>
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} 需要權限以在磁碟上儲存您的 E2E 金鑰。
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} 需要權限以在磁碟上儲存您的 E2E 金鑰。
 \n
 \n請在下個彈出視窗中允許存取以讓您可以手動匯出您的金鑰。</string>
     <string name="no_network_indicator">目前沒有網路連線</string>
     <string name="settings_add_3pid_confirm_password_title">確認您的密碼</string>
-    <string name="template_settings_add_3pid_flow_not_supported">您無法在行動裝置上的 ${app_name} 做這件事</string>
+    <string name="settings_add_3pid_flow_not_supported">您無法在行動裝置上的 ${app_name} 做這件事</string>
     <string name="settings_add_3pid_authentication_needed">需要驗證</string>
     <string name="settings_integrations">整合</string>
     <string name="settings_integrations_summary">使用整合管理員以管理機器人、橋接、小工具與貼紙包。
@@ -1753,7 +1753,7 @@
 \n再次登入以存取您的帳號資料與訊息。</string>
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">除非您登入以復原您的加密金鑰，否則您將會失去對安全訊息的存取權。</string>
     <string name="soft_logout_clear_data_dialog_submit">清除資料</string>
-    <string name="template_soft_logout_sso_not_same_user_error">使用者 %1$s 目前的工作階段與您提供的使用者 %2$s 憑證。${app_name} 並不支援。
+    <string name="soft_logout_sso_not_same_user_error">使用者 %1$s 目前的工作階段與您提供的使用者 %2$s 憑證。${app_name} 並不支援。
 \n請先清除您的資料，然後再以其他帳號登入。</string>
     <string name="permalink_malformed">您的 matrix.to 連結格式錯誤</string>
     <string name="bug_report_error_too_short">描述太短了</string>
@@ -1771,7 +1771,7 @@
     <string name="devices_other_devices">其他工作階段</string>
     <string name="autocomplete_limited_results">僅顯示第一個結果，輸入更多字母……</string>
     <string name="settings_developer_mode_fail_fast_title">快速失敗</string>
-    <string name="template_settings_developer_mode_fail_fast_summary">在發生非預期的錯誤時，${app_name} 可能更常當機</string>
+    <string name="settings_developer_mode_fail_fast_summary">在發生非預期的錯誤時，${app_name} 可能更常當機</string>
     <string name="command_description_shrug">將 ¯\\_(ツ)_/¯ 附加到純文字訊息中</string>
     <string name="create_room_encryption_title">啟用加密</string>
     <string name="create_room_encryption_description">加密一旦啟用就無法停用。</string>
@@ -1841,9 +1841,9 @@
     <string name="room_member_power_level_moderator_in">%1$s 中的板主</string>
     <string name="room_member_power_level_custom_in">%2$s 中的自訂 (%1$d)</string>
     <string name="room_member_jump_to_read_receipt">跳至讀取回條</string>
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} 無法處理類型為「%1$s」的事件</string>
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} 無法處理類型為「%1$s」的訊息</string>
-    <string name="template_rendering_event_error_exception">在彩現 id「%1$s」事件的內容時，${app_name} 遇到問題</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} 無法處理類型為「%1$s」的事件</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} 無法處理類型為「%1$s」的訊息</string>
+    <string name="rendering_event_error_exception">在彩現 id「%1$s」事件的內容時，${app_name} 遇到問題</string>
     <string name="unignore">取消忽略</string>
     <string name="verify_cannot_cross_sign">此工作階段無法與您其他的工作階段分享此驗證。
 \n驗證將會儲存在本機並在未來版本的應用程式中共享。</string>
@@ -1927,7 +1927,7 @@
     <string name="event_redacted_by_user_reason_with_reason">被使用者刪除的活動，理由：%1$s</string>
     <string name="event_redacted_by_admin_reason_with_reason">由聊天室管理員管理的活動，理由：%1$s</string>
     <string name="keys_backup_restore_success_title_already_up_to_date">金鑰已為最新！</string>
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
     <string name="settings_key_requests">金鑰請求</string>
     <string name="e2e_use_keybackup">解鎖已加密的訊息歷史</string>
     <string name="refresh">重新整理</string>
@@ -2028,13 +2028,13 @@
     <string name="media_file_added_to_gallery">媒體檔案已新增至媒體庫中</string>
     <string name="error_adding_media_file_to_gallery">無法新增媒體檔案到媒體庫中</string>
     <string name="change_password_summary">設定新的帳號密碼……</string>
-    <string name="template_use_other_session_content_description">在您的其他裝置上使用最新的 ${app_name}、${app_name} Web、${app_name} 桌面版、${app_name} iOS、${app_name} for Android 或其他有交叉簽章功能的 Matrix 客戶端</string>
-    <string name="template_app_desktop_web">${app_name} Web
+    <string name="use_other_session_content_description">在您的其他裝置上使用最新的 ${app_name}、${app_name} Web、${app_name} 桌面版、${app_name} iOS、${app_name} for Android 或其他有交叉簽章功能的 Matrix 客戶端</string>
+    <string name="app_desktop_web">${app_name} Web
 \n${app_name} 桌面版</string>
-    <string name="template_app_ios_android">${app_name} iOS
+    <string name="app_ios_android">${app_name} iOS
 \n${app_name} Android</string>
     <string name="or_other_mx_capable_client">或其他有交叉簽章功能的 Matrix 客戶端</string>
-    <string name="template_use_latest_app">在您的其他裝置上使用最新的 ${app_name}：</string>
+    <string name="use_latest_app">在您的其他裝置上使用最新的 ${app_name}：</string>
     <string name="command_description_discard_session">強制丟棄目前在加密聊天室中的外發群組工作階段</string>
     <string name="command_description_discard_session_not_handled">僅在加密聊天室中支援</string>
     <string name="enter_secret_storage_passphrase_or_key">使用您的 %1$s 或使用您的 %2$s 以繼續。</string>
@@ -2094,11 +2094,11 @@
     <string name="choose_locale_loading_locales">正在載入可用的語言……</string>
     <string name="open_terms_of">開啟 %s 的條款</string>
     <string name="disconnect_identity_server_dialog_content">從身份識別伺服器 %s 斷線？</string>
-    <string name="template_identity_server_error_outdated_identity_server">此身份識別伺服器太舊了。${app_name} 僅支援 API V2。</string>
+    <string name="identity_server_error_outdated_identity_server">此身份識別伺服器太舊了。${app_name} 僅支援 API V2。</string>
     <string name="identity_server_error_outdated_home_server">此動作是不可能的。家伺服器太舊了。</string>
     <string name="identity_server_error_no_identity_server_configured">請先設定身份識別伺服器。</string>
     <string name="identity_server_error_terms_not_signed">請先在設定中同意身份識別伺服器的條款。</string>
-    <string name="template_identity_server_error_bulk_sha256_not_supported">為了保護您的隱私，${app_name} 僅支援傳送雜湊過的使用者電子郵件與電話號碼。</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">為了保護您的隱私，${app_name} 僅支援傳送雜湊過的使用者電子郵件與電話號碼。</string>
     <string name="identity_server_error_binding_error">關聯失敗。</string>
     <string name="identity_server_error_no_current_binding_error">目前沒有此識別符的關聯。</string>
     <string name="identity_server_set_default_notice">您的家伺服器 (%1$s) 建議將 %2$s 用於您的身份識別伺服器</string>
@@ -2112,7 +2112,7 @@
     <string name="action_copy">複製</string>
     <string name="dialog_title_success">成功</string>
     <string name="bottom_action_notification">通知</string>
-    <string name="template_call_failed_no_connection">${app_name} 呼叫失敗</string>
+    <string name="call_failed_no_connection">${app_name} 呼叫失敗</string>
     <string name="call_failed_no_connection_description">建立即時連線失敗。
 \n請要求您家伺服器的管理員設定 TURN 伺服器以讓通話的運作更可靠。</string>
     <string name="call_select_sound_device">選取音效裝置</string>
@@ -2307,13 +2307,13 @@
     <string name="delete_account_data_warning">刪除類型為 %1$s 的帳號資料？
 \n
 \n小心使用，它可能會導致意料之外的行為。</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_off">每次打開 ${app_name} 時都需要 PIN 碼。</string>
-    <string name="template_settings_security_pin_code_grace_period_summary_on">未使用 ${app_name} 2分鐘後，要求輸入 PIN 碼。</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">每次打開 ${app_name} 時都需要 PIN 碼。</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">未使用 ${app_name} 2分鐘後，要求輸入 PIN 碼。</string>
     <string name="settings_security_pin_code_grace_period_title">2分鐘後要求輸入 PIN 碼</string>
     <string name="settings_security_pin_code_notifications_summary_off">在簡易通知中僅顯示未讀訊息數量。</string>
     <string name="settings_security_pin_code_notifications_summary_on">顯示如聊天室名稱與訊息內容等詳細資訊。</string>
     <string name="settings_security_pin_code_notifications_title">在通知中顯示內容</string>
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">PIN 碼是解鎖 ${app_name} 的唯一方式。</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">PIN 碼是解鎖 ${app_name} 的唯一方式。</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">啟用特定裝置的生物識別技術，如指紋與臉部辨識。</string>
     <string name="settings_security_application_protection_screen_title">設定保護</string>
     <string name="settings_security_application_protection_summary">使用 PIN 碼與生物識別技術來保護存取權。</string>
@@ -2385,8 +2385,8 @@
     <string name="user_code_share">分享我的條碼</string>
     <string name="user_code_scan">掃描 QR code</string>
     <string name="not_a_valid_qr_code">不是有效的 Matrix QR code</string>
-    <string name="template_invite_friends_rich_title">🔐️ 在 ${app_name} 上加入我</string>
-    <string name="template_invite_friends_text">嗨，和我在 ${app_name} 上聊天吧：%s</string>
+    <string name="invite_friends_rich_title">🔐️ 在 ${app_name} 上加入我</string>
+    <string name="invite_friends_text">嗨，和我在 ${app_name} 上聊天吧：%s</string>
     <string name="invite_friends">邀請朋友</string>
     <string name="topic_prefix">"主題： "</string>
     <string name="add_people">新增夥伴</string>
@@ -2499,7 +2499,7 @@
     <string name="settings_show_emoji_keyboard_summary">在訊息編輯器上新增按鈕以開啟表情符號鍵盤</string>
     <string name="settings_show_emoji_keyboard">顯示表情符號鍵盤</string>
     <string name="authentication_error">驗證失敗</string>
-    <string name="template_re_authentication_default_confirm_text">${app_name} 需要您輸入您的憑證來執行此動作。</string>
+    <string name="re_authentication_default_confirm_text">${app_name} 需要您輸入您的憑證來執行此動作。</string>
     <string name="re_authentication_activity_title">需要重新驗證</string>
     <string name="failed_to_initialize_cross_signing">未能設定交叉簽章</string>
     <string name="error_unauthorized">未授權，缺少有效的身份驗證憑證</string>
@@ -2806,7 +2806,7 @@
     <string name="settings_notification_other">其他</string>
     <string name="settings_notification_mentions_and_keywords">提及與關鍵字</string>
     <string name="settings_notification_default">預設通知</string>
-    <string name="template_link_this_email_with_your_account">設定中的 %s 可直接在 ${app_name} 中接收邀請。</string>
+    <string name="link_this_email_with_your_account">設定中的 %s 可直接在 ${app_name} 中接收邀請。</string>
     <string name="link_this_email_settings_link">將此電子郵件與您的帳號連結</string>
     <string name="this_invite_to_this_space_was_sent">此空間的邀請已傳送給與您的帳號無關的 %s</string>
     <string name="this_invite_to_this_room_was_sent">此聊天室的邀請已傳送給與您的帳號無關的 %s</string>
@@ -2963,7 +2963,7 @@
     </plurals>
     <string name="preference_system_settings">系統設定</string>
     <string name="preference_versions">版本</string>
-    <string name="template_preference_help_summary">取得關於使用 ${app_name} 的協助</string>
+    <string name="preference_help_summary">取得關於使用 ${app_name} 的協助</string>
     <string name="preference_help_title">說明與支援</string>
     <string name="preference_help">說明</string>
     <string name="preference_root_legals">法律</string>
@@ -2971,15 +2971,15 @@
     <string name="legals_third_party_notices">第三方函式庫</string>
     <string name="legals_identity_server_title">您的身份識別伺服器政策</string>
     <string name="legals_home_server_title">您的家伺服器政策</string>
-    <string name="template_legals_application_title">${app_name} 政策</string>
+    <string name="legals_application_title">${app_name} 政策</string>
     <string name="analytics_opt_in_list_item_3">您隨時可以在設定中關閉此功能</string>
     <string name="analytics_opt_in_list_item_2">我們<b>不會</b>與第三方分享資訊</string>
     <string name="analytics_opt_in_list_item_1">我們<b>不會</b>記錄或分析任何帳號資料</string>
     <string name="analytics_opt_in_content_link">這裡</string>
-    <string name="template_analytics_opt_in_content">透過分享匿名使用資料協助我們找出問題並改善 ${app_name}。為了了解人們如何使用多裝置，我們將會產生隨機識別字串，在您的裝置間共享。
+    <string name="analytics_opt_in_content">透過分享匿名使用資料協助我們找出問題並改善 ${app_name}。為了了解人們如何使用多裝置，我們將會產生隨機識別字串，在您的裝置間共享。
 \n
 \n您可以閱讀我們的條款 %s。</string>
-    <string name="template_analytics_opt_in_title">協助改善 ${app_name}</string>
+    <string name="analytics_opt_in_title">協助改善 ${app_name}</string>
     <string name="action_enable">啟用</string>
     <string name="restart_the_application_to_apply_changes">重新啟動應用程式以讓變更生效。</string>
     <string name="labs_enable_latex_maths">啟用 LaTeX 數學</string>
@@ -3002,8 +3002,8 @@
     <string name="settings_enable_location_sharing_summary">啟用後，您就能將您的位置傳送至任何聊天室</string>
     <string name="settings_enable_location_sharing">啟用位置分享</string>
     <string name="location_share_external">開啟以</string>
-    <string name="template_location_not_available_dialog_content">${app_name} 無法存取您的位置。請稍後再試。</string>
-    <string name="template_location_not_available_dialog_title">${app_name} 無法存取您的位置</string>
+    <string name="location_not_available_dialog_content">${app_name} 無法存取您的位置。請稍後再試。</string>
+    <string name="location_not_available_dialog_title">${app_name} 無法存取您的位置</string>
     <string name="location_share">分享位置</string>
     <string name="a11y_location_share_icon">分享位置</string>
     <string name="location_activity_title_preview">位置</string>

--- a/vector/src/main/res/values/donottranslate.xml
+++ b/vector/src/main/res/values/donottranslate.xml
@@ -12,7 +12,7 @@
     <string name="matrix_room_alias_prefix" translatable="false">#</string>
 
     <!-- Temporary string -->
-    <string name="template_not_implemented" translatable="false">Not implemented yet in ${app_name}</string>
+    <string name="not_implemented" translatable="false">Not implemented yet in ${app_name}</string>
 
     <!-- onboarding english only word play -->
     <string name="cut_the_slack_from_teams" translatable="false">Cut the slack from teams.</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -513,7 +513,7 @@
     <string name="matrix_only_filter">Matrix contacts only</string>
     <string name="no_conversation_placeholder">No conversations</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_no_contact_access_placeholder">You didn’t allow ${app_name} to access your local contacts</string>
+    <string name="no_contact_access_placeholder">You didn’t allow ${app_name} to access your local contacts</string>
     <string name="no_result_placeholder">No results</string>
     <string name="no_more_results">No more results</string>
     <string name="people_no_identity_server">No identity server configured.</string>
@@ -585,7 +585,7 @@
     <string name="call_failed_dont_ask_again">Do not ask me again</string>
 
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_call_failed_no_connection">${app_name} Call Failed</string>
+    <string name="call_failed_no_connection">${app_name} Call Failed</string>
     <string name="call_failed_no_connection_description">Failed to establish real time connection.\nPlease ask the administrator of your homeserver to configure a TURN server in order for calls to work reliably.</string>
 
     <string name="call_select_sound_device">Select Sound Device</string>
@@ -700,7 +700,7 @@
 
     <string name="e2e_re_request_encryption_key_dialog_title">Request sent</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_e2e_re_request_encryption_key_dialog_content">Please launch ${app_name} on another device that can decrypt the message so it can send the keys to this session.</string>
+    <string name="e2e_re_request_encryption_key_dialog_content">Please launch ${app_name} on another device that can decrypt the message so it can send the keys to this session.</string>
 
     <!-- read receipts list Screen -->
     <string name="read_receipts_list">Read Receipts List</string>
@@ -742,7 +742,7 @@
     <string name="settings_call_show_confirmation_dialog_title">Prevent accidental call</string>
     <string name="settings_call_show_confirmation_dialog_summary">Ask for confirmation before starting a call</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_call_ringtone_use_app_ringtone">Use default ${app_name} ringtone for incoming calls</string>
+    <string name="settings_call_ringtone_use_app_ringtone">Use default ${app_name} ringtone for incoming calls</string>
     <string name="settings_call_ringtone_use_default_stun">Allow fallback call assist server</string>
     <string name="settings_call_ringtone_use_default_stun_sum">Will use "%s" as assist when your homeserver does not offer one (your IP address will be shared during a call)</string>
     <string name="settings_call_ringtone_title">Incoming call ringtone</string>
@@ -794,19 +794,19 @@
     <!-- permissions Android M -->
     <string name="permissions_rationale_popup_title">Information</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_permissions_rationale_msg_storage">${app_name} needs permission to access your photo and video library to send and save attachments.\n\nPlease allow access on the next pop-up to be able to send files from your phone.</string>
+    <string name="permissions_rationale_msg_storage">${app_name} needs permission to access your photo and video library to send and save attachments.\n\nPlease allow access on the next pop-up to be able to send files from your phone.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_permissions_rationale_msg_camera">${app_name} needs permission to access your camera to take pictures and video calls.</string>
+    <string name="permissions_rationale_msg_camera">${app_name} needs permission to access your camera to take pictures and video calls.</string>
     <string name="permissions_rationale_msg_camera_explanation">\n\nPlease allow access on the next pop-up to be able to make the call.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_permissions_rationale_msg_record_audio">${app_name} needs permission to access your microphone to perform audio calls.</string>
+    <string name="permissions_rationale_msg_record_audio">${app_name} needs permission to access your microphone to perform audio calls.</string>
     <string name="permissions_rationale_msg_record_audio_explanation">\n\nPlease allow access on the next pop-up to be able to make the call.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_permissions_rationale_msg_camera_and_audio">${app_name} needs permission to access your camera and your microphone to perform video calls.\n\nPlease allow access on the next pop-ups to be able to make the call.</string>
+    <string name="permissions_rationale_msg_camera_and_audio">${app_name} needs permission to access your camera and your microphone to perform video calls.\n\nPlease allow access on the next pop-ups to be able to make the call.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_permissions_rationale_msg_contacts">${app_name} can check your address book to find other Matrix users based on their email and phone numbers. If you agree to share your address book for this purpose, please allow access on the next pop-up.</string>
+    <string name="permissions_rationale_msg_contacts">${app_name} can check your address book to find other Matrix users based on their email and phone numbers. If you agree to share your address book for this purpose, please allow access on the next pop-up.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_permissions_msg_contacts_warning_other_androids">${app_name} can check your address book to find other Matrix users based on their email and phone numbers.\n\nDo you agree to share your address book for this purpose?</string>
+    <string name="permissions_msg_contacts_warning_other_androids">${app_name} can check your address book to find other Matrix users based on their email and phone numbers.\n\nDo you agree to share your address book for this purpose?</string>
 
     <string name="permissions_action_not_performed_missing_permissions">Sorry. Action not performed, due to missing permissions</string>
     <string name="permissions_denied_qr_code">To scan a QR code, you need to allow camera access.</string>
@@ -1123,7 +1123,7 @@
     <string name="settings_app_info_link_summary">Show the application info in the system settings.</string>
     <string name="settings_add_3pid_confirm_password_title">Confirm your password</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_add_3pid_flow_not_supported">You can\'t do this from ${app_name} mobile</string>
+    <string name="settings_add_3pid_flow_not_supported">You can\'t do this from ${app_name} mobile</string>
     <string name="settings_add_3pid_authentication_needed">Authentication is required</string>
 
     <string name="settings_emails">Email addresses</string>
@@ -1173,7 +1173,7 @@
     <string name="settings_troubleshoot_test_device_settings_title">Session Settings.</string>
     <string name="settings_troubleshoot_test_device_settings_success">Notifications are enabled for this session.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_troubleshoot_test_device_settings_failed">Notifications are not enabled for this session.\nPlease check the ${app_name} settings.</string>
+    <string name="settings_troubleshoot_test_device_settings_failed">Notifications are not enabled for this session.\nPlease check the ${app_name} settings.</string>
     <string name="settings_troubleshoot_test_device_settings_quickfix">Enable</string>
 
     <string name="settings_troubleshoot_test_bing_settings_title">Custom Settings.</string>
@@ -1185,18 +1185,18 @@
     <string name="settings_troubleshoot_test_play_services_title">Play Services Check</string>
     <string name="settings_troubleshoot_test_play_services_success">Google Play Services APK is available and up-to-date.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_troubleshoot_test_play_services_failed">${app_name} uses Google Play Services to deliver push messages but it doesn’t seem to be configured correctly:\n%1$s</string>
+    <string name="settings_troubleshoot_test_play_services_failed">${app_name} uses Google Play Services to deliver push messages but it doesn’t seem to be configured correctly:\n%1$s</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Fix Play Services</string>
 
     <string name="settings_troubleshoot_test_fcm_title">Firebase Token</string>
     <string name="settings_troubleshoot_test_fcm_success">FCM token successfully retrieved:\n%1$s</string>
     <string name="settings_troubleshoot_test_fcm_failed">Failed to retrieved FCM token:\n%1$s</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]\nThis error is out of control of ${app_name} and according to Google, this error indicates that the device has too many apps registered with FCM. The error only occurs in cases where there are extreme numbers of apps, so it should not affect the average user.</string>
+    <string name="settings_troubleshoot_test_fcm_failed_too_many_registration">[%1$s]\nThis error is out of control of ${app_name} and according to Google, this error indicates that the device has too many apps registered with FCM. The error only occurs in cases where there are extreme numbers of apps, so it should not affect the average user.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]\nThis error is out of control of ${app_name}. It can occur for several reasons. Maybe it will work if you retry later, you can also check that Google Play Service is not restricted in data usage in the system settings, or that your device clock is correct, or it can happen on custom ROM.</string>
+    <string name="settings_troubleshoot_test_fcm_failed_service_not_available">[%1$s]\nThis error is out of control of ${app_name}. It can occur for several reasons. Maybe it will work if you retry later, you can also check that Google Play Service is not restricted in data usage in the system settings, or that your device clock is correct, or it can happen on custom ROM.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]\nThis error is out of control of ${app_name}. There is no Google account on the phone. Please open the account manager and add a Google account.</string>
+    <string name="settings_troubleshoot_test_fcm_failed_account_missing">[%1$s]\nThis error is out of control of ${app_name}. There is no Google account on the phone. Please open the account manager and add a Google account.</string>
     <string name="settings_troubleshoot_test_fcm_failed_account_missing_quick_fix">Add Account</string>
 
     <string name="settings_troubleshoot_test_token_registration_title">Token Registration</string>
@@ -1219,19 +1219,19 @@
     <string name="settings_troubleshoot_test_service_boot_title">Start on boot</string>
     <string name="settings_troubleshoot_test_service_boot_success">Service will start when the device is restarted.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_troubleshoot_test_service_boot_failed">The service will not start when the device is restarted, you will not receive notifications until ${app_name} has been opened once.</string>
+    <string name="settings_troubleshoot_test_service_boot_failed">The service will not start when the device is restarted, you will not receive notifications until ${app_name} has been opened once.</string>
     <string name="settings_troubleshoot_test_service_boot_quickfix">Enable Start on boot</string>
 
     <string name="settings_troubleshoot_test_bg_restricted_title">Check background restrictions</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_troubleshoot_test_bg_restricted_success">Background restrictions are disabled for ${app_name}. This test should be run using mobile data (no WIFI).\n%1$s</string>
+    <string name="settings_troubleshoot_test_bg_restricted_success">Background restrictions are disabled for ${app_name}. This test should be run using mobile data (no WIFI).\n%1$s</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_troubleshoot_test_bg_restricted_failed">Background restrictions are enabled for ${app_name}.\nWork that the app tries to do will be aggressively restricted while it is in the background, and this could affect notifications.\n%1$s</string>
+    <string name="settings_troubleshoot_test_bg_restricted_failed">Background restrictions are enabled for ${app_name}.\nWork that the app tries to do will be aggressively restricted while it is in the background, and this could affect notifications.\n%1$s</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Disable restrictions</string>
 
     <string name="settings_troubleshoot_test_battery_title">Battery Optimization</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_troubleshoot_test_battery_success">${app_name} is not affected by Battery Optimization.</string>
+    <string name="settings_troubleshoot_test_battery_success">${app_name} is not affected by Battery Optimization.</string>
     <string name="settings_troubleshoot_test_battery_failed">If a user leaves a device unplugged and stationary for a period of time, with the screen off, the device enters Doze mode. This prevents apps from accessing the network and defers their jobs, syncs, and standard alarms. </string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignore Optimization</string>
 
@@ -1283,10 +1283,10 @@
     <string name="settings_background_fdroid_sync_mode">Background Sync Mode</string>
     <string name="settings_background_fdroid_sync_mode_battery">Optimized for battery</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_background_fdroid_sync_mode_battery_description">${app_name} will sync in background in way that preserves the device’s limited resources (battery).\nDepending on your device resource state, the sync may be deferred by the operating system.</string>
+    <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} will sync in background in way that preserves the device’s limited resources (battery).\nDepending on your device resource state, the sync may be deferred by the operating system.</string>
     <string name="settings_background_fdroid_sync_mode_real_time">Optimized for real time</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_background_fdroid_sync_mode_real_time_description">${app_name} will sync in background periodically at precise time (configurable).\nThis will impact radio and battery usage, there will be a permanent notification displayed stating that ${app_name} is listening for events.</string>
+    <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} will sync in background periodically at precise time (configurable).\nThis will impact radio and battery usage, there will be a permanent notification displayed stating that ${app_name} is listening for events.</string>
     <string name="settings_background_fdroid_sync_mode_disabled">No background sync</string>
     <string name="settings_background_fdroid_sync_mode_disabled_description">You will not be notified of incoming messages when the app is in background.</string>
     <string name="settings_background_sync_update_error">Failed to update settings.</string>
@@ -1370,27 +1370,27 @@
     <string name="settings_discovery_manage">Manage your discovery settings.</string>
     <string name="startup_notification_privacy_title">Notification Privacy</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_startup_notification_privacy_message">${app_name} can run in the background to manage your notifications securely and privately. This might affect battery usage.</string>
+    <string name="startup_notification_privacy_message">${app_name} can run in the background to manage your notifications securely and privately. This might affect battery usage.</string>
     <string name="startup_notification_privacy_button_grant">Grant permission</string>
     <string name="startup_notification_privacy_button_other">Choose another option</string>
 
     <string name="startup_notification_fdroid_battery_optim_title">Background Connection</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_startup_notification_fdroid_battery_optim_message">${app_name} needs to keep a low impact background connection in order to have reliable notifications.\nOn the next screen you will be prompted to allow ${app_name} to always run in background, please accept.</string>
+    <string name="startup_notification_fdroid_battery_optim_message">${app_name} needs to keep a low impact background connection in order to have reliable notifications.\nOn the next screen you will be prompted to allow ${app_name} to always run in background, please accept.</string>
     <string name="startup_notification_fdroid_battery_optim_button_grant">Grant permission</string>
 
     <!-- analytics -->
     <string name="settings_analytics">Analytics</string>
     <string name="settings_opt_in_of_analytics">Send analytics data</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_opt_in_of_analytics_summary">${app_name} collects anonymous analytics to allow us to improve the application.</string>
+    <string name="settings_opt_in_of_analytics_summary">${app_name} collects anonymous analytics to allow us to improve the application.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_opt_in_of_analytics_prompt">Please enable analytics to help us improve ${app_name}.</string>
+    <string name="settings_opt_in_of_analytics_prompt">Please enable analytics to help us improve ${app_name}.</string>
     <string name="settings_opt_in_of_analytics_ok">Yes, I want to help!</string>
 
-    <string name="template_analytics_opt_in_title">Help improve ${app_name}</string>
+    <string name="analytics_opt_in_title">Help improve ${app_name}</string>
     <!-- The template will be replaced by the value of the resource analytics_opt_in_content_link -->
-    <string name="template_analytics_opt_in_content">Help us identify issues and improve ${app_name} by sharing anonymous usage data. To understand how people use multiple devices, we’ll generate a random identifier, shared by your devices.\n\nYou can read all our terms %s.</string>
+    <string name="analytics_opt_in_content">Help us identify issues and improve ${app_name} by sharing anonymous usage data. To understand how people use multiple devices, we’ll generate a random identifier, shared by your devices.\n\nYou can read all our terms %s.</string>
     <string name="analytics_opt_in_content_link">here</string>
     <string name="analytics_opt_in_list_item_1">We <b>don\'t</b> record or profile any account data</string>
     <string name="analytics_opt_in_list_item_2">We <b>don\'t</b> share information with third parties</string>
@@ -1416,7 +1416,7 @@
     <string name="settings_integration_allow">Allow integrations</string>
     <string name="settings_integration_manager">Integration manager</string>
 
-    <string name="template_legals_application_title">${app_name} policy</string>
+    <string name="legals_application_title">${app_name} policy</string>
     <string name="legals_home_server_title">Your homeserver policy</string>
     <string name="legals_identity_server_title">Your identity server policy</string>
     <string name="legals_third_party_notices">Third party libraries</string>
@@ -2004,7 +2004,7 @@
     <!-- Key Backup -->
 
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_keys_backup_passphrase_not_empty_error_message">Please delete the passphrase if you want ${app_name} to generate a recovery key.</string>
+    <string name="keys_backup_passphrase_not_empty_error_message">Please delete the passphrase if you want ${app_name} to generate a recovery key.</string>
     <string name="keys_backup_no_session_error">No Matrix session available</string>
 
     <string name="keys_backup_setup_step1_title">Never lose encrypted messages</string>
@@ -2147,7 +2147,7 @@
     <string name="autodiscover_invalid_response">Invalid homeserver discovery response</string>
     <string name="autodiscover_well_known_autofill_dialog_title">"Autocomplete Server Options</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_autodiscover_well_known_autofill_dialog_message">${app_name} detected a custom server configuration for your userId domain \"%1$s\":\n%2$s</string>
+    <string name="autodiscover_well_known_autofill_dialog_message">${app_name} detected a custom server configuration for your userId domain \"%1$s\":\n%2$s</string>
     <string name="autodiscover_well_known_autofill_confirm">Use Config</string>
 
     <string name="invalid_or_expired_credentials">You have been logged out due to invalid or expired credentials.</string>
@@ -2244,7 +2244,7 @@
 
     <string name="room_preview_no_preview">"This room can't be previewed"</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_room_preview_world_readable_room_not_supported_yet">The preview of world-readable room is not supported yet in ${app_name}</string>
+    <string name="room_preview_world_readable_room_not_supported_yet">The preview of world-readable room is not supported yet in ${app_name}</string>
     <string name="room_preview_not_found">This room is not accessible at this time.\nTry again later, or ask a room admin to check if you have access.</string>
     <string name="room_preview_no_preview_join">"This room can't be previewed. Do you want to join it?"</string>
     <string name="fab_menu_create_room">"Rooms"</string>
@@ -2298,7 +2298,7 @@
 
     <string name="preference_help">Help</string>
     <string name="preference_help_title">Help and support</string>
-    <string name="template_preference_help_summary">Get help with using ${app_name}</string>
+    <string name="preference_help_summary">Get help with using ${app_name}</string>
     <string name="preference_versions">Versions</string>
     <string name="preference_system_settings">System settings</string>
 
@@ -2503,7 +2503,7 @@
     <string name="content_reported_as_inappropriate_content">"This content was reported as inappropriate.\n\nIf you don't want to see any more content from this user, you can ignore them to hide their messages."</string>
 
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_permissions_rationale_msg_keys_backup_export">${app_name} needs permission to save your E2E keys on disk.\n\nPlease allow access on the next pop-up to be able to export your keys manually.</string>
+    <string name="permissions_rationale_msg_keys_backup_export">${app_name} needs permission to save your E2E keys on disk.\n\nPlease allow access on the next pop-up to be able to export your keys manually.</string>
 
     <string name="no_network_indicator">There is no network connection right now</string>
 
@@ -2550,7 +2550,7 @@
     <string name="ftue_auth_carousel_control_body">Choose where your conversations are kept, giving you control and independence. Connected via Matrix.</string>
     <string name="ftue_auth_carousel_encrypted_body">End-to-end encrypted and no phone number required. No ads or datamining.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_ftue_auth_carousel_workplace_body" translatable="false">${app_name} is also great for the workplace. It’s trusted by the world’s most secure organisations.</string>
+    <string name="ftue_auth_carousel_workplace_body" translatable="false">${app_name} is also great for the workplace. It’s trusted by the world’s most secure organisations.</string>
 
     <string name="ftue_auth_use_case_title">Who will you chat to the most?</string>
     <string name="ftue_auth_use_case_subtitle">We\'ll help you get connected.</string>
@@ -2722,7 +2722,7 @@
     <string name="soft_logout_clear_data_dialog_e2e_warning_content">You’ll lose access to secure messages unless you sign in to recover your encryption keys.</string>
     <string name="soft_logout_clear_data_dialog_submit">Clear data</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_soft_logout_sso_not_same_user_error">The current session is for user %1$s and you provide credentials for user %2$s. This is not supported by ${app_name}.\nPlease first clear data, then sign in again on another account.</string>
+    <string name="soft_logout_sso_not_same_user_error">The current session is for user %1$s and you provide credentials for user %2$s. This is not supported by ${app_name}.\nPlease first clear data, then sign in again on another account.</string>
 
     <string name="permalink_malformed">Your matrix.to link was malformed</string>
     <string name="bug_report_error_too_short">The description is too short</string>
@@ -2745,7 +2745,7 @@
 
     <string name="settings_developer_mode_fail_fast_title">Fail-fast</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_developer_mode_fail_fast_summary">${app_name} may crash more often when an unexpected error occurs</string>
+    <string name="settings_developer_mode_fail_fast_summary">${app_name} may crash more often when an unexpected error occurs</string>
 
     <string name="settings_developer_mode_show_info_on_screen_title">Show debug info on screen</string>
     <string name="settings_developer_mode_show_info_on_screen_summary">Show some useful info to help debugging the application</string>
@@ -2866,11 +2866,11 @@
     <string name="room_member_jump_to_read_receipt">Jump to read receipt</string>
 
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_rendering_event_error_type_of_event_not_handled">${app_name} does not handle events of type \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_event_not_handled">${app_name} does not handle events of type \'%1$s\'</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_rendering_event_error_type_of_message_not_handled">${app_name} does not handle message of type \'%1$s\'</string>
+    <string name="rendering_event_error_type_of_message_not_handled">${app_name} does not handle message of type \'%1$s\'</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_rendering_event_error_exception">${app_name} encountered an issue when rendering content of event with id \'%1$s\'</string>
+    <string name="rendering_event_error_exception">${app_name} encountered an issue when rendering content of event with id \'%1$s\'</string>
 
     <string name="unignore">Unignore</string>
 
@@ -3009,7 +3009,7 @@
     <string name="keys_backup_restore_success_title_already_up_to_date">Keys are already up to date!</string>
 
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_login_default_session_public_name">${app_name} Android</string>
+    <string name="login_default_session_public_name">${app_name} Android</string>
 
     <string name="settings_key_requests">Key Requests</string>
     <string name="settings_export_trail">Export Audit</string>
@@ -3166,14 +3166,14 @@
     <string name="change_password_summary">Set a new account password…</string>
 
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_use_other_session_content_description">Use the latest ${app_name} on your other devices, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} for Android, or another cross-signing capable Matrix client</string>
+    <string name="use_other_session_content_description">Use the latest ${app_name} on your other devices, ${app_name} Web, ${app_name} Desktop, ${app_name} iOS, ${app_name} for Android, or another cross-signing capable Matrix client</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_app_desktop_web">${app_name} Web\n${app_name} Desktop</string>
+    <string name="app_desktop_web">${app_name} Web\n${app_name} Desktop</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_app_ios_android">${app_name} iOS\n${app_name} Android</string>
+    <string name="app_ios_android">${app_name} iOS\n${app_name} Android</string>
     <string name="or_other_mx_capable_client">or another cross-signing capable Matrix client</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_use_latest_app">Use the latest ${app_name} on your other devices:</string>
+    <string name="use_latest_app">Use the latest ${app_name} on your other devices:</string>
     <string name="command_description_discard_session">Forces the current outbound group session in an encrypted room to be discarded</string>
     <string name="command_description_discard_session_not_handled">Only supported in encrypted rooms</string>
     <!-- first will be replaced by recovery_passphrase, second will be replaced by recovery_key-->
@@ -3229,9 +3229,9 @@
     <string name="invite_users_to_room_title">Invite Users</string>
     <string name="invite_friends">Invite friends</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_invite_friends_text">Hey, talk to me on ${app_name}: %s</string>
+    <string name="invite_friends_text">Hey, talk to me on ${app_name}: %s</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_invite_friends_rich_title">🔐️ Join me on ${app_name}</string>
+    <string name="invite_friends_rich_title">🔐️ Join me on ${app_name}</string>
     <string name="invitation_sent_to_one_user">Invitation sent to %1$s</string>
     <string name="invitations_sent_to_two_users">Invitations sent to %1$s and %2$s</string>
     <string name="not_a_valid_qr_code">"It's not a valid matrix QR code"</string>
@@ -3253,12 +3253,12 @@
     <string name="open_terms_of">Open terms of %s</string>
     <string name="disconnect_identity_server_dialog_content">Disconnect from the identity server %s?</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_identity_server_error_outdated_identity_server">This identity server is outdated. ${app_name} support only API V2.</string>
+    <string name="identity_server_error_outdated_identity_server">This identity server is outdated. ${app_name} support only API V2.</string>
     <string name="identity_server_error_outdated_home_server">This operation is not possible. The homeserver is outdated.</string>
     <string name="identity_server_error_no_identity_server_configured">Please first configure an identity server.</string>
     <string name="identity_server_error_terms_not_signed">Please first accepts the terms of the identity server in the settings.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_identity_server_error_bulk_sha256_not_supported">For your privacy, ${app_name} only supports sending hashed user emails and phone number.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">For your privacy, ${app_name} only supports sending hashed user emails and phone number.</string>
     <string name="identity_server_error_binding_error">The association has failed.</string>
     <string name="identity_server_error_no_current_binding_error">There is no current association with this identifier.</string>
     <string name="identity_server_user_consent_not_provided">The user consent has not been provided.</string>
@@ -3363,15 +3363,15 @@
     <string name="settings_security_pin_code_use_biometrics_title">Enable biometrics</string>
     <string name="settings_security_pin_code_use_biometrics_summary_on">Enable device specific biometrics, like fingerprints and face recognition.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_security_pin_code_use_biometrics_summary_off">PIN code is the only way to unlock ${app_name}.</string>
+    <string name="settings_security_pin_code_use_biometrics_summary_off">PIN code is the only way to unlock ${app_name}.</string>
     <string name="settings_security_pin_code_notifications_title">Show content in notifications</string>
     <string name="settings_security_pin_code_notifications_summary_on">Show details like room names and message content.</string>
     <string name="settings_security_pin_code_notifications_summary_off">Only display number of unread messages in a simple notification.</string>
     <string name="settings_security_pin_code_grace_period_title">Require PIN after 2 minutes</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_security_pin_code_grace_period_summary_on">PIN code is required after 2 minutes of not using ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_on">PIN code is required after 2 minutes of not using ${app_name}.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_settings_security_pin_code_grace_period_summary_off">PIN code is required every time you open ${app_name}.</string>
+    <string name="settings_security_pin_code_grace_period_summary_off">PIN code is required every time you open ${app_name}.</string>
     <string name="settings_security_pin_code_change_pin_title">Change PIN</string>
     <string name="settings_security_pin_code_change_pin_summary">Change your current PIN</string>
     <string name="auth_pin_confirm_to_disable_title">Confirm PIN to disable PIN</string>
@@ -3447,7 +3447,7 @@
 
     <string name="re_authentication_activity_title">Re-Authentication Needed</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="template_re_authentication_default_confirm_text">${app_name} requires you to enter your credentials to perform this action.</string>
+    <string name="re_authentication_default_confirm_text">${app_name} requires you to enter your credentials to perform this action.</string>
     <string name="authentication_error">Failed to authenticate</string>
 
     <string name="a11y_screenshot">Screenshot</string>
@@ -3686,7 +3686,7 @@
 
     <string name="link_this_email_settings_link">Link this email with your account</string>
     <!-- %s will be replaced by the value of link_this_email_settings_link and styled as a link -->
-    <string name="template_link_this_email_with_your_account">%s in Settings to receive invites directly in ${app_name}.</string>
+    <string name="link_this_email_with_your_account">%s in Settings to receive invites directly in ${app_name}.</string>
 
     <string name="labs_enable_latex_maths">Enable LaTeX mathematics</string>
     <string name="restart_the_application_to_apply_changes">Restart the application for the change to take effect.</string>
@@ -3744,8 +3744,8 @@
     <string name="a11y_location_share_icon">Share location</string>
     <string name="a11y_static_map_image">Map</string>
     <string name="location_share">Share location</string>
-    <string name="template_location_not_available_dialog_title">${app_name} could not access your location</string>
-    <string name="template_location_not_available_dialog_content">${app_name} could not access your location. Please try again later.</string>
+    <string name="location_not_available_dialog_title">${app_name} could not access your location</string>
+    <string name="location_not_available_dialog_content">${app_name} could not access your location. Please try again later.</string>
     <string name="location_share_external">Open with</string>
     <string name="settings_enable_location_sharing">Enable location sharing</string>
     <string name="settings_enable_location_sharing_summary">Once enabled you will be able to send your location to any room</string>


### PR DESCRIPTION
Fixes #5341 

Upgrade the dependency to generate strings using template.

It requires changing lots of strings key. But Weblate is currently locked, so this is fine.

1st and 3rd commit are interesting, the 2nd one is basically replacing `<string name="template_` by `<string name="` everywhere.

Tested OK on this screen for instance, where title and subtitle contains a template:

<img width="429" alt="image" src="https://user-images.githubusercontent.com/3940906/155546663-c4f0d6da-48cf-43ae-bf18-51942066fb50.png">
