### PR TITLE
Giving avatar/display name error dialogs human readable error messages

### DIFF
--- a/changelog.d/5418.feature
+++ b/changelog.d/5418.feature
@@ -1,0 +1,1 @@
+Improves settings error dialog messaging when changing avatar or display name fails

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsBaseFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsBaseFragment.kt
@@ -148,24 +148,6 @@ abstract class VectorSettingsBaseFragment : PreferenceFragmentCompat(), Maverick
         }
     }
 
-    /**
-     * A request has been processed.
-     * Display a toast if there is a an error message
-     *
-     * @param errorMessage the error message
-     */
-    protected fun onCommonDone(errorMessage: String?) {
-        if (!isAdded) {
-            return
-        }
-        activity?.runOnUiThread {
-            if (errorMessage != null && errorMessage.isNotBlank()) {
-                displayErrorDialog(errorMessage)
-            }
-            hideLoadingView()
-        }
-    }
-
     protected fun displayErrorDialog(throwable: Throwable) {
         displayErrorDialog(errorFormatter.toHumanReadable(throwable))
     }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsGeneralFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsGeneralFragment.kt
@@ -329,7 +329,14 @@ class VectorSettingsGeneralFragment @Inject constructor(
                 session.updateAvatar(session.myUserId, uri, getFilenameFromUri(context, uri) ?: UUID.randomUUID().toString())
             }
             if (!isAdded) return@launch
-            onCommonDone(result.fold({ null }, { it.localizedMessage }))
+
+            result.fold(
+                    onSuccess = { hideLoadingView() },
+                    onFailure = {
+                        hideLoadingView()
+                        displayErrorDialog(it)
+                    }
+            )
         }
     }
 
@@ -466,14 +473,15 @@ class VectorSettingsGeneralFragment @Inject constructor(
                 val result = runCatching { session.setDisplayName(session.myUserId, value) }
                 if (!isAdded) return@launch
                 result.fold(
-                        {
+                        onSuccess = {
                             // refresh the settings value
                             mDisplayNamePreference.summary = value
                             mDisplayNamePreference.text = value
-                            onCommonDone(null)
+                            hideLoadingView()
                         },
-                        {
-                            onCommonDone(it.localizedMessage)
+                        onFailure = {
+                            hideLoadingView()
+                            displayErrorDialog(it)
                         }
                 )
             }


### PR DESCRIPTION
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Reuses the error dialog logic which translates exceptions to human readable strings in the settings screen

## Motivation and context

Fixes #5418 - The error messages for display name/avatar changing are making use of the raw exception instead of the nicely formatted message included within the exception

## Screenshots / GIFs

| BEFORE | AFTER |
| --- | --- |
|![Screenshot_20220303_155653](https://user-images.githubusercontent.com/1848238/156605690-ff085582-ce5a-4240-9fd4-fb813d1fafb2.png)|![Screenshot_20220303_160945](https://user-images.githubusercontent.com/1848238/156605688-3b9a8d45-3c30-42e9-b53a-81958f3d5cb1.png)

## Tests

- Via the settings
- Attempt to change the display name to one longer than 256 characters


## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 31 (Sv2)
