### PR TITLE
Use ColorPrimary for attachmentGalleryButton tint

### DIFF
--- a/changelog.d/5501.misc
+++ b/changelog.d/5501.misc
@@ -1,0 +1,1 @@
+Use ColorPrimary for attachmentGalleryButton tint

--- a/vector/src/main/res/layout/view_attachment_type_selector.xml
+++ b/vector/src/main/res/layout/view_attachment_type_selector.xml
@@ -40,7 +40,8 @@
                 android:layout_height="@dimen/layout_touch_size"
                 android:background="?android:attr/selectableItemBackground"
                 android:contentDescription="@string/attachment_type_gallery"
-                android:src="@drawable/ic_attachment_gallery" />
+                android:src="@drawable/ic_attachment_gallery"
+                app:tint="?colorPrimary" />
 
             <ImageButton
                 android:id="@+id/attachmentStickersButton"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [X] Other :

## Content
In view_attachment_type_selector.xml, for the icon: attchmentGalleryButton a tint is not set.
For the forked projet like Tchap, we prefer use colorPrimary for the tint.
<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
![Screenshot_1646919323](https://user-images.githubusercontent.com/15031750/157672818-0c0ee242-fb40-4fb6-96ce-778ca0866f8b.png)

<!-- Only if UI have been changed -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s): Pixel 4 API 30

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [X] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [X] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
