### PR TITLE
Remove deprecated warning in TestMatrix, and reduce severity of identity server error

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,6 @@ env:
   CI_GRADLE_ARG_PROPERTIES: >
     -Porg.gradle.jvmargs=-Xmx4g
     -Porg.gradle.parallel=false
-    -PallWarningsAsErrors=false
 jobs:
   # Build Android Tests [Matrix SDK]
   build-android-test-matrix-sdk:
@@ -298,7 +297,7 @@ jobs:
             touch emulator.log
             chmod 777 emulator.log
             adb logcat >> emulator.log &
-            ./gradlew $CI_GRADLE_ARG_PROPERTIES -PallWarningsAsErrors=false connectedGplayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=im.vector.app.ui.UiAllScreensSanityTest || (adb pull storage/emulated/0/Pictures/failure_screenshots && exit 1 )
+            ./gradlew $CI_GRADLE_ARG_PROPERTIES connectedGplayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=im.vector.app.ui.UiAllScreensSanityTest || (adb pull storage/emulated/0/Pictures/failure_screenshots && exit 1 )
       - name: Upload Test Report Log
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Run unit tests
-        run: ./gradlew clean test $CI_GRADLE_ARG_PROPERTIES -PallWarningsAsErrors=false --stacktrace
+        run: ./gradlew clean test $CI_GRADLE_ARG_PROPERTIES --stacktrace
       - name: Format unit test results
         if: always()
         run: python3 ./tools/ci/render_test_output.py unit ./**/build/test-results/**/*.xml

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/CommonTestHelper.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/CommonTestHelper.kt
@@ -71,7 +71,7 @@ class CommonTestHelper(context: Context) {
                     )
             )
         }
-        matrix = TestMatrix.getInstance(context)
+        matrix = TestMatrix.getInstance()
     }
 
     fun createAccount(userNamePrefix: String, testParams: SessionTestParams): Session {

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/TestMatrix.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/TestMatrix.kt
@@ -105,16 +105,9 @@ internal class TestMatrix constructor(context: Context, matrixConfiguration: Mat
             }
         }
 
-        fun getInstance(context: Context): TestMatrix {
-            if (isInit.compareAndSet(false, true)) {
-                val appContext = context.applicationContext
-                if (appContext is MatrixConfiguration.Provider) {
-                    val matrixConfiguration = (appContext as MatrixConfiguration.Provider).providesMatrixConfiguration()
-                    instance = TestMatrix(appContext, matrixConfiguration)
-                } else {
-                    throw IllegalStateException("Matrix is not initialized properly." +
-                            " You should call Matrix.initialize or let your application implements MatrixConfiguration.Provider.")
-                }
+        fun getInstance(): TestMatrix {
+            if (isInit.compareAndSet(false, false)) {
+                throw IllegalStateException("Matrix is not initialized properly. You should call TestMatrix.initialize first")
             }
             return instance
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/signout/SignOutTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/signout/SignOutTask.kt
@@ -18,6 +18,7 @@ package org.matrix.android.sdk.internal.session.signout
 
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.failure.MatrixError
+import org.matrix.android.sdk.api.session.identity.IdentityServiceError
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.session.cleanup.CleanupSession
@@ -65,7 +66,13 @@ internal class DefaultSignOutTask @Inject constructor(
 
         // Logout from identity server if any
         runCatching { identityDisconnectTask.execute(Unit) }
-                .onFailure { Timber.w(it, "Unable to disconnect identity server") }
+                .onFailure {
+                    if (it is IdentityServiceError.NoIdentityServerConfigured) {
+                        Timber.i("No identity server configured to disconnect")
+                    } else {
+                        Timber.w(it, "Unable to disconnect identity server")
+                    }
+                }
 
         Timber.d("SignOut: cleanup session...")
         cleanupSession.cleanup()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [X] Other : logging tidy-up

## Content

This exception is printed in the logs on every sign-out that did not have an identity server configured:
```
2022-03-08 10:02:48.129 14210-14267/? I/System.out: W/DefaultSignOutTask: Unable to disconnect identity server
2022-03-08 10:02:48.129 14210-14267/? I/System.out: org.matrix.android.sdk.api.session.identity.IdentityServiceError$NoIdentityServerConfigured
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.matrix.android.sdk.internal.session.identity.DefaultIdentityDisconnectTask.execute(IdentityDisconnectTask.kt:36)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.matrix.android.sdk.internal.session.identity.DefaultIdentityDisconnectTask.execute(IdentityDisconnectTask.kt:29)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.matrix.android.sdk.internal.session.signout.DefaultSignOutTask.execute(SignOutTask.kt:67)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.matrix.android.sdk.internal.session.signout.DefaultSignOutTask$execute$1.invokeSuspend(Unknown Source:15)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source:1)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source:1)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.matrix.android.sdk.common.CommonTestHelper.runBlockingTest(CommonTestHelper.kt:400)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.matrix.android.sdk.common.CommonTestHelper.signOutAndClose(CommonTestHelper.kt:433)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.matrix.android.sdk.common.CryptoTestData.cleanUp(CryptoTestData.kt:35)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.matrix.android.sdk.internal.crypto.verification.qrcode.VerificationTest.doTest(VerificationTest.kt:251)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.matrix.android.sdk.internal.crypto.verification.qrcode.VerificationTest.test_aliceAndBob_all_all(VerificationTest.kt:143)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at java.lang.reflect.Method.invoke(Native Method)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at net.lachlanmckee.timberjunit.TimberTestRule$TimberStatement.evaluate(TimberTestRule.java:185)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.rules.RunRules.evaluate(RunRules.java:20)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at androidx.test.ext.junit.runners.AndroidJUnit4.run(AndroidJUnit4.java:162)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.Suite.runChild(Suite.java:128)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.Suite.runChild(Suite.java:27)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
2022-03-08 10:02:48.129 14210-14267/? I/System.out:     at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
2022-03-08 10:02:48.130 14210-14267/? I/System.out:     at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
2022-03-08 10:02:48.130 14210-14267/? I/System.out:     at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
2022-03-08 10:02:48.130 14210-14267/? I/System.out:     at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
2022-03-08 10:02:48.130 14210-14267/? I/System.out:     at androidx.test.internal.runner.TestExecutor.execute(TestExecutor.java:56)
2022-03-08 10:02:48.130 14210-14267/? I/System.out:     at androidx.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:444)
2022-03-08 10:02:48.130 14210-14267/? I/System.out:     at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2145)
2022-03-08 10:02:48.130 14210-14267/? I/System.out: D/DefaultSignOutTask: SignOut: cleanup session...
```
This makes it look like a bad thing has happened, but practically in the case of no configured identity server, there's no problem.

I have also removed the usage of `MatrixConfiguration.Provider`, as I do not believe we use this piece of logic in the test suite at present.

## Motivation and context

I'm reading the logs a lot recently, and I keep finding this exception then having to discount it as not a real issue in the test suite.

By removing usage of `MatrixConfiguration.Provider`, we can remove `-PallWarningsAsError=false` and pick up new failures (and I also remove warnings from test runs in the development environment)

## Screenshots / GIFs

<!-- Only if UI have been changed -->

## Tests

I ran the test suite again and the logout exception wasn't printed in most cases, and the exception that would have been generated if we hadn't initialized the provider was also not thrown.

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
