### PR TITLE
Fix Media cache size with negative values in the General Settings screen 

### DIFF
--- a/changelog.d/5394.bugfix
+++ b/changelog.d/5394.bugfix
@@ -1,0 +1,1 @@
+Fix incorrect media cache size in settings

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/file/FileService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/file/FileService.kt
@@ -117,5 +117,5 @@ interface FileService {
     /**
      * Get size of cached files
      */
-    fun getCacheSize(): Int
+    fun getCacheSize(): Long
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultFileService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultFileService.kt
@@ -323,13 +323,13 @@ internal class DefaultFileService @Inject constructor(
         return FileProvider.getUriForFile(context, authority, targetFile)
     }
 
-    override fun getCacheSize(): Int {
+    override fun getCacheSize(): Long {
         return downloadFolder.walkTopDown()
                 .onEnter {
                     Timber.v("Get size of ${it.absolutePath}")
                     true
                 }
-                .sumOf { it.length().toInt() }
+                .sumOf { it.length() }
     }
 
     override fun clearCache() {

--- a/vector/src/main/java/im/vector/app/core/utils/FileUtils.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/FileUtils.kt
@@ -125,11 +125,11 @@ fun getFileExtension(fileUri: String): String? {
  * Size
  * ========================================================================================== */
 
-fun getSizeOfFiles(root: File): Int {
+fun getSizeOfFiles(root: File): Long {
     return root.walkTopDown()
             .onEnter {
                 Timber.v("Get size of ${it.absolutePath}")
                 true
             }
-            .sumOf { it.length().toInt() }
+            .sumOf { it.length() }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsGeneralFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsGeneralFragment.kt
@@ -251,7 +251,7 @@ class VectorSettingsGeneralFragment @Inject constructor(
                     Glide.get(requireContext()).clearMemory()
                     session.fileService().clearCache()
 
-                    var newSize: Int
+                    var newSize: Long
 
                     withContext(Dispatchers.IO) {
                         // On BG thread
@@ -261,7 +261,7 @@ class VectorSettingsGeneralFragment @Inject constructor(
                         newSize += session.fileService().getCacheSize()
                     }
 
-                    it.summary = TextUtils.formatFileSize(requireContext(), newSize.toLong())
+                    it.summary = TextUtils.formatFileSize(requireContext(), newSize)
 
                     hideLoadingView()
                 }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fix https://github.com/vector-im/element-android/issues/5394
Negative media cache sizes due to Int overflow.

Signed-off-by: Tiago Loureiro [tiago@beeper.com](mailto:tiago@beeper.com)

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed -->


## Tested devices

- [x] Physical
- [x] Emulator

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
