### PR TITLE
Add padding before first own message

### DIFF
--- a/changelog.d/5384.misc
+++ b/changelog.d/5384.misc
@@ -1,0 +1,1 @@
+Add top margin before our first message

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageItem.kt
@@ -105,6 +105,9 @@ abstract class AbsMessageItem<H : AbsMessageItem.Holder> : AbsBaseMessageItem<H>
         } else {
             holder.timeView.isVisible = false
         }
+
+        holder.additionalTopSpace.isVisible = attributes.informationData.messageLayout.addTopMargin
+
         // Render send state indicator
         holder.sendStateImageView.render(attributes.informationData.sendStateDecoration)
         holder.eventSendingIndicator.isVisible = attributes.informationData.sendStateDecoration == SendStateDecoration.SENDING_MEDIA
@@ -154,6 +157,7 @@ abstract class AbsMessageItem<H : AbsMessageItem.Holder> : AbsBaseMessageItem<H>
 
     abstract class Holder(@IdRes stubId: Int) : AbsBaseMessageItem.Holder(stubId) {
 
+        val additionalTopSpace by bind<View>(R.id.additionalTopSpace)
         val avatarImageView by bind<ImageView>(R.id.messageAvatarImageView)
         val memberNameView by bind<TextView>(R.id.messageMemberNameView)
         val timeView by bind<TextView>(R.id.messageTimeView)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/style/TimelineMessageLayout.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/style/TimelineMessageLayout.kt
@@ -24,12 +24,14 @@ sealed interface TimelineMessageLayout : Parcelable {
     val layoutRes: Int
     val showAvatar: Boolean
     val showDisplayName: Boolean
+    val addTopMargin: Boolean
     val showTimestamp: Boolean
 
     @Parcelize
     data class Default(override val showAvatar: Boolean,
                        override val showDisplayName: Boolean,
                        override val showTimestamp: Boolean,
+                       override val addTopMargin: Boolean = false,
             // Keep defaultLayout generated on epoxy items
                        override val layoutRes: Int = 0) : TimelineMessageLayout
 
@@ -38,6 +40,7 @@ sealed interface TimelineMessageLayout : Parcelable {
             override val showAvatar: Boolean,
             override val showDisplayName: Boolean,
             override val showTimestamp: Boolean = true,
+            override val addTopMargin: Boolean = false,
             val isIncoming: Boolean,
             val isPseudoBubble: Boolean,
             val cornersRadius: CornersRadius,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/style/TimelineMessageLayoutFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/style/TimelineMessageLayoutFactory.kt
@@ -118,6 +118,7 @@ class TimelineMessageLayoutFactory @Inject constructor(private val session: Sess
                     TimelineMessageLayout.Bubble(
                             showAvatar = showInformation && !isSentByMe,
                             showDisplayName = showInformation && !isSentByMe,
+                            addTopMargin = isFirstFromThisSender && isSentByMe,
                             isIncoming = !isSentByMe,
                             cornersRadius = cornersRadius,
                             isPseudoBubble = messageContent.isPseudoBubble(),

--- a/vector/src/main/res/layout/view_message_bubble.xml
+++ b/vector/src/main/res/layout/view_message_bubble.xml
@@ -26,12 +26,18 @@
         android:padding="2dp"
         tools:src="@sample/user_round_avatars" />
 
+    <View
+        android:id="@+id/additionalTopSpace"
+        android:layout_height="12dp"
+        android:layout_width="0dp"
+        android:layout_toEndOf="@id/messageStartGuideline" />
+
     <TextView
         android:id="@+id/messageMemberNameView"
         style="@style/Widget.Vector.TextView.Subtitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
+        android:layout_below="@id/additionalTopSpace"
         android:layout_alignParentEnd="true"
         android:layout_marginStart="12dp"
         android:layout_marginEnd="4dp"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Add a padding before the first message send by ourselves. It is the same size than a displayed name.

## Motivation and context

It is easier to view our messages from others if the padding is a bit bigger.

## Screenshots / GIFs

|Before|After|
|-|-|
|![Capture d’écran de 2022-03-01 00-39-42](https://user-images.githubusercontent.com/31284753/156077863-b2a889a2-00b0-4bdc-9b9a-a36ee9833132.png)|![Capture d’écran de 2022-03-01 00-35-07](https://user-images.githubusercontent.com/31284753/156077885-b726fdf8-2ff7-4a4c-a89b-eed9754f1a34.png)|

**Edit**: adding a table for better comparison of screnshoots

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 9

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [x] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
