### PR TITLE
Lifting debug overrides to their own abstraction

### DIFF
--- a/changelog.d/5361.misc
+++ b/changelog.d/5361.misc
@@ -1,0 +1,1 @@
+Creates dedicated VectorOverrides for forcing behaviour for local testing/development

--- a/vector/src/debug/java/im/vector/app/features/debug/di/FeaturesModule.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/di/FeaturesModule.kt
@@ -23,8 +23,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import im.vector.app.features.DefaultVectorFeatures
+import im.vector.app.features.DefaultVectorOverrides
 import im.vector.app.features.VectorFeatures
+import im.vector.app.features.VectorOverrides
 import im.vector.app.features.debug.features.DebugVectorFeatures
+import im.vector.app.features.debug.features.DebugVectorOverrides
 
 @InstallIn(SingletonComponent::class)
 @Module
@@ -32,6 +35,9 @@ interface FeaturesModule {
 
     @Binds
     fun bindFeatures(debugFeatures: DebugVectorFeatures): VectorFeatures
+
+    @Binds
+    fun bindOverrides(debugOverrides: DebugVectorOverrides): VectorOverrides
 
     companion object {
 
@@ -43,6 +49,16 @@ interface FeaturesModule {
         @Provides
         fun providesDebugVectorFeatures(context: Context, defaultVectorFeatures: DefaultVectorFeatures): DebugVectorFeatures {
             return DebugVectorFeatures(context, defaultVectorFeatures)
+        }
+
+        @Provides
+        fun providesDefaultVectorOverrides(): DefaultVectorOverrides {
+            return DefaultVectorOverrides()
+        }
+
+        @Provides
+        fun providesDebugVectorOverrides(context: Context): DebugVectorOverrides {
+            return DebugVectorOverrides(context)
         }
     }
 }

--- a/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorOverrides.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorOverrides.kt
@@ -23,36 +23,32 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
 import im.vector.app.features.VectorOverrides
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.matrix.android.sdk.api.extensions.orFalse
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "vector_overrides")
-private val forceDialPadDisplay = booleanPreferencesKey("force_dial_pad_display")
-private val forceLoginFallback = booleanPreferencesKey("force_login_fallback")
+private val keyForceDialPadDisplay = booleanPreferencesKey("force_dial_pad_display")
+private val keyForceLoginFallback = booleanPreferencesKey("force_login_fallback")
 
 class DebugVectorOverrides(private val context: Context) : VectorOverrides {
 
-    override fun forceDialPad() = forceDialPadDisplayFlow
-    override fun forceLoginFallback() = forceLoginFallbackFlow
+    override val forceDialPad = context.dataStore.data.map { preferences ->
+        preferences[keyForceDialPadDisplay].orFalse()
+    }
+
+    override val forceLoginFallback = context.dataStore.data.map { preferences ->
+        preferences[keyForceLoginFallback].orFalse()
+    }
 
     suspend fun setForceDialPadDisplay(force: Boolean) {
         context.dataStore.edit { settings ->
-            settings[forceDialPadDisplay] = force
+            settings[keyForceDialPadDisplay] = force
         }
-    }
-
-    private val forceDialPadDisplayFlow: Flow<Boolean> = context.dataStore.data.map { preferences ->
-        preferences[forceDialPadDisplay].orFalse()
     }
 
     suspend fun setForceLoginFallback(force: Boolean) {
         context.dataStore.edit { settings ->
-            settings[forceLoginFallback] = force
+            settings[keyForceLoginFallback] = force
         }
-    }
-
-    private val forceLoginFallbackFlow: Flow<Boolean> = context.dataStore.data.map { preferences ->
-        preferences[forceLoginFallback].orFalse()
     }
 }

--- a/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorOverrides.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorOverrides.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.debug.features
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import im.vector.app.features.VectorOverrides
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.matrix.android.sdk.api.extensions.orFalse
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "vector_overrides")
+private val forceDialPadDisplay = booleanPreferencesKey("force_dial_pad_display")
+private val forceLoginFallback = booleanPreferencesKey("force_login_fallback")
+
+class DebugVectorOverrides(private val context: Context) : VectorOverrides {
+
+    override fun forceDialPad() = forceDialPadDisplayFlow
+    override fun forceLoginFallback() = forceLoginFallbackFlow
+
+    suspend fun setForceDialPadDisplay(force: Boolean) {
+        context.dataStore.edit { settings ->
+            settings[forceDialPadDisplay] = force
+        }
+    }
+
+    private val forceDialPadDisplayFlow: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[forceDialPadDisplay].orFalse()
+    }
+
+    suspend fun setForceLoginFallback(force: Boolean) {
+        context.dataStore.edit { settings ->
+            settings[forceLoginFallback] = force
+        }
+    }
+
+    private val forceLoginFallbackFlow: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[forceLoginFallback].orFalse()
+    }
+}

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsFragment.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsFragment.kt
@@ -50,5 +50,6 @@ class DebugPrivateSettingsFragment : VectorBaseFragment<FragmentDebugPrivateSett
 
     override fun invalidate() = withState(viewModel) {
         views.forceDialPadTabDisplay.isChecked = it.dialPadVisible
+        views.forceLoginFallback.isChecked = it.forceLoginFallback
     }
 }

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewModel.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewModel.kt
@@ -44,12 +44,12 @@ class DebugPrivateSettingsViewModel @AssistedInject constructor(
     }
 
     private fun observeVectorDataStore() {
-        debugVectorOverrides.forceDialPad().setOnEach {
+        debugVectorOverrides.forceDialPad.setOnEach {
             copy(
                     dialPadVisible = it
             )
         }
-        debugVectorOverrides.forceLoginFallback().setOnEach {
+        debugVectorOverrides.forceLoginFallback.setOnEach {
             copy(forceLoginFallback = it)
         }
     }

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewModel.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewModel.kt
@@ -24,12 +24,12 @@ import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.EmptyViewEvents
 import im.vector.app.core.platform.VectorViewModel
-import im.vector.app.features.settings.VectorDataStore
+import im.vector.app.features.debug.features.DebugVectorOverrides
 import kotlinx.coroutines.launch
 
 class DebugPrivateSettingsViewModel @AssistedInject constructor(
         @Assisted initialState: DebugPrivateSettingsViewState,
-        private val vectorDataStore: VectorDataStore
+        private val debugVectorOverrides: DebugVectorOverrides
 ) : VectorViewModel<DebugPrivateSettingsViewState, DebugPrivateSettingsViewActions, EmptyViewEvents>(initialState) {
 
     @AssistedFactory
@@ -44,11 +44,12 @@ class DebugPrivateSettingsViewModel @AssistedInject constructor(
     }
 
     private fun observeVectorDataStore() {
-        vectorDataStore.forceDialPadDisplayFlow.setOnEach {
-            copy(dialPadVisible = it)
+        debugVectorOverrides.forceDialPad().setOnEach {
+            copy(
+                    dialPadVisible = it
+            )
         }
-
-        vectorDataStore.forceLoginFallbackFlow.setOnEach {
+        debugVectorOverrides.forceLoginFallback().setOnEach {
             copy(forceLoginFallback = it)
         }
     }
@@ -62,13 +63,13 @@ class DebugPrivateSettingsViewModel @AssistedInject constructor(
 
     private fun handleSetDialPadVisibility(action: DebugPrivateSettingsViewActions.SetDialPadVisibility) {
         viewModelScope.launch {
-            vectorDataStore.setForceDialPadDisplay(action.force)
+            debugVectorOverrides.setForceDialPadDisplay(action.force)
         }
     }
 
     private fun handleSetForceLoginFallbackEnabled(action: DebugPrivateSettingsViewActions.SetForceLoginFallbackEnabled) {
         viewModelScope.launch {
-            vectorDataStore.setForceLoginFallbackFlow(action.force)
+            debugVectorOverrides.setForceLoginFallback(action.force)
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/DefaultVectorOverrides.kt
+++ b/vector/src/main/java/im/vector/app/features/DefaultVectorOverrides.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+interface VectorOverrides {
+    fun forceDialPad(): Flow<Boolean>
+    fun forceLoginFallback(): Flow<Boolean>
+}
+
+class DefaultVectorOverrides : VectorOverrides {
+    override fun forceDialPad() = flowOf(false)
+    override fun forceLoginFallback() = flowOf(false)
+}

--- a/vector/src/main/java/im/vector/app/features/DefaultVectorOverrides.kt
+++ b/vector/src/main/java/im/vector/app/features/DefaultVectorOverrides.kt
@@ -20,11 +20,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
 interface VectorOverrides {
-    fun forceDialPad(): Flow<Boolean>
-    fun forceLoginFallback(): Flow<Boolean>
+    val forceDialPad: Flow<Boolean>
+    val forceLoginFallback: Flow<Boolean>
 }
 
 class DefaultVectorOverrides : VectorOverrides {
-    override fun forceDialPad() = flowOf(false)
-    override fun forceLoginFallback() = flowOf(false)
+    override val forceDialPad = flowOf(false)
+    override val forceLoginFallback = flowOf(false)
 }

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
@@ -108,7 +108,7 @@ class HomeDetailViewModel @AssistedInject constructor(
                     pushCounter = nbOfPush
             )
         }
-        vectorOverrides.forceDialPad().setOnEach { force ->
+        vectorOverrides.forceDialPad.setOnEach { force ->
             copy(
                     forceDialPadTab = force
             )

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
@@ -28,6 +28,7 @@ import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.extensions.singletonEntryPoint
 import im.vector.app.core.platform.VectorViewModel
+import im.vector.app.features.VectorOverrides
 import im.vector.app.features.call.dialpad.DialPadLookup
 import im.vector.app.features.call.lookup.CallProtocolsChecker
 import im.vector.app.features.call.webrtc.WebRtcCallManager
@@ -67,7 +68,8 @@ class HomeDetailViewModel @AssistedInject constructor(
         private val callManager: WebRtcCallManager,
         private val directRoomHelper: DirectRoomHelper,
         private val appStateHandler: AppStateHandler,
-        private val autoAcceptInvites: AutoAcceptInvites
+        private val autoAcceptInvites: AutoAcceptInvites,
+        private val vectorOverrides: VectorOverrides
 ) : VectorViewModel<HomeDetailViewState, HomeDetailAction, HomeDetailViewEvents>(initialState),
         CallProtocolsChecker.Listener {
 
@@ -106,8 +108,7 @@ class HomeDetailViewModel @AssistedInject constructor(
                     pushCounter = nbOfPush
             )
         }
-
-        vectorDataStore.forceDialPadDisplayFlow.setOnEach { force ->
+        vectorOverrides.forceDialPad().setOnEach { force ->
             copy(
                     forceDialPadTab = force
             )

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -104,7 +104,7 @@ class OnboardingViewModel @AssistedInject constructor(
     }
 
     private fun observeDataStore() = viewModelScope.launch {
-        vectorOverrides.forceLoginFallback().setOnEach { isForceLoginFallbackEnabled ->
+        vectorOverrides.forceLoginFallback.setOnEach { isForceLoginFallbackEnabled ->
             copy(isForceLoginFallbackEnabled = isForceLoginFallbackEnabled)
         }
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -37,6 +37,7 @@ import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.utils.ensureTrailingSlash
 import im.vector.app.features.VectorFeatures
+import im.vector.app.features.VectorOverrides
 import im.vector.app.features.analytics.AnalyticsTracker
 import im.vector.app.features.analytics.extensions.toTrackingValue
 import im.vector.app.features.analytics.plan.UserProperties
@@ -81,6 +82,7 @@ class OnboardingViewModel @AssistedInject constructor(
         private val vectorFeatures: VectorFeatures,
         private val analyticsTracker: AnalyticsTracker,
         private val vectorDataStore: VectorDataStore,
+        private val vectorOverrides: VectorOverrides
 ) : VectorViewModel<OnboardingViewState, OnboardingAction, OnboardingViewEvents>(initialState) {
 
     @AssistedFactory
@@ -102,7 +104,7 @@ class OnboardingViewModel @AssistedInject constructor(
     }
 
     private fun observeDataStore() = viewModelScope.launch {
-        vectorDataStore.forceLoginFallbackFlow.setOnEach { isForceLoginFallbackEnabled ->
+        vectorOverrides.forceLoginFallback().setOnEach { isForceLoginFallbackEnabled ->
             copy(isForceLoginFallbackEnabled = isForceLoginFallbackEnabled)
         }
     }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorDataStore.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorDataStore.kt
@@ -19,13 +19,11 @@ package im.vector.app.features.settings
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import org.matrix.android.sdk.api.extensions.orFalse
 import javax.inject.Inject
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "vector_settings")
@@ -44,31 +42,6 @@ class VectorDataStore @Inject constructor(
         context.dataStore.edit { settings ->
             val currentCounterValue = settings[pushCounter] ?: 0
             settings[pushCounter] = currentCounterValue + 1
-        }
-    }
-
-    // For debug only
-    private val forceDialPadDisplay = booleanPreferencesKey("force_dial_pad_display")
-
-    val forceDialPadDisplayFlow: Flow<Boolean> = context.dataStore.data.map { preferences ->
-        preferences[forceDialPadDisplay].orFalse()
-    }
-
-    suspend fun setForceDialPadDisplay(force: Boolean) {
-        context.dataStore.edit { settings ->
-            settings[forceDialPadDisplay] = force
-        }
-    }
-
-    private val forceLoginFallback = booleanPreferencesKey("force_login_fallback")
-
-    val forceLoginFallbackFlow: Flow<Boolean> = context.dataStore.data.map { preferences ->
-        preferences[forceLoginFallback].orFalse()
-    }
-
-    suspend fun setForceLoginFallbackFlow(force: Boolean) {
-        context.dataStore.edit { settings ->
-            settings[forceLoginFallback] = force
         }
     }
 }

--- a/vector/src/release/java/im/vector/app/core/di/FeaturesModule.kt
+++ b/vector/src/release/java/im/vector/app/core/di/FeaturesModule.kt
@@ -22,6 +22,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import im.vector.app.features.DefaultVectorFeatures
 import im.vector.app.features.VectorFeatures
+import im.vector.app.features.DefaultVectorOverrides
+import im.vector.app.features.VectorOverrides
 
 @InstallIn(SingletonComponent::class)
 @Module
@@ -30,5 +32,10 @@ object FeaturesModule {
     @Provides
     fun providesFeatures(): VectorFeatures {
         return DefaultVectorFeatures()
+    }
+
+    @Provides
+    fun providesOverrides(): VectorOverrides {
+        return DefaultVectorOverrides()
     }
 }


### PR DESCRIPTION
 ## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content
Lifts the debug only options to their own `VectorOverrides` class, this class is explicitly for overriding behaviour for testing and is not meant to be user facing. The `release` build type will use the interface defaults, effectively the same as `VectorFeatures`.

## Motivation and context

To avoid leaking debug only content within the `VectorDataStore` and provide a single point of reference for adding feature overrides for testing

## Screenshots / GIFs

No UI changes

## Tests

- Open the debug menu -> private settings 
- enable force dial pad tab
- see the dial pad tab in the home activity

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Sv2 (31)
