### PR TITLE
Run sonarqube as part of nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,6 @@ env:
     -Porg.gradle.jvmargs=-Xmx4g
     -Porg.gradle.parallel=false
     -PallWarningsAsErrors=false
-
 jobs:
   # Build Android Tests [Matrix SDK]
   build-android-test-matrix-sdk:
@@ -263,8 +262,6 @@ jobs:
     # No concurrency required, runs every time on a schedule.
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: develop
       - name: Set up Python 3.8
         uses: actions/setup-python@v3
         with:
@@ -311,12 +308,39 @@ jobs:
             emulator.log
             failure_screenshots/
 
+  sonarqube:
+    runs-on: macos-latest
+    if: always()
+    needs:
+      - integration-tests
+      - ui-tests
+#      - unit-tests  TODO: code coverage from here too
+      - build-android-test-matrix-sdk 
+      - build-android-test-app
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - run: ./gradlew sonarqube $CI_GRADLE_ARG_PROPERTIES
+        env:
+          - SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
 # Notify the channel about scheduled runs, do not notify for manually triggered runs
   notify:
     runs-on: ubuntu-latest
     needs:
       - integration-tests
       - ui-tests
+#      - unit-tests
+      - build-android-test-matrix-sdk 
+      - build-android-test-app
+      - sonarqube
     if: always() && github.event_name != 'workflow_dispatch'
     # No concurrency required, runs every time on a schedule.
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -333,7 +333,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - run: ./gradlew sonarqube $CI_GRADLE_ARG_PROPERTIES
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          ORG_GRADLE_PROJECT_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
 # Notify the channel about scheduled runs, do not notify for manually triggered runs
   notify:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -319,6 +319,10 @@ jobs:
       - build-android-test-app
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -329,7 +329,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - run: ./gradlew sonarqube $CI_GRADLE_ARG_PROPERTIES
         env:
-          - SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
 # Notify the channel about scheduled runs, do not notify for manually triggered runs
   notify:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -333,7 +333,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - run: ./gradlew sonarqube $CI_GRADLE_ARG_PROPERTIES
         env:
-          ORG_GRADLE_PROJECT_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          ORG_GRADLE_PROJECT_SONAR_LOGIN: ${{ secrets.SONAR_TOKEN }}
 
 # Notify the channel about scheduled runs, do not notify for manually triggered runs
   notify:

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ apply plugin: 'org.sonarqube'
 
 // To run a sonar analysis:
 // Run './gradlew sonarqube -Dsonar.login=<REPLACE_WITH_SONAR_KEY>'
-// The SONAR_KEY is stored in passbolt
+// The SONAR_KEY is stored in passbolt as Token Sonar Cloud Bma
 
 sonarqube {
     properties {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [X] Technical
- [ ] Other :

## Content

Nightly runs of sonarqube code quality checks

Requires @bmarty to add a secret to github for this project called "SONAR_TOKEN", which can be done at any time.

## Motivation and context

Automate away our sonarqube runs. An extension to this will be adding jacoco support and reporting code coverage metrics to sonarqube as well.

Code coverage could be implemented by codecov instead of sonarqube, and is done so by other element client implementations; so this PR may not be the end result.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
