### PR TITLE
Run ImageUtils requests async

### DIFF
--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/ImageUtils.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/ImageUtils.kt
@@ -23,35 +23,51 @@ import android.graphics.ImageDecoder
 import android.net.Uri
 import android.os.Build
 import androidx.exifinterface.media.ExifInterface
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
 object ImageUtils {
 
     fun getBitmap(context: Context, uri: Uri): Bitmap? {
-        return try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                ImageDecoder.decodeBitmap(ImageDecoder.createSource(context.contentResolver, uri))
-            } else {
-                context.contentResolver.openInputStream(uri)?.use { inputStream ->
-                    BitmapFactory.decodeStream(inputStream)
+        var bitmap: Bitmap? = null
+        runBlocking {
+            val job = async {
+                try {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        ImageDecoder.decodeBitmap(ImageDecoder.createSource(context.contentResolver, uri))
+                    } else {
+                        context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                            BitmapFactory.decodeStream(inputStream)
+                        }
+                    }
+                } catch (e: Exception) {
+                    Timber.e(e, "Cannot decode Bitmap: %s", uri.toString())
+                    null
                 }
             }
-        } catch (e: Exception) {
-            Timber.e(e, "Cannot decode Bitmap: %s", uri.toString())
-            null
+            bitmap = job.await()
         }
+
+        return bitmap
     }
 
     fun getOrientation(context: Context, uri: Uri): Int {
         var orientation = 0
-        context.contentResolver.openInputStream(uri)?.use { inputStream ->
-            try {
-                ExifInterface(inputStream).let {
-                    orientation = it.rotationDegrees
-                }
-            } catch (e: Exception) {
-                Timber.e(e, "Cannot read orientation: %s", uri.toString())
+        runBlocking {
+            val job = async {
+                context.contentResolver.openInputStream(uri)?.use {
+                    inputStream ->
+                        try {
+                            ExifInterface(inputStream).let {
+                                orientation = it.rotationDegrees
+                            }
+                        } catch (e: Exception) {
+                            Timber.e(e, "Cannot read orientation: %s", uri.toString())
+                        }
+                    }
             }
+            job.await()
         }
         return orientation
     }


### PR DESCRIPTION
Fixes #5236: Run file requests in background to not block ui thread

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Run operations in `ImageUtils` async to avoid blocking the UI thread and therefore crashing the app if the file chosen must be downloaded from some location

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Tests

- Step 1: Installed debug build and logged in to existing account
- Step 2: Shared some files

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
