### PR TITLE
"Add space" copy is replaced with "create space" in left sliding panel

### DIFF
--- a/changelog.d/5516.misc
+++ b/changelog.d/5516.misc
@@ -1,0 +1,1 @@
+"Add space" copy is replaced with "create space" in left sliding panel

--- a/vector/src/main/res/layout/item_space_add.xml
+++ b/vector/src/main/res/layout/item_space_add.xml
@@ -36,7 +36,7 @@
         android:layout_marginEnd="@dimen/layout_horizontal_margin"
         android:ellipsize="end"
         android:maxLines="1"
-        android:text="@string/add_space"
+        android:text="@string/create_space"
         android:textColor="?colorPrimary"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : misc

## Content

Android should use "Create space" in the left panel instead of "Add Space" because "adding" suggests other actions like joining an existing space.

## Motivation and context

https://github.com/vector-im/element-android/issues/5516

## Screenshots / GIFs

![image](https://user-images.githubusercontent.com/66663241/158140181-f369f726-e1d7-4750-bba9-ca02ad8a72a6.png)


## Tests

- Login/Signup
- Open left slider
- Scroll to bottom
- Check copy

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): A12 (API 31)

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
