### PR TITLE
Michaelk/nightly tests logcat

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -115,6 +115,9 @@ jobs:
         if: always()
         id: get-comment-body-session
         run: python3 ./tools/ci/render_test_output.py session ./matrix-sdk-android/build/outputs/androidTest-results/connected/*.xml
+      - name: Remove adb logcat
+        if: always()
+        run: pkill -9 adb
       - name: Run integration tests for  Matrix SDK [org.matrix.android.sdk.account] API[${{ matrix.api-level }}]
         if: always()
         uses: reactivecircus/android-emulator-runner@v2
@@ -136,6 +139,9 @@ jobs:
         if: always()
         id: get-comment-body-account
         run: python3 ./tools/ci/render_test_output.py account ./matrix-sdk-android/build/outputs/androidTest-results/connected/*.xml
+      - name: Remove adb logcat
+        if: always()
+        run: pkill -9 adb
       # package: org.matrix.android.sdk.internal
       - name: Run integration tests for Matrix SDK [org.matrix.android.sdk.internal] API[${{ matrix.api-level }}]
         if: always()
@@ -158,6 +164,9 @@ jobs:
         if: always()
         id: get-comment-body-internal
         run: python3 ./tools/ci/render_test_output.py internal ./matrix-sdk-android/build/outputs/androidTest-results/connected/*.xml
+      - name: Remove adb logcat
+        if: always()
+        run: pkill -9 adb
       # package: org.matrix.android.sdk.ordering
       - name: Run integration tests for Matrix SDK [org.matrix.android.sdk.ordering] API[${{ matrix.api-level }}]
         if: always()
@@ -180,6 +189,9 @@ jobs:
         if: always()
         id: get-comment-body-ordering
         run: python3 ./tools/ci/render_test_output.py ordering ./matrix-sdk-android/build/outputs/androidTest-results/connected/*.xml
+      - name: Remove adb logcat
+        if: always()
+        run: pkill -9 adb
       # package: class PermalinkParserTest
       - name: Run integration tests for Matrix SDK class [org.matrix.android.sdk.PermalinkParserTest] API[${{ matrix.api-level }}]
         if: always()
@@ -202,6 +214,9 @@ jobs:
         if: always()
         id: get-comment-body-permalink
         run: python3 ./tools/ci/render_test_output.py permalink ./matrix-sdk-android/build/outputs/androidTest-results/connected/*.xml
+      - name: Remove adb logcat
+        if: always()
+        run: pkill -9 adb
       # package: class PermalinkParserTest
       - name: Find Comment
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -104,7 +104,13 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           emulator-build: 7425822
-          script: ./gradlew $CI_GRADLE_ARG_PROPERTIES -Pandroid.testInstrumentationRunnerArguments.package='org.matrix.android.sdk.session' matrix-sdk-android:connectedDebugAndroidTest
+          script: |
+            adb root
+            adb logcat -c
+            touch emulator-session.log
+            chmod 777 emulator-session.log
+            adb logcat >> emulator-session.log &
+            ./gradlew $CI_GRADLE_ARG_PROPERTIES -Pandroid.testInstrumentationRunnerArguments.package='org.matrix.android.sdk.session' matrix-sdk-android:connectedDebugAndroidTest
       - name: Read Results [org.matrix.android.sdk.session]
         if: always()
         id: get-comment-body-session
@@ -119,7 +125,13 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           emulator-build: 7425822
-          script: ./gradlew $CI_GRADLE_ARG_PROPERTIES  -Pandroid.testInstrumentationRunnerArguments.package='org.matrix.android.sdk.account' matrix-sdk-android:connectedDebugAndroidTest
+          script: |
+            adb root
+            adb logcat -c
+            touch emulator-account.log
+            chmod 777 emulator-account.log
+            adb logcat >> emulator-account.log &
+            ./gradlew $CI_GRADLE_ARG_PROPERTIES  -Pandroid.testInstrumentationRunnerArguments.package='org.matrix.android.sdk.account' matrix-sdk-android:connectedDebugAndroidTest
       - name: Read Results [org.matrix.android.sdk.account]
         if: always()
         id: get-comment-body-account
@@ -135,7 +147,13 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           emulator-build: 7425822
-          script: ./gradlew $CI_GRADLE_ARG_PROPERTIES  -Pandroid.testInstrumentationRunnerArguments.package='org.matrix.android.sdk.internal' matrix-sdk-android:connectedDebugAndroidTest
+          script: |
+            adb root
+            adb logcat -c
+            touch emulator-internal.log
+            chmod 777 emulator-internal.log
+            adb logcat >> emulator-internal.log &
+            ./gradlew $CI_GRADLE_ARG_PROPERTIES  -Pandroid.testInstrumentationRunnerArguments.package='org.matrix.android.sdk.internal' matrix-sdk-android:connectedDebugAndroidTest
       - name: Read Results [org.matrix.android.sdk.internal]
         if: always()
         id: get-comment-body-internal
@@ -151,7 +169,13 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           emulator-build: 7425822
-          script: ./gradlew $CI_GRADLE_ARG_PROPERTIES  -Pandroid.testInstrumentationRunnerArguments.package='org.matrix.android.sdk.ordering' matrix-sdk-android:connectedDebugAndroidTest
+          script: |
+            adb root
+            adb logcat -c
+            touch emulator-ordering.log
+            chmod 777 emulator-ordering.log
+            adb logcat >> emulator-ordering.log &
+            ./gradlew $CI_GRADLE_ARG_PROPERTIES  -Pandroid.testInstrumentationRunnerArguments.package='org.matrix.android.sdk.ordering' matrix-sdk-android:connectedDebugAndroidTest
       - name: Read Results [org.matrix.android.sdk.ordering]
         if: always()
         id: get-comment-body-ordering
@@ -167,7 +191,13 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           emulator-build: 7425822
-          script: ./gradlew $CI_GRADLE_ARG_PROPERTIES  -Pandroid.testInstrumentationRunnerArguments.class='org.matrix.android.sdk.PermalinkParserTest' matrix-sdk-android:connectedDebugAndroidTest
+          script: |
+            adb root
+            adb logcat -c
+            touch emulator-permalink.log
+            chmod 777 emulator-permalink.log
+            adb logcat >> emulator-permalink.log &
+            ./gradlew $CI_GRADLE_ARG_PROPERTIES  -Pandroid.testInstrumentationRunnerArguments.class='org.matrix.android.sdk.PermalinkParserTest' matrix-sdk-android:connectedDebugAndroidTest
       - name: Read Results [org.matrix.android.sdk.PermalinkParserTest]
         if: always()
         id: get-comment-body-permalink
@@ -196,6 +226,17 @@ jobs:
             - `[org.matrix.android.sdk.ordering]`<br>${{ steps.get-comment-body-ordering.outputs.ordering }}
             - `[org.matrix.android.sdk.PermalinkParserTest]`<br>${{ steps.get-comment-body-permalink.outputs.permalink }}
           edit-mode: replace
+      - name: Upload Test Report Log
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: integrationtest-error-results
+          path: |
+            emulator-permalink.log
+            emulator-internal.log
+            emulator-ordering.log
+            emulator-account.log
+            emulator-session.log
 
   ui-tests:
     name: UI Tests (Synapse)
@@ -250,7 +291,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: sanity-error-results
+          name: uitest-error-results
           path: |
             emulator.log
             failure_screenshots/


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [X] Technical
- [ ] Other :

## Content

GHA integration test action now preserves logcat entries during the test run.

## Motivation and context

Assists with diagnosing unit test failures, eg https://github.com/vector-im/element-android/issues/5385

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
