### PR TITLE
Upgrades to Material 1.5.0 (dependency only)

### DIFF
--- a/changelog.d/5392.misc
+++ b/changelog.d/5392.misc
@@ -1,0 +1,1 @@
+Upgrades material dependency version from 1.4.0 to 1.5.0

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -71,8 +71,7 @@ ext.libs = [
                 'espressoIntents'         : "androidx.test.espresso:espresso-intents:$espresso"
         ],
         google      : [
-                // TODO There is 1.6.0?
-                'material'                : "com.google.android.material:material:1.4.0"
+                'material'                : "com.google.android.material:material:1.5.0"
         ],
         dagger      : [
                 'dagger'                  : "com.google.dagger:dagger:$dagger",


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

Upgrading the material library dependency from 1.4.0 > 1.5.0 without any other changes

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

[There's another PR up](https://github.com/vector-im/element-android/pull/5359) that implements a design change to upgrade our material components themselves to the new Material You design scheme.

This however is a decision that design needs to make and may take a while.

So while I continue to maintain that PR in the midst of that decision, this PR simply serves as an upgrade to keep our dependencies up-to-date without any user-facing changes.

This being merge would thus close [Issue 5291](https://github.com/vector-im/element-android/issues/5291). I would however recommend a new issue be raised for the upgrade of the app's look to Material You

**I'm currently testing that this indeed doesn't change anything user-facing

## Screenshots / GIFs

<!-- Only if UI have been changed -->

N/A

## Tests

<!-- Explain how you tested your development -->

- Smoke test around the app seeing that the UI is unchanged
- Confirm this through the debug menu pages

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 10

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
