### PR TITLE
 Americanize words/phrases in default en-US strings

### DIFF
--- a/changelog.d/3677.misc
+++ b/changelog.d/3677.misc
@@ -1,0 +1,1 @@
+Update strings for American / United States English

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -272,8 +272,8 @@
 
     <string name="notice_end_to_end_ok">%1$s turned on end-to-end encryption.</string>
     <string name="notice_end_to_end_ok_by_you">You turned on end-to-end encryption.</string>
-    <string name="notice_end_to_end_unknown_algorithm">%1$s turned on end-to-end encryption (unrecognised algorithm %2$s).</string>
-    <string name="notice_end_to_end_unknown_algorithm_by_you">You turned on end-to-end encryption (unrecognised algorithm %1$s).</string>
+    <string name="notice_end_to_end_unknown_algorithm">%1$s turned on end-to-end encryption (unrecognized algorithm %2$s).</string>
+    <string name="notice_end_to_end_unknown_algorithm_by_you">You turned on end-to-end encryption (unrecognized algorithm %1$s).</string>
 
     <!-- theme -->
     <string name="system_theme">System Default</string>
@@ -400,7 +400,7 @@
 
     <!-- Bottom navigation buttons -->
     <string name="bottom_action_notification">Notifications</string>
-    <string name="bottom_action_favourites">Favourites</string>
+    <string name="bottom_action_favourites">Favorites</string>
     <string name="bottom_action_people">People</string>
     <string name="bottom_action_rooms">Rooms</string>
 
@@ -726,7 +726,7 @@
     <string name="thread_list_modal_all_threads_subtitle">Shows all threads from current room</string>
     <string name="thread_list_modal_my_threads_title">My Threads</string>
     <string name="thread_list_modal_my_threads_subtitle">Shows all threads you’ve participated in</string>
-    <string name="thread_list_empty_title">Keep discussions organised with threads</string>
+    <string name="thread_list_empty_title">Keep discussions organized with threads</string>
     <string name="thread_list_empty_subtitle">Threads help keep your conversations on-topic and easy to track.</string>
     <!-- Parameter %s will be replaced by the value of string reply_in_thread -->
     <string name="thread_list_empty_notice">Tip: Long tap a message and use “%s”.</string>
@@ -758,7 +758,7 @@
     <string name="settings_app_info_link_summary">Show the application info in the system settings.</string>
 
     <string name="settings_emails">Email addresses</string>
-    <string name="settings_emails_empty">No email has been added to your account</string>
+    <string name="settings_emails_empty">No email address has been added to your account</string>
     <string name="settings_phone_numbers">Phone numbers</string>
     <string name="settings_remove_three_pid_confirmation_content">Remove %s?</string>
     <string name="error_threepid_auth_failed">Ensure that you have clicked on the link in the email we have sent to you.</string>
@@ -767,7 +767,7 @@
     <string name="settings_notification_by_event">Notification importance by event</string>
 
     <string name="settings_notification_emails_category">Email notification</string>
-    <string name="settings_notification_emails_no_emails">To receive email with notification, please associate an email to your Matrix account</string>
+    <string name="settings_notification_emails_no_emails">To receive email with notification, please associate an email address to your Matrix account</string>
 
     <!-- The variable is a single email address, eg Enable email notifications for example@matrix.org -->
     <string name="settings_notification_emails_enable_for_email">Enable email notifications for %s</string>
@@ -1027,7 +1027,7 @@
     <string name="settings_unignore_user">Show all messages from %s?\n\nNote that this action will restart the app and it may take some time.</string>
 
     <string name="settings_emails_and_phone_numbers_title">Emails and phone numbers</string>
-    <string name="settings_emails_and_phone_numbers_summary">Manage emails and phone numbers linked to your Matrix account</string>
+    <string name="settings_emails_and_phone_numbers_summary">Manage email addresses and phone numbers linked to your Matrix account</string>
 
     <string name="settings_select_country">Choose a country</string>
 
@@ -1708,20 +1708,20 @@
     <string name="settings_discovery_identity_server_info">You are currently using %1$s to discover and be discoverable by existing contacts you know.</string>
     <string name="settings_discovery_identity_server_info_none">You are not currently using an identity server. To discover and be discoverable by existing contacts you know, configure one below.</string>
     <string name="settings_discovery_emails_title">Discoverable email addresses</string>
-    <string name="settings_discovery_no_mails">Discovery options will appear once you have added an email.</string>
+    <string name="settings_discovery_no_mails">Discovery options will appear once you have added an email address.</string>
     <string name="settings_discovery_no_msisdn">Discovery options will appear once you have added a phone number.</string>
     <string name="settings_discovery_disconnect_identity_server_info">Disconnecting from your identity server will mean you won’t be discoverable by other users and you won’t be able to invite others by email or phone.</string>
     <string name="settings_discovery_msisdn_title">Discoverable phone numbers</string>
-    <string name="settings_discovery_confirm_mail">We sent you a confirm email to %s, check your email and click on the confirmation link</string>
-    <string name="settings_discovery_confirm_mail_not_clicked">We sent you a confirm email to %s, please first check your email and click on the confirmation link</string>
+    <string name="settings_discovery_confirm_mail">We sent an email to %s. Check your email and click on the confirmation link.</string>
+    <string name="settings_discovery_confirm_mail_not_clicked">We sent an email to %s. Check your email and click on the confirmation link.</string>
     <string name="settings_discovery_consent_title">Send emails and phone numbers</string>
-    <string name="settings_discovery_consent_notice_on">You have given your consent to send emails and phone numbers to this identity server to discover other users from your contacts.</string>
+    <string name="settings_discovery_consent_notice_on">You have given your consent to send email addresses and phone numbers to this identity server to discover other users from your contacts.</string>
     <string name="settings_discovery_consent_notice_off_2">Your contacts are private. To discover users from your contacts, we need your permission to send contact info to your identity server.</string>
     <string name="settings_discovery_consent_action_revoke">Revoke my consent</string>
     <string name="settings_discovery_consent_action_give_consent">Give consent</string>
 
-    <string name="identity_server_consent_dialog_title_2">Send emails and phone numbers to %s</string>
-    <string name="identity_server_consent_dialog_content_3">To discover existing contacts, you need to send contact info (emails and phone numbers) to your identity server. We hash your data before sending for privacy.</string>
+    <string name="identity_server_consent_dialog_title_2">Send email addresses and phone numbers to %s</string>
+    <string name="identity_server_consent_dialog_content_3">To discover existing contacts, you need to send contact info (email addresses and phone numbers) to your identity server. We hash your data before sending for privacy.</string>
     <string name="identity_server_consent_dialog_content_question">Do you agree to send this info?</string>
 
     <string name="settings_discovery_enter_identity_server">Enter an identity server URL</string>
@@ -1864,7 +1864,7 @@
     <string name="login_splash_title">It\'s your conversation. Own it.</string>
     <string name="login_splash_text1">Chat with people directly or in groups</string>
     <string name="login_splash_text2">Keep conversations private with encryption</string>
-    <string name="login_splash_text3">Extend &amp; customise your experience</string>
+    <string name="login_splash_text3">Extend &amp; customize your experience</string>
     <string name="login_splash_submit">Get started</string>
     <string name="login_splash_create_account">Create account</string>
     <string name="login_splash_already_have_account">I already have an account</string>
@@ -1907,7 +1907,7 @@
     <string name="login_registration_disabled">Sorry, this server isn’t accepting new accounts.</string>
     <string name="login_registration_not_supported">The application is not able to create an account on this homeserver.\n\nDo you want to signup using a web client?</string>
 
-    <string name="login_login_with_email_error">This email is not associated to any account.</string>
+    <string name="login_login_with_email_error">This email address is not associated to any account.</string>
 
     <!-- Replaced string is the homeserver url -->
     <string name="login_reset_password_on">Reset password on %1$s</string>
@@ -1920,7 +1920,7 @@
     <string name="login_reset_password_warning_content">Changing your password will reset any end-to-end encryption keys on all of your sessions, making encrypted chat history unreadable. Set up Key Backup or export your room keys from another session before resetting your password.</string>
     <string name="login_reset_password_warning_submit">Continue</string>
 
-    <string name="login_reset_password_error_not_found">This email is not linked to any account</string>
+    <string name="login_reset_password_error_not_found">This email address is not linked to any account</string>
 
     <string name="login_reset_password_mail_confirmation_title">Check your inbox</string>
     <!-- Replaced string is an email -->
@@ -1937,7 +1937,7 @@
     <string name="login_reset_password_cancel_confirmation_content">Your password is not yet changed.\n\nStop the password change process?</string>
 
     <string name="login_set_email_title">Set email address</string>
-    <string name="login_set_email_notice">Set an email to recover your account. Later, you can optionally allow people you know to discover you by your email.</string>
+    <string name="login_set_email_notice">Set an email address to recover your account. Later, you can optionally allow people you know to discover you by this address.</string>
     <string name="login_set_email_mandatory_hint">Email</string>
     <string name="login_set_email_optional_hint">Email (optional)</string>
     <string name="login_set_email_submit">Next</string>
@@ -2085,8 +2085,8 @@
     <string name="sent_location">Shared their location</string>
 
     <string name="verification_request_waiting">Waiting…</string>
-    <string name="verification_request_other_cancelled">%s cancelled</string>
-    <string name="verification_request_you_cancelled">You cancelled</string>
+    <string name="verification_request_other_cancelled">%s canceled</string>
+    <string name="verification_request_you_cancelled">You canceled</string>
     <string name="verification_request_other_accepted">%s accepted</string>
     <string name="verification_request_you_accepted">You accepted</string>
     <string name="verification_sent">Verification Sent</string>
@@ -2226,7 +2226,7 @@
 
     <string name="verification_profile_device_verified_because">This session is trusted for secure messaging because %1$s (%2$s) verified it:</string>
     <string name="verification_profile_device_new_signing">%1$s (%2$s) signed in using a new session:</string>
-    <string name="verification_profile_device_untrust_info">Until this user trusts this session, messages sent to and from it are labelled with warnings. Alternatively, you can manually verify it.</string>
+    <string name="verification_profile_device_untrust_info">Until this user trusts this session, messages sent to and from it are labeled with warnings. Alternatively, you can manually verify it.</string>
 
 
     <string name="initialize_cross_signing">Initialize CrossSigning</string>
@@ -2295,8 +2295,8 @@
         One of the following may be compromised:\n\n- Your password\n- Your homeserver\n- This device, or the other device\n- The internet connection either device is using\n\nWe recommend you change your password &amp; recovery key in Settings immediately.
     </string>
 
-    <string name="verify_cancelled_notice">Verification has been cancelled. You can start verification again.</string>
-    <string name="verification_cancelled">Verification Cancelled</string>
+    <string name="verify_cancelled_notice">Verification has been canceled. You can start verification again.</string>
+    <string name="verification_cancelled">Verification Canceled</string>
 
     <string name="recovery_passphrase">Recovery Passphrase</string>
     <string name="message_key">Message Key</string>
@@ -2489,7 +2489,7 @@
     <string name="identity_server_error_no_identity_server_configured">Please first configure an identity server.</string>
     <string name="identity_server_error_terms_not_signed">Please first accepts the terms of the identity server in the settings.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="identity_server_error_bulk_sha256_not_supported">For your privacy, ${app_name} only supports sending hashed user emails and phone number.</string>
+    <string name="identity_server_error_bulk_sha256_not_supported">For your privacy, ${app_name} only supports sending hashed user email addresses and phone number.</string>
     <string name="identity_server_error_binding_error">The association has failed.</string>
     <string name="identity_server_error_no_current_binding_error">There is no current association with this identifier.</string>
     <string name="identity_server_user_consent_not_provided">The user consent has not been provided.</string>
@@ -2724,7 +2724,7 @@
     <string name="create_spaces_who_are_you_working_with">Who are you working with?</string>
     <string name="create_spaces_make_sure_access">Make sure the right people have access to %s.</string>
     <string name="create_spaces_just_me">Just me</string>
-    <string name="create_spaces_organise_rooms">A private space to organise your rooms</string>
+    <string name="create_spaces_organise_rooms">A private space to organize your rooms</string>
     <string name="create_spaces_me_and_teammates">Me and teammates</string>
     <string name="create_spaces_private_teammates">A private space for you &amp; your teammates</string>
     <string name="space_type_public">Public</string>
@@ -2868,7 +2868,7 @@
     <!-- %s will be replaced by an email at runtime -->
     <string name="this_invite_to_this_space_was_sent">This invite to this space was sent to %s which is not associated with your account</string>
 
-    <string name="link_this_email_settings_link">Link this email with your account</string>
+    <string name="link_this_email_settings_link">Link this email address with your account</string>
     <!-- %s will be replaced by the value of link_this_email_settings_link and styled as a link -->
     <string name="link_this_email_with_your_account">%s in Settings to receive invites directly in ${app_name}.</string>
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Internationali**z**ation

## Content

Per @bmarty, `en-US` is the default value on Android platform, so I as a native American English speaker I have updated spelling of relevant words and expressions accordingly.

## Motivation and context

Fixes #3677, which suggested a PR against this file instead of doing things through Weblate. As this is my first PR for this project, hopefully I haven't missed anything, but please let me know if so.

## Screenshots / GIFs

N/A

## Tests

N/A

## Tested devices

N/A

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)