### PR TITLE
FTUE - Onboarding registration steps unit tests

### DIFF
--- a/changelog.d/5408.misc
+++ b/changelog.d/5408.misc
@@ -1,0 +1,1 @@
+Improved onboarding registration unit test coverage

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
@@ -25,26 +25,26 @@ import org.matrix.android.sdk.api.auth.data.Credentials
 import org.matrix.android.sdk.api.auth.registration.RegisterThreePid
 import org.matrix.android.sdk.internal.network.ssl.Fingerprint
 
-sealed class OnboardingAction : VectorViewModelAction {
-    data class OnGetStarted(val resetLoginConfig: Boolean, val onboardingFlow: OnboardingFlow) : OnboardingAction()
-    data class OnIAlreadyHaveAnAccount(val resetLoginConfig: Boolean, val onboardingFlow: OnboardingFlow) : OnboardingAction()
+sealed interface OnboardingAction : VectorViewModelAction {
+    data class OnGetStarted(val resetLoginConfig: Boolean, val onboardingFlow: OnboardingFlow) : OnboardingAction
+    data class OnIAlreadyHaveAnAccount(val resetLoginConfig: Boolean, val onboardingFlow: OnboardingFlow) : OnboardingAction
 
-    data class UpdateServerType(val serverType: ServerType) : OnboardingAction()
-    data class UpdateHomeServer(val homeServerUrl: String) : OnboardingAction()
-    data class UpdateUseCase(val useCase: FtueUseCase) : OnboardingAction()
-    object ResetUseCase : OnboardingAction()
-    data class UpdateSignMode(val signMode: SignMode) : OnboardingAction()
-    data class LoginWithToken(val loginToken: String) : OnboardingAction()
-    data class WebLoginSuccess(val credentials: Credentials) : OnboardingAction()
-    data class InitWith(val loginConfig: LoginConfig?) : OnboardingAction()
-    data class ResetPassword(val email: String, val newPassword: String) : OnboardingAction()
-    object ResetPasswordMailConfirmed : OnboardingAction()
+    data class UpdateServerType(val serverType: ServerType) : OnboardingAction
+    data class UpdateHomeServer(val homeServerUrl: String) : OnboardingAction
+    data class UpdateUseCase(val useCase: FtueUseCase) : OnboardingAction
+    object ResetUseCase : OnboardingAction
+    data class UpdateSignMode(val signMode: SignMode) : OnboardingAction
+    data class LoginWithToken(val loginToken: String) : OnboardingAction
+    data class WebLoginSuccess(val credentials: Credentials) : OnboardingAction
+    data class InitWith(val loginConfig: LoginConfig?) : OnboardingAction
+    data class ResetPassword(val email: String, val newPassword: String) : OnboardingAction
+    object ResetPasswordMailConfirmed : OnboardingAction
 
     // Login or Register, depending on the signMode
-    data class LoginOrRegister(val username: String, val password: String, val initialDeviceName: String) : OnboardingAction()
+    data class LoginOrRegister(val username: String, val password: String, val initialDeviceName: String) : OnboardingAction
 
     // Register actions
-    open class RegisterAction : OnboardingAction()
+    open class RegisterAction : OnboardingAction
 
     data class AddThreePid(val threePid: RegisterThreePid) : RegisterAction()
     object SendAgainThreePid : RegisterAction()
@@ -60,7 +60,7 @@ sealed class OnboardingAction : VectorViewModelAction {
     object RegisterDummy : RegisterAction()
 
     // Reset actions
-    open class ResetAction : OnboardingAction()
+    open class ResetAction : OnboardingAction
 
     object ResetHomeServerType : ResetAction()
     object ResetHomeServerUrl : ResetAction()
@@ -69,16 +69,16 @@ sealed class OnboardingAction : VectorViewModelAction {
     object ResetResetPassword : ResetAction()
 
     // Homeserver history
-    object ClearHomeServerHistory : OnboardingAction()
+    object ClearHomeServerHistory : OnboardingAction
 
-    data class PostViewEvent(val viewEvent: OnboardingViewEvents) : OnboardingAction()
+    data class PostViewEvent(val viewEvent: OnboardingViewEvents) : OnboardingAction
 
-    data class UserAcceptCertificate(val fingerprint: Fingerprint) : OnboardingAction()
+    data class UserAcceptCertificate(val fingerprint: Fingerprint) : OnboardingAction
 
-    object PersonalizeProfile : OnboardingAction()
-    data class UpdateDisplayName(val displayName: String) : OnboardingAction()
-    object UpdateDisplayNameSkipped : OnboardingAction()
-    data class ProfilePictureSelected(val uri: Uri) : OnboardingAction()
-    object SaveSelectedProfilePicture : OnboardingAction()
-    object UpdateProfilePictureSkipped : OnboardingAction()
+    object PersonalizeProfile : OnboardingAction
+    data class UpdateDisplayName(val displayName: String) : OnboardingAction
+    object UpdateDisplayNameSkipped : OnboardingAction
+    data class ProfilePictureSelected(val uri: Uri) : OnboardingAction
+    object SaveSelectedProfilePicture : OnboardingAction
+    object UpdateProfilePictureSkipped : OnboardingAction
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
@@ -22,7 +22,6 @@ import im.vector.app.features.login.LoginConfig
 import im.vector.app.features.login.ServerType
 import im.vector.app.features.login.SignMode
 import org.matrix.android.sdk.api.auth.data.Credentials
-import org.matrix.android.sdk.api.auth.registration.RegisterThreePid
 import org.matrix.android.sdk.internal.network.ssl.Fingerprint
 
 sealed interface OnboardingAction : VectorViewModelAction {
@@ -42,22 +41,9 @@ sealed interface OnboardingAction : VectorViewModelAction {
 
     // Login or Register, depending on the signMode
     data class LoginOrRegister(val username: String, val password: String, val initialDeviceName: String) : OnboardingAction
+    object StopEmailValidationCheck : OnboardingAction
 
-    // Register actions
-    open class RegisterAction : OnboardingAction
-
-    data class AddThreePid(val threePid: RegisterThreePid) : RegisterAction()
-    object SendAgainThreePid : RegisterAction()
-
-    // TODO Confirm Email (from link in the email, open in the phone, intercepted by the app)
-    data class ValidateThreePid(val code: String) : RegisterAction()
-
-    data class CheckIfEmailHasBeenValidated(val delayMillis: Long) : RegisterAction()
-    object StopEmailValidationCheck : RegisterAction()
-
-    data class CaptchaDone(val captchaResponse: String) : RegisterAction()
-    object AcceptTerms : RegisterAction()
-    object RegisterDummy : RegisterAction()
+    data class PostRegisterAction(val registerAction: RegisterAction) : OnboardingAction
 
     // Reset actions
     open class ResetAction : OnboardingAction

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
@@ -46,13 +46,13 @@ sealed interface OnboardingAction : VectorViewModelAction {
     data class PostRegisterAction(val registerAction: RegisterAction) : OnboardingAction
 
     // Reset actions
-    open class ResetAction : OnboardingAction
+    sealed interface ResetAction : OnboardingAction
 
-    object ResetHomeServerType : ResetAction()
-    object ResetHomeServerUrl : ResetAction()
-    object ResetSignMode : ResetAction()
-    object ResetLogin : ResetAction()
-    object ResetResetPassword : ResetAction()
+    object ResetHomeServerType : ResetAction
+    object ResetHomeServerUrl : ResetAction
+    object ResetSignMode : ResetAction
+    object ResetLogin : ResetAction
+    object ResetResetPassword : ResetAction
 
     // Homeserver history
     object ClearHomeServerHistory : OnboardingAction

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -276,9 +276,14 @@ class OnboardingViewModel @AssistedInject constructor(
             kotlin.runCatching { registrationActionHandler.handleRegisterAction(registrationWizard, action) }
                     .fold(
                             onSuccess = {
-                                when (it) {
-                                    is RegistrationResult.Success      -> onSessionCreated(it.session, isAccountCreated = true)
-                                    is RegistrationResult.FlowResponse -> onFlowResponse(it.flowResult)
+                                when {
+                                    action.ignoresResult() -> {
+                                        // do nothing
+                                    }
+                                    else                   -> when (it) {
+                                        is RegistrationResult.Success      -> onSessionCreated(it.session, isAccountCreated = true)
+                                        is RegistrationResult.FlowResponse -> onFlowResponse(it.flowResult)
+                                    }
                                 }
                             },
                             onFailure = {

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -273,7 +273,7 @@ class OnboardingViewModel @AssistedInject constructor(
             if (action.hasLoadingState()) {
                 setState { copy(asyncRegistration = Loading()) }
             }
-            kotlin.runCatching { registrationActionHandler.handleRegisterAction(registrationWizard, action) }
+            runCatching { registrationActionHandler.handleRegisterAction(registrationWizard, action) }
                     .fold(
                             onSuccess = {
                                 when {

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -373,7 +373,7 @@ class OnboardingViewModel @AssistedInject constructor(
         }
 
         when (action.signMode) {
-            SignMode.SignUp             -> handleRegisterAction(RegisterAction.RegisterDummy)
+            SignMode.SignUp             -> handleRegisterAction(RegisterAction.StartRegistration)
             SignMode.SignIn             -> startAuthenticationFlow()
             SignMode.SignInWithMatrixId -> _viewEvents.post(OnboardingViewEvents.OnSignModeSelected(SignMode.SignInWithMatrixId))
             SignMode.Unknown            -> Unit

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -83,6 +83,7 @@ class OnboardingViewModel @AssistedInject constructor(
         private val vectorFeatures: VectorFeatures,
         private val analyticsTracker: AnalyticsTracker,
         private val uriFilenameResolver: UriFilenameResolver,
+        private val registrationActionHandler: RegistrationActionHandler,
         private val vectorOverrides: VectorOverrides
 ) : VectorViewModel<OnboardingViewState, OnboardingAction, OnboardingViewEvents>(initialState) {
 
@@ -116,15 +117,15 @@ class OnboardingViewModel @AssistedInject constructor(
 
     private val matrixOrgUrl = stringProvider.getString(R.string.matrix_org_server_url).ensureTrailingSlash()
 
+    private val registrationWizard: RegistrationWizard
+        get() = authenticationService.getRegistrationWizard()
+
     val currentThreePid: String?
-        get() = registrationWizard?.currentThreePid
+        get() = registrationWizard.currentThreePid
 
     // True when login and password has been sent with success to the homeserver
     val isRegistrationStarted: Boolean
         get() = authenticationService.isRegistrationStarted
-
-    private val registrationWizard: RegistrationWizard?
-        get() = authenticationService.getRegistrationWizard()
 
     private val loginWizard: LoginWizard?
         get() = authenticationService.getLoginWizard()
@@ -153,7 +154,7 @@ class OnboardingViewModel @AssistedInject constructor(
             is OnboardingAction.WebLoginSuccess            -> handleWebLoginSuccess(action)
             is OnboardingAction.ResetPassword              -> handleResetPassword(action)
             is OnboardingAction.ResetPasswordMailConfirmed -> handleResetPasswordMailConfirmed()
-            is OnboardingAction.RegisterAction             -> handleRegisterAction(action)
+            is OnboardingAction.PostRegisterAction         -> handleRegisterAction(action.registerAction)
             is OnboardingAction.ResetAction                -> handleResetAction(action)
             is OnboardingAction.UserAcceptCertificate      -> handleUserAcceptCertificate(action)
             OnboardingAction.ClearHomeServerHistory        -> handleClearHomeServerHistory()
@@ -164,6 +165,7 @@ class OnboardingViewModel @AssistedInject constructor(
             is OnboardingAction.ProfilePictureSelected     -> handleProfilePictureSelected(action)
             OnboardingAction.SaveSelectedProfilePicture    -> updateProfilePicture()
             is OnboardingAction.PostViewEvent              -> _viewEvents.post(action.viewEvent)
+            OnboardingAction.StopEmailValidationCheck      -> currentJob = null
         }.exhaustive
     }
 
@@ -266,131 +268,36 @@ class OnboardingViewModel @AssistedInject constructor(
         }
     }
 
-    private fun handleRegisterAction(action: OnboardingAction.RegisterAction) {
-        when (action) {
-            is OnboardingAction.CaptchaDone                  -> handleCaptchaDone(action)
-            is OnboardingAction.AcceptTerms                  -> handleAcceptTerms()
-            is OnboardingAction.RegisterDummy                -> handleRegisterDummy()
-            is OnboardingAction.AddThreePid                  -> handleAddThreePid(action)
-            is OnboardingAction.SendAgainThreePid            -> handleSendAgainThreePid()
-            is OnboardingAction.ValidateThreePid             -> handleValidateThreePid(action)
-            is OnboardingAction.CheckIfEmailHasBeenValidated -> handleCheckIfEmailHasBeenValidated(action)
-            is OnboardingAction.StopEmailValidationCheck     -> handleStopEmailValidationCheck()
-        }
-    }
-
-    private fun handleCheckIfEmailHasBeenValidated(action: OnboardingAction.CheckIfEmailHasBeenValidated) {
-        // We do not want the common progress bar to be displayed, so we do not change asyncRegistration value in the state
-        currentJob = executeRegistrationStep(withLoading = false) {
-            it.checkIfEmailHasBeenValidated(action.delayMillis)
-        }
-    }
-
-    private fun handleStopEmailValidationCheck() {
-        currentJob = null
-    }
-
-    private fun handleValidateThreePid(action: OnboardingAction.ValidateThreePid) {
-        currentJob = executeRegistrationStep {
-            it.handleValidateThreePid(action.code)
-        }
-    }
-
-    private fun executeRegistrationStep(withLoading: Boolean = true,
-                                        block: suspend (RegistrationWizard) -> RegistrationResult): Job {
-        if (withLoading) {
-            setState { copy(asyncRegistration = Loading()) }
-        }
-        return viewModelScope.launch {
-            try {
-                registrationWizard?.let { block(it) }
-                /*
-                   // Simulate registration disabled
-                   throw Failure.ServerError(MatrixError(
-                           code = MatrixError.FORBIDDEN,
-                           message = "Registration is disabled"
-                   ), 403))
-                */
-            } catch (failure: Throwable) {
-                if (failure !is CancellationException) {
-                    _viewEvents.post(OnboardingViewEvents.Failure(failure))
-                }
-                null
-            }
-                    ?.let { data ->
-                        when (data) {
-                            is RegistrationResult.Success      -> onSessionCreated(data.session, isAccountCreated = true)
-                            is RegistrationResult.FlowResponse -> onFlowResponse(data.flowResult)
-                        }
-                    }
-
-            setState {
-                copy(
-                        asyncRegistration = Uninitialized
-                )
-            }
-        }
-    }
-
-    private fun handleAddThreePid(action: OnboardingAction.AddThreePid) {
-        setState { copy(asyncRegistration = Loading()) }
+    private fun handleRegisterAction(action: RegisterAction) {
         currentJob = viewModelScope.launch {
-            try {
-                registrationWizard?.addThreePid(action.threePid)
-            } catch (failure: Throwable) {
-                _viewEvents.post(OnboardingViewEvents.Failure(failure))
+            if (action.hasLoadingState()) {
+                setState { copy(asyncRegistration = Loading()) }
             }
-            setState {
-                copy(
-                        asyncRegistration = Uninitialized
-                )
-            }
-        }
-    }
-
-    private fun handleSendAgainThreePid() {
-        setState { copy(asyncRegistration = Loading()) }
-        currentJob = viewModelScope.launch {
-            try {
-                registrationWizard?.sendAgainThreePid()
-            } catch (failure: Throwable) {
-                _viewEvents.post(OnboardingViewEvents.Failure(failure))
-            }
-            setState {
-                copy(
-                        asyncRegistration = Uninitialized
-                )
-            }
-        }
-    }
-
-    private fun handleAcceptTerms() {
-        currentJob = executeRegistrationStep {
-            it.acceptTerms()
-        }
-    }
-
-    private fun handleRegisterDummy() {
-        currentJob = executeRegistrationStep {
-            it.dummy()
+            kotlin.runCatching { registrationActionHandler.handleRegisterAction(registrationWizard, action) }
+                    .fold(
+                            onSuccess = {
+                                when (it) {
+                                    is RegistrationResult.Success      -> onSessionCreated(it.session, isAccountCreated = true)
+                                    is RegistrationResult.FlowResponse -> onFlowResponse(it.flowResult)
+                                }
+                            },
+                            onFailure = {
+                                if (it !is CancellationException) {
+                                    _viewEvents.post(OnboardingViewEvents.Failure(it))
+                                }
+                            }
+                    )
+            setState { copy(asyncRegistration = Uninitialized) }
         }
     }
 
     private fun handleRegisterWith(action: OnboardingAction.LoginOrRegister) {
         reAuthHelper.data = action.password
-        currentJob = executeRegistrationStep {
-            it.createAccount(
-                    action.username,
-                    action.password,
-                    action.initialDeviceName
-            )
-        }
-    }
-
-    private fun handleCaptchaDone(action: OnboardingAction.CaptchaDone) {
-        currentJob = executeRegistrationStep {
-            it.performReCaptcha(action.captchaResponse)
-        }
+        handleRegisterAction(RegisterAction.CreateAccount(
+                action.username,
+                action.password,
+                action.initialDeviceName
+        ))
     }
 
     private fun handleResetAction(action: OnboardingAction.ResetAction) {
@@ -461,7 +368,7 @@ class OnboardingViewModel @AssistedInject constructor(
         }
 
         when (action.signMode) {
-            SignMode.SignUp             -> startRegistrationFlow()
+            SignMode.SignUp             -> handleRegisterAction(RegisterAction.RegisterDummy)
             SignMode.SignIn             -> startAuthenticationFlow()
             SignMode.SignInWithMatrixId -> _viewEvents.post(OnboardingViewEvents.OnSignModeSelected(SignMode.SignInWithMatrixId))
             SignMode.Unknown            -> Unit
@@ -499,7 +406,7 @@ class OnboardingViewModel @AssistedInject constructor(
 
         // If there is a pending email validation continue on this step
         try {
-            if (registrationWizard?.isRegistrationStarted == true) {
+            if (registrationWizard.isRegistrationStarted) {
                 currentThreePid?.let {
                     handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnSendEmailSuccess(it)))
                 }
@@ -730,12 +637,6 @@ class OnboardingViewModel @AssistedInject constructor(
         }
     }
 
-    private fun startRegistrationFlow() {
-        currentJob = executeRegistrationStep {
-            it.getRegistrationFlow()
-        }
-    }
-
     private fun startAuthenticationFlow() {
         // Ensure Wizard is ready
         loginWizard
@@ -745,13 +646,16 @@ class OnboardingViewModel @AssistedInject constructor(
 
     private fun onFlowResponse(flowResult: FlowResult) {
         // If dummy stage is mandatory, and password is already sent, do the dummy stage now
-        if (isRegistrationStarted &&
-                flowResult.missingStages.any { it is Stage.Dummy && it.mandatory }) {
+        if (isRegistrationStarted && flowResult.missingStages.any { it is Stage.Dummy && it.mandatory }) {
             handleRegisterDummy()
         } else {
             // Notify the user
             _viewEvents.post(OnboardingViewEvents.RegistrationFlowResult(flowResult, isRegistrationStarted))
         }
+    }
+
+    private fun handleRegisterDummy() {
+        handleRegisterAction(RegisterAction.RegisterDummy)
     }
 
     private suspend fun onSessionCreated(session: Session, isAccountCreated: Boolean) {

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -165,7 +165,7 @@ class OnboardingViewModel @AssistedInject constructor(
             is OnboardingAction.ProfilePictureSelected     -> handleProfilePictureSelected(action)
             OnboardingAction.SaveSelectedProfilePicture    -> updateProfilePicture()
             is OnboardingAction.PostViewEvent              -> _viewEvents.post(action.viewEvent)
-            OnboardingAction.StopEmailValidationCheck      -> currentJob = null
+            OnboardingAction.StopEmailValidationCheck      -> cancelWaitForEmailValidation()
         }.exhaustive
     }
 
@@ -914,6 +914,10 @@ class OnboardingViewModel @AssistedInject constructor(
 
     private fun completePersonalization() {
         _viewEvents.post(OnboardingViewEvents.OnPersonalizationComplete)
+    }
+
+    private fun cancelWaitForEmailValidation() {
+        currentJob = null
     }
 }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/RegistrationActionHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/RegistrationActionHandler.kt
@@ -55,6 +55,12 @@ sealed interface RegisterAction {
     object RegisterDummy : RegisterAction
 }
 
+fun RegisterAction.ignoresResult() = when (this) {
+    is RegisterAction.AddThreePid       -> true
+    is RegisterAction.SendAgainThreePid -> true
+    else                                -> false
+}
+
 fun RegisterAction.hasLoadingState() = when (this) {
     is RegisterAction.CheckIfEmailHasBeenValidated -> false
     else                                           -> true

--- a/vector/src/main/java/im/vector/app/features/onboarding/RegistrationActionHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/RegistrationActionHandler.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.onboarding
+
+import org.matrix.android.sdk.api.auth.registration.RegisterThreePid
+import org.matrix.android.sdk.api.auth.registration.RegistrationResult
+import org.matrix.android.sdk.api.auth.registration.RegistrationWizard
+import javax.inject.Inject
+
+class RegistrationActionHandler @Inject constructor() {
+
+    suspend fun handleRegisterAction(registrationWizard: RegistrationWizard, action: RegisterAction): RegistrationResult {
+        return when (action) {
+            RegisterAction.StartRegistration               -> registrationWizard.getRegistrationFlow()
+            is RegisterAction.CaptchaDone                  -> registrationWizard.performReCaptcha(action.captchaResponse)
+            is RegisterAction.AcceptTerms                  -> registrationWizard.acceptTerms()
+            is RegisterAction.RegisterDummy                -> registrationWizard.dummy()
+            is RegisterAction.AddThreePid                  -> registrationWizard.addThreePid(action.threePid)
+            is RegisterAction.SendAgainThreePid            -> registrationWizard.sendAgainThreePid()
+            is RegisterAction.ValidateThreePid             -> registrationWizard.handleValidateThreePid(action.code)
+            is RegisterAction.CheckIfEmailHasBeenValidated -> registrationWizard.checkIfEmailHasBeenValidated(action.delayMillis)
+            is RegisterAction.CreateAccount                -> registrationWizard.createAccount(action.username, action.password, action.initialDeviceName)
+        }
+    }
+}
+
+sealed interface RegisterAction {
+    object StartRegistration : RegisterAction
+    data class CreateAccount(val username: String, val password: String, val initialDeviceName: String) : RegisterAction
+
+    data class AddThreePid(val threePid: RegisterThreePid) : RegisterAction
+    object SendAgainThreePid : RegisterAction
+
+    // TODO Confirm Email (from link in the email, open in the phone, intercepted by the app)
+    data class ValidateThreePid(val code: String) : RegisterAction
+
+    data class CheckIfEmailHasBeenValidated(val delayMillis: Long) : RegisterAction
+
+    data class CaptchaDone(val captchaResponse: String) : RegisterAction
+    object AcceptTerms : RegisterAction
+    object RegisterDummy : RegisterAction
+}
+
+fun RegisterAction.hasLoadingState() = when (this) {
+    is RegisterAction.CheckIfEmailHasBeenValidated -> false
+    else                                           -> true
+}

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCaptchaFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCaptchaFragment.kt
@@ -39,6 +39,7 @@ import im.vector.app.databinding.FragmentLoginCaptchaBinding
 import im.vector.app.features.login.JavascriptResponse
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewState
+import im.vector.app.features.onboarding.RegisterAction
 import kotlinx.parcelize.Parcelize
 import org.matrix.android.sdk.internal.di.MoshiProvider
 import timber.log.Timber
@@ -181,7 +182,7 @@ class FtueAuthCaptchaFragment @Inject constructor(
 
                     val response = javascriptResponse?.response
                     if (javascriptResponse?.action == "verifyCallback" && response != null) {
-                        viewModel.handle(OnboardingAction.CaptchaDone(response))
+                        viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.CaptchaDone(response)))
                     }
                 }
                 return true

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthGenericTextInputFormFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthGenericTextInputFormFragment.kt
@@ -37,6 +37,7 @@ import im.vector.app.databinding.FragmentLoginGenericTextInputFormBinding
 import im.vector.app.features.login.TextInputFormFragmentMode
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewEvents
+import im.vector.app.features.onboarding.RegisterAction
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.parcelize.Parcelize
@@ -138,7 +139,7 @@ class FtueAuthGenericTextInputFormFragment @Inject constructor() : AbstractFtueA
     private fun onOtherButtonClicked() {
         when (params.mode) {
             TextInputFormFragmentMode.ConfirmMsisdn -> {
-                viewModel.handle(OnboardingAction.SendAgainThreePid)
+                viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.SendAgainThreePid))
             }
             else                                    -> {
                 // Should not happen, button is not displayed
@@ -152,19 +153,19 @@ class FtueAuthGenericTextInputFormFragment @Inject constructor() : AbstractFtueA
 
         if (text.isEmpty()) {
             // Perform dummy action
-            viewModel.handle(OnboardingAction.RegisterDummy)
+            viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.RegisterDummy))
         } else {
             when (params.mode) {
                 TextInputFormFragmentMode.SetEmail      -> {
-                    viewModel.handle(OnboardingAction.AddThreePid(RegisterThreePid.Email(text)))
+                    viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.AddThreePid(RegisterThreePid.Email(text))))
                 }
                 TextInputFormFragmentMode.SetMsisdn     -> {
                     getCountryCodeOrShowError(text)?.let { countryCode ->
-                        viewModel.handle(OnboardingAction.AddThreePid(RegisterThreePid.Msisdn(text, countryCode)))
+                        viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.AddThreePid(RegisterThreePid.Msisdn(text, countryCode))))
                     }
                 }
                 TextInputFormFragmentMode.ConfirmMsisdn -> {
-                    viewModel.handle(OnboardingAction.ValidateThreePid(text))
+                    viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.ValidateThreePid(text)))
                 }
             }
         }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthWaitForEmailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthWaitForEmailFragment.kt
@@ -25,6 +25,7 @@ import com.airbnb.mvrx.args
 import im.vector.app.R
 import im.vector.app.databinding.FragmentLoginWaitForEmailBinding
 import im.vector.app.features.onboarding.OnboardingAction
+import im.vector.app.features.onboarding.RegisterAction
 import kotlinx.parcelize.Parcelize
 import org.matrix.android.sdk.api.failure.is401
 import javax.inject.Inject
@@ -54,7 +55,7 @@ class FtueAuthWaitForEmailFragment @Inject constructor() : AbstractFtueAuthFragm
     override fun onResume() {
         super.onResume()
 
-        viewModel.handle(OnboardingAction.CheckIfEmailHasBeenValidated(0))
+        viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.CheckIfEmailHasBeenValidated(0)))
     }
 
     override fun onPause() {
@@ -70,7 +71,7 @@ class FtueAuthWaitForEmailFragment @Inject constructor() : AbstractFtueAuthFragm
     override fun onError(throwable: Throwable) {
         if (throwable.is401()) {
             // Try again, with a delay
-            viewModel.handle(OnboardingAction.CheckIfEmailHasBeenValidated(10_000))
+            viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.CheckIfEmailHasBeenValidated(10_000)))
         } else {
             super.onError(throwable)
         }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/terms/FtueAuthTermsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/terms/FtueAuthTermsFragment.kt
@@ -32,6 +32,7 @@ import im.vector.app.features.login.terms.LoginTermsViewState
 import im.vector.app.features.login.terms.PolicyController
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewState
+import im.vector.app.features.onboarding.RegisterAction
 import im.vector.app.features.onboarding.ftueauth.AbstractFtueAuthFragment
 import kotlinx.parcelize.Parcelize
 import org.matrix.android.sdk.internal.auth.registration.LocalizedFlowDataLoginTerms
@@ -111,7 +112,7 @@ class FtueAuthTermsFragment @Inject constructor(
     }
 
     private fun submit() {
-        viewModel.handle(OnboardingAction.AcceptTerms)
+        viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.AcceptTerms))
     }
 
     override fun updateWithState(state: OnboardingViewState) {

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -126,7 +126,7 @@ class OnboardingViewModelTest {
         viewModel.handle(OnboardingAction.UpdateSignMode(SignMode.SignUp))
 
         test
-                .assertStatesWithPrevious(
+                .assertStatesChanges(
                         initialState,
                         { copy(signMode = SignMode.SignUp) },
                         { copy(asyncRegistration = Loading()) },
@@ -144,7 +144,7 @@ class OnboardingViewModelTest {
         viewModel.handle(OnboardingAction.PostRegisterAction(A_LOADABLE_REGISTER_ACTION))
 
         test
-                .assertStatesWithPrevious(
+                .assertStatesChanges(
                         initialState,
                         { copy(asyncRegistration = Loading()) },
                         { copy(asyncRegistration = Uninitialized) }
@@ -174,7 +174,7 @@ class OnboardingViewModelTest {
         viewModel.handle(OnboardingAction.PostRegisterAction(A_RESULT_IGNORED_REGISTER_ACTION))
 
         test
-                .assertStatesWithPrevious(
+                .assertStatesChanges(
                         initialState,
                         { copy(asyncRegistration = Loading()) },
                         { copy(asyncRegistration = Uninitialized) }
@@ -192,7 +192,7 @@ class OnboardingViewModelTest {
         viewModel.handle(OnboardingAction.PostRegisterAction(A_LOADABLE_REGISTER_ACTION))
 
         test
-                .assertStatesWithPrevious(
+                .assertStatesChanges(
                         initialState,
                         { copy(asyncRegistration = Loading()) },
                         { copy(asyncLoginAction = Success(Unit), personalizationState = A_HOMESERVER_CAPABILITIES.toPersonalisationState()) },
@@ -210,7 +210,7 @@ class OnboardingViewModelTest {
         viewModel.handle(OnboardingAction.PostRegisterAction(A_LOADABLE_REGISTER_ACTION))
 
         test
-                .assertStatesWithPrevious(
+                .assertStatesChanges(
                         initialState,
                         { copy(asyncRegistration = Loading()) },
                         { copy(asyncLoginAction = Success(Unit), personalizationState = A_HOMESERVER_CAPABILITIES.toPersonalisationState()) },
@@ -229,7 +229,7 @@ class OnboardingViewModelTest {
         viewModel.handle(OnboardingAction.UpdateDisplayName(A_DISPLAY_NAME))
 
         test
-                .assertStatesWithPrevious(personalisedInitialState, expectedSuccessfulDisplayNameUpdateStates())
+                .assertStatesChanges(personalisedInitialState, expectedSuccessfulDisplayNameUpdateStates())
                 .assertEvents(OnboardingViewEvents.OnChooseProfilePicture)
                 .finish()
         fakeSession.fakeProfileService.verifyUpdatedName(fakeSession.myUserId, A_DISPLAY_NAME)
@@ -244,7 +244,7 @@ class OnboardingViewModelTest {
         viewModel.handle(OnboardingAction.UpdateDisplayName(A_DISPLAY_NAME))
 
         test
-                .assertStatesWithPrevious(personalisedInitialState, expectedSuccessfulDisplayNameUpdateStates())
+                .assertStatesChanges(personalisedInitialState, expectedSuccessfulDisplayNameUpdateStates())
                 .assertEvents(OnboardingViewEvents.OnPersonalizationComplete)
                 .finish()
         fakeSession.fakeProfileService.verifyUpdatedName(fakeSession.myUserId, A_DISPLAY_NAME)
@@ -258,7 +258,7 @@ class OnboardingViewModelTest {
         viewModel.handle(OnboardingAction.UpdateDisplayName(A_DISPLAY_NAME))
 
         test
-                .assertStatesWithPrevious(
+                .assertStatesChanges(
                         initialState,
                         { copy(asyncDisplayName = Loading()) },
                         { copy(asyncDisplayName = Fail(AN_ERROR)) },

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -50,10 +50,6 @@ import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilities
 private const val A_DISPLAY_NAME = "a display name"
 private const val A_PICTURE_FILENAME = "a-picture.png"
 private val AN_ERROR = RuntimeException("an error!")
-private val AN_UNSUPPORTED_PERSONALISATION_STATE = PersonalizationState(
-        supportsChangingDisplayName = false,
-        supportsChangingProfilePicture = false
-)
 private val A_LOADABLE_REGISTER_ACTION = RegisterAction.StartRegistration
 
 class OnboardingViewModelTest {
@@ -78,7 +74,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `when handling PostViewEvent then emits contents as view event`() = runBlockingTest {
+    fun `when handling PostViewEvent, then emits contents as view event`() = runBlockingTest {
         val test = viewModel.test(this)
 
         viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnTakeMeHome))
@@ -89,7 +85,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given supports changing display name when handling PersonalizeProfile then emits contents choose display name`() = runBlockingTest {
+    fun `given supports changing display name, when handling PersonalizeProfile, then emits contents choose display name`() = runBlockingTest {
         val initialState = initialState.copy(personalizationState = PersonalizationState(supportsChangingDisplayName = true, supportsChangingProfilePicture = false))
         viewModel = createViewModel(initialState)
         val test = viewModel.test(this)
@@ -102,7 +98,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given only supports changing profile picture when handling PersonalizeProfile then emits contents choose profile picture`() = runBlockingTest {
+    fun `given only supports changing profile picture, when handling PersonalizeProfile, then emits contents choose profile picture`() = runBlockingTest {
         val initialState = initialState.copy(personalizationState = PersonalizationState(supportsChangingDisplayName = false, supportsChangingProfilePicture = true))
         viewModel = createViewModel(initialState)
         val test = viewModel.test(this)
@@ -115,7 +111,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given register action requires more steps when handling action then posts next steps`() = runBlockingTest {
+    fun `given register action requires more steps, when handling action, then posts next steps`() = runBlockingTest {
         val test = viewModel.test(this)
         val flowResult = FlowResult(missingStages = listOf(Stage.Email(true)), completedStages = listOf(Stage.Email(true)))
         givenRegistrationResultFor(A_LOADABLE_REGISTER_ACTION, RegistrationResult.FlowResponse(flowResult))
@@ -133,7 +129,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given registration has started and has dummy step to do when handling action then ignores other steps and executes dummy`() = runBlockingTest {
+    fun `given registration has started and has dummy step to do, when handling action, then ignores other steps and executes dummy`() = runBlockingTest {
         val test = viewModel.test(this)
 
         val homeServerCapabilities = HomeServerCapabilities(canChangeDisplayName = true, canChangeAvatar = true)
@@ -160,7 +156,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given homeserver does not support personalisation when registering account then updates state and emits account created event`() = runBlockingTest {
+    fun `given homeserver does not support personalisation, when registering account, then updates state and emits account created event`() = runBlockingTest {
         val homeServerCapabilities = HomeServerCapabilities(canChangeDisplayName = false, canChangeAvatar = false)
         fakeSession.fakeHomeServerCapabilitiesService.givenCapabilities(homeServerCapabilities)
         givenRegistrationResultFor(A_LOADABLE_REGISTER_ACTION, RegistrationResult.Success(fakeSession))
@@ -181,7 +177,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given changing profile picture is supported when updating display name then updates upstream user display name and moves to choose profile picture`() = runBlockingTest {
+    fun `given changing profile picture is supported, when updating display name, then updates upstream user display name and moves to choose profile picture`() = runBlockingTest {
         val personalisedInitialState = initialState.copy(personalizationState = PersonalizationState(supportsChangingProfilePicture = true))
         viewModel = createViewModel(personalisedInitialState)
         val test = viewModel.test(this)
@@ -196,7 +192,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given changing profile picture is not supported when updating display name then updates upstream user display name and completes personalization`() = runBlockingTest {
+    fun `given changing profile picture is not supported, when updating display name, then updates upstream user display name and completes personalization`() = runBlockingTest {
         val personalisedInitialState = initialState.copy(personalizationState = PersonalizationState(supportsChangingProfilePicture = false))
         viewModel = createViewModel(personalisedInitialState)
         val test = viewModel.test(this)
@@ -211,7 +207,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given upstream failure when handling display name update then emits failure event`() = runBlockingTest {
+    fun `given upstream failure, when handling display name update, then emits failure event`() = runBlockingTest {
         val test = viewModel.test(this)
         fakeSession.fakeProfileService.givenSetDisplayNameErrors(AN_ERROR)
 
@@ -228,7 +224,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `when handling profile picture selected then updates selected picture state`() = runBlockingTest {
+    fun `when handling profile picture selected, then updates selected picture state`() = runBlockingTest {
         val test = viewModel.test(this)
 
         viewModel.handle(OnboardingAction.ProfilePictureSelected(fakeUri.instance))
@@ -243,7 +239,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given a selected picture when handling save selected profile picture then updates upstream avatar and completes personalization`() = runBlockingTest {
+    fun `given a selected picture, when handling save selected profile picture, then updates upstream avatar and completes personalization`() = runBlockingTest {
         val initialStateWithPicture = givenPictureSelected(fakeUri.instance, A_PICTURE_FILENAME)
         viewModel = createViewModel(initialStateWithPicture)
         val test = viewModel.test(this)
@@ -258,7 +254,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given upstream update avatar fails when saving selected profile picture then emits failure event`() = runBlockingTest {
+    fun `given upstream update avatar fails, when saving selected profile picture, then emits failure event`() = runBlockingTest {
         fakeSession.fakeProfileService.givenUpdateAvatarErrors(AN_ERROR)
         val initialStateWithPicture = givenPictureSelected(fakeUri.instance, A_PICTURE_FILENAME)
         viewModel = createViewModel(initialStateWithPicture)
@@ -273,7 +269,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given no selected picture when saving selected profile picture then emits failure event`() = runBlockingTest {
+    fun `given no selected picture, when saving selected profile picture, then emits failure event`() = runBlockingTest {
         val test = viewModel.test(this)
 
         viewModel.handle(OnboardingAction.SaveSelectedProfilePicture)
@@ -285,7 +281,7 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `when handling profile picture skipped then completes personalization`() = runBlockingTest {
+    fun `when handling profile skipped, then completes personalization`() = runBlockingTest {
         val test = viewModel.test(this)
 
         viewModel.handle(OnboardingAction.UpdateProfilePictureSkipped)

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -23,6 +23,7 @@ import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.test.MvRxTestRule
 import im.vector.app.features.login.ReAuthHelper
+import im.vector.app.features.login.SignMode
 import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.fakes.FakeAnalyticsTracker
 import im.vector.app.test.fakes.FakeAuthenticationService
@@ -114,6 +115,24 @@ class OnboardingViewModelTest {
 
         test
                 .assertEvents(OnboardingViewEvents.OnChooseProfilePicture)
+                .finish()
+    }
+
+    @Test
+    fun `when handling SignUp then sets sign mode to sign up and starts registration`() = runBlockingTest {
+        givenRegistrationResultFor(RegisterAction.StartRegistration, ANY_CONTINUING_REGISTRATION_RESULT)
+        val test = viewModel.test(this)
+
+        viewModel.handle(OnboardingAction.UpdateSignMode(SignMode.SignUp))
+
+        test
+                .assertStatesWithPrevious(
+                        initialState,
+                        { copy(signMode = SignMode.SignUp) },
+                        { copy(asyncRegistration = Loading()) },
+                        { copy(asyncRegistration = Uninitialized) }
+                )
+                .assertEvents(OnboardingViewEvents.RegistrationFlowResult(ANY_CONTINUING_REGISTRATION_RESULT.flowResult, isRegistrationStarted = true))
                 .finish()
     }
 

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -196,7 +196,7 @@ class OnboardingViewModelTest {
         viewModel.handle(OnboardingAction.UpdateDisplayName(A_DISPLAY_NAME))
 
         test
-                .assertStates(expectedSuccessfulDisplayNameUpdateStates(personalisedInitialState))
+                .assertStatesWithPrevious(personalisedInitialState, expectedSuccessfulDisplayNameUpdateStates())
                 .assertEvents(OnboardingViewEvents.OnChooseProfilePicture)
                 .finish()
         fakeSession.fakeProfileService.verifyUpdatedName(fakeSession.myUserId, A_DISPLAY_NAME)
@@ -211,7 +211,7 @@ class OnboardingViewModelTest {
         viewModel.handle(OnboardingAction.UpdateDisplayName(A_DISPLAY_NAME))
 
         test
-                .assertStates(expectedSuccessfulDisplayNameUpdateStates(personalisedInitialState))
+                .assertStatesWithPrevious(personalisedInitialState, expectedSuccessfulDisplayNameUpdateStates())
                 .assertEvents(OnboardingViewEvents.OnPersonalizationComplete)
                 .finish()
         fakeSession.fakeProfileService.verifyUpdatedName(fakeSession.myUserId, A_DISPLAY_NAME)
@@ -339,14 +339,10 @@ class OnboardingViewModelTest {
             state.copy(asyncProfilePicture = Fail(cause))
     )
 
-    private fun expectedSuccessfulDisplayNameUpdateStates(personalisedInitialState: OnboardingViewState): List<OnboardingViewState> {
+    private fun expectedSuccessfulDisplayNameUpdateStates(): List<OnboardingViewState.() -> OnboardingViewState> {
         return listOf(
-                personalisedInitialState,
-                personalisedInitialState.copy(asyncDisplayName = Loading()),
-                personalisedInitialState.copy(
-                        asyncDisplayName = Success(Unit),
-                        personalizationState = personalisedInitialState.personalizationState.copy(displayName = A_DISPLAY_NAME)
-                )
+                { copy(asyncDisplayName = Loading()) },
+                { copy(asyncDisplayName = Success(Unit), personalizationState = personalizationState.copy(displayName = A_DISPLAY_NAME)) }
         )
     }
 

--- a/vector/src/test/java/im/vector/app/features/onboarding/RegistrationActionHandlerTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/RegistrationActionHandlerTest.kt
@@ -37,9 +37,6 @@ private val A_PID_TO_REGISTER = RegisterThreePid.Email("an email")
 
 class RegistrationActionHandlerTest {
 
-    private val fakeRegistrationWizard = FakeRegistrationWizard()
-    private val registrationActionHandler = RegistrationActionHandler()
-
     @Test
     fun `when handling register action then delegates to wizard`() = runBlockingTest {
         val cases = listOf(
@@ -60,6 +57,8 @@ class RegistrationActionHandlerTest {
     }
 
     private suspend fun testSuccessfulActionDelegation(case: Case) {
+        val registrationActionHandler = RegistrationActionHandler()
+        val fakeRegistrationWizard = FakeRegistrationWizard()
         fakeRegistrationWizard.givenSuccessFor(result = A_SESSION, case.expect)
 
         val result = registrationActionHandler.handleRegisterAction(fakeRegistrationWizard, case.action)
@@ -71,3 +70,5 @@ class RegistrationActionHandlerTest {
 private fun case(action: RegisterAction, expect: suspend RegistrationWizard.() -> RegistrationResult) = Case(action, expect)
 
 private class Case(val action: RegisterAction, val expect: suspend RegistrationWizard.() -> RegistrationResult)
+
+

--- a/vector/src/test/java/im/vector/app/features/onboarding/RegistrationActionHandlerTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/RegistrationActionHandlerTest.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.onboarding
 
 import im.vector.app.test.fakes.FakeRegistrationWizard
 import im.vector.app.test.fakes.FakeSession
+import io.mockk.coVerifyAll
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
@@ -63,6 +64,7 @@ class RegistrationActionHandlerTest {
 
         val result = registrationActionHandler.handleRegisterAction(fakeRegistrationWizard, case.action)
 
+        coVerifyAll { case.expect(fakeRegistrationWizard) }
         result shouldBeEqualTo AN_EXPECTED_RESULT
     }
 }
@@ -70,5 +72,3 @@ class RegistrationActionHandlerTest {
 private fun case(action: RegisterAction, expect: suspend RegistrationWizard.() -> RegistrationResult) = Case(action, expect)
 
 private class Case(val action: RegisterAction, val expect: suspend RegistrationWizard.() -> RegistrationResult)
-
-

--- a/vector/src/test/java/im/vector/app/features/onboarding/RegistrationActionHandlerTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/RegistrationActionHandlerTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.onboarding
+
+import im.vector.app.test.fakes.FakeRegistrationWizard
+import im.vector.app.test.fakes.FakeSession
+import kotlinx.coroutines.test.runBlockingTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.matrix.android.sdk.api.auth.registration.RegisterThreePid
+import org.matrix.android.sdk.api.auth.registration.RegistrationResult
+import org.matrix.android.sdk.api.auth.registration.RegistrationWizard
+
+private val A_SESSION = FakeSession()
+private val AN_EXPECTED_RESULT = RegistrationResult.Success(A_SESSION)
+private const val A_USERNAME = "a username"
+private const val A_PASSWORD = "a password"
+private const val AN_INITIAL_DEVICE_NAME = "a device name"
+private const val A_CAPTCHA_RESPONSE = "a captcha response"
+private const val A_PID_CODE = "a pid code"
+private const val EMAIL_VALIDATED_DELAY = 10000L
+private val A_PID_TO_REGISTER = RegisterThreePid.Email("an email")
+
+class RegistrationActionHandlerTest {
+
+    private val fakeRegistrationWizard = FakeRegistrationWizard()
+    private val registrationActionHandler = RegistrationActionHandler()
+
+    @Test
+    fun `when handling register action then delegates to wizard`() = runBlockingTest {
+        val cases = listOf(
+                case(RegisterAction.StartRegistration) { getRegistrationFlow() },
+                case(RegisterAction.CaptchaDone(A_CAPTCHA_RESPONSE)) { performReCaptcha(A_CAPTCHA_RESPONSE) },
+                case(RegisterAction.AcceptTerms) { acceptTerms() },
+                case(RegisterAction.RegisterDummy) { dummy() },
+                case(RegisterAction.AddThreePid(A_PID_TO_REGISTER)) { addThreePid(A_PID_TO_REGISTER) },
+                case(RegisterAction.SendAgainThreePid) { sendAgainThreePid() },
+                case(RegisterAction.ValidateThreePid(A_PID_CODE)) { handleValidateThreePid(A_PID_CODE) },
+                case(RegisterAction.CheckIfEmailHasBeenValidated(EMAIL_VALIDATED_DELAY)) { checkIfEmailHasBeenValidated(EMAIL_VALIDATED_DELAY) },
+                case(RegisterAction.CreateAccount(A_USERNAME, A_PASSWORD, AN_INITIAL_DEVICE_NAME)) {
+                    createAccount(A_USERNAME, A_PASSWORD, AN_INITIAL_DEVICE_NAME)
+                }
+        )
+
+        cases.forEach { testSuccessfulActionDelegation(it) }
+    }
+
+    private suspend fun testSuccessfulActionDelegation(case: Case) {
+        fakeRegistrationWizard.givenSuccessFor(result = A_SESSION, case.expect)
+
+        val result = registrationActionHandler.handleRegisterAction(fakeRegistrationWizard, case.action)
+
+        result shouldBeEqualTo AN_EXPECTED_RESULT
+    }
+}
+
+private fun case(action: RegisterAction, expect: suspend RegistrationWizard.() -> RegistrationResult) = Case(action, expect)
+
+private class Case(val action: RegisterAction, val expect: suspend RegistrationWizard.() -> RegistrationResult)

--- a/vector/src/test/java/im/vector/app/test/Extensions.kt
+++ b/vector/src/test/java/im/vector/app/test/Extensions.kt
@@ -56,6 +56,10 @@ class ViewModelTest<S, VE>(
     }
 
     fun assertStatesWithPrevious(initial: S, vararg expected: S.() -> S): ViewModelTest<S, VE> {
+        return assertStatesWithPrevious(initial, expected.toList())
+    }
+
+    fun assertStatesWithPrevious(initial: S, expected: List<S.() -> S>): ViewModelTest<S, VE> {
         val reducedExpectedStates = expected.fold(mutableListOf(initial)) { acc, curr ->
             val next = curr.invoke(acc.last())
             acc.add(next)

--- a/vector/src/test/java/im/vector/app/test/Extensions.kt
+++ b/vector/src/test/java/im/vector/app/test/Extensions.kt
@@ -55,6 +55,17 @@ class ViewModelTest<S, VE>(
         return this
     }
 
+    fun assertStatesWithPrevious(initial: S, vararg expected: S.() -> S): ViewModelTest<S, VE> {
+        val reducedExpectedStates = expected.fold(mutableListOf(initial)) { acc, curr ->
+            val next = curr.invoke(acc.last())
+            acc.add(next)
+            acc
+        }
+
+        states.assertValues(reducedExpectedStates)
+        return this
+    }
+
     fun assertStates(expected: List<S>): ViewModelTest<S, VE> {
         states.assertValues(expected)
         return this

--- a/vector/src/test/java/im/vector/app/test/Extensions.kt
+++ b/vector/src/test/java/im/vector/app/test/Extensions.kt
@@ -55,11 +55,15 @@ class ViewModelTest<S, VE>(
         return this
     }
 
-    fun assertStatesWithPrevious(initial: S, vararg expected: S.() -> S): ViewModelTest<S, VE> {
-        return assertStatesWithPrevious(initial, expected.toList())
+    fun assertStatesChanges(initial: S, vararg expected: S.() -> S): ViewModelTest<S, VE> {
+        return assertStatesChanges(initial, expected.toList())
     }
 
-    fun assertStatesWithPrevious(initial: S, expected: List<S.() -> S>): ViewModelTest<S, VE> {
+    /**
+     * Asserts the expected states are in the same order as the actual state emissions
+     * Each expected lambda is given the previous expected state, starting with the initial
+     */
+    fun assertStatesChanges(initial: S, expected: List<S.() -> S>): ViewModelTest<S, VE> {
         val reducedExpectedStates = expected.fold(mutableListOf(initial)) { acc, curr ->
             val next = curr.invoke(acc.last())
             acc.add(next)

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
@@ -23,8 +23,13 @@ import org.matrix.android.sdk.api.auth.AuthenticationService
 import org.matrix.android.sdk.api.auth.registration.RegistrationWizard
 
 class FakeAuthenticationService : AuthenticationService by mockk() {
+
     fun givenRegistrationWizard(registrationWizard: RegistrationWizard) {
         every { getRegistrationWizard() } returns registrationWizard
+    }
+
+    fun givenRegistrationStarted(started: Boolean) {
+        every { isRegistrationStarted } returns started
     }
 
     fun expectReset() {

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeRegisterActionHandler.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeRegisterActionHandler.kt
@@ -16,23 +16,28 @@
 
 package im.vector.app.test.fakes
 
+import im.vector.app.features.onboarding.RegisterAction
+import im.vector.app.features.onboarding.RegistrationActionHandler
 import io.mockk.coEvery
 import io.mockk.mockk
 import org.matrix.android.sdk.api.auth.registration.RegistrationResult
 import org.matrix.android.sdk.api.auth.registration.RegistrationWizard
-import org.matrix.android.sdk.api.session.Session
 
-class FakeRegistrationWizard : RegistrationWizard by mockk() {
+class FakeRegisterActionHandler {
 
-    fun givenSuccessfulDummy(session: Session) {
-        givenSuccessFor(session) { dummy() }
+    val instance = mockk<RegistrationActionHandler>()
+
+    fun givenResultFor(wizard: RegistrationWizard, action: RegisterAction, result: RegistrationResult) {
+        coEvery { instance.handleRegisterAction(wizard, action) } answers {
+            it.invocation.args.first()
+            result
+        }
     }
 
-    fun givenSuccessFor(result: Session, expect: suspend RegistrationWizard.() -> RegistrationResult) {
-        coEvery { expect(this@FakeRegistrationWizard) } returns RegistrationResult.Success(result)
-    }
-
-    fun givenSuccessfulAcceptTerms(session: Session) {
-        coEvery { acceptTerms() } returns RegistrationResult.Success(session)
+    fun givenResultsFor(wizard: RegistrationWizard, result: List<Pair<RegisterAction, RegistrationResult>>) {
+        coEvery { instance.handleRegisterAction(wizard, any()) } answers {
+            val actionArg = it.invocation.args[1] as RegisterAction
+            result.first { it.first == actionArg }.second
+        }
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeRegisterActionHandler.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeRegisterActionHandler.kt
@@ -27,13 +27,6 @@ class FakeRegisterActionHandler {
 
     val instance = mockk<RegistrationActionHandler>()
 
-    fun givenResultFor(wizard: RegistrationWizard, action: RegisterAction, result: RegistrationResult) {
-        coEvery { instance.handleRegisterAction(wizard, action) } answers { call ->
-            call.invocation.args.first()
-            result
-        }
-    }
-
     fun givenResultsFor(wizard: RegistrationWizard, result: List<Pair<RegisterAction, RegistrationResult>>) {
         coEvery { instance.handleRegisterAction(wizard, any()) } answers { call ->
             val actionArg = call.invocation.args[1] as RegisterAction

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeRegisterActionHandler.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeRegisterActionHandler.kt
@@ -28,15 +28,15 @@ class FakeRegisterActionHandler {
     val instance = mockk<RegistrationActionHandler>()
 
     fun givenResultFor(wizard: RegistrationWizard, action: RegisterAction, result: RegistrationResult) {
-        coEvery { instance.handleRegisterAction(wizard, action) } answers {
-            it.invocation.args.first()
+        coEvery { instance.handleRegisterAction(wizard, action) } answers { call ->
+            call.invocation.args.first()
             result
         }
     }
 
     fun givenResultsFor(wizard: RegistrationWizard, result: List<Pair<RegisterAction, RegistrationResult>>) {
-        coEvery { instance.handleRegisterAction(wizard, any()) } answers {
-            val actionArg = it.invocation.args[1] as RegisterAction
+        coEvery { instance.handleRegisterAction(wizard, any()) } answers { call ->
+            val actionArg = call.invocation.args[1] as RegisterAction
             result.first { it.first == actionArg }.second
         }
     }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeRegistrationWizard.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeRegistrationWizard.kt
@@ -24,15 +24,7 @@ import org.matrix.android.sdk.api.session.Session
 
 class FakeRegistrationWizard : RegistrationWizard by mockk() {
 
-    fun givenSuccessfulDummy(session: Session) {
-        givenSuccessFor(session) { dummy() }
-    }
-
     fun givenSuccessFor(result: Session, expect: suspend RegistrationWizard.() -> RegistrationResult) {
         coEvery { expect(this@FakeRegistrationWizard) } returns RegistrationResult.Success(result)
-    }
-
-    fun givenSuccessfulAcceptTerms(session: Session) {
-        coEvery { acceptTerms() } returns RegistrationResult.Success(session)
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeRegistrationWizard.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeRegistrationWizard.kt
@@ -22,7 +22,7 @@ import org.matrix.android.sdk.api.auth.registration.RegistrationResult
 import org.matrix.android.sdk.api.auth.registration.RegistrationWizard
 import org.matrix.android.sdk.api.session.Session
 
-class FakeRegistrationWizard : RegistrationWizard by mockk() {
+class FakeRegistrationWizard : RegistrationWizard by mockk(relaxed = false) {
 
     fun givenSuccessFor(result: Session, expect: suspend RegistrationWizard.() -> RegistrationResult) {
         coEvery { expect(this@FakeRegistrationWizard) } returns RegistrationResult.Success(result)

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorFeatures.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorFeatures.kt
@@ -23,5 +23,5 @@ class FakeVectorFeatures : VectorFeatures {
     override fun isOnboardingAlreadyHaveAccountSplashEnabled() = true
     override fun isOnboardingSplashCarouselEnabled() = true
     override fun isOnboardingUseCaseEnabled() = true
-    override fun isOnboardingPersonalizeEnabled() = false
+    override fun isOnboardingPersonalizeEnabled() = true
 }

--- a/vector/src/test/java/im/vector/app/test/fixtures/HomeserverCapabilityFixture.kt
+++ b/vector/src/test/java/im/vector/app/test/fixtures/HomeserverCapabilityFixture.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fixtures
+
+import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilities
+import org.matrix.android.sdk.api.session.homeserver.RoomVersionCapabilities
+
+fun aHomeServerCapabilities(
+        canChangePassword: Boolean = true,
+        canChangeDisplayName: Boolean = true,
+        canChangeAvatar: Boolean = true,
+        canChange3pid: Boolean = true,
+        maxUploadFileSize: Long = 100L,
+        lastVersionIdentityServerSupported: Boolean = false,
+        defaultIdentityServerUrl: String? = null,
+        roomVersions: RoomVersionCapabilities? = null
+) = HomeServerCapabilities(
+        canChangePassword,
+        canChangeDisplayName,
+        canChangeAvatar,
+        canChange3pid,
+        maxUploadFileSize,
+        lastVersionIdentityServerSupported,
+        defaultIdentityServerUrl,
+        roomVersions
+)


### PR DESCRIPTION
Marked as draft as this relies on #5389

## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Adds unit tests around the Registration steps within the `OnboardingViewModel`

- Extracts out the `RegistrationWizard` action interactions to it's own class to make testing the view model easier
- Converts the `RegisterAction` to sealed interface to allow for compile time type checking 

## Motivation and context

To improve the test coverage around the authentication flows. Could be considered part of #5200 

## Screenshots / GIFs

No UI changes

## Tests

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):
