### PR TITLE
Fix missing messages when forward paging with chunks > 50 messages

### DIFF
--- a/changelog.d/5448.bugfix
+++ b/changelog.d/5448.bugfix
@@ -1,0 +1,1 @@
+Fix missing messages when loading messages forwards


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- offsets() was not limiting in the right direction when loading
  messages forwards
- after fixing offsets(), more recent messages would not be loaded due
  to the isLastForward() check, so better prioritize the SUCCESS
  LoadMoreResult over the REACHED_END here

## Motivation and context

Fixes https://github.com/vector-im/element-android/issues/5448

## Tests

1. Permalink the latest message in a room
2. Go back to room list
3. Receive lots of new messages in that room (e.g. 100)
4. Open the room from the permalink
5. Check if all messages are shown


## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 11

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>