### PR TITLE
FTUE - Capability based personalisation flow

### DIFF
--- a/changelog.d/5375.wip
+++ b/changelog.d/5375.wip
@@ -1,1 +1,1 @@
-Dynamically showing/hiding onboarding personalisation screens based on the the users homeserver capabilities
+Dynamically showing/hiding onboarding personalisation screens based on the users homeserver capabilities

--- a/changelog.d/5375.wip
+++ b/changelog.d/5375.wip
@@ -1,0 +1,1 @@
+Dynamically showing/hiding onboarding personalisation screens based on the the users homeserver capabilities

--- a/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorOverrides.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorOverrides.kt
@@ -63,7 +63,7 @@ class DebugVectorOverrides(private val context: Context) : VectorOverrides {
         }
     }
 
-    suspend fun updateHomeserverCapabilities(block: HomeserverCapabilitiesOverride.() -> HomeserverCapabilitiesOverride) {
+    suspend fun setHomeserverCapabilities(block: HomeserverCapabilitiesOverride.() -> HomeserverCapabilitiesOverride) {
         val capabilitiesOverride = block(forceHomeserverCapabilities.firstOrNull() ?: HomeserverCapabilitiesOverride(null, null))
         context.dataStore.edit { settings ->
             when (capabilitiesOverride.canChangeDisplayName) {

--- a/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorOverrides.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorOverrides.kt
@@ -22,13 +22,17 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
+import im.vector.app.features.HomeserverCapabilitiesOverride
 import im.vector.app.features.VectorOverrides
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import org.matrix.android.sdk.api.extensions.orFalse
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "vector_overrides")
 private val keyForceDialPadDisplay = booleanPreferencesKey("force_dial_pad_display")
 private val keyForceLoginFallback = booleanPreferencesKey("force_login_fallback")
+private val forceCanChangeDisplayName = booleanPreferencesKey("force_can_change_display_name")
+private val forceCanChangeAvatar = booleanPreferencesKey("force_can_change_avatar")
 
 class DebugVectorOverrides(private val context: Context) : VectorOverrides {
 
@@ -40,6 +44,13 @@ class DebugVectorOverrides(private val context: Context) : VectorOverrides {
         preferences[keyForceLoginFallback].orFalse()
     }
 
+    override val forceHomeserverCapabilities = context.dataStore.data.map { preferences ->
+        HomeserverCapabilitiesOverride(
+                canChangeDisplayName = preferences[forceCanChangeDisplayName],
+                canChangeAvatar = preferences[forceCanChangeAvatar]
+        )
+    }
+
     suspend fun setForceDialPadDisplay(force: Boolean) {
         context.dataStore.edit { settings ->
             settings[keyForceDialPadDisplay] = force
@@ -49,6 +60,20 @@ class DebugVectorOverrides(private val context: Context) : VectorOverrides {
     suspend fun setForceLoginFallback(force: Boolean) {
         context.dataStore.edit { settings ->
             settings[keyForceLoginFallback] = force
+        }
+    }
+
+    suspend fun updateHomeserverCapabilities(block: HomeserverCapabilitiesOverride.() -> HomeserverCapabilitiesOverride) {
+        val capabilitiesOverride = block(forceHomeserverCapabilities.firstOrNull() ?: HomeserverCapabilitiesOverride(null, null))
+        context.dataStore.edit { settings ->
+            when (capabilitiesOverride.canChangeDisplayName) {
+                null -> settings.remove(forceCanChangeDisplayName)
+                else -> settings[forceCanChangeDisplayName] = capabilitiesOverride.canChangeDisplayName
+            }
+            when (capabilitiesOverride.canChangeAvatar) {
+                null -> settings.remove(forceCanChangeAvatar)
+                else -> settings[forceCanChangeAvatar] = capabilitiesOverride.canChangeAvatar
+            }
         }
     }
 }

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsFragment.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsFragment.kt
@@ -50,6 +50,12 @@ class DebugPrivateSettingsFragment : VectorBaseFragment<FragmentDebugPrivateSett
 
     override fun invalidate() = withState(viewModel) {
         views.forceDialPadTabDisplay.isChecked = it.dialPadVisible
+        views.forceChangeDisplayNameCapability.bind(it.homeserverCapabilityOverrides.displayName) { option ->
+            viewModel.handle(DebugPrivateSettingsViewActions.SetDisplayNameCapabilityOverride(option))
+        }
+        views.forceChangeAvatarCapability.bind(it.homeserverCapabilityOverrides.avatar) { option ->
+            viewModel.handle(DebugPrivateSettingsViewActions.SetAvatarCapabilityOverride(option))
+        }
         views.forceLoginFallback.isChecked = it.forceLoginFallback
     }
 }

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewActions.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewActions.kt
@@ -18,7 +18,9 @@ package im.vector.app.features.debug.settings
 
 import im.vector.app.core.platform.VectorViewModelAction
 
-sealed class DebugPrivateSettingsViewActions : VectorViewModelAction {
-    data class SetDialPadVisibility(val force: Boolean) : DebugPrivateSettingsViewActions()
-    data class SetForceLoginFallbackEnabled(val force: Boolean) : DebugPrivateSettingsViewActions()
+sealed interface DebugPrivateSettingsViewActions : VectorViewModelAction {
+    data class SetDialPadVisibility(val force: Boolean) : DebugPrivateSettingsViewActions
+    data class SetForceLoginFallbackEnabled(val force: Boolean) : DebugPrivateSettingsViewActions
+    data class SetDisplayNameCapabilityOverride(val option: BooleanHomeserverCapabilitiesOverride?) : DebugPrivateSettingsViewActions
+    data class SetAvatarCapabilityOverride(val option: BooleanHomeserverCapabilitiesOverride?) : DebugPrivateSettingsViewActions
 }

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewModel.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewModel.kt
@@ -89,14 +89,14 @@ class DebugPrivateSettingsViewModel @AssistedInject constructor(
     private fun handSetDisplayNameCapabilityOverride(action: SetDisplayNameCapabilityOverride) {
         viewModelScope.launch {
             val forceDisplayName = action.option.toBoolean()
-            debugVectorOverrides.updateHomeserverCapabilities { copy(canChangeDisplayName = forceDisplayName) }
+            debugVectorOverrides.setHomeserverCapabilities { copy(canChangeDisplayName = forceDisplayName) }
         }
     }
 
     private fun handSetAvatarCapabilityOverride(action: SetAvatarCapabilityOverride) {
         viewModelScope.launch {
             val forceAvatar = action.option.toBoolean()
-            debugVectorOverrides.updateHomeserverCapabilities { copy(canChangeAvatar = forceAvatar) }
+            debugVectorOverrides.setHomeserverCapabilities { copy(canChangeAvatar = forceAvatar) }
         }
     }
 }

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewModel.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewModel.kt
@@ -22,9 +22,12 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
+import im.vector.app.core.extensions.exhaustive
 import im.vector.app.core.platform.EmptyViewEvents
 import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.features.debug.features.DebugVectorOverrides
+import im.vector.app.features.debug.settings.DebugPrivateSettingsViewActions.SetAvatarCapabilityOverride
+import im.vector.app.features.debug.settings.DebugPrivateSettingsViewActions.SetDisplayNameCapabilityOverride
 import kotlinx.coroutines.launch
 
 class DebugPrivateSettingsViewModel @AssistedInject constructor(
@@ -40,10 +43,10 @@ class DebugPrivateSettingsViewModel @AssistedInject constructor(
     companion object : MavericksViewModelFactory<DebugPrivateSettingsViewModel, DebugPrivateSettingsViewState> by hiltMavericksViewModelFactory()
 
     init {
-        observeVectorDataStore()
+        observeVectorOverrides()
     }
 
-    private fun observeVectorDataStore() {
+    private fun observeVectorOverrides() {
         debugVectorOverrides.forceDialPad.setOnEach {
             copy(
                     dialPadVisible = it
@@ -52,13 +55,23 @@ class DebugPrivateSettingsViewModel @AssistedInject constructor(
         debugVectorOverrides.forceLoginFallback.setOnEach {
             copy(forceLoginFallback = it)
         }
+        debugVectorOverrides.forceHomeserverCapabilities.setOnEach {
+            val activeDisplayNameOption = BooleanHomeserverCapabilitiesOverride.from(it.canChangeDisplayName)
+            val activeAvatarOption = BooleanHomeserverCapabilitiesOverride.from(it.canChangeAvatar)
+            copy(homeserverCapabilityOverrides = homeserverCapabilityOverrides.copy(
+                    displayName = homeserverCapabilityOverrides.displayName.copy(activeOption = activeDisplayNameOption),
+                    avatar = homeserverCapabilityOverrides.displayName.copy(activeOption = activeAvatarOption),
+            ))
+        }
     }
 
     override fun handle(action: DebugPrivateSettingsViewActions) {
         when (action) {
             is DebugPrivateSettingsViewActions.SetDialPadVisibility         -> handleSetDialPadVisibility(action)
             is DebugPrivateSettingsViewActions.SetForceLoginFallbackEnabled -> handleSetForceLoginFallbackEnabled(action)
-        }
+            is SetDisplayNameCapabilityOverride                             -> handSetDisplayNameCapabilityOverride(action)
+            is SetAvatarCapabilityOverride                                  -> handSetAvatarCapabilityOverride(action)
+        }.exhaustive
     }
 
     private fun handleSetDialPadVisibility(action: DebugPrivateSettingsViewActions.SetDialPadVisibility) {
@@ -70,6 +83,20 @@ class DebugPrivateSettingsViewModel @AssistedInject constructor(
     private fun handleSetForceLoginFallbackEnabled(action: DebugPrivateSettingsViewActions.SetForceLoginFallbackEnabled) {
         viewModelScope.launch {
             debugVectorOverrides.setForceLoginFallback(action.force)
+        }
+    }
+
+    private fun handSetDisplayNameCapabilityOverride(action: SetDisplayNameCapabilityOverride) {
+        viewModelScope.launch {
+            val forceDisplayName = action.option.toBoolean()
+            debugVectorOverrides.updateHomeserverCapabilities { copy(canChangeDisplayName = forceDisplayName) }
+        }
+    }
+
+    private fun handSetAvatarCapabilityOverride(action: SetAvatarCapabilityOverride) {
+        viewModelScope.launch {
+            val forceAvatar = action.option.toBoolean()
+            debugVectorOverrides.updateHomeserverCapabilities { copy(canChangeAvatar = forceAvatar) }
         }
     }
 }

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewModel.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewModel.kt
@@ -60,7 +60,7 @@ class DebugPrivateSettingsViewModel @AssistedInject constructor(
             val activeAvatarOption = BooleanHomeserverCapabilitiesOverride.from(it.canChangeAvatar)
             copy(homeserverCapabilityOverrides = homeserverCapabilityOverrides.copy(
                     displayName = homeserverCapabilityOverrides.displayName.copy(activeOption = activeDisplayNameOption),
-                    avatar = homeserverCapabilityOverrides.displayName.copy(activeOption = activeAvatarOption),
+                    avatar = homeserverCapabilityOverrides.avatar.copy(activeOption = activeAvatarOption),
             ))
         }
     }

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewState.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewState.kt
@@ -17,8 +17,23 @@
 package im.vector.app.features.debug.settings
 
 import com.airbnb.mvrx.MavericksState
+import im.vector.app.features.debug.settings.OverrideDropdownView.OverrideDropdown
 
 data class DebugPrivateSettingsViewState(
         val dialPadVisible: Boolean = false,
         val forceLoginFallback: Boolean = false,
+        val homeserverCapabilityOverrides: HomeserverCapabilityOverrides = HomeserverCapabilityOverrides()
 ) : MavericksState
+
+data class HomeserverCapabilityOverrides(
+        val displayName: OverrideDropdown<BooleanHomeserverCapabilitiesOverride> = OverrideDropdown(
+                label = "Override display name capability",
+                activeOption = null,
+                options = listOf(BooleanHomeserverCapabilitiesOverride.ForceEnabled, BooleanHomeserverCapabilitiesOverride.ForceDisabled)
+        ),
+        val avatar: OverrideDropdown<BooleanHomeserverCapabilitiesOverride> = OverrideDropdown(
+                label = "Override avatar capability",
+                activeOption = null,
+                options = listOf(BooleanHomeserverCapabilitiesOverride.ForceEnabled, BooleanHomeserverCapabilitiesOverride.ForceDisabled)
+        )
+)

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/OverrideDropdownView.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/OverrideDropdownView.kt
@@ -19,34 +19,33 @@ package im.vector.app.features.debug.settings
 import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.LinearLayout
-import android.widget.TextView
-import androidx.appcompat.widget.AppCompatSpinner
 import im.vector.app.R
+import im.vector.app.databinding.ViewBooleanDropdownBinding
 
 class OverrideDropdownView @JvmOverloads constructor(
         context: Context,
         attrs: AttributeSet? = null
 ) : LinearLayout(context, attrs) {
 
-    private val labelView: TextView
-    private val optionsSpinner: AppCompatSpinner
+    private val binding = ViewBooleanDropdownBinding.inflate(
+            LayoutInflater.from(context),
+            this
+    )
 
     init {
         orientation = HORIZONTAL
         gravity = Gravity.CENTER_VERTICAL
-        inflate(context, R.layout.view_boolean_dropdown, this)
-        labelView = findViewById(R.id.feature_label)
-        optionsSpinner = findViewById(R.id.feature_options)
     }
 
     fun <T : OverrideOption> bind(feature: OverrideDropdown<T>, listener: Listener<T>) {
-        labelView.text = feature.label
+        binding.overrideLabel.text = feature.label
 
-        optionsSpinner.apply {
+        binding.overrideOptions.apply {
             val arrayAdapter = ArrayAdapter<String>(context, android.R.layout.simple_spinner_dropdown_item)
             val options = listOf("Inactive") + feature.options.map { it.label }
             arrayAdapter.addAll(options)

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/OverrideDropdownView.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/OverrideDropdownView.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.debug.settings
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.Gravity
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.widget.AppCompatSpinner
+import im.vector.app.R
+
+class OverrideDropdownView @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null
+) : LinearLayout(context, attrs) {
+
+    private val labelView: TextView
+    private val optionsSpinner: AppCompatSpinner
+
+    init {
+        orientation = HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+        inflate(context, R.layout.view_boolean_dropdown, this)
+        labelView = findViewById(R.id.feature_label)
+        optionsSpinner = findViewById(R.id.feature_options)
+    }
+
+    fun <T: OverrideOption> bind(feature: OverrideDropdown<T>, listener: Listener<T>) {
+        labelView.text = feature.label
+
+        optionsSpinner.apply {
+            val arrayAdapter = ArrayAdapter<String>(context, android.R.layout.simple_spinner_dropdown_item)
+            val options = listOf("Inactive") + feature.options.map { it.label }
+            arrayAdapter.addAll(options)
+            adapter = arrayAdapter
+
+            feature.activeOption?.let {
+                setSelection(options.indexOf(it.label), false)
+            }
+
+            onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+                override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                    when (position) {
+                        0    -> listener.onOverrideSelected(option = null)
+                        else -> listener.onOverrideSelected(feature.options[position - 1])
+                    }
+                }
+
+                override fun onNothingSelected(parent: AdapterView<*>?) {
+                    // do nothing
+                }
+            }
+        }
+    }
+
+    fun interface Listener<T> {
+        fun onOverrideSelected(option: T?)
+    }
+
+    data class OverrideDropdown<T: OverrideOption>(
+            val label: String,
+            val options: List<T>,
+            val activeOption: T?,
+    )
+}
+
+interface OverrideOption {
+    val label: String
+}

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/OverrideDropdownView.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/OverrideDropdownView.kt
@@ -43,7 +43,7 @@ class OverrideDropdownView @JvmOverloads constructor(
         optionsSpinner = findViewById(R.id.feature_options)
     }
 
-    fun <T: OverrideOption> bind(feature: OverrideDropdown<T>, listener: Listener<T>) {
+    fun <T : OverrideOption> bind(feature: OverrideDropdown<T>, listener: Listener<T>) {
         labelView.text = feature.label
 
         optionsSpinner.apply {
@@ -75,7 +75,7 @@ class OverrideDropdownView @JvmOverloads constructor(
         fun onOverrideSelected(option: T?)
     }
 
-    data class OverrideDropdown<T: OverrideOption>(
+    data class OverrideDropdown<T : OverrideOption>(
             val label: String,
             val options: List<T>,
             val activeOption: T?,

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/PrivateSettingOverrides.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/PrivateSettingOverrides.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.debug.settings
+
+sealed interface BooleanHomeserverCapabilitiesOverride : OverrideOption {
+
+    companion object {
+        fun from(value: Boolean?) = when (value) {
+            null  -> null
+            true  -> ForceEnabled
+            false -> ForceDisabled
+        }
+    }
+
+    object ForceEnabled : BooleanHomeserverCapabilitiesOverride {
+        override val label = "Force enabled"
+    }
+
+    object ForceDisabled : BooleanHomeserverCapabilitiesOverride {
+        override val label = "Force disabled"
+    }
+}
+
+fun BooleanHomeserverCapabilitiesOverride?.toBoolean() = when (this) {
+    null                                                -> null
+    BooleanHomeserverCapabilitiesOverride.ForceDisabled -> false
+    BooleanHomeserverCapabilitiesOverride.ForceEnabled  -> true
+}

--- a/vector/src/debug/res/layout/fragment_debug_private_settings.xml
+++ b/vector/src/debug/res/layout/fragment_debug_private_settings.xml
@@ -31,6 +31,24 @@
                 android:layout_height="wrap_content"
                 android:text="Force login and registration fallback" />
 
+            <im.vector.app.features.debug.settings.OverrideDropdownView
+                android:id="@+id/forceChangeDisplayNameCapability"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="4dp" />
+
+            <im.vector.app.features.debug.settings.OverrideDropdownView
+                android:id="@+id/forceChangeAvatarCapability"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="4dp" />
+
         </LinearLayout>
 
     </ScrollView>

--- a/vector/src/debug/res/layout/view_boolean_dropdown.xml
+++ b/vector/src/debug/res/layout/view_boolean_dropdown.xml
@@ -6,7 +6,7 @@
     tools:parentTag="android.widget.LinearLayout">
 
     <TextView
-        android:id="@+id/feature_label"
+        android:id="@+id/overrideLabel"
         style="@style/Widget.Vector.TextView.Subtitle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -17,7 +17,7 @@
         tools:text="Login version" />
 
     <androidx.appcompat.widget.AppCompatSpinner
-        android:id="@+id/feature_options"
+        android:id="@+id/overrideOptions"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1" />

--- a/vector/src/debug/res/layout/view_boolean_dropdown.xml
+++ b/vector/src/debug/res/layout/view_boolean_dropdown.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:parentTag="android.widget.LinearLayout">
+
+    <TextView
+        android:id="@+id/feature_label"
+        style="@style/Widget.Vector.TextView.Subtitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:textColor="?vctr_content_primary"
+        tools:text="Login version" />
+
+    <androidx.appcompat.widget.AppCompatSpinner
+        android:id="@+id/feature_options"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1" />
+
+</merge>

--- a/vector/src/main/java/im/vector/app/features/DefaultVectorOverrides.kt
+++ b/vector/src/main/java/im/vector/app/features/DefaultVectorOverrides.kt
@@ -22,9 +22,16 @@ import kotlinx.coroutines.flow.flowOf
 interface VectorOverrides {
     val forceDialPad: Flow<Boolean>
     val forceLoginFallback: Flow<Boolean>
+    val forceHomeserverCapabilities: Flow<HomeserverCapabilitiesOverride>?
 }
+
+data class HomeserverCapabilitiesOverride(
+        val canChangeDisplayName: Boolean?,
+        val canChangeAvatar: Boolean?
+)
 
 class DefaultVectorOverrides : VectorOverrides {
     override val forceDialPad = flowOf(false)
     override val forceLoginFallback = flowOf(false)
+    override val forceHomeserverCapabilities: Flow<HomeserverCapabilitiesOverride>? = null
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
@@ -75,6 +75,7 @@ sealed class OnboardingAction : VectorViewModelAction {
 
     data class UserAcceptCertificate(val fingerprint: Fingerprint) : OnboardingAction()
 
+    object PersonalizeProfile : OnboardingAction()
     data class UpdateDisplayName(val displayName: String) : OnboardingAction()
     object UpdateDisplayNameSkipped : OnboardingAction()
     data class ProfilePictureSelected(val uri: Uri) : OnboardingAction()

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingVariant.kt
@@ -22,4 +22,3 @@ interface OnboardingVariant {
     fun onNewIntent(intent: Intent?)
     fun initUiAndData(isFirstCreation: Boolean)
     fun setIsLoading(isLoading: Boolean)
-}

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingVariant.kt
@@ -22,3 +22,4 @@ interface OnboardingVariant {
     fun onNewIntent(intent: Intent?)
     fun initUiAndData(isFirstCreation: Boolean)
     fun setIsLoading(isLoading: Boolean)
+}

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewEvents.kt
@@ -51,9 +51,8 @@ sealed class OnboardingViewEvents : VectorViewEvents {
     object OnAccountCreated : OnboardingViewEvents()
     object OnAccountSignedIn : OnboardingViewEvents()
     object OnTakeMeHome : OnboardingViewEvents()
-    object OnPersonalizeProfile : OnboardingViewEvents()
-    object OnDisplayNameUpdated : OnboardingViewEvents()
-    object OnDisplayNameSkipped : OnboardingViewEvents()
+    object OnChooseDisplayName : OnboardingViewEvents()
+    object OnChooseProfilePicture : OnboardingViewEvents()
     object OnPersonalizationComplete : OnboardingViewEvents()
     object OnBack : OnboardingViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -159,7 +159,7 @@ class OnboardingViewModel @AssistedInject constructor(
             OnboardingAction.ClearHomeServerHistory        -> handleClearHomeServerHistory()
             is OnboardingAction.UpdateDisplayName          -> updateDisplayName(action.displayName)
             OnboardingAction.UpdateDisplayNameSkipped      -> handleDisplayNameStepComplete()
-            OnboardingAction.UpdateProfilePictureSkipped   -> _viewEvents.post(OnboardingViewEvents.OnPersonalizationComplete)
+            OnboardingAction.UpdateProfilePictureSkipped   -> completePersonalization()
             OnboardingAction.PersonalizeProfile            -> handlePersonalizeProfile()
             is OnboardingAction.ProfilePictureSelected     -> handleProfilePictureSelected(action)
             OnboardingAction.SaveSelectedProfilePicture    -> updateProfilePicture()
@@ -954,7 +954,7 @@ class OnboardingViewModel @AssistedInject constructor(
         withPersonalisationState {
             when {
                 it.supportsChangingProfilePicture -> _viewEvents.post(OnboardingViewEvents.OnChooseProfilePicture)
-                else                              -> _viewEvents.post(OnboardingViewEvents.OnPersonalizationComplete)
+                else                              -> completePersonalization()
             }
         }
     }
@@ -1000,6 +1000,10 @@ class OnboardingViewModel @AssistedInject constructor(
     }
 
     private fun onProfilePictureSaved() {
+        completePersonalization()
+    }
+
+    private fun completePersonalization() {
         _viewEvents.post(OnboardingViewEvents.OnPersonalizationComplete)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -768,7 +768,7 @@ class OnboardingViewModel @AssistedInject constructor(
         when (isAccountCreated) {
             true  -> {
                 val homeServerCapabilities = session.getHomeServerCapabilities()
-                val capabilityOverrides = vectorOverrides.forceHomeserverCapabilities()?.firstOrNull()
+                val capabilityOverrides = vectorOverrides.forceHomeserverCapabilities?.firstOrNull()
                 val personalizationState = state.personalizationState.copy(
                         supportsChangingDisplayName = capabilityOverrides?.canChangeDisplayName ?: homeServerCapabilities.canChangeDisplayName,
                         supportsChangingProfilePicture = capabilityOverrides?.canChangeAvatar ?: homeServerCapabilities.canChangeAvatar
@@ -934,7 +934,9 @@ class OnboardingViewModel @AssistedInject constructor(
             when {
                 it.supportsChangingDisplayName    -> _viewEvents.post(OnboardingViewEvents.OnChooseDisplayName)
                 it.supportsChangingProfilePicture -> _viewEvents.post(OnboardingViewEvents.OnChooseDisplayName)
-                else                              -> throw IllegalStateException("It should not be possible to personalize without supporting display name or avatar changing")
+                else                              -> {
+                    throw IllegalStateException("It should not be possible to personalize without supporting display name or avatar changing")
+                }
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -48,7 +48,6 @@ import im.vector.app.features.login.ReAuthHelper
 import im.vector.app.features.login.ServerType
 import im.vector.app.features.login.SignMode
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.auth.AuthenticationService

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -48,6 +48,7 @@ import im.vector.app.features.login.ReAuthHelper
 import im.vector.app.features.login.ServerType
 import im.vector.app.features.login.SignMode
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.MatrixPatterns.getDomain
 import org.matrix.android.sdk.api.auth.AuthenticationService

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -933,7 +933,7 @@ class OnboardingViewModel @AssistedInject constructor(
         withPersonalisationState {
             when {
                 it.supportsChangingDisplayName    -> _viewEvents.post(OnboardingViewEvents.OnChooseDisplayName)
-                it.supportsChangingProfilePicture -> _viewEvents.post(OnboardingViewEvents.OnChooseDisplayName)
+                it.supportsChangingProfilePicture -> _viewEvents.post(OnboardingViewEvents.OnChooseProfilePicture)
                 else                              -> {
                     throw IllegalStateException("It should not be possible to personalize without supporting display name or avatar changing")
                 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -81,7 +81,6 @@ class OnboardingViewModel @AssistedInject constructor(
         private val stringProvider: StringProvider,
         private val homeServerHistoryService: HomeServerHistoryService,
         private val vectorFeatures: VectorFeatures,
-        private val vectorOverrides: VectorOverrides,
         private val analyticsTracker: AnalyticsTracker,
         private val uriFilenameResolver: UriFilenameResolver,
         private val vectorOverrides: VectorOverrides
@@ -158,12 +157,13 @@ class OnboardingViewModel @AssistedInject constructor(
             is OnboardingAction.ResetAction                -> handleResetAction(action)
             is OnboardingAction.UserAcceptCertificate      -> handleUserAcceptCertificate(action)
             OnboardingAction.ClearHomeServerHistory        -> handleClearHomeServerHistory()
-            is OnboardingAction.PostViewEvent              -> _viewEvents.post(action.viewEvent)
             is OnboardingAction.UpdateDisplayName          -> updateDisplayName(action.displayName)
-            OnboardingAction.UpdateDisplayNameSkipped      -> _viewEvents.post(OnboardingViewEvents.OnDisplayNameSkipped)
+            OnboardingAction.UpdateDisplayNameSkipped      -> handleDisplayNameStepComplete()
             OnboardingAction.UpdateProfilePictureSkipped   -> _viewEvents.post(OnboardingViewEvents.OnPersonalizationComplete)
+            OnboardingAction.PersonalizeProfile            -> handlePersonalizeProfile()
             is OnboardingAction.ProfilePictureSelected     -> handleProfilePictureSelected(action)
             OnboardingAction.SaveSelectedProfilePicture    -> updateProfilePicture()
+            is OnboardingAction.PostViewEvent              -> _viewEvents.post(action.viewEvent)
         }.exhaustive
     }
 
@@ -921,10 +921,29 @@ class OnboardingViewModel @AssistedInject constructor(
                             personalizationState = personalizationState.copy(displayName = displayName)
                     )
                 }
-                _viewEvents.post(OnboardingViewEvents.OnDisplayNameUpdated)
+                handleDisplayNameStepComplete()
             } catch (error: Throwable) {
                 setState { copy(asyncDisplayName = Fail(error)) }
                 _viewEvents.post(OnboardingViewEvents.Failure(error))
+            }
+        }
+    }
+
+    private fun handlePersonalizeProfile() {
+        withPersonalisationState {
+            when {
+                it.supportsChangingDisplayName    -> _viewEvents.post(OnboardingViewEvents.OnChooseDisplayName)
+                it.supportsChangingProfilePicture -> _viewEvents.post(OnboardingViewEvents.OnChooseDisplayName)
+                else                              -> throw IllegalStateException("It should not be possible to personalize without supporting display name or avatar changing")
+            }
+        }
+    }
+
+    private fun handleDisplayNameStepComplete() {
+        withPersonalisationState {
+            when {
+                it.supportsChangingProfilePicture -> _viewEvents.post(OnboardingViewEvents.OnChooseProfilePicture)
+                else                              -> _viewEvents.post(OnboardingViewEvents.OnPersonalizationComplete)
             }
         }
     }
@@ -933,6 +952,10 @@ class OnboardingViewModel @AssistedInject constructor(
         setState {
             copy(personalizationState = personalizationState.copy(selectedPictureUri = action.uri))
         }
+    }
+
+    private fun withPersonalisationState(block: (PersonalizationState) -> Unit) {
+        withState { block(it.personalizationState) }
     }
 
     private fun updateProfilePicture() {

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -767,12 +767,7 @@ class OnboardingViewModel @AssistedInject constructor(
 
         when (isAccountCreated) {
             true  -> {
-                val homeServerCapabilities = session.getHomeServerCapabilities()
-                val capabilityOverrides = vectorOverrides.forceHomeserverCapabilities?.firstOrNull()
-                val personalizationState = state.personalizationState.copy(
-                        supportsChangingDisplayName = capabilityOverrides?.canChangeDisplayName ?: homeServerCapabilities.canChangeDisplayName,
-                        supportsChangingProfilePicture = capabilityOverrides?.canChangeAvatar ?: homeServerCapabilities.canChangeAvatar
-                )
+                val personalizationState = createPersonalizationState(session, state)
                 setState {
                     copy(asyncLoginAction = Success(Unit), personalizationState = personalizationState)
                 }
@@ -782,6 +777,20 @@ class OnboardingViewModel @AssistedInject constructor(
                 setState { copy(asyncLoginAction = Success(Unit)) }
                 _viewEvents.post(OnboardingViewEvents.OnAccountSignedIn)
             }
+        }
+    }
+
+    private suspend fun createPersonalizationState(session: Session, state: OnboardingViewState): PersonalizationState {
+        return when {
+            vectorFeatures.isOnboardingPersonalizeEnabled() -> {
+                val homeServerCapabilities = session.getHomeServerCapabilities()
+                val capabilityOverrides = vectorOverrides.forceHomeserverCapabilities?.firstOrNull()
+                state.personalizationState.copy(
+                        supportsChangingDisplayName = capabilityOverrides?.canChangeDisplayName ?: homeServerCapabilities.canChangeDisplayName,
+                        supportsChangingProfilePicture = capabilityOverrides?.canChangeAvatar ?: homeServerCapabilities.canChangeAvatar
+                )
+            }
+            else                                            -> state.personalizationState
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
@@ -22,7 +22,6 @@ import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.PersistState
-import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
 import im.vector.app.features.login.LoginMode
 import im.vector.app.features.login.ServerType
@@ -82,10 +81,6 @@ data class OnboardingViewState(
                 asyncRegistration is Loading ||
                 asyncDisplayName is Loading ||
                 asyncProfilePicture is Loading
-    }
-
-    fun isAuthTaskCompleted(): Boolean {
-        return asyncLoginAction is Success
     }
 }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
@@ -97,6 +97,11 @@ enum class OnboardingFlow {
 
 @Parcelize
 data class PersonalizationState(
+        val supportsChangingDisplayName: Boolean = false,
+        val supportsChangingProfilePicture: Boolean = false,
         val displayName: String? = null,
         val selectedPictureUri: Uri? = null
-) : Parcelable
+) : Parcelable {
+
+    fun supportsPersonalization() = supportsChangingDisplayName || supportsChangingProfilePicture
+}

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthAccountCreatedFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthAccountCreatedFragment.kt
@@ -20,11 +20,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.databinding.FragmentFtueAccountCreatedBinding
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewEvents
+import im.vector.app.features.onboarding.OnboardingViewState
 import javax.inject.Inject
 
 class FtueAuthAccountCreatedFragment @Inject constructor(
@@ -44,6 +46,13 @@ class FtueAuthAccountCreatedFragment @Inject constructor(
         views.accountCreatedSubtitle.text = getString(R.string.ftue_account_created_subtitle, activeSessionHolder.getActiveSession().myUserId)
         views.accountCreatedPersonalize.debouncedClicks { viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnPersonalizeProfile)) }
         views.accountCreatedTakeMeHome.debouncedClicks { viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnTakeMeHome)) }
+        views.accountCreatedTakeMeHomeCta.debouncedClicks { viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnTakeMeHome)) }
+    }
+
+    override fun updateWithState(state: OnboardingViewState) {
+        val canPersonalize = state.personalizationState.supportsPersonalization()
+        views.personalizeButtonGroup.isVisible = canPersonalize
+        views.takeMeHomeButtonGroup.isVisible = !canPersonalize
     }
 
     override fun resetViewModel() {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthAccountCreatedFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthAccountCreatedFragment.kt
@@ -44,7 +44,7 @@ class FtueAuthAccountCreatedFragment @Inject constructor(
 
     private fun setupViews() {
         views.accountCreatedSubtitle.text = getString(R.string.ftue_account_created_subtitle, activeSessionHolder.getActiveSession().myUserId)
-        views.accountCreatedPersonalize.debouncedClicks { viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnPersonalizeProfile)) }
+        views.accountCreatedPersonalize.debouncedClicks { viewModel.handle(OnboardingAction.PersonalizeProfile) }
         views.accountCreatedTakeMeHome.debouncedClicks { viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnTakeMeHome)) }
         views.accountCreatedTakeMeHomeCta.debouncedClicks { viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnTakeMeHome)) }
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseProfilePictureFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthChooseProfilePictureFragment.kt
@@ -22,6 +22,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.view.isInvisible
 import com.airbnb.mvrx.withState
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
@@ -70,6 +71,8 @@ class FtueAuthChooseProfilePictureFragment @Inject constructor(
     }
 
     override fun updateWithState(state: OnboardingViewState) {
+        views.profilePictureToolbar.isInvisible = !state.personalizationState.supportsChangingDisplayName
+
         val hasSetPicture = state.personalizationState.selectedPictureUri != null
         views.profilePictureSubmit.isEnabled = hasSetPicture
         views.changeProfilePictureIcon.setImageResource(if (hasSetPicture) R.drawable.ic_edit else R.drawable.ic_camera_plain)
@@ -92,5 +95,15 @@ class FtueAuthChooseProfilePictureFragment @Inject constructor(
 
     override fun resetViewModel() {
         // Nothing to do
+    }
+
+    override fun onBackPressed(toolbarButton: Boolean): Boolean {
+        return when (withState(viewModel) { it.personalizationState.supportsChangingDisplayName }) {
+            true  -> super.onBackPressed(toolbarButton)
+            false -> {
+                viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnTakeMeHome))
+                true
+            }
+        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -122,16 +122,8 @@ class FtueAuthVariant(
 
     private fun updateWithState(viewState: OnboardingViewState) {
         isForceLoginFallbackEnabled = viewState.isForceLoginFallbackEnabled
-        views.loginLoading.isVisible = shouldShowLoading(viewState)
+        views.loginLoading.isVisible = viewState.isLoading()
     }
-
-    private fun shouldShowLoading(viewState: OnboardingViewState) =
-            if (vectorFeatures.isOnboardingPersonalizeEnabled()) {
-                viewState.isLoading()
-            } else {
-                // Keep loading when during success because of the delay when switching to the next Activity
-                viewState.isLoading() || viewState.isAuthTaskCompleted()
-            }
 
     override fun setIsLoading(isLoading: Boolean) = Unit
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -429,4 +429,5 @@ class FtueAuthVariant(
                 option = commonOption
         )
     }
+
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -232,10 +232,9 @@ class FtueAuthVariant(
             }
             is OnboardingViewEvents.OnAccountCreated                           -> onAccountCreated()
             OnboardingViewEvents.OnAccountSignedIn                             -> onAccountSignedIn()
-            OnboardingViewEvents.OnPersonalizeProfile                          -> onPersonalizeProfile()
+            OnboardingViewEvents.OnChooseDisplayName                           -> onChooseDisplayName()
             OnboardingViewEvents.OnTakeMeHome                                  -> navigateToHome(createdAccount = true)
-            OnboardingViewEvents.OnDisplayNameUpdated                          -> onDisplayNameUpdated()
-            OnboardingViewEvents.OnDisplayNameSkipped                          -> onDisplayNameUpdated()
+            OnboardingViewEvents.OnChooseProfilePicture                        -> onChooseProfilePicture()
             OnboardingViewEvents.OnPersonalizationComplete                     -> navigateToHome(createdAccount = true)
             OnboardingViewEvents.OnBack                                        -> activity.popBackstack()
         }.exhaustive
@@ -412,14 +411,14 @@ class FtueAuthVariant(
         activity.finish()
     }
 
-    private fun onPersonalizeProfile() {
+    private fun onChooseDisplayName() {
         activity.addFragmentToBackstack(views.loginFragmentContainer,
                 FtueAuthChooseDisplayNameFragment::class.java,
                 option = commonOption
         )
     }
 
-    private fun onDisplayNameUpdated() {
+    private fun onChooseProfilePicture() {
         activity.addFragmentToBackstack(views.loginFragmentContainer,
                 FtueAuthChooseProfilePictureFragment::class.java,
                 option = commonOption

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -230,7 +230,7 @@ class FtueAuthVariant(
                         FtueAuthUseCaseFragment::class.java,
                         option = commonOption)
             }
-            OnboardingViewEvents.OnAccountCreated                              -> onAccountCreated()
+            is OnboardingViewEvents.OnAccountCreated                           -> onAccountCreated()
             OnboardingViewEvents.OnAccountSignedIn                             -> onAccountSignedIn()
             OnboardingViewEvents.OnPersonalizeProfile                          -> onPersonalizeProfile()
             OnboardingViewEvents.OnTakeMeHome                                  -> navigateToHome(createdAccount = true)
@@ -399,15 +399,11 @@ class FtueAuthVariant(
     }
 
     private fun onAccountCreated() {
-        if (vectorFeatures.isOnboardingPersonalizeEnabled()) {
-            activity.supportFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
-            activity.replaceFragment(
-                    views.loginFragmentContainer,
-                    FtueAuthAccountCreatedFragment::class.java,
-            )
-        } else {
-            navigateToHome(createdAccount = true)
-        }
+        activity.supportFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        activity.replaceFragment(
+                views.loginFragmentContainer,
+                FtueAuthAccountCreatedFragment::class.java
+        )
     }
 
     private fun navigateToHome(createdAccount: Boolean) {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -424,5 +424,4 @@ class FtueAuthVariant(
                 option = commonOption
         )
     }
-
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -429,5 +429,4 @@ class FtueAuthVariant(
                 option = commonOption
         )
     }
-
 }

--- a/vector/src/main/res/layout/fragment_ftue_account_created.xml
+++ b/vector/src/main/res/layout/fragment_ftue_account_created.xml
@@ -86,6 +86,14 @@
         app:layout_constraintBottom_toTopOf="@id/accountCreatedPersonalize"
         app:layout_constraintTop_toBottomOf="@id/accountCreatedSubtitle" />
 
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/personalizeButtonGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:constraint_referenced_ids="accountCreatedPersonalize,accountCreatedTakeMeHome"
+        tools:visibility="visible" />
+
     <Button
         android:id="@+id/accountCreatedPersonalize"
         style="@style/Widget.Vector.Button.Login"
@@ -96,11 +104,10 @@
         android:textAllCaps="true"
         android:textColor="?colorSecondary"
         android:transitionName="loginSubmitTransition"
-        app:layout_constraintBottom_toTopOf="@id/accountCreatedSpace5"
+        app:layout_constraintBottom_toTopOf="@id/accountCreatedTakeMeHome"
         app:layout_constraintEnd_toEndOf="@id/ftueAuthGutterEnd"
         app:layout_constraintStart_toStartOf="@id/ftueAuthGutterStart"
-        app:layout_constraintTop_toBottomOf="@id/accountCreatedSpace4"
-        tools:text="@string/ftue_account_created_personalize" />
+        app:layout_constraintTop_toBottomOf="@id/accountCreatedSpace4" />
 
     <Button
         android:id="@+id/accountCreatedTakeMeHome"
@@ -111,10 +118,39 @@
         android:textAllCaps="true"
         android:textColor="@color/element_background_light"
         android:transitionName="loginSubmitTransition"
-        app:layout_constraintBottom_toTopOf="@id/accountCreatedSpace5"
+        app:layout_constraintBottom_toTopOf="@id/ctaBottomBarrier"
         app:layout_constraintEnd_toEndOf="@id/ftueAuthGutterEnd"
         app:layout_constraintStart_toStartOf="@id/ftueAuthGutterStart"
         app:layout_constraintTop_toBottomOf="@id/accountCreatedPersonalize" />
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/takeMeHomeButtonGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:constraint_referenced_ids="accountCreatedTakeMeHomeCta" />
+
+    <Button
+        android:id="@+id/accountCreatedTakeMeHomeCta"
+        style="@style/Widget.Vector.Button.Login"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:backgroundTint="@color/element_background_light"
+        android:text="@string/ftue_account_created_take_me_home"
+        android:textAllCaps="true"
+        android:textColor="?colorSecondary"
+        android:transitionName="loginSubmitTransition"
+        app:layout_constraintBottom_toTopOf="@id/ctaBottomBarrier"
+        app:layout_constraintEnd_toEndOf="@id/ftueAuthGutterEnd"
+        app:layout_constraintStart_toStartOf="@id/ftueAuthGutterStart"
+        app:layout_constraintTop_toBottomOf="@id/accountCreatedSpace4" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/ctaBottomBarrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="accountCreatedTakeMeHomeCta,accountCreatedTakeMeHome" />
 
     <Space
         android:id="@+id/accountCreatedSpace5"
@@ -122,6 +158,6 @@
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHeight_percent="0.05"
-        app:layout_constraintTop_toBottomOf="@id/accountCreatedPersonalize" />
+        app:layout_constraintTop_toBottomOf="@id/ctaBottomBarrier" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/main/res/layout/fragment_ftue_profile_picture.xml
+++ b/vector/src/main/res/layout/fragment_ftue_profile_picture.xml
@@ -90,6 +90,25 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <ImageView
+            android:id="@+id/changeProfilePictureButton"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:adjustViewBounds="true"
+            android:background="@drawable/bg_rounded_button"
+            android:backgroundTint="?vctr_system"
+            android:contentDescription="@string/ftue_profile_picture_title"
+            android:padding="10dp"
+            android:src="@drawable/ic_camera_plain"
+            app:layout_constraintBottom_toBottomOf="@id/profilePictureView"
+            app:layout_constraintEnd_toEndOf="@id/profilePictureView"
+            app:layout_constraintHeight_percent="0.08"
+            app:layout_constraintHorizontal_bias="1"
+            app:layout_constraintStart_toStartOf="@id/profilePictureView"
+            app:layout_constraintTop_toTopOf="@id/profilePictureView"
+            app:layout_constraintVertical_bias="1"
+            app:tint="?vctr_content_secondary" />
+
         <Space
             android:id="@+id/avatarTitleSpacing"
             android:layout_width="match_parent"

--- a/vector/src/main/res/layout/fragment_ftue_profile_picture.xml
+++ b/vector/src/main/res/layout/fragment_ftue_profile_picture.xml
@@ -31,6 +31,7 @@
             style="@style/Widget.Vector.Toolbar.Settings"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:visibility="invisible"
             app:layout_constraintBottom_toTopOf="@id/profilePictureView"
             app:layout_constraintTop_toBottomOf="@id/profilePictureToolbar"
             app:layout_constraintTop_toTopOf="parent"

--- a/vector/src/main/res/layout/fragment_ftue_profile_picture.xml
+++ b/vector/src/main/res/layout/fragment_ftue_profile_picture.xml
@@ -90,25 +90,6 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <ImageView
-            android:id="@+id/changeProfilePictureButton"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:adjustViewBounds="true"
-            android:background="@drawable/bg_rounded_button"
-            android:backgroundTint="?vctr_system"
-            android:contentDescription="@string/ftue_profile_picture_title"
-            android:padding="10dp"
-            android:src="@drawable/ic_camera_plain"
-            app:layout_constraintBottom_toBottomOf="@id/profilePictureView"
-            app:layout_constraintEnd_toEndOf="@id/profilePictureView"
-            app:layout_constraintHeight_percent="0.08"
-            app:layout_constraintHorizontal_bias="1"
-            app:layout_constraintStart_toStartOf="@id/profilePictureView"
-            app:layout_constraintTop_toTopOf="@id/profilePictureView"
-            app:layout_constraintVertical_bias="1"
-            app:tint="?vctr_content_secondary" />
-
         <Space
             android:id="@+id/avatarTitleSpacing"
             android:layout_width="match_parent"

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -22,7 +22,6 @@ import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.test.MvRxTestRule
-import im.vector.app.features.DefaultVectorOverrides
 import im.vector.app.features.login.ReAuthHelper
 import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.fakes.FakeAnalyticsTracker
@@ -36,6 +35,7 @@ import im.vector.app.test.fakes.FakeStringProvider
 import im.vector.app.test.fakes.FakeUri
 import im.vector.app.test.fakes.FakeUriFilenameResolver
 import im.vector.app.test.fakes.FakeVectorFeatures
+import im.vector.app.test.fakes.FakeVectorOverrides
 import im.vector.app.test.test
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
@@ -264,7 +264,7 @@ class OnboardingViewModelTest {
                 FakeVectorFeatures(),
                 FakeAnalyticsTracker(),
                 fakeUriFilenameResolver.instance,
-                DefaultVectorOverrides()
+                FakeVectorOverrides()
         )
     }
 

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -83,6 +83,32 @@ class OnboardingViewModelTest {
     }
 
     @Test
+    fun `given supports changing display name when handling PersonalizeProfile then emits contents choose display name`() = runBlockingTest {
+        val initialState = initialState.copy(personalizationState = PersonalizationState(supportsChangingDisplayName = true, supportsChangingProfilePicture = false))
+        viewModel = createViewModel(initialState)
+        val test = viewModel.test(this)
+
+        viewModel.handle(OnboardingAction.PersonalizeProfile)
+
+        test
+                .assertEvents(OnboardingViewEvents.OnChooseDisplayName)
+                .finish()
+    }
+
+    @Test
+    fun `given only supports changing profile picture when handling PersonalizeProfile then emits contents choose profile picture`() = runBlockingTest {
+        val initialState = initialState.copy(personalizationState = PersonalizationState(supportsChangingDisplayName = false, supportsChangingProfilePicture = true))
+        viewModel = createViewModel(initialState)
+        val test = viewModel.test(this)
+
+        viewModel.handle(OnboardingAction.PersonalizeProfile)
+
+        test
+                .assertEvents(OnboardingViewEvents.OnChooseProfilePicture)
+                .finish()
+    }
+
+    @Test
     fun `given homeserver does not support personalisation when registering account then updates state and emits account created event`() = runBlockingTest {
         fakeSession.fakeHomeServerCapabilitiesService.givenCapabilities(HomeServerCapabilities(canChangeDisplayName = false, canChangeAvatar = false))
         givenSuccessfullyCreatesAccount()

--- a/vector/src/test/java/im/vector/app/test/Extensions.kt
+++ b/vector/src/test/java/im/vector/app/test/Extensions.kt
@@ -21,7 +21,6 @@ import im.vector.app.core.platform.VectorViewEvents
 import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.core.platform.VectorViewModelAction
 import kotlinx.coroutines.CoroutineScope
-import org.hamcrest.Matcher
 
 fun String.trimIndentOneLine() = trimIndent().replace("\n", "")
 

--- a/vector/src/test/java/im/vector/app/test/Extensions.kt
+++ b/vector/src/test/java/im/vector/app/test/Extensions.kt
@@ -21,6 +21,7 @@ import im.vector.app.core.platform.VectorViewEvents
 import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.core.platform.VectorViewModelAction
 import kotlinx.coroutines.CoroutineScope
+import org.hamcrest.Matcher
 
 fun String.trimIndentOneLine() = trimIndent().replace("\n", "")
 

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
@@ -18,7 +18,6 @@ package im.vector.app.test.fakes
 
 import io.mockk.coJustRun
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
 import org.matrix.android.sdk.api.auth.AuthenticationService
 import org.matrix.android.sdk.api.auth.registration.RegistrationWizard

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
@@ -16,7 +16,19 @@
 
 package im.vector.app.test.fakes
 
+import io.mockk.coJustRun
+import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import org.matrix.android.sdk.api.auth.AuthenticationService
+import org.matrix.android.sdk.api.auth.registration.RegistrationWizard
 
-class FakeAuthenticationService : AuthenticationService by mockk()
+class FakeAuthenticationService : AuthenticationService by mockk() {
+    fun givenRegistrationWizard(registrationWizard: RegistrationWizard) {
+        every { getRegistrationWizard() } returns registrationWizard
+    }
+
+    fun expectReset() {
+        coJustRun { reset() }
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeHomeServerCapabilitiesService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeHomeServerCapabilitiesService.kt
@@ -16,20 +16,14 @@
 
 package im.vector.app.test.fakes
 
-import im.vector.app.core.di.ActiveSessionHolder
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
-import org.matrix.android.sdk.api.session.Session
+import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilities
+import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilitiesService
 
-class FakeActiveSessionHolder(
-        private val fakeSession: FakeSession = FakeSession()
-) {
-    val instance = mockk<ActiveSessionHolder> {
-        every { getActiveSession() } returns fakeSession
-    }
+class FakeHomeServerCapabilitiesService : HomeServerCapabilitiesService by mockk() {
 
-    fun expectSetsActiveSession(session: Session) {
-        justRun { instance.setActiveSession(session) }
+    fun givenCapabilities(homeServerCapabilities: HomeServerCapabilities) {
+        every { getHomeServerCapabilities() } returns homeServerCapabilities
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeRegistrationWizard.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeRegistrationWizard.kt
@@ -16,20 +16,15 @@
 
 package im.vector.app.test.fakes
 
-import im.vector.app.core.di.ActiveSessionHolder
-import io.mockk.every
-import io.mockk.justRun
+import io.mockk.coEvery
 import io.mockk.mockk
+import org.matrix.android.sdk.api.auth.registration.RegistrationResult
+import org.matrix.android.sdk.api.auth.registration.RegistrationWizard
 import org.matrix.android.sdk.api.session.Session
 
-class FakeActiveSessionHolder(
-        private val fakeSession: FakeSession = FakeSession()
-) {
-    val instance = mockk<ActiveSessionHolder> {
-        every { getActiveSession() } returns fakeSession
-    }
+class FakeRegistrationWizard : RegistrationWizard by mockk() {
 
-    fun expectSetsActiveSession(session: Session) {
-        justRun { instance.setActiveSession(session) }
+    fun givenSuccessfulDummy(session: Session) {
+        coEvery { dummy() } returns RegistrationResult.Success(session)
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorOverrides.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorOverrides.kt
@@ -16,20 +16,8 @@
 
 package im.vector.app.test.fakes
 
-import im.vector.app.core.di.ActiveSessionHolder
-import io.mockk.every
-import io.mockk.justRun
+import im.vector.app.features.DefaultVectorOverrides
+import im.vector.app.features.VectorOverrides
 import io.mockk.mockk
-import org.matrix.android.sdk.api.session.Session
 
-class FakeActiveSessionHolder(
-        private val fakeSession: FakeSession = FakeSession()
-) {
-    val instance = mockk<ActiveSessionHolder> {
-        every { getActiveSession() } returns fakeSession
-    }
-
-    fun expectSetsActiveSession(session: Session) {
-        justRun { instance.setActiveSession(session) }
-    }
-}
+class FakeVectorOverrides : VectorOverrides by DefaultVectorOverrides()

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorOverrides.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorOverrides.kt
@@ -18,6 +18,5 @@ package im.vector.app.test.fakes
 
 import im.vector.app.features.DefaultVectorOverrides
 import im.vector.app.features.VectorOverrides
-import io.mockk.mockk
 
 class FakeVectorOverrides : VectorOverrides by DefaultVectorOverrides()


### PR DESCRIPTION
## Type of change

- [x] WIP Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Draft PR, relies on #5361  #5323 

Dynamically shows/hides the personalisation onboarding screen based on the homeservers capabilities.

when display name and profile picture are not supported
- Account created only offers the `Take me home` button

when only changing display name is supported
- Account created personalisation is enabled but only shows the display name step 

when only changing profile picture is supported
- Account created personalisation is enabled but only change profile picture step, removing the toolbar back to the match the display name flow

Also introduces debug overrides for the homeserver capabilities to make testing the different options easier.

## Motivation and context

To only show personalisation options to users on homeservers which support them. Part of #5200 

## Screenshots / GIFs


| ALL OPTIONS DISABLED | ONLY DISPLAY NAME | ONLY PROFILE PICTURE | ALL ENABLED |
| --- | --- | --- | --- |
![all-disabled](https://user-images.githubusercontent.com/1848238/155974441-6f232460-5667-4061-bcc2-1e1bf9993caa.gif)|![per-display-only](https://user-images.githubusercontent.com/1848238/155974438-f3865d6c-dd78-4d5d-8f7d-fc9a4ee3f0af.gif)|![per-only-picture](https://user-images.githubusercontent.com/1848238/155974436-7bfb1213-5259-427b-ad44-995eb71d42af.gif)|![pre-all-enabled](https://user-images.githubusercontent.com/1848238/155974445-63679437-2b68-42d0-8b77-a41be5778fa9.gif)

## Tests

- With a fresh install
- Enable the Personalisation feature flag
- Enable or disable forced homeserver capabilities within the private settings

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 29