### PR TITLE
Fixing unit test compilation error

### DIFF
--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -47,7 +47,6 @@ import im.vector.app.features.login.LoginMode
 import im.vector.app.features.login.ReAuthHelper
 import im.vector.app.features.login.ServerType
 import im.vector.app.features.login.SignMode
-import im.vector.app.features.settings.VectorDataStore
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.MatrixPatterns.getDomain
@@ -81,7 +80,6 @@ class OnboardingViewModel @AssistedInject constructor(
         private val homeServerHistoryService: HomeServerHistoryService,
         private val vectorFeatures: VectorFeatures,
         private val analyticsTracker: AnalyticsTracker,
-        private val vectorDataStore: VectorDataStore,
         private val vectorOverrides: VectorOverrides
 ) : VectorViewModel<OnboardingViewState, OnboardingAction, OnboardingViewEvents>(initialState) {
 

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -20,6 +20,7 @@ import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.test.MvRxTestRule
+import im.vector.app.features.DefaultVectorOverrides
 import im.vector.app.features.login.ReAuthHelper
 import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.fakes.FakeAnalyticsTracker
@@ -110,7 +111,8 @@ class OnboardingViewModelTest {
                 FakeStringProvider().instance,
                 FakeHomeServerHistoryService(),
                 FakeVectorFeatures(),
-                FakeAnalyticsTracker()
+                FakeAnalyticsTracker(),
+                DefaultVectorOverrides(),
         )
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Adds missing `VectorOverride` instance in test, temporarily uses the `Default` instance as it's replaced by a Fake in [#5375](https://github.com/vector-im/element-android/pull/5375/files#diff-05c6932fe7e57fc02d437f108829986761ec74e6e15b916f853f28c56ad3202aR22)

## Motivation and context

Fixes test compilation error caused by git's automerge with develop

## Screenshots / GIFs

No app changes

## Tests
The CI!

## Tested devices
N/A
