### PR TITLE
Read receipt in wrong order

### DIFF
--- a/changelog.d/5514.bugfix
+++ b/changelog.d/5514.bugfix
@@ -1,0 +1,1 @@
+Read receipt in wrong order

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/ReadReceiptsItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/ReadReceiptsItemFactory.kt
@@ -37,22 +37,16 @@ class ReadReceiptsItemFactory @Inject constructor(private val avatarRenderer: Av
         val readReceiptsData = readReceipts
                 .map {
                     ReadReceiptData(it.roomMember.userId, it.roomMember.avatarUrl, it.roomMember.displayName, it.originServerTs)
-                }.toList()
-        val readReceiptsDataSorted = sortItem(readReceiptsData)
+                }
+                .sortedByDescending { it.timestamp }
         return ReadReceiptsItem_()
                 .id("read_receipts_$eventId")
                 .eventId(eventId)
-                .readReceipts(readReceiptsDataSorted)
+                .readReceipts(readReceiptsData)
                 .avatarRenderer(avatarRenderer)
                 .shouldHideReadReceipts(isFromThreadTimeLine)
                 .clickListener {
-                    callback?.onReadReceiptsClicked(readReceiptsDataSorted)
+                    callback?.onReadReceiptsClicked(readReceiptsData)
                 }
-    }
-
-    fun sortItem(readReceipt: List<ReadReceiptData>): List<ReadReceiptData> {
-        return readReceipt.sortedByDescending {
-            it.timestamp
-        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/ReadReceiptsItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/ReadReceiptsItemFactory.kt
@@ -37,17 +37,22 @@ class ReadReceiptsItemFactory @Inject constructor(private val avatarRenderer: Av
         val readReceiptsData = readReceipts
                 .map {
                     ReadReceiptData(it.roomMember.userId, it.roomMember.avatarUrl, it.roomMember.displayName, it.originServerTs)
-                }
-                .toList()
-
+                }.toList()
+        val readReceiptsDataSorted = sortItem(readReceiptsData)
         return ReadReceiptsItem_()
                 .id("read_receipts_$eventId")
                 .eventId(eventId)
-                .readReceipts(readReceiptsData)
+                .readReceipts(readReceiptsDataSorted)
                 .avatarRenderer(avatarRenderer)
                 .shouldHideReadReceipts(isFromThreadTimeLine)
                 .clickListener {
-                    callback?.onReadReceiptsClicked(readReceiptsData)
+                    callback?.onReadReceiptsClicked(readReceiptsDataSorted)
                 }
+    }
+
+    fun sortItem(readReceipt: List<ReadReceiptData>): List<ReadReceiptData> {
+        return readReceipt.sortedByDescending {
+            it.timestamp
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content
Update read receipt order in the factory.

<!-- Describe shortly what has been changed -->

## Motivation and context
#5514 

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed -->

## Tests

<!-- Explain how you tested your development -->
Open ready receipt details on a message (especially if there is some events hidden before it)

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
