### PR TITLE
Swap to using github action to configure synapse server in CI builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,7 +87,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Start synapse server
-        uses: michaelkaye/setup-matrix-synapse@v0.2.0
+        uses: michaelkaye/setup-matrix-synapse@v0.3.0
         with:
           uploadLogs: true
           httpPort: 8080
@@ -274,7 +274,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Start synapse server
-        uses: michaelkaye/setup-matrix-synapse@v0.2.0
+        uses: michaelkaye/setup-matrix-synapse@v0.3.0
         with:
           uploadLogs: true
           httpPort: 8080

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,11 +87,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Start synapse server
-        run: |
-          pip install matrix-synapse
-          curl https://raw.githubusercontent.com/matrix-org/synapse/develop/demo/start.sh -o start.sh
-          chmod 777 start.sh
-          ./start.sh --no-rate-limit
+        uses: michaelkaye/setup-matrix-synapse@v0.2.0
+        with:
+          uploadLogs: true
+          httpPort: 8080
+          disableRateLimiting: true
       # package: org.matrix.android.sdk.session
       - name: Run integration tests for  Matrix SDK [org.matrix.android.sdk.session] API[${{ matrix.api-level }}]
         uses: reactivecircus/android-emulator-runner@v2
@@ -274,10 +274,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Start synapse server
-        run: |
-          pip install matrix-synapse
-          curl -sL https://raw.githubusercontent.com/matrix-org/synapse/develop/demo/start.sh \
-            | sed s/127.0.0.1/0.0.0.0/g | sed 's/http:\/\/localhost/http:\/\/10.0.2.2/g' | bash -s -- --no-rate-limit
+        uses: michaelkaye/setup-matrix-synapse@v0.2.0
+        with:
+          uploadLogs: true
+          httpPort: 8080
+          disableRateLimiting: true
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [X] Technical
- [ ] Other :

## Content

Rather than use a shell script to start and stop synapse, use a github action instead

## Motivation and context

The synapse demo script changed which caused CI to fail, so fixing it up so it's internal to GHA rather than re-using a script not quite designed for this purpose.

Additional benefits is that this should retain the configuration and logs of the synapse homeserver for analysis after the run.


## Tests

Tested by manual runs 

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
