### PR TITLE
Changes room hierarchy endpoint to stable

### DIFF
--- a/changelog.d/5443.misc
+++ b/changelog.d/5443.misc
@@ -1,0 +1,1 @@
+Adds stable room hierarchy endpoint with a fallback to the unstable one

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -175,7 +175,7 @@ dependencies {
     // Note: version sticks to 1.9.2 due to https://github.com/mockk/mockk/issues/281
     testImplementation libs.mockk.mockk
     testImplementation libs.tests.kluent
-    implementation libs.jetbrains.coroutinesAndroid
+    testImplementation libs.jetbrains.coroutinesTest
     // Plant Timber tree for test
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     // Transitively required for mocking realm as monarchy doesn't expose Rx

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkConstants.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkConstants.kt
@@ -21,7 +21,7 @@ internal object NetworkConstants {
     private const val URI_API_PREFIX_PATH = "_matrix/client"
     const val URI_API_PREFIX_PATH_ = "$URI_API_PREFIX_PATH/"
     const val URI_API_PREFIX_PATH_R0 = "$URI_API_PREFIX_PATH/r0/"
-    const val URI_API_PREFIX_PATH_V1 = "${URI_API_PREFIX_PATH}/v1/"
+    const val URI_API_PREFIX_PATH_V1 = "$URI_API_PREFIX_PATH/v1/"
     const val URI_API_PREFIX_PATH_UNSTABLE = "$URI_API_PREFIX_PATH/unstable/"
 
     // Media

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkConstants.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkConstants.kt
@@ -21,6 +21,7 @@ internal object NetworkConstants {
     private const val URI_API_PREFIX_PATH = "_matrix/client"
     const val URI_API_PREFIX_PATH_ = "$URI_API_PREFIX_PATH/"
     const val URI_API_PREFIX_PATH_R0 = "$URI_API_PREFIX_PATH/r0/"
+    const val URI_API_PREFIX_PATH_V1 = "${URI_API_PREFIX_PATH}v1/"
     const val URI_API_PREFIX_PATH_UNSTABLE = "$URI_API_PREFIX_PATH/unstable/"
 
     // Media

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkConstants.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/NetworkConstants.kt
@@ -21,7 +21,7 @@ internal object NetworkConstants {
     private const val URI_API_PREFIX_PATH = "_matrix/client"
     const val URI_API_PREFIX_PATH_ = "$URI_API_PREFIX_PATH/"
     const val URI_API_PREFIX_PATH_R0 = "$URI_API_PREFIX_PATH/r0/"
-    const val URI_API_PREFIX_PATH_V1 = "${URI_API_PREFIX_PATH}v1/"
+    const val URI_API_PREFIX_PATH_V1 = "${URI_API_PREFIX_PATH}/v1/"
     const val URI_API_PREFIX_PATH_UNSTABLE = "$URI_API_PREFIX_PATH/unstable/"
 
     // Media

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpaceService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpaceService.kt
@@ -123,7 +123,7 @@ internal class DefaultSpaceService @Inject constructor(
         val spacesResponse = getSpacesResponse(spaceId, suggestedOnly, limit, from)
         val spaceRootResponse = spacesResponse.getRoot(spaceId)
         val spaceRoot = spaceRootResponse?.toRoomSummary() ?: createBlankRoomSummary(spaceId)
-        val spaceChildren = spacesResponse.rooms.mapToSpaceChildInfoList(spaceId, spaceRootResponse, knownStateList)
+        val spaceChildren = spacesResponse.rooms.mapSpaceChildren(spaceId, spaceRootResponse, knownStateList)
 
         return SpaceHierarchyData(
                 rootSummary = spaceRoot,
@@ -167,7 +167,7 @@ internal class DefaultSpaceService @Inject constructor(
             joinRules = null
     )
 
-    private fun List<SpaceChildSummaryResponse>?.mapToSpaceChildInfoList(
+    private fun List<SpaceChildSummaryResponse>?.mapSpaceChildren(
             spaceId: String,
             spaceRootResponse: SpaceChildSummaryResponse?,
             knownStateList: List<Event>?,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpaceService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpaceService.kt
@@ -113,70 +113,106 @@ internal class DefaultSpaceService @Inject constructor(
         return peekSpaceTask.execute(PeekSpaceTask.Params(spaceId))
     }
 
-    override suspend fun querySpaceChildren(spaceId: String,
-                                            suggestedOnly: Boolean?,
-                                            limit: Int?,
-                                            from: String?,
-                                            knownStateList: List<Event>?): SpaceHierarchyData {
-        return resolveSpaceInfoTask.execute(
-                ResolveSpaceInfoTask.Params(
-                        spaceId = spaceId, limit = limit, maxDepth = 1, from = from, suggestedOnly = suggestedOnly
-                )
-        ).let { response ->
-            val spaceDesc = response.rooms?.firstOrNull { it.roomId == spaceId }
-            val root = RoomSummary(
-                    roomId = spaceDesc?.roomId ?: spaceId,
-                    roomType = spaceDesc?.roomType,
-                    name = spaceDesc?.name ?: "",
-                    displayName = spaceDesc?.name ?: "",
-                    topic = spaceDesc?.topic ?: "",
-                    joinedMembersCount = spaceDesc?.numJoinedMembers,
-                    avatarUrl = spaceDesc?.avatarUrl ?: "",
-                    encryptionEventTs = null,
-                    typingUsers = emptyList(),
-                    isEncrypted = false,
-                    flattenParentIds = emptyList(),
-                    canonicalAlias = spaceDesc?.canonicalAlias,
-                    joinRules = RoomJoinRules.PUBLIC.takeIf { spaceDesc?.worldReadable == true }
-            )
-            val children = response.rooms
-                    ?.filter { it.roomId != spaceId }
-                    ?.flatMap { childSummary ->
-                        (spaceDesc?.childrenState ?: knownStateList)
-                                ?.filter { it.stateKey == childSummary.roomId && it.type == EventType.STATE_SPACE_CHILD }
-                                ?.mapNotNull { childStateEv ->
-                                    // create a child entry for everytime this room is the child of a space
-                                    // beware that a room could appear then twice in this list
-                                    childStateEv.content.toModel<SpaceChildContent>()?.let { childStateEvContent ->
-                                        SpaceChildInfo(
-                                                childRoomId = childSummary.roomId,
-                                                isKnown = true,
-                                                roomType = childSummary.roomType,
-                                                name = childSummary.name,
-                                                topic = childSummary.topic,
-                                                avatarUrl = childSummary.avatarUrl,
-                                                order = childStateEvContent.order,
-//                                                        autoJoin = childStateEvContent.autoJoin ?: false,
-                                                viaServers = childStateEvContent.via.orEmpty(),
-                                                activeMemberCount = childSummary.numJoinedMembers,
-                                                parentRoomId = childStateEv.roomId,
-                                                suggested = childStateEvContent.suggested,
-                                                canonicalAlias = childSummary.canonicalAlias,
-                                                aliases = childSummary.aliases,
-                                                worldReadable = childSummary.worldReadable
-                                        )
-                                    }
-                                }.orEmpty()
-                    }
-                    .orEmpty()
-            SpaceHierarchyData(
-                    rootSummary = root,
-                    children = children,
-                    childrenState = spaceDesc?.childrenState.orEmpty(),
-                    nextToken = response.nextBatch
-            )
-        }
+    override suspend fun querySpaceChildren(
+            spaceId: String,
+            suggestedOnly: Boolean?,
+            limit: Int?,
+            from: String?,
+            knownStateList: List<Event>?
+    ): SpaceHierarchyData {
+        val spacesResponse = getSpacesResponse(spaceId, suggestedOnly, limit, from)
+        val spaceRootResponse = spacesResponse.getRoot(spaceId)
+        val spaceRoot = spaceRootResponse?.toRoomSummary() ?: createBlankRoomSummary(spaceId)
+        val spaceChildren = spacesResponse.rooms.mapToSpaceChildInfoList(spaceId, spaceRootResponse, knownStateList)
+
+        return SpaceHierarchyData(
+                rootSummary = spaceRoot,
+                children = spaceChildren,
+                childrenState = spaceRootResponse?.childrenState.orEmpty(),
+                nextToken = spacesResponse.nextBatch
+        )
     }
+
+    private suspend fun getSpacesResponse(spaceId: String, suggestedOnly: Boolean?, limit: Int?, from: String?) =
+            resolveSpaceInfoTask.execute(
+                    ResolveSpaceInfoTask.Params(spaceId = spaceId, limit = limit, maxDepth = 1, from = from, suggestedOnly = suggestedOnly)
+            )
+
+    private fun SpacesResponse.getRoot(spaceId: String) = rooms?.firstOrNull { it.roomId == spaceId }
+
+    private fun SpaceChildSummaryResponse.toRoomSummary() = RoomSummary(
+            roomId = roomId,
+            roomType = roomType,
+            name = name ?: "",
+            displayName = name ?: "",
+            topic = topic ?: "",
+            joinedMembersCount = numJoinedMembers,
+            avatarUrl = avatarUrl ?: "",
+            encryptionEventTs = null,
+            typingUsers = emptyList(),
+            isEncrypted = false,
+            flattenParentIds = emptyList(),
+            canonicalAlias = canonicalAlias,
+            joinRules = RoomJoinRules.PUBLIC.takeIf { isWorldReadable }
+    )
+
+    private fun createBlankRoomSummary(spaceId: String) = RoomSummary(
+            roomId = spaceId,
+            joinedMembersCount = null,
+            encryptionEventTs = null,
+            typingUsers = emptyList(),
+            isEncrypted = false,
+            flattenParentIds = emptyList(),
+            canonicalAlias = null,
+            joinRules = null
+    )
+
+    private fun List<SpaceChildSummaryResponse>?.mapToSpaceChildInfoList(
+            spaceId: String,
+            spaceRootResponse: SpaceChildSummaryResponse?,
+            knownStateList: List<Event>?,
+    ) = this?.filterIdIsNot(spaceId)
+            ?.toSpaceChildInfoList(spaceRootResponse, knownStateList)
+            .orEmpty()
+
+    private fun List<SpaceChildSummaryResponse>.filterIdIsNot(spaceId: String) = filter { it.roomId != spaceId }
+
+    private fun List<SpaceChildSummaryResponse>.toSpaceChildInfoList(
+            rootRoomResponse: SpaceChildSummaryResponse?,
+            knownStateList: List<Event>?,
+    ) = flatMap { spaceChildSummary ->
+        (rootRoomResponse?.childrenState ?: knownStateList)
+                ?.filter { it.isChildOf(spaceChildSummary) }
+                ?.mapNotNull { childStateEvent -> childStateEvent.toSpaceChildInfo(spaceChildSummary) }
+                .orEmpty()
+    }
+
+    private fun Event.isChildOf(space: SpaceChildSummaryResponse) = stateKey == space.roomId && type == EventType.STATE_SPACE_CHILD
+
+    private fun Event.toSpaceChildInfo(summary: SpaceChildSummaryResponse) = content.toModel<SpaceChildContent>()?.let { content ->
+        createSpaceChildInfo(summary, this, content)
+    }
+
+    private fun createSpaceChildInfo(
+            summary: SpaceChildSummaryResponse,
+            stateEvent: Event,
+            content: SpaceChildContent
+    ) = SpaceChildInfo(
+            childRoomId = summary.roomId,
+            isKnown = true,
+            roomType = summary.roomType,
+            name = summary.name,
+            topic = summary.topic,
+            avatarUrl = summary.avatarUrl,
+            order = content.order,
+            viaServers = content.via.orEmpty(),
+            activeMemberCount = summary.numJoinedMembers,
+            parentRoomId = stateEvent.roomId,
+            suggested = content.suggested,
+            canonicalAlias = summary.canonicalAlias,
+            aliases = summary.aliases,
+            worldReadable = summary.isWorldReadable
+    )
 
     override suspend fun joinSpace(spaceIdOrAlias: String,
                                    reason: String?,
@@ -191,10 +227,6 @@ internal class DefaultSpaceService @Inject constructor(
     override suspend fun rejectInvite(spaceId: String, reason: String?) {
         leaveRoomTask.execute(LeaveRoomTask.Params(spaceId, reason))
     }
-
-//    override fun getSpaceParentsOfRoom(roomId: String): List<SpaceSummary> {
-//        return spaceSummaryDataSource.getParentsOfRoom(roomId)
-//    }
 
     override suspend fun setSpaceParent(childRoomId: String, parentSpaceId: String, canonical: Boolean, viaServers: List<String>) {
         // Should we perform some validation here?,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
@@ -38,16 +38,14 @@ internal class DefaultResolveSpaceInfoTask @Inject constructor(
 ) : ResolveSpaceInfoTask {
 
     override suspend fun execute(params: ResolveSpaceInfoTask.Params) = executeRequest(globalErrorReceiver) {
-        getSpaceHierarchy(params)
+        try {
+            getSpaceHierarchy(params)
+        } catch (e: HttpException) {
+            getUnstableSpaceHierarchy(params)
+        }
     }
 
-    private suspend fun getSpaceHierarchy(params: ResolveSpaceInfoTask.Params) = try {
-        getStableSpaceHierarchy(params)
-    } catch (e: HttpException) {
-        getUnstableSpaceHierarchy(params)
-    }
-
-    private suspend fun getStableSpaceHierarchy(params: ResolveSpaceInfoTask.Params) =
+    private suspend fun getSpaceHierarchy(params: ResolveSpaceInfoTask.Params) =
             spaceApi.getSpaceHierarchy(
                     spaceId = params.spaceId,
                     suggestedOnly = params.suggestedOnly,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
@@ -19,6 +19,7 @@ package org.matrix.android.sdk.internal.session.space
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.task.Task
+import timber.log.Timber
 import javax.inject.Inject
 
 internal interface ResolveSpaceInfoTask : Task<ResolveSpaceInfoTask.Params, SpacesResponse> {
@@ -38,12 +39,17 @@ internal class DefaultResolveSpaceInfoTask @Inject constructor(
 ) : ResolveSpaceInfoTask {
     override suspend fun execute(params: ResolveSpaceInfoTask.Params): SpacesResponse {
         return executeRequest(globalErrorReceiver) {
-            spaceApi.getSpaceHierarchy(
-                    spaceId = params.spaceId,
-                    suggestedOnly = params.suggestedOnly,
-                    limit = params.limit,
-                    maxDepth = params.maxDepth,
-                    from = params.from)
+            try {
+                throw RuntimeException("Test space task exception")
+            } catch (e: Throwable) {
+                Timber.i("Test fall back api")
+                spaceApi.getSpaceHierarchy(
+                        spaceId = params.spaceId,
+                        suggestedOnly = params.suggestedOnly,
+                        limit = params.limit,
+                        maxDepth = params.maxDepth,
+                        from = params.from)
+            }
         }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
@@ -19,6 +19,7 @@ package org.matrix.android.sdk.internal.session.space
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.task.Task
+import timber.log.Timber
 import javax.inject.Inject
 
 internal interface ResolveSpaceInfoTask : Task<ResolveSpaceInfoTask.Params, SpacesResponse> {
@@ -39,10 +40,12 @@ internal class DefaultResolveSpaceInfoTask @Inject constructor(
     private lateinit var params: ResolveSpaceInfoTask.Params
 
     override suspend fun execute(params: ResolveSpaceInfoTask.Params): SpacesResponse {
-        return executeRequest(globalErrorReceiver) {
+        val result = executeRequest(globalErrorReceiver) {
             this.params = params
             getSpaceHierarchy()
         }
+        Timber.w("Space Info result: $result")
+        return result
     }
 
     private suspend fun getSpaceHierarchy() = try {
@@ -57,7 +60,9 @@ internal class DefaultResolveSpaceInfoTask @Inject constructor(
                     suggestedOnly = params.suggestedOnly,
                     limit = params.limit,
                     maxDepth = params.maxDepth,
-                    from = params.from)
+                    from = params.from).also {
+                        Timber.w("Spaces response stable: $it")
+            }
 
     private suspend fun getUnstableSpaceHierarchy() =
             spaceApi.getSpaceHierarchyUnstable(
@@ -65,5 +70,7 @@ internal class DefaultResolveSpaceInfoTask @Inject constructor(
                     suggestedOnly = params.suggestedOnly,
                     limit = params.limit,
                     maxDepth = params.maxDepth,
-                    from = params.from)
+                    from = params.from).also {
+                Timber.w("Spaces response unstable: $it")
+            }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
@@ -19,7 +19,6 @@ package org.matrix.android.sdk.internal.session.space
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.task.Task
-import retrofit2.HttpException
 import javax.inject.Inject
 
 internal interface ResolveSpaceInfoTask : Task<ResolveSpaceInfoTask.Params, SpacesResponse> {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
@@ -48,7 +48,7 @@ internal class DefaultResolveSpaceInfoTask @Inject constructor(
 
     private suspend fun getSpaceHierarchy() = try {
         getStableSpaceHierarchy()
-    } catch (e: HttpException) {
+    } catch (e: Throwable) {
         getUnstableSpaceHierarchy()
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
@@ -51,6 +51,8 @@ internal class DefaultResolveSpaceInfoTask @Inject constructor(
     private suspend fun getSpaceHierarchy() = try {
         getStableSpaceHierarchy()
     } catch (e: Throwable) {
+        Timber.w("Stable space hierarchy failed: ${e.message}")
+        e.printStackTrace()
         getUnstableSpaceHierarchy()
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
@@ -19,6 +19,7 @@ package org.matrix.android.sdk.internal.session.space
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.task.Task
+import retrofit2.HttpException
 import javax.inject.Inject
 
 internal interface ResolveSpaceInfoTask : Task<ResolveSpaceInfoTask.Params, SpacesResponse> {
@@ -45,7 +46,7 @@ internal class DefaultResolveSpaceInfoTask @Inject constructor(
 
     private suspend fun getSpaceHierarchy() = try {
         getStableSpaceHierarchy()
-    } catch (e: Throwable) {
+    } catch (e: HttpException) {
         getUnstableSpaceHierarchy()
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
@@ -37,32 +37,31 @@ internal class DefaultResolveSpaceInfoTask @Inject constructor(
         private val globalErrorReceiver: GlobalErrorReceiver
 ) : ResolveSpaceInfoTask {
 
-    private lateinit var params: ResolveSpaceInfoTask.Params
-
     override suspend fun execute(params: ResolveSpaceInfoTask.Params) = executeRequest(globalErrorReceiver) {
-        this.params = params
-        getSpaceHierarchy()
+        getSpaceHierarchy(params)
     }
 
-    private suspend fun getSpaceHierarchy() = try {
-        getStableSpaceHierarchy()
+    private suspend fun getSpaceHierarchy(params: ResolveSpaceInfoTask.Params) = try {
+        getStableSpaceHierarchy(params)
     } catch (e: HttpException) {
-        getUnstableSpaceHierarchy()
+        getUnstableSpaceHierarchy(params)
     }
 
-    private suspend fun getStableSpaceHierarchy() =
+    private suspend fun getStableSpaceHierarchy(params: ResolveSpaceInfoTask.Params) =
             spaceApi.getSpaceHierarchy(
                     spaceId = params.spaceId,
                     suggestedOnly = params.suggestedOnly,
                     limit = params.limit,
                     maxDepth = params.maxDepth,
-                    from = params.from)
+                    from = params.from,
+            )
 
-    private suspend fun getUnstableSpaceHierarchy() =
+    private suspend fun getUnstableSpaceHierarchy(params: ResolveSpaceInfoTask.Params) =
             spaceApi.getSpaceHierarchyUnstable(
                     spaceId = params.spaceId,
                     suggestedOnly = params.suggestedOnly,
                     limit = params.limit,
                     maxDepth = params.maxDepth,
-                    from = params.from)
+                    from = params.from,
+            )
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/ResolveSpaceInfoTask.kt
@@ -19,7 +19,6 @@ package org.matrix.android.sdk.internal.session.space
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.task.Task
-import timber.log.Timber
 import javax.inject.Inject
 
 internal interface ResolveSpaceInfoTask : Task<ResolveSpaceInfoTask.Params, SpacesResponse> {
@@ -39,20 +38,14 @@ internal class DefaultResolveSpaceInfoTask @Inject constructor(
 
     private lateinit var params: ResolveSpaceInfoTask.Params
 
-    override suspend fun execute(params: ResolveSpaceInfoTask.Params): SpacesResponse {
-        val result = executeRequest(globalErrorReceiver) {
-            this.params = params
-            getSpaceHierarchy()
-        }
-        Timber.w("Space Info result: $result")
-        return result
+    override suspend fun execute(params: ResolveSpaceInfoTask.Params) = executeRequest(globalErrorReceiver) {
+        this.params = params
+        getSpaceHierarchy()
     }
 
     private suspend fun getSpaceHierarchy() = try {
         getStableSpaceHierarchy()
     } catch (e: Throwable) {
-        Timber.w("Stable space hierarchy failed: ${e.message}")
-        e.printStackTrace()
         getUnstableSpaceHierarchy()
     }
 
@@ -62,9 +55,7 @@ internal class DefaultResolveSpaceInfoTask @Inject constructor(
                     suggestedOnly = params.suggestedOnly,
                     limit = params.limit,
                     maxDepth = params.maxDepth,
-                    from = params.from).also {
-                        Timber.w("Spaces response stable: $it")
-            }
+                    from = params.from)
 
     private suspend fun getUnstableSpaceHierarchy() =
             spaceApi.getSpaceHierarchyUnstable(
@@ -72,7 +63,5 @@ internal class DefaultResolveSpaceInfoTask @Inject constructor(
                     suggestedOnly = params.suggestedOnly,
                     limit = params.limit,
                     maxDepth = params.maxDepth,
-                    from = params.from).also {
-                Timber.w("Spaces response unstable: $it")
-            }
+                    from = params.from)
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/SpaceApi.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/SpaceApi.kt
@@ -31,7 +31,7 @@ internal interface SpaceApi {
      * @param from: Optional. Pagination token given to retrieve the next set of rooms.
      * Note that if a pagination token is provided, then the parameters given for suggested_only and max_depth must be the same.
      */
-    @GET(NetworkConstants.URI_API_PREFIX_PATH_V1 + "rooms/{roomID}/hierarchy")
+    @GET(NetworkConstants.URI_API_PREFIX_PATH_V1 + "rooms/{roomId}/hierarchy")
     suspend fun getSpaceHierarchy(
             @Path("roomId") spaceId: String,
             @Query("suggested_only") suggestedOnly: Boolean?,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/SpaceApi.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/SpaceApi.kt
@@ -31,8 +31,19 @@ internal interface SpaceApi {
      * @param from: Optional. Pagination token given to retrieve the next set of rooms.
      * Note that if a pagination token is provided, then the parameters given for suggested_only and max_depth must be the same.
      */
-    @GET(NetworkConstants.URI_API_PREFIX_PATH_ + "rooms/{roomID}/hierarchy")
+    @GET(NetworkConstants.URI_API_PREFIX_PATH_V1 + "rooms/{roomID}/hierarchy")
     suspend fun getSpaceHierarchy(
+            @Path("roomId") spaceId: String,
+            @Query("suggested_only") suggestedOnly: Boolean?,
+            @Query("limit") limit: Int?,
+            @Query("max_depth") maxDepth: Int?,
+            @Query("from") from: String?): SpacesResponse
+
+    /**
+     * Unstable version of [getSpaceHierarchy]
+     */
+    @GET(NetworkConstants.URI_API_PREFIX_PATH_UNSTABLE + "org.matrix.msc2946/rooms/{roomId}/hierarchy")
+    suspend fun getSpaceHierarchyUnstable(
             @Path("roomId") spaceId: String,
             @Query("suggested_only") suggestedOnly: Boolean?,
             @Query("limit") limit: Int?,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/SpaceApi.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/SpaceApi.kt
@@ -31,7 +31,7 @@ internal interface SpaceApi {
      * @param from: Optional. Pagination token given to retrieve the next set of rooms.
      * Note that if a pagination token is provided, then the parameters given for suggested_only and max_depth must be the same.
      */
-    @GET(NetworkConstants.URI_API_PREFIX_PATH_UNSTABLE + "org.matrix.msc2946/rooms/{roomId}/hierarchy")
+    @GET(NetworkConstants.URI_API_PREFIX_PATH_ + "rooms/{roomID}/hierarchy")
     suspend fun getSpaceHierarchy(
             @Path("roomId") spaceId: String,
             @Query("suggested_only") suggestedOnly: Boolean?,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/SpaceChildSummaryResponse.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/SpaceChildSummaryResponse.kt
@@ -81,7 +81,7 @@ internal data class SpaceChildSummaryResponse(
          * Required. Whether the room may be viewed by guest users without joining.
          */
         @Json(name = "world_readable")
-        val worldReadable: Boolean = false,
+        val isWorldReadable: Boolean = false,
 
         /**
          * Required. Whether guest users may join the room and participate in it. If they can,

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/space/DefaultResolveSpaceInfoTaskTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/space/DefaultResolveSpaceInfoTaskTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.space
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.matrix.android.sdk.test.fakes.FakeGlobalErrorReceiver
+import org.matrix.android.sdk.test.fakes.FakeSpaceApi
+
+@ExperimentalCoroutinesApi
+class DefaultResolveSpaceInfoTaskTest {
+
+    private val spaceApi = FakeSpaceApi()
+    private val globalErrorReceiver = FakeGlobalErrorReceiver()
+    private val resolveSpaceInfoTask = DefaultResolveSpaceInfoTask(spaceApi.instance, globalErrorReceiver)
+
+    @Test
+    fun `given stable endpoint works, when execute, then return stable api data`() = runBlockingTest {
+        spaceApi.givenStableEndpointWorks()
+
+        val result = resolveSpaceInfoTask.execute(spaceApi.params)
+
+        result shouldBeEqualTo spaceApi.response
+    }
+
+    @Test
+    fun `given stable endpoint fails, when execute, then fallback to unstable endpoint`() = runBlockingTest {
+        spaceApi.givenStableEndpointFails()
+        spaceApi.givenUnstableEndpointWorks()
+
+        val result = resolveSpaceInfoTask.execute(spaceApi.params)
+
+        result shouldBeEqualTo spaceApi.response
+    }
+}

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/space/DefaultResolveSpaceInfoTaskTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/space/DefaultResolveSpaceInfoTaskTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeSpaceApi.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeSpaceApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeSpaceApi.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeSpaceApi.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.test.fakes
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.matrix.android.sdk.internal.session.space.SpaceApi
+import org.matrix.android.sdk.internal.session.space.SpacesResponse
+import org.matrix.android.sdk.test.fixtures.ResolveSpaceInfoTaskParamsFixture
+import org.matrix.android.sdk.test.fixtures.SpacesResponseFixture
+import retrofit2.HttpException
+import retrofit2.Response
+
+internal class FakeSpaceApi {
+
+    val instance: SpaceApi = mockk()
+    val params = ResolveSpaceInfoTaskParamsFixture.aResolveSpaceInfoTaskParams()
+    val response = SpacesResponseFixture.aSpacesResponse()
+
+    fun givenStableEndpointWorks() {
+        coEvery { instance.getSpaceHierarchy(params.spaceId, params.suggestedOnly, params.limit, params.maxDepth, params.from) } returns response
+    }
+
+    fun givenStableEndpointFails() {
+        val errorResponse = Response.error<SpacesResponse>(500, "".toResponseBody())
+        coEvery { instance.getSpaceHierarchy(params.spaceId, params.suggestedOnly, params.limit, params.maxDepth, params.from) } throws HttpException(errorResponse)
+    }
+
+    fun givenUnstableEndpointWorks() {
+        coEvery { instance.getSpaceHierarchyUnstable(params.spaceId, params.suggestedOnly, params.limit, params.maxDepth, params.from) } returns response
+    }
+}

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeSpaceApi.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeSpaceApi.kt
@@ -19,24 +19,23 @@ package org.matrix.android.sdk.test.fakes
 import io.mockk.coEvery
 import io.mockk.mockk
 import org.matrix.android.sdk.internal.session.space.SpaceApi
+import org.matrix.android.sdk.internal.session.space.SpacesResponse
 import org.matrix.android.sdk.test.fixtures.ResolveSpaceInfoTaskParamsFixture
-import org.matrix.android.sdk.test.fixtures.SpacesResponseFixture
 
 internal class FakeSpaceApi {
 
     val instance: SpaceApi = mockk()
     val params = ResolveSpaceInfoTaskParamsFixture.aResolveSpaceInfoTaskParams()
-    val response = SpacesResponseFixture.aSpacesResponse()
 
-    fun givenStableEndpointWorks() {
+    fun givenStableEndpointReturns(response: SpacesResponse) {
         coEvery { instance.getSpaceHierarchy(params.spaceId, params.suggestedOnly, params.limit, params.maxDepth, params.from) } returns response
     }
 
-    fun givenStableEndpointFails() {
-        coEvery { instance.getSpaceHierarchy(params.spaceId, params.suggestedOnly, params.limit, params.maxDepth, params.from) } throws Exception()
+    fun givenStableEndpointThrows(throwable: Throwable) {
+        coEvery { instance.getSpaceHierarchy(params.spaceId, params.suggestedOnly, params.limit, params.maxDepth, params.from) } throws throwable
     }
 
-    fun givenUnstableEndpointWorks() {
+    fun givenUnstableEndpointReturns(response: SpacesResponse) {
         coEvery { instance.getSpaceHierarchyUnstable(params.spaceId, params.suggestedOnly, params.limit, params.maxDepth, params.from) } returns response
     }
 }

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeSpaceApi.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeSpaceApi.kt
@@ -18,13 +18,9 @@ package org.matrix.android.sdk.test.fakes
 
 import io.mockk.coEvery
 import io.mockk.mockk
-import okhttp3.ResponseBody.Companion.toResponseBody
 import org.matrix.android.sdk.internal.session.space.SpaceApi
-import org.matrix.android.sdk.internal.session.space.SpacesResponse
 import org.matrix.android.sdk.test.fixtures.ResolveSpaceInfoTaskParamsFixture
 import org.matrix.android.sdk.test.fixtures.SpacesResponseFixture
-import retrofit2.HttpException
-import retrofit2.Response
 
 internal class FakeSpaceApi {
 
@@ -37,8 +33,7 @@ internal class FakeSpaceApi {
     }
 
     fun givenStableEndpointFails() {
-        val errorResponse = Response.error<SpacesResponse>(500, "".toResponseBody())
-        coEvery { instance.getSpaceHierarchy(params.spaceId, params.suggestedOnly, params.limit, params.maxDepth, params.from) } throws HttpException(errorResponse)
+        coEvery { instance.getSpaceHierarchy(params.spaceId, params.suggestedOnly, params.limit, params.maxDepth, params.from) } throws Exception()
     }
 
     fun givenUnstableEndpointWorks() {

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fixtures/ResolveSpaceInfoTaskParamsFixture.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fixtures/ResolveSpaceInfoTaskParamsFixture.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fixtures/ResolveSpaceInfoTaskParamsFixture.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fixtures/ResolveSpaceInfoTaskParamsFixture.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.test.fixtures
+
+import org.matrix.android.sdk.internal.session.space.ResolveSpaceInfoTask
+
+internal object ResolveSpaceInfoTaskParamsFixture {
+    fun aResolveSpaceInfoTaskParams(
+            spaceId: String = "",
+            limit: Int? = null,
+            maxDepth: Int? = null,
+            from: String? = null,
+            suggestedOnly: Boolean? = null,
+    ) = ResolveSpaceInfoTask.Params(
+            spaceId,
+            limit,
+            maxDepth,
+            from,
+            suggestedOnly,
+    )
+}

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fixtures/SpacesResponseFixture.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fixtures/SpacesResponseFixture.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright 2021 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fixtures/SpacesResponseFixture.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fixtures/SpacesResponseFixture.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.test.fixtures
+
+import org.matrix.android.sdk.internal.session.space.SpaceChildSummaryResponse
+import org.matrix.android.sdk.internal.session.space.SpacesResponse
+
+internal object SpacesResponseFixture {
+    fun aSpacesResponse(
+            nextBatch: String? = null,
+            rooms: List<SpaceChildSummaryResponse>? = null,
+    ) = SpacesResponse(
+            nextBatch,
+            rooms,
+    )
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

Adds stable room hierarchy endpoint with a fallback to the unstable one

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

Closes https://github.com/vector-im/element-android/issues/4462

## Screenshots / GIFs

<!-- Only if UI have been changed -->

N/A

## Tests

<!-- Explain how you tested your development -->

**Testing Normal Functionality**
1. Login with any account belonging to spaces, preferrably one with subspaces too
2. Open the home navigation drawer and see that you can see your spaces and subspaces as normal

**Testing Fallback**
- Set debug points in ResolveSpaceInfoTask lines 49 and 51
- Force a fail on the stable request (either via code or via a network interceptor) and see that it falls back to the unstable API

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 10

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
