### PR TITLE
Use different tags for unit tests and android test compilation.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build Android Tests 
     runs-on: ubuntu-latest 
     concurrency:
-      group: ${{ github.ref == 'refs/heads/main' && format('unit-tests-main-{0}', github.sha) || github.ref == 'refs/heads/develop' && format('unit-tests-develop-{0}', github.sha) || format('unit-tests-{0}', github.ref) }}
+      group: ${{ github.ref == 'refs/heads/main' && format('unit-tests-main-{0}', github.sha) || github.ref == 'refs/heads/develop' && format('unit-tests-develop-{0}', github.sha) || format('build-android-tests-{0}', github.ref) }}
       cancel-in-progress: true
     steps: 
       - uses: actions/checkout@v3 


### PR DESCRIPTION
Otherwise we will cancel one in favour of the other.

see eg https://github.com/vector-im/element-android/runs/5513822281?check_suite_focus=true