### PR TITLE
[Export e2ee keys] use appName instead of element

### DIFF
--- a/changelog.d/5326.misc
+++ b/changelog.d/5326.misc
@@ -1,0 +1,1 @@
+[Export e2ee keys] use appName instead of element

--- a/vector/src/main/java/im/vector/app/core/extensions/Fragment.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/Fragment.kt
@@ -169,7 +169,7 @@ const val POP_BACK_STACK_EXCLUSIVE = 0
 
 fun Fragment.queryExportKeys(userId: String, activityResultLauncher: ActivityResultLauncher<Intent>) {
     val timestamp = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date())
-    val appName = getString(R.string.app_name)
+    val appName = getString(R.string.app_name).replace(" ", "-")
 
     selectTxtFileToWrite(
             activity = requireActivity(),
@@ -181,7 +181,7 @@ fun Fragment.queryExportKeys(userId: String, activityResultLauncher: ActivityRes
 
 fun Activity.queryExportKeys(userId: String, activityResultLauncher: ActivityResultLauncher<Intent>) {
     val timestamp = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date())
-    val appName = getString(R.string.app_name)
+    val appName = getString(R.string.app_name).replace(" ", "-")
 
     selectTxtFileToWrite(
             activity = this,

--- a/vector/src/main/java/im/vector/app/core/extensions/Fragment.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/Fragment.kt
@@ -169,22 +169,24 @@ const val POP_BACK_STACK_EXCLUSIVE = 0
 
 fun Fragment.queryExportKeys(userId: String, activityResultLauncher: ActivityResultLauncher<Intent>) {
     val timestamp = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date())
+    val appName = getString(R.string.app_name)
 
     selectTxtFileToWrite(
             activity = requireActivity(),
             activityResultLauncher = activityResultLauncher,
-            defaultFileName = "element-megolm-export-$userId-$timestamp.txt",
+            defaultFileName = "$appName-megolm-export-$userId-$timestamp.txt",
             chooserHint = getString(R.string.keys_backup_setup_step1_manual_export)
     )
 }
 
 fun Activity.queryExportKeys(userId: String, activityResultLauncher: ActivityResultLauncher<Intent>) {
     val timestamp = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date())
+    val appName = getString(R.string.app_name)
 
     selectTxtFileToWrite(
             activity = this,
             activityResultLauncher = activityResultLauncher,
-            defaultFileName = "element-megolm-export-$userId-$timestamp.txt",
+            defaultFileName = "$appName-megolm-export-$userId-$timestamp.txt",
             chooserHint = getString(R.string.keys_backup_setup_step1_manual_export)
     )
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [] Bugfix
- [ ] Technical
- [X] Other : Improvement 

## Content
Use the appName instead of the string "element" in the filename.
<!-- Describe shortly what has been changed -->

## Motivation and context
In forked application like Tchap, we have "element" in the name of the file.

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
For element debug
![Screenshot_1645780114](https://user-images.githubusercontent.com/15031750/155687452-66938fce-8d06-4360-9af9-7cfad455ae5b.png)

<!-- Only if UI have been changed -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s): 30

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [X] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
