### PR TITLE
FTUE - Single loading state

### DIFF
--- a/changelog.d/5517.misc
+++ b/changelog.d/5517.misc
@@ -1,0 +1,1 @@
+Flattening the asynchronous onboarding state and passing all errors through the same pipeline

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
@@ -64,6 +64,11 @@ fun Throwable.isInvalidPassword(): Boolean {
             error.message == "Invalid password"
 }
 
+fun Throwable.isRegistrationDisabled(): Boolean {
+    return this is Failure.ServerError && error.code == MatrixError.M_FORBIDDEN &&
+            httpCode == HttpsURLConnection.HTTP_FORBIDDEN
+}
+
 fun Throwable.isInvalidUIAAuth(): Boolean {
     return this is Failure.ServerError &&
             error.code == MatrixError.M_FORBIDDEN &&
@@ -104,8 +109,8 @@ fun Throwable.isRegistrationAvailabilityError(): Boolean {
     return this is Failure.ServerError &&
             httpCode == HttpsURLConnection.HTTP_BAD_REQUEST && /* 400 */
             (error.code == MatrixError.M_USER_IN_USE ||
-            error.code == MatrixError.M_INVALID_USERNAME ||
-            error.code == MatrixError.M_EXCLUSIVE)
+                    error.code == MatrixError.M_INVALID_USERNAME ||
+                    error.code == MatrixError.M_EXCLUSIVE)
 }
 
 /**

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
@@ -58,6 +58,11 @@ fun Throwable.getRetryDelay(defaultValue: Long): Long {
             ?: defaultValue
 }
 
+fun Throwable.isInvalidUsername(): Boolean {
+    return this is Failure.ServerError &&
+            error.code == MatrixError.M_INVALID_USERNAME
+}
+
 fun Throwable.isInvalidPassword(): Boolean {
     return this is Failure.ServerError &&
             error.code == MatrixError.M_FORBIDDEN &&
@@ -67,6 +72,16 @@ fun Throwable.isInvalidPassword(): Boolean {
 fun Throwable.isRegistrationDisabled(): Boolean {
     return this is Failure.ServerError && error.code == MatrixError.M_FORBIDDEN &&
             httpCode == HttpsURLConnection.HTTP_FORBIDDEN
+}
+
+fun Throwable.isWeakPassword(): Boolean {
+    return this is Failure.ServerError && error.code == MatrixError.M_WEAK_PASSWORD
+}
+
+fun Throwable.isLoginEmailUnknown(): Boolean {
+    return this is Failure.ServerError &&
+            error.code == MatrixError.M_FORBIDDEN &&
+            error.message.isEmpty()
 }
 
 fun Throwable.isInvalidUIAAuth(): Boolean {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
@@ -58,6 +58,10 @@ fun Throwable.getRetryDelay(defaultValue: Long): Long {
             ?: defaultValue
 }
 
+fun Throwable.isUsernameInUse(): Boolean {
+    return this is Failure.ServerError && error.code == MatrixError.M_USER_IN_USE
+}
+
 fun Throwable.isInvalidUsername(): Boolean {
     return this is Failure.ServerError &&
             error.code == MatrixError.M_INVALID_USERNAME

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -828,20 +828,20 @@ class OnboardingViewModel @AssistedInject constructor(
     }
 
     private fun updateDisplayName(displayName: String) {
-        setState { copy(asyncDisplayName = Loading()) }
+        setState { copy(isLoading = true) }
         viewModelScope.launch {
             val activeSession = activeSessionHolder.getActiveSession()
             try {
                 activeSession.setDisplayName(activeSession.myUserId, displayName)
                 setState {
                     copy(
-                            asyncDisplayName = Success(Unit),
+                            isLoading = false,
                             personalizationState = personalizationState.copy(displayName = displayName)
                     )
                 }
                 handleDisplayNameStepComplete()
             } catch (error: Throwable) {
-                setState { copy(asyncDisplayName = Fail(error)) }
+                setState { copy(isLoading = false) }
                 _viewEvents.post(OnboardingViewEvents.Failure(error))
             }
         }
@@ -883,7 +883,7 @@ class OnboardingViewModel @AssistedInject constructor(
             when (val pictureUri = state.personalizationState.selectedPictureUri) {
                 null -> _viewEvents.post(OnboardingViewEvents.Failure(NullPointerException("picture uri is missing from state")))
                 else -> {
-                    setState { copy(asyncProfilePicture = Loading()) }
+                    setState { copy(isLoading = true) }
                     viewModelScope.launch {
                         val activeSession = activeSessionHolder.getActiveSession()
                         try {
@@ -894,12 +894,12 @@ class OnboardingViewModel @AssistedInject constructor(
                             )
                             setState {
                                 copy(
-                                        asyncProfilePicture = Success(Unit),
+                                        isLoading = false,
                                 )
                             }
                             onProfilePictureSaved()
                         } catch (error: Throwable) {
-                            setState { copy(asyncProfilePicture = Fail(error)) }
+                            setState { copy(isLoading = false) }
                             _viewEvents.post(OnboardingViewEvents.Failure(error))
                         }
                     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
@@ -34,8 +34,7 @@ data class OnboardingViewState(
         val asyncResetPassword: Async<Unit> = Uninitialized,
         val asyncResetMailConfirmed: Async<Unit> = Uninitialized,
         val asyncRegistration: Async<Unit> = Uninitialized,
-        val asyncDisplayName: Async<Unit> = Uninitialized,
-        val asyncProfilePicture: Async<Unit> = Uninitialized,
+        val isLoading: Boolean = false,
 
         @PersistState
         val onboardingFlow: OnboardingFlow? = null,
@@ -73,14 +72,12 @@ data class OnboardingViewState(
         val personalizationState: PersonalizationState = PersonalizationState()
 ) : MavericksState {
 
-    fun isLoading(): Boolean {
+    fun legacyIsLoading(): Boolean {
         return asyncLoginAction is Loading ||
                 asyncHomeServerLoginFlowRequest is Loading ||
                 asyncResetPassword is Loading ||
                 asyncResetMailConfirmed is Loading ||
-                asyncRegistration is Loading ||
-                asyncDisplayName is Loading ||
-                asyncProfilePicture is Loading
+                asyncRegistration is Loading
     }
 }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
@@ -18,20 +18,14 @@ package im.vector.app.features.onboarding
 
 import android.net.Uri
 import android.os.Parcelable
-import com.airbnb.mvrx.Async
-import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.PersistState
-import com.airbnb.mvrx.Uninitialized
 import im.vector.app.features.login.LoginMode
 import im.vector.app.features.login.ServerType
 import im.vector.app.features.login.SignMode
 import kotlinx.parcelize.Parcelize
 
 data class OnboardingViewState(
-        val asyncHomeServerLoginFlowRequest: Async<Unit> = Uninitialized,
-        val asyncResetPassword: Async<Unit> = Uninitialized,
-        val asyncResetMailConfirmed: Async<Unit> = Uninitialized,
         val isLoading: Boolean = false,
 
         @PersistState
@@ -68,14 +62,7 @@ data class OnboardingViewState(
 
         @PersistState
         val personalizationState: PersonalizationState = PersonalizationState()
-) : MavericksState {
-
-    fun legacyIsLoading(): Boolean {
-        return asyncHomeServerLoginFlowRequest is Loading ||
-                asyncResetPassword is Loading ||
-                asyncResetMailConfirmed is Loading
-    }
-}
+) : MavericksState
 
 enum class OnboardingFlow {
     SignIn,

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
@@ -29,11 +29,9 @@ import im.vector.app.features.login.SignMode
 import kotlinx.parcelize.Parcelize
 
 data class OnboardingViewState(
-        val asyncLoginAction: Async<Unit> = Uninitialized,
         val asyncHomeServerLoginFlowRequest: Async<Unit> = Uninitialized,
         val asyncResetPassword: Async<Unit> = Uninitialized,
         val asyncResetMailConfirmed: Async<Unit> = Uninitialized,
-        val asyncRegistration: Async<Unit> = Uninitialized,
         val isLoading: Boolean = false,
 
         @PersistState
@@ -73,11 +71,9 @@ data class OnboardingViewState(
 ) : MavericksState {
 
     fun legacyIsLoading(): Boolean {
-        return asyncLoginAction is Loading ||
-                asyncHomeServerLoginFlowRequest is Loading ||
+        return asyncHomeServerLoginFlowRequest is Loading ||
                 asyncResetPassword is Loading ||
-                asyncResetMailConfirmed is Loading ||
-                asyncRegistration is Loading
+                asyncResetMailConfirmed is Loading
     }
 }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/AbstractFtueAuthFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/AbstractFtueAuthFragment.kt
@@ -34,8 +34,6 @@ import im.vector.app.features.onboarding.OnboardingViewModel
 import im.vector.app.features.onboarding.OnboardingViewState
 import kotlinx.coroutines.CancellationException
 import org.matrix.android.sdk.api.failure.Failure
-import org.matrix.android.sdk.api.failure.MatrixError
-import javax.net.ssl.HttpsURLConnection
 
 /**
  * Parent Fragment for all the login/registration screens
@@ -85,21 +83,8 @@ abstract class AbstractFtueAuthFragment<VB : ViewBinding> : VectorBaseFragment<V
             is CancellationException                  ->
                 /* Ignore this error, user has cancelled the action */
                 Unit
-            is Failure.ServerError                    ->
-                if (throwable.error.code == MatrixError.M_FORBIDDEN &&
-                        throwable.httpCode == HttpsURLConnection.HTTP_FORBIDDEN /* 403 */) {
-                    MaterialAlertDialogBuilder(requireActivity())
-                            .setTitle(R.string.dialog_title_error)
-                            .setMessage(getString(R.string.login_registration_disabled))
-                            .setPositiveButton(R.string.ok, null)
-                            .show()
-                } else {
-                    onError(throwable)
-                }
-            is Failure.UnrecognizedCertificateFailure ->
-                showUnrecognizedCertificateFailure(throwable)
-            else                                      ->
-                onError(throwable)
+            is Failure.UnrecognizedCertificateFailure -> showUnrecognizedCertificateFailure(throwable)
+            else                                      -> onError(throwable)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
@@ -72,33 +72,6 @@ class FtueAuthLoginFragment @Inject constructor() : AbstractSSOFtueAuthFragment<
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewModel.viewEvents
-                .stream()
-                .onEach {
-                    when (it) {
-                        is OnboardingViewEvents.Failure -> {
-                            if (it.throwable is Failure.ServerError &&
-                                    it.throwable.error.code == MatrixError.M_FORBIDDEN &&
-                                    it.throwable.error.message.isEmpty()) {
-                                // Login with email, but email unknown
-                                views.loginFieldTil.error = getString(R.string.login_login_with_email_error)
-                            } else {
-                                // Trick to display the error without text.
-                                views.loginFieldTil.error = " "
-                                if (it.throwable.isInvalidPassword() && spaceInPassword()) {
-                                    views.passwordFieldTil.error = getString(R.string.auth_invalid_login_param_space_in_password)
-                                } else {
-                                    views.passwordFieldTil.error = errorFormatter.toHumanReadable(it.throwable)
-                                }
-                            }
-                        }
-                        else                            -> {
-                            // do nothing
-                        }
-                    }
-                }
-                .launchIn(lifecycleScope)
-
         setupSubmitButton()
         setupForgottenPasswordButton()
 
@@ -302,6 +275,23 @@ class FtueAuthLoginFragment @Inject constructor() : AbstractSSOFtueAuthFragment<
         if (state.isLoading) {
             // Ensure password is hidden
             views.passwordField.hidePassword()
+        }
+    }
+
+    override fun showFailure(throwable: Throwable) {
+        if (throwable is Failure.ServerError &&
+                throwable.error.code == MatrixError.M_FORBIDDEN &&
+                throwable.error.message.isEmpty()) {
+            // Login with email, but email unknown
+            views.loginFieldTil.error = getString(R.string.login_login_with_email_error)
+        } else {
+            // Trick to display the error without text.
+            views.loginFieldTil.error = " "
+            if (throwable.isInvalidPassword() && spaceInPassword()) {
+                views.passwordFieldTil.error = getString(R.string.auth_invalid_login_param_space_in_password)
+            } else {
+                views.passwordFieldTil.error = errorFormatter.toHumanReadable(throwable)
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
@@ -48,6 +48,7 @@ import org.matrix.android.sdk.api.failure.isInvalidPassword
 import org.matrix.android.sdk.api.failure.isInvalidUsername
 import org.matrix.android.sdk.api.failure.isLoginEmailUnknown
 import org.matrix.android.sdk.api.failure.isRegistrationDisabled
+import org.matrix.android.sdk.api.failure.isUsernameInUse
 import org.matrix.android.sdk.api.failure.isWeakPassword
 import reactivecircus.flowbinding.android.widget.textChanges
 import javax.inject.Inject
@@ -260,26 +261,26 @@ class FtueAuthLoginFragment @Inject constructor() : AbstractSSOFtueAuthFragment<
         // Trick to display the error without text.
         views.loginFieldTil.error = " "
         when {
-            throwable.isInvalidUsername()                               -> {
+            throwable.isUsernameInUse() || throwable.isInvalidUsername() -> {
                 views.loginFieldTil.error = errorFormatter.toHumanReadable(throwable)
             }
-            throwable.isLoginEmailUnknown()                             -> {
+            throwable.isLoginEmailUnknown()                              -> {
                 views.loginFieldTil.error = getString(R.string.login_login_with_email_error)
             }
-            throwable.isInvalidPassword() && spaceInPassword()          -> {
+            throwable.isInvalidPassword() && spaceInPassword()           -> {
                 views.passwordFieldTil.error = getString(R.string.auth_invalid_login_param_space_in_password)
             }
-            throwable.isWeakPassword() || throwable.isInvalidPassword() -> {
+            throwable.isWeakPassword() || throwable.isInvalidPassword()  -> {
                 views.passwordFieldTil.error = errorFormatter.toHumanReadable(throwable)
             }
-            throwable.isRegistrationDisabled()                          -> {
+            throwable.isRegistrationDisabled()                           -> {
                 MaterialAlertDialogBuilder(requireActivity())
                         .setTitle(R.string.dialog_title_error)
                         .setMessage(getString(R.string.login_registration_disabled))
                         .setPositiveButton(R.string.ok, null)
                         .show()
             }
-            else                                                        -> {
+            else                                                         -> {
                 super.onError(throwable)
             }
         }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
@@ -44,10 +44,11 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import org.matrix.android.sdk.api.failure.Failure
-import org.matrix.android.sdk.api.failure.MatrixError
 import org.matrix.android.sdk.api.failure.isInvalidPassword
+import org.matrix.android.sdk.api.failure.isInvalidUsername
+import org.matrix.android.sdk.api.failure.isLoginEmailUnknown
 import org.matrix.android.sdk.api.failure.isRegistrationDisabled
+import org.matrix.android.sdk.api.failure.isWeakPassword
 import reactivecircus.flowbinding.android.widget.textChanges
 import javax.inject.Inject
 
@@ -259,34 +260,26 @@ class FtueAuthLoginFragment @Inject constructor() : AbstractSSOFtueAuthFragment<
         // Trick to display the error without text.
         views.loginFieldTil.error = " "
         when {
-            throwable is Failure.ServerError &&
-                    throwable.error.code == MatrixError.M_FORBIDDEN &&
-                    throwable.error.message.isEmpty()                                               -> {
-                // Login with email, but email unknown
+            throwable.isInvalidUsername()                               -> {
+                views.loginFieldTil.error = errorFormatter.toHumanReadable(throwable)
+            }
+            throwable.isLoginEmailUnknown()                             -> {
                 views.loginFieldTil.error = getString(R.string.login_login_with_email_error)
             }
-
-            throwable is Failure.ServerError && throwable.error.code == MatrixError.M_WEAK_PASSWORD -> {
-                views.passwordFieldTil.error = errorFormatter.toHumanReadable(throwable)
-            }
-
-            throwable.isInvalidPassword() && spaceInPassword()                                      -> {
+            throwable.isInvalidPassword() && spaceInPassword()          -> {
                 views.passwordFieldTil.error = getString(R.string.auth_invalid_login_param_space_in_password)
             }
-
-            throwable.isInvalidPassword()                                                           -> {
+            throwable.isWeakPassword() || throwable.isInvalidPassword() -> {
                 views.passwordFieldTil.error = errorFormatter.toHumanReadable(throwable)
             }
-
-            throwable.isRegistrationDisabled()                                                      -> {
+            throwable.isRegistrationDisabled()                          -> {
                 MaterialAlertDialogBuilder(requireActivity())
                         .setTitle(R.string.dialog_title_error)
                         .setMessage(getString(R.string.login_registration_disabled))
                         .setPositiveButton(R.string.ok, null)
                         .show()
             }
-
-            else                                                                                    -> {
+            else                                                        -> {
                 super.onError(throwable)
             }
         }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthResetPasswordFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthResetPasswordFragment.kt
@@ -54,7 +54,7 @@ class FtueAuthResetPasswordFragment @Inject constructor() : AbstractFtueAuthFrag
         setupSubmitButton()
     }
 
-    override fun showFailure(throwable: Throwable) {
+    override fun onError(throwable: Throwable) {
         views.resetPasswordEmailTil.error = errorFormatter.toHumanReadable(throwable)
     }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthResetPasswordFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthResetPasswordFragment.kt
@@ -21,8 +21,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.lifecycleScope
-import com.airbnb.mvrx.Fail
-import com.airbnb.mvrx.Loading
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import im.vector.app.R
 import im.vector.app.core.extensions.hideKeyboard
@@ -53,8 +51,11 @@ class FtueAuthResetPasswordFragment @Inject constructor() : AbstractFtueAuthFrag
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         setupSubmitButton()
+    }
+
+    override fun showFailure(throwable: Throwable) {
+        views.resetPasswordEmailTil.error = errorFormatter.toHumanReadable(throwable)
     }
 
     private fun setupUi(state: OnboardingViewState) {
@@ -115,16 +116,9 @@ class FtueAuthResetPasswordFragment @Inject constructor() : AbstractFtueAuthFrag
 
     override fun updateWithState(state: OnboardingViewState) {
         setupUi(state)
-
-        when (state.asyncResetPassword) {
-            is Loading -> {
-                // Ensure new password is hidden
-                views.passwordField.hidePassword()
-            }
-            is Fail    -> {
-                views.resetPasswordEmailTil.error = errorFormatter.toHumanReadable(state.asyncResetPassword.error)
-            }
-            else       -> Unit
+        if (state.isLoading) {
+            // Ensure new password is hidden
+            views.passwordField.hidePassword()
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthResetPasswordMailConfirmationFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthResetPasswordMailConfirmationFragment.kt
@@ -59,7 +59,7 @@ class FtueAuthResetPasswordMailConfirmationFragment @Inject constructor() : Abst
         setupUi(state)
     }
 
-    override fun showFailure(throwable: Throwable) {
+    override fun onError(throwable: Throwable) {
         // Link in email not yet clicked ?
         val message = if (throwable.is401()) {
             getString(R.string.auth_reset_password_error_unauthorized)

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthResetPasswordMailConfirmationFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthResetPasswordMailConfirmationFragment.kt
@@ -20,7 +20,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.airbnb.mvrx.Fail
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import im.vector.app.R
 import im.vector.app.databinding.FragmentLoginResetPasswordMailConfirmationBinding
@@ -58,23 +57,20 @@ class FtueAuthResetPasswordMailConfirmationFragment @Inject constructor() : Abst
 
     override fun updateWithState(state: OnboardingViewState) {
         setupUi(state)
+    }
 
-        when (state.asyncResetMailConfirmed) {
-            is Fail -> {
-                // Link in email not yet clicked ?
-                val message = if (state.asyncResetMailConfirmed.error.is401()) {
-                    getString(R.string.auth_reset_password_error_unauthorized)
-                } else {
-                    errorFormatter.toHumanReadable(state.asyncResetMailConfirmed.error)
-                }
-
-                MaterialAlertDialogBuilder(requireActivity())
-                        .setTitle(R.string.dialog_title_error)
-                        .setMessage(message)
-                        .setPositiveButton(R.string.ok, null)
-                        .show()
-            }
-            else    -> Unit
+    override fun showFailure(throwable: Throwable) {
+        // Link in email not yet clicked ?
+        val message = if (throwable.is401()) {
+            getString(R.string.auth_reset_password_error_unauthorized)
+        } else {
+            errorFormatter.toHumanReadable(throwable)
         }
+
+        MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(R.string.dialog_title_error)
+                .setMessage(message)
+                .setPositiveButton(R.string.ok, null)
+                .show()
     }
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -121,7 +121,7 @@ class FtueAuthVariant(
 
     private fun updateWithState(viewState: OnboardingViewState) {
         isForceLoginFallbackEnabled = viewState.isForceLoginFallbackEnabled
-        views.loginLoading.isVisible = viewState.isLoading || viewState.legacyIsLoading()
+        views.loginLoading.isVisible = viewState.isLoading
     }
 
     override fun setIsLoading(isLoading: Boolean) = Unit

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -121,7 +121,7 @@ class FtueAuthVariant(
 
     private fun updateWithState(viewState: OnboardingViewState) {
         isForceLoginFallbackEnabled = viewState.isForceLoginFallbackEnabled
-        views.loginLoading.isVisible = viewState.isLoading()
+        views.loginLoading.isVisible = viewState.isLoading || viewState.legacyIsLoading()
     }
 
     override fun setIsLoading(isLoading: Boolean) = Unit

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -17,7 +17,6 @@
 package im.vector.app.features.onboarding
 
 import android.net.Uri
-import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
@@ -260,8 +259,8 @@ class OnboardingViewModelTest {
         test
                 .assertStatesChanges(
                         initialState,
-                        { copy(asyncDisplayName = Loading()) },
-                        { copy(asyncDisplayName = Fail(AN_ERROR)) },
+                        { copy(isLoading = true) },
+                        { copy(isLoading = false) },
                 )
                 .assertEvents(OnboardingViewEvents.Failure(AN_ERROR))
                 .finish()
@@ -307,7 +306,7 @@ class OnboardingViewModelTest {
         viewModel.handle(OnboardingAction.SaveSelectedProfilePicture)
 
         test
-                .assertStates(expectedProfilePictureFailureStates(initialStateWithPicture, AN_ERROR))
+                .assertStates(expectedProfilePictureFailureStates(initialStateWithPicture))
                 .assertEvents(OnboardingViewEvents.Failure(AN_ERROR))
                 .finish()
     }
@@ -362,20 +361,20 @@ class OnboardingViewModelTest {
 
     private fun expectedProfilePictureSuccessStates(state: OnboardingViewState) = listOf(
             state,
-            state.copy(asyncProfilePicture = Loading()),
-            state.copy(asyncProfilePicture = Success(Unit))
+            state.copy(isLoading = true),
+            state.copy(isLoading = false)
     )
 
-    private fun expectedProfilePictureFailureStates(state: OnboardingViewState, cause: Exception) = listOf(
+    private fun expectedProfilePictureFailureStates(state: OnboardingViewState) = listOf(
             state,
-            state.copy(asyncProfilePicture = Loading()),
-            state.copy(asyncProfilePicture = Fail(cause))
+            state.copy(isLoading = true),
+            state.copy(isLoading = false)
     )
 
     private fun expectedSuccessfulDisplayNameUpdateStates(): List<OnboardingViewState.() -> OnboardingViewState> {
         return listOf(
-                { copy(asyncDisplayName = Loading()) },
-                { copy(asyncDisplayName = Success(Unit), personalizationState = personalizationState.copy(displayName = A_DISPLAY_NAME)) }
+                { copy(isLoading = true) },
+                { copy(isLoading = false, personalizationState = personalizationState.copy(displayName = A_DISPLAY_NAME)) }
         )
     }
 

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -128,8 +128,8 @@ class OnboardingViewModelTest {
                 .assertStatesChanges(
                         initialState,
                         { copy(signMode = SignMode.SignUp) },
-                        { copy(asyncRegistration = Loading()) },
-                        { copy(asyncRegistration = Uninitialized) }
+                        { copy(isLoading = true) },
+                        { copy(isLoading = false) }
                 )
                 .assertEvents(OnboardingViewEvents.RegistrationFlowResult(ANY_CONTINUING_REGISTRATION_RESULT.flowResult, isRegistrationStarted = true))
                 .finish()
@@ -145,8 +145,8 @@ class OnboardingViewModelTest {
         test
                 .assertStatesChanges(
                         initialState,
-                        { copy(asyncRegistration = Loading()) },
-                        { copy(asyncRegistration = Uninitialized) }
+                        { copy(isLoading = true) },
+                        { copy(isLoading = false) }
                 )
                 .assertEvents(OnboardingViewEvents.RegistrationFlowResult(ANY_CONTINUING_REGISTRATION_RESULT.flowResult, isRegistrationStarted = true))
                 .finish()
@@ -175,8 +175,8 @@ class OnboardingViewModelTest {
         test
                 .assertStatesChanges(
                         initialState,
-                        { copy(asyncRegistration = Loading()) },
-                        { copy(asyncRegistration = Uninitialized) }
+                        { copy(isLoading = true) },
+                        { copy(isLoading = false) }
                 )
                 .assertNoEvents()
                 .finish()
@@ -193,9 +193,8 @@ class OnboardingViewModelTest {
         test
                 .assertStatesChanges(
                         initialState,
-                        { copy(asyncRegistration = Loading()) },
-                        { copy(asyncLoginAction = Success(Unit), personalizationState = A_HOMESERVER_CAPABILITIES.toPersonalisationState()) },
-                        { copy(asyncLoginAction = Success(Unit), asyncRegistration = Uninitialized) }
+                        { copy(isLoading = true) },
+                        { copy(isLoading = false, personalizationState = A_HOMESERVER_CAPABILITIES.toPersonalisationState()) }
                 )
                 .assertEvents(OnboardingViewEvents.OnAccountCreated)
                 .finish()
@@ -211,9 +210,8 @@ class OnboardingViewModelTest {
         test
                 .assertStatesChanges(
                         initialState,
-                        { copy(asyncRegistration = Loading()) },
-                        { copy(asyncLoginAction = Success(Unit), personalizationState = A_HOMESERVER_CAPABILITIES.toPersonalisationState()) },
-                        { copy(asyncRegistration = Uninitialized) }
+                        { copy(isLoading = true) },
+                        { copy(isLoading = false, personalizationState = A_HOMESERVER_CAPABILITIES.toPersonalisationState()) }
                 )
                 .assertEvents(OnboardingViewEvents.OnAccountCreated)
                 .finish()

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -17,9 +17,6 @@
 package im.vector.app.features.onboarding
 
 import android.net.Uri
-import com.airbnb.mvrx.Loading
-import com.airbnb.mvrx.Success
-import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.test.MvRxTestRule
 import im.vector.app.features.login.ReAuthHelper
 import im.vector.app.features.login.SignMode


### PR DESCRIPTION
Marked as draft as this relies on #5408 

## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Flattens the onboarding `async states` down into a single `isLoading` 
- Uses a single flow for error handling instead of splitting them across state and events, all errors flow through the events, it's up to the individual fragments to explicitly opt into custom error handling

## Motivation and context

To simplify, remove code duplication and avoid redundant state updates 

## Screenshots / GIFs

| GENERIC | INVALID USERNAME | IN USE |
| --- | --- | --- |
|![o-no-network](https://user-images.githubusercontent.com/1848238/157873985-754c04b5-358a-4b59-a178-4c8e87dcca6a.png)|![o-invalid-username](https://user-images.githubusercontent.com/1848238/157873982-7d1c3241-c96f-444b-a4a7-a185a13338a4.png)|![Screenshot_20220311_131849](https://user-images.githubusercontent.com/1848238/157873979-33ff5f93-d195-4b34-9054-bf0ad5bf3e6d.png)

## Tests

- In the sign up page
- cause an error 
  - Disconnect from the internet and attempt to create an account
  - Use an invalid account name
  - Attempt to use an existing account
  - Type a password with more than 512 characters

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Pocofone f1 (28)