### PR TITLE
Querying content provider files off of the main thread

### DIFF
--- a/changelog.d/5236.bugfix
+++ b/changelog.d/5236.bugfix
@@ -1,0 +1,1 @@
+Fixing crash when selecting files which requiring hitting the network (eg next cloud)

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/AudioPicker.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/AudioPicker.kt
@@ -30,7 +30,7 @@ class AudioPicker : Picker<MultiPickerAudioType>() {
      * Call this function from onActivityResult(int, int, Intent).
      * Returns selected audio files or empty list if user did not select any files.
      */
-    override fun getSelectedFiles(context: Context, data: Intent?): List<MultiPickerAudioType> {
+    override suspend fun getSelectedFiles(context: Context, data: Intent?): List<MultiPickerAudioType> {
         return getSelectedUriList(data).mapNotNull { selectedUri ->
             selectedUri.toMultiPickerAudioType(context)
         }

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/CameraPicker.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/CameraPicker.kt
@@ -53,7 +53,7 @@ class CameraPicker {
      * or result code is not Activity.RESULT_OK
      * or user cancelled the operation.
      */
-    fun getTakenPhoto(context: Context, photoUri: Uri): MultiPickerImageType? {
+    suspend fun getTakenPhoto(context: Context, photoUri: Uri): MultiPickerImageType? {
         return photoUri.toMultiPickerImageType(context)
     }
 

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/ContactPicker.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/ContactPicker.kt
@@ -34,7 +34,7 @@ class ContactPicker : Picker<MultiPickerContactType>() {
      * Call this function from onActivityResult(int, int, Intent).
      * Returns selected contact or empty list if user did not select any contacts.
      */
-    override fun getSelectedFiles(context: Context, data: Intent?): List<MultiPickerContactType> {
+    override suspend fun getSelectedFiles(context: Context, data: Intent?): List<MultiPickerContactType> {
         val contactList = mutableListOf<MultiPickerContactType>()
 
         data?.data?.let { selectedUri ->

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/FilePicker.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/FilePicker.kt
@@ -40,7 +40,7 @@ class FilePicker : Picker<MultiPickerBaseType>() {
      * Call this function from onActivityResult(int, int, Intent).
      * Returns selected files or empty list if user did not select any files.
      */
-    override fun getSelectedFiles(context: Context, data: Intent?): List<MultiPickerBaseType> {
+    override suspend fun getSelectedFiles(context: Context, data: Intent?): List<MultiPickerBaseType> {
         return getSelectedUriList(data).mapNotNull { selectedUri ->
             val type = context.contentResolver.getType(selectedUri)
 

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/ImagePicker.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/ImagePicker.kt
@@ -30,7 +30,7 @@ class ImagePicker : Picker<MultiPickerImageType>() {
      * Call this function from onActivityResult(int, int, Intent).
      * Returns selected image files or empty list if user did not select any files.
      */
-    override fun getSelectedFiles(context: Context, data: Intent?): List<MultiPickerImageType> {
+    override suspend fun getSelectedFiles(context: Context, data: Intent?): List<MultiPickerImageType> {
         return getSelectedUriList(data).mapNotNull { selectedUri ->
             selectedUri.toMultiPickerImageType(context)
         }

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/MediaPicker.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/MediaPicker.kt
@@ -32,7 +32,7 @@ class MediaPicker : Picker<MultiPickerBaseMediaType>() {
      * Call this function from onActivityResult(int, int, Intent).
      * Returns selected image/video files or empty list if user did not select any files.
      */
-    override fun getSelectedFiles(context: Context, data: Intent?): List<MultiPickerBaseMediaType> {
+    override suspend fun getSelectedFiles(context: Context, data: Intent?): List<MultiPickerBaseMediaType> {
         return getSelectedUriList(data).mapNotNull { selectedUri ->
             val mimeType = context.contentResolver.getType(selectedUri)
 

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/Picker.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/Picker.kt
@@ -34,13 +34,13 @@ abstract class Picker<T> {
      * Call this function from onActivityResult(int, int, Intent).
      * @return selected files or empty list if user did not select any files.
      */
-    abstract fun getSelectedFiles(context: Context, data: Intent?): List<T>
+    abstract suspend fun getSelectedFiles(context: Context, data: Intent?): List<T>
 
     /**
      * Use this function to retrieve files which are shared from another application or internally
      * by using android.intent.action.SEND or android.intent.action.SEND_MULTIPLE actions.
      */
-    fun getIncomingFiles(context: Context, data: Intent?): List<T> {
+    suspend fun getIncomingFiles(context: Context, data: Intent?): List<T> {
         if (data == null) return emptyList()
 
         val uriList = mutableListOf<Uri>()

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/VideoPicker.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/VideoPicker.kt
@@ -30,7 +30,7 @@ class VideoPicker : Picker<MultiPickerVideoType>() {
      * Call this function from onActivityResult(int, int, Intent).
      * Returns selected video files or empty list if user did not select any files.
      */
-    override fun getSelectedFiles(context: Context, data: Intent?): List<MultiPickerVideoType> {
+    override suspend fun getSelectedFiles(context: Context, data: Intent?): List<MultiPickerVideoType> {
         return getSelectedUriList(data).mapNotNull { selectedUri ->
             selectedUri.toMultiPickerVideoType(context)
         }

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/ContentResolverUtil.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/ContentResolverUtil.kt
@@ -26,7 +26,7 @@ import im.vector.lib.multipicker.entity.MultiPickerAudioType
 import im.vector.lib.multipicker.entity.MultiPickerImageType
 import im.vector.lib.multipicker.entity.MultiPickerVideoType
 
-internal fun Uri.toMultiPickerImageType(context: Context): MultiPickerImageType? {
+internal suspend fun Uri.toMultiPickerImageType(context: Context): MultiPickerImageType? {
     val projection = arrayOf(
             MediaStore.Images.Media.DISPLAY_NAME,
             MediaStore.Images.Media.SIZE

--- a/vector/src/main/java/im/vector/app/core/dialogs/GalleryOrCameraDialogHelper.kt
+++ b/vector/src/main/java/im/vector/app/core/dialogs/GalleryOrCameraDialogHelper.kt
@@ -20,6 +20,7 @@ import android.app.Activity
 import android.net.Uri
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.yalantis.ucrop.UCrop
 import im.vector.app.R
@@ -34,6 +35,7 @@ import im.vector.app.core.utils.registerForPermissionsResult
 import im.vector.app.features.media.createUCropWithDefaultSettings
 import im.vector.lib.multipicker.MultiPicker
 import im.vector.lib.multipicker.entity.MultiPickerImageType
+import kotlinx.coroutines.launch
 import java.io.File
 
 /**
@@ -67,20 +69,24 @@ class GalleryOrCameraDialogHelper(
     private val takePhotoActivityResultLauncher = fragment.registerStartForActivityResult { activityResult ->
         if (activityResult.resultCode == Activity.RESULT_OK) {
             avatarCameraUri?.let { uri ->
-                MultiPicker.get(MultiPicker.CAMERA)
-                        .getTakenPhoto(activity, uri)
-                        ?.let { startUCrop(it) }
+                fragment.lifecycleScope.launch {
+                    MultiPicker.get(MultiPicker.CAMERA)
+                            .getTakenPhoto(activity, uri)
+                            ?.let { startUCrop(it) }
+                }
             }
         }
     }
 
     private val pickImageActivityResultLauncher = fragment.registerStartForActivityResult { activityResult ->
         if (activityResult.resultCode == Activity.RESULT_OK) {
-            MultiPicker
-                    .get(MultiPicker.IMAGE)
-                    .getSelectedFiles(activity, activityResult.data)
-                    .firstOrNull()
-                    ?.let { startUCrop(it) }
+            fragment.lifecycleScope.launch {
+                MultiPicker
+                        .get(MultiPicker.IMAGE)
+                        .getSelectedFiles(activity, activityResult.data)
+                        .firstOrNull()
+                        ?.let { startUCrop(it) }
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentsHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentsHelper.kt
@@ -121,7 +121,7 @@ class AttachmentsHelper(val context: Context, val callback: Callback) : Restorab
     /**
      * This methods aims to handle the result data.
      */
-    fun onFileResult(data: Intent?) {
+    suspend fun onFileResult(data: Intent?) {
         callback.onContentAttachmentsReady(
                 MultiPicker.get(MultiPicker.FILE)
                         .getSelectedFiles(context, data)
@@ -129,7 +129,7 @@ class AttachmentsHelper(val context: Context, val callback: Callback) : Restorab
         )
     }
 
-    fun onAudioResult(data: Intent?) {
+    suspend fun onAudioResult(data: Intent?) {
         callback.onContentAttachmentsReady(
                 MultiPicker.get(MultiPicker.AUDIO)
                         .getSelectedFiles(context, data)
@@ -137,7 +137,7 @@ class AttachmentsHelper(val context: Context, val callback: Callback) : Restorab
         )
     }
 
-    fun onContactResult(data: Intent?) {
+    suspend fun onContactResult(data: Intent?) {
         MultiPicker.get(MultiPicker.CONTACT)
                 .getSelectedFiles(context, data)
                 .firstOrNull()
@@ -147,7 +147,7 @@ class AttachmentsHelper(val context: Context, val callback: Callback) : Restorab
                 }
     }
 
-    fun onMediaResult(data: Intent?) {
+    suspend fun onMediaResult(data: Intent?) {
         callback.onContentAttachmentsReady(
                 MultiPicker.get(MultiPicker.MEDIA)
                         .getSelectedFiles(context, data)
@@ -155,7 +155,7 @@ class AttachmentsHelper(val context: Context, val callback: Callback) : Restorab
         )
     }
 
-    fun onCameraResult() {
+    suspend fun onCameraResult() {
         captureUri?.let { captureUri ->
             MultiPicker.get(MultiPicker.CAMERA)
                     .getTakenPhoto(context, captureUri)
@@ -179,7 +179,7 @@ class AttachmentsHelper(val context: Context, val callback: Callback) : Restorab
         }
     }
 
-    fun onVideoResult(data: Intent?) {
+    suspend fun onVideoResult(data: Intent?) {
         callback.onContentAttachmentsReady(
                 MultiPicker.get(MultiPicker.VIDEO)
                         .getSelectedFiles(context, data)
@@ -192,7 +192,7 @@ class AttachmentsHelper(val context: Context, val callback: Callback) : Restorab
      *
      * @return true if it can handle the intent data, false otherwise
      */
-    fun handleShareIntent(context: Context, intent: Intent): Boolean {
+    suspend fun handleShareIntent(context: Context, intent: Intent): Boolean {
         val type = intent.resolveType(context) ?: return false
         if (type.startsWith("image")) {
             callback.onContentAttachmentsReady(

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1266,25 +1266,33 @@ class TimelineFragment @Inject constructor(
 
     private val attachmentFileActivityResultLauncher = registerStartForActivityResult {
         if (it.resultCode == Activity.RESULT_OK) {
-            attachmentsHelper.onFileResult(it.data)
+            lifecycleScope.launch {
+                attachmentsHelper.onFileResult(it.data)
+            }
         }
     }
 
     private val attachmentContactActivityResultLauncher = registerStartForActivityResult {
         if (it.resultCode == Activity.RESULT_OK) {
-            attachmentsHelper.onContactResult(it.data)
+            lifecycleScope.launch {
+                attachmentsHelper.onContactResult(it.data)
+            }
         }
     }
 
     private val attachmentMediaActivityResultLauncher = registerStartForActivityResult {
         if (it.resultCode == Activity.RESULT_OK) {
-            attachmentsHelper.onMediaResult(it.data)
+            lifecycleScope.launch {
+                attachmentsHelper.onMediaResult(it.data)
+            }
         }
     }
 
     private val attachmentCameraActivityResultLauncher = registerStartForActivityResult {
         if (it.resultCode == Activity.RESULT_OK) {
-            attachmentsHelper.onCameraResult()
+            lifecycleScope.launch {
+                attachmentsHelper.onCameraResult()
+            }
         }
     }
 
@@ -1487,8 +1495,10 @@ class TimelineFragment @Inject constructor(
                 messageComposerViewModel.handle(MessageComposerAction.EnterRegularMode(views.composerLayout.text.toString(), false))
             }
 
-            override fun onRichContentSelected(contentUri: Uri): Boolean {
-                return sendUri(contentUri)
+            override fun onRichContentSelected(contentUri: Uri) {
+                lifecycleScope.launch {
+                    sendUri(contentUri)
+                }
             }
 
             override fun onTextChanged(text: CharSequence) {
@@ -1533,13 +1543,12 @@ class TimelineFragment @Inject constructor(
                 .launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
-    private fun sendUri(uri: Uri): Boolean {
+    private suspend fun sendUri(uri: Uri) {
         val shareIntent = Intent(Intent.ACTION_SEND, uri)
         val isHandled = attachmentsHelper.handleShareIntent(requireContext(), shareIntent)
         if (!isHandled) {
             Toast.makeText(requireContext(), R.string.error_handling_incoming_share, Toast.LENGTH_SHORT).show()
         }
-        return isHandled
     }
 
     override fun invalidate() = withState(timelineViewModel, messageComposerViewModel) { mainState, messageComposerState ->

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/ComposerEditText.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/ComposerEditText.kt
@@ -41,7 +41,7 @@ class ComposerEditText @JvmOverloads constructor(
 ) : AppCompatEditText(context, attrs, defStyleAttr) {
 
     interface Callback {
-        fun onRichContentSelected(contentUri: Uri): Boolean
+        fun onRichContentSelected(contentUri: Uri)
         fun onTextChanged(text: CharSequence)
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerView.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerView.kt
@@ -65,8 +65,8 @@ class MessageComposerView @JvmOverloads constructor(
         collapse(false)
 
         views.composerEditText.callback = object : ComposerEditText.Callback {
-            override fun onRichContentSelected(contentUri: Uri): Boolean {
-                return callback?.onRichContentSelected(contentUri) ?: false
+            override fun onRichContentSelected(contentUri: Uri) {
+                callback?.onRichContentSelected(contentUri)
             }
 
             override fun onTextChanged(text: CharSequence) {


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

**NOTE - this is currently untested with nextcloud** Importing files from the gallery is working as expected

A follow up from @akallabeth 's #5416

Ensures the content provider calls to select files are handled on a background thread, I've avoided injecting the dispatchers for the time being as there's a long chain of static calls. 

- Removes the return value from `onRichContentSelected` as it wasn't being used

## Motivation and context

To fix a crash when selecting files from nextcloud #5236 

## Screenshots / GIFs

// TODO

## Tests

// TODO

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

