### PR TITLE
Fix missing/swapped/duplicated messages due to wrong TimelineChunk modifications or insertions

### DIFF
--- a/changelog.d/5528.bugfix
+++ b/changelog.d/5528.bugfix
@@ -1,0 +1,1 @@
+Fix cases of missing, swapped, or duplicated messages

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
@@ -447,7 +447,7 @@ internal class TimelineChunk(private val chunkEntity: ChunkEntity,
         for (range in modifications) {
             for (modificationIndex in (range.startIndex until range.startIndex + range.length)) {
                 val updatedEntity = results[modificationIndex] ?: continue
-                val displayIndex = builtEventsIndexes.getOrDefault(updatedEntity.eventId, null)
+                val displayIndex = builtEventsIndexes[updatedEntity.eventId]
                 if (displayIndex == null) {
                     continue
                 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
@@ -447,8 +447,12 @@ internal class TimelineChunk(private val chunkEntity: ChunkEntity,
         for (range in modifications) {
             for (modificationIndex in (range.startIndex until range.startIndex + range.length)) {
                 val updatedEntity = results[modificationIndex] ?: continue
+                val displayIndex = builtEventsIndexes.getOrDefault(updatedEntity.eventId, null)
+                if (displayIndex == null) {
+                    continue
+                }
                 try {
-                    builtEvents[modificationIndex] = updatedEntity.buildAndDecryptIfNeeded()
+                    builtEvents[displayIndex] = updatedEntity.buildAndDecryptIfNeeded()
                 } catch (failure: Throwable) {
                     Timber.v("Fail to update items at index: $modificationIndex")
                 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
@@ -436,8 +436,8 @@ internal class TimelineChunk(private val chunkEntity: ChunkEntity,
                 // Check consistency to item before insertions
                 if (range.startIndex > 0) {
                     val firstInsertion = results[range.startIndex]!!
-                    val lastBeforeInsertion = builtEvents[range.startIndex-1]
-                    if (firstInsertion.displayIndex+1 != lastBeforeInsertion.displayIndex) {
+                    val lastBeforeInsertion = builtEvents[range.startIndex - 1]
+                    if (firstInsertion.displayIndex + 1 != lastBeforeInsertion.displayIndex) {
                         Timber.i("handleDatabaseChangeSet: skip insertion at ${range.startIndex}/${builtEvents.size}, " +
                                 "displayIndex mismatch at ${range.startIndex}: ${firstInsertion.displayIndex} -> ${lastBeforeInsertion.displayIndex}")
                         continue
@@ -445,11 +445,11 @@ internal class TimelineChunk(private val chunkEntity: ChunkEntity,
                 }
                 // Check consistency to item after insertions
                 if (range.startIndex < builtEvents.size) {
-                    val lastInsertion = results[range.startIndex+range.length-1]!!
+                    val lastInsertion = results[range.startIndex + range.length - 1]!!
                     val firstAfterInsertion = builtEvents[range.startIndex]
-                    if (firstAfterInsertion.displayIndex+1 != lastInsertion.displayIndex) {
+                    if (firstAfterInsertion.displayIndex + 1 != lastInsertion.displayIndex) {
                         Timber.i("handleDatabaseChangeSet: skip insertion at ${range.startIndex}/${builtEvents.size}, " +
-                                "displayIndex mismatch at ${range.startIndex+range.length}: " +
+                                "displayIndex mismatch at ${range.startIndex + range.length}: " +
                                 "${firstAfterInsertion.displayIndex} -> ${lastInsertion.displayIndex}")
                         continue
                     }


### PR DESCRIPTION
I was observing cases where `builtEvents[modificationIndex]` was not
having the same `eventId` as the `udpatedEntity` in `handleDatabaseChangeSet()`.

In particular, I observed both cases that
- there was no item in the list yet with the same `eventId` as the updated
  one
- there was an item with the same `eventId` already in the list, but at a
  different position.

Whenever this happened, the timeline would render missing, duplicated,
or swapped messages in the timeline.

Instead of relying on `modificationIndex` to be the same for both the
change set and `builtEvents`, look up the proper index by `eventId`.

~~Note: I'm not entirely sure if this is the correct way to fix this.
Is the previously used assumption that `displayIndex == modificationIndex` something that should hold?
If yes, this PR is likely not the correct fix.
If no, could the insertions in `handleDatabaseChangeSet()` also be broken, since I'm only addressing modification's indices here?~~

For insertions, inconsistencies could also occur, if the chunk was not fully loaded yet, so check this as well.

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Look up indices for event modifications, instead of using the ones from the change set.

## Motivation and context

Messages were sometimes showing swapped, duplicated, or missing.

## Screenshots / GIFs

<!-- Only if UI have been changed -->

## Tests

Observe if messages are rendered correctly. I also used following commits to further debug this:
- https://github.com/SchildiChat/SchildiChat-android/commit/7bfd3c8dca6ca0c63706c27569cae427420f1952
- https://github.com/SchildiChat/SchildiChat-android/commit/12e4853c59f038cff11c320df25c849a0f3eb008
- https://github.com/SchildiChat/SchildiChat-android/commit/4b12f162a07904061a645b40589385dfd98e1287

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
