### PR TITLE
Fixing overlapping room image and title

### DIFF
--- a/changelog.d/5468.bugfix
+++ b/changelog.d/5468.bugfix
@@ -1,0 +1,1 @@
+Fixing room titles overlapping the room image in the room toolbar

--- a/vector/src/main/res/layout/view_room_detail_toolbar.xml
+++ b/vector/src/main/res/layout/view_room_detail_toolbar.xml
@@ -59,6 +59,13 @@
         tools:ignore="MissingConstraints"
         tools:visibility="invisible" />
 
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/imageGroupBarrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="end"
+        app:constraint_referenced_ids="roomToolbarDecorationImageView,roomToolbarAvatarImageView,roomToolbarPresenceImageView,roomToolbarPublicImageView" />
+
     <TextView
         android:id="@+id/roomToolbarTitleView"
         android:layout_width="0dp"
@@ -72,7 +79,7 @@
         app:layout_constraintBottom_toBottomOf="@id/roomToolbarAvatarImageView"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toEndOf="@id/roomToolbarDecorationImageView"
+        app:layout_constraintStart_toEndOf="@id/imageGroupBarrier"
         app:layout_constraintTop_toTopOf="@id/roomToolbarAvatarImageView"
         app:layout_constraintVertical_chainStyle="packed"
         app:layout_goneMarginStart="7dp"


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes #5468 

Introduces a barrier which contains all the possible leading icons, allowing us to be sure the text is always aligned to the right of whichever icon is currently present. 

## Motivation and context

The room toolbar title is overlapping image due to missing constraints when the badge icon is not present

## Screenshots / GIFs

| BEFORE | AFTER | 
| --- | --- |
|![before-rt](https://user-images.githubusercontent.com/1848238/157414031-3a154080-3d20-4121-ac9d-8021727186c0.png)|![after-rt](https://user-images.githubusercontent.com/1848238/157414041-a7002dd4-74e3-43a8-b39a-135135f8b155.png)
|![before-rt2](https://user-images.githubusercontent.com/1848238/157414029-b6acf30a-2183-4105-b8f3-8c76ba9ce04b.png)|![after-rt2](https://user-images.githubusercontent.com/1848238/157414037-e8e2dbf9-0b09-49a8-8268-6a2f2ebb788d.png)
|![before-rt3](https://user-images.githubusercontent.com/1848238/157414022-de415111-a884-4282-b6b2-7e6b68127556.png)|![after-rt3](https://user-images.githubusercontent.com/1848238/157414035-77ef9a8c-6183-476a-8495-90a6053eea8d.png)


## Tests

- Open a room a clear room, such as element-android
- Notice the room title overlaps the images 

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Pocofone f1 (28)
