### PR TITLE
Cleanup enabling threads from buildConfig

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,11 +144,6 @@ project(":library:diff-match-patch") {
     }
 }
 
-// Global configurations across all modules
-ext {
-    isThreadingEnabled = true
-}
-
 //project(":matrix-sdk-android") {
 //    sonarqube {
 //        properties {

--- a/changelog.d/5379.misc
+++ b/changelog.d/5379.misc
@@ -1,0 +1,1 @@
+Cleanup unused threads build configurations

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -38,8 +38,6 @@ android {
         resValue "string", "git_sdk_revision_unix_date", "\"${gitRevisionUnixDate()}\""
         resValue "string", "git_sdk_revision_date", "\"${gitRevisionDate()}\""
 
-        // Indicates whether or not threading support is enabled
-        buildConfigField "Boolean", "THREADING_ENABLED", "${isThreadingEnabled}"
         defaultConfig {
             consumerProguardFiles 'proguard-rules.pro'
         }

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -146,9 +146,6 @@ android {
         //  This *must* only be set in trusted environments.
         buildConfigField "Boolean", "handleCallAssertedIdentityEvents", "false"
 
-        // Indicates whether or not threading support is enabled
-        buildConfigField "Boolean", "THREADING_ENABLED", "${isThreadingEnabled}"
-
         buildConfigField "Boolean", "enableLocationSharing", "true"
         buildConfigField "String", "mapTilerKey", "\"fU3vlMsMn4Jb6dnEIFsx\""
 


### PR DESCRIPTION
Removed unused threads **buildConfig** configurations. Enable/Disable threads can be performed from lab settings