### PR TITLE
Fixes timeline crash due to additionalTopSpace

### DIFF
--- a/changelog.d/5534.bugfix
+++ b/changelog.d/5534.bugfix
@@ -1,0 +1,1 @@
+Fixes crash upon opening timeline due to additionalTopSpace

--- a/changelog.d/5534.bugfix
+++ b/changelog.d/5534.bugfix
@@ -1,1 +1,0 @@
-Fixes crash upon opening timeline due to additionalTopSpace

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageItem.kt
@@ -106,8 +106,6 @@ abstract class AbsMessageItem<H : AbsMessageItem.Holder> : AbsBaseMessageItem<H>
             holder.timeView.isVisible = false
         }
 
-        holder.additionalTopSpace.isVisible = attributes.informationData.messageLayout.addTopMargin
-
         // Render send state indicator
         holder.sendStateImageView.render(attributes.informationData.sendStateDecoration)
         holder.eventSendingIndicator.isVisible = attributes.informationData.sendStateDecoration == SendStateDecoration.SENDING_MEDIA
@@ -157,7 +155,6 @@ abstract class AbsMessageItem<H : AbsMessageItem.Holder> : AbsBaseMessageItem<H>
 
     abstract class Holder(@IdRes stubId: Int) : AbsBaseMessageItem.Holder(stubId) {
 
-        val additionalTopSpace by bind<View>(R.id.additionalTopSpace)
         val avatarImageView by bind<ImageView>(R.id.messageAvatarImageView)
         val memberNameView by bind<TextView>(R.id.messageMemberNameView)
         val timeView by bind<TextView>(R.id.messageTimeView)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/style/TimelineMessageLayout.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/style/TimelineMessageLayout.kt
@@ -21,43 +21,44 @@ import im.vector.app.R
 import kotlinx.parcelize.Parcelize
 
 sealed interface TimelineMessageLayout : Parcelable {
+
     val layoutRes: Int
     val showAvatar: Boolean
     val showDisplayName: Boolean
-    val addTopMargin: Boolean
     val showTimestamp: Boolean
 
     @Parcelize
-    data class Default(override val showAvatar: Boolean,
-                       override val showDisplayName: Boolean,
-                       override val showTimestamp: Boolean,
-                       override val addTopMargin: Boolean = false,
-            // Keep defaultLayout generated on epoxy items
-                       override val layoutRes: Int = 0) : TimelineMessageLayout
+    data class Default(
+        override val showAvatar: Boolean,
+        override val showDisplayName: Boolean,
+        override val showTimestamp: Boolean,
+        // Keep defaultLayout generated on epoxy items
+        override val layoutRes: Int = 0,
+    ) : TimelineMessageLayout
 
     @Parcelize
     data class Bubble(
-            override val showAvatar: Boolean,
-            override val showDisplayName: Boolean,
-            override val showTimestamp: Boolean = true,
-            override val addTopMargin: Boolean = false,
-            val isIncoming: Boolean,
-            val isPseudoBubble: Boolean,
-            val cornersRadius: CornersRadius,
-            val timestampAsOverlay: Boolean,
-            override val layoutRes: Int = if (isIncoming) {
-                R.layout.item_timeline_event_bubble_incoming_base
-            } else {
-                R.layout.item_timeline_event_bubble_outgoing_base
-            }
+        override val showAvatar: Boolean,
+        override val showDisplayName: Boolean,
+        override val showTimestamp: Boolean = true,
+        val addTopMargin: Boolean = false,
+        val isIncoming: Boolean,
+        val isPseudoBubble: Boolean,
+        val cornersRadius: CornersRadius,
+        val timestampAsOverlay: Boolean,
+        override val layoutRes: Int = if (isIncoming) {
+            R.layout.item_timeline_event_bubble_incoming_base
+        } else {
+            R.layout.item_timeline_event_bubble_outgoing_base
+        },
     ) : TimelineMessageLayout {
 
         @Parcelize
         data class CornersRadius(
-                val topStartRadius: Float,
-                val topEndRadius: Float,
-                val bottomStartRadius: Float,
-                val bottomEndRadius: Float
+            val topStartRadius: Float,
+            val topEndRadius: Float,
+            val bottomStartRadius: Float,
+            val bottomEndRadius: Float,
         ) : Parcelable
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/view/MessageBubbleView.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/view/MessageBubbleView.kt
@@ -42,9 +42,11 @@ import im.vector.app.features.home.room.detail.timeline.style.shapeAppearanceMod
 import im.vector.app.features.themes.ThemeUtils
 import timber.log.Timber
 
-class MessageBubbleView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null,
-                                                  defStyleAttr: Int = 0) :
-        RelativeLayout(context, attrs, defStyleAttr), TimelineMessageLayoutRenderer {
+class MessageBubbleView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : RelativeLayout(context, attrs, defStyleAttr), TimelineMessageLayoutRenderer {
 
     private var isIncoming: Boolean = false
 
@@ -87,22 +89,43 @@ class MessageBubbleView @JvmOverloads constructor(context: Context, attrs: Attri
             outlineProvider = ViewOutlineProvider.BACKGROUND
             clipToOutline = true
             background = RippleDrawable(
-                    ContextCompat.getColorStateList(context, R.color.mtrl_btn_ripple_color) ?: ColorStateList.valueOf(Color.TRANSPARENT),
-                    bubbleDrawable,
-                    rippleMaskDrawable)
+                ContextCompat.getColorStateList(context, R.color.mtrl_btn_ripple_color) ?: ColorStateList.valueOf(Color.TRANSPARENT),
+                bubbleDrawable,
+                rippleMaskDrawable)
         }
     }
 
     override fun renderMessageLayout(messageLayout: TimelineMessageLayout) {
-        if (messageLayout !is TimelineMessageLayout.Bubble) {
-            Timber.v("Can't render messageLayout $messageLayout")
-            return
+        (messageLayout as? TimelineMessageLayout.Bubble)
+            ?.updateDrawables()
+            ?.setConstraintsAndColor()
+            ?.toggleMessageOverlay()
+            ?.setPadding()
+            ?.setMargins()
+            ?.setAdditionalTopSpace()
+            ?: Timber.v("Can't render messageLayout $messageLayout")
+    }
+
+    private fun TimelineMessageLayout.Bubble.updateDrawables() = apply {
+        val shapeAppearanceModel = cornersRadius.shapeAppearanceModel()
+        bubbleDrawable.apply {
+            this.shapeAppearanceModel = shapeAppearanceModel
+            this.fillColor = if (isPseudoBubble) {
+                ColorStateList.valueOf(Color.TRANSPARENT)
+            } else {
+                val backgroundColorAttr = if (isIncoming) R.attr.vctr_message_bubble_inbound else R.attr.vctr_message_bubble_outbound
+                val backgroundColor = ThemeUtils.getColor(context, backgroundColorAttr)
+                ColorStateList.valueOf(backgroundColor)
+            }
         }
-        updateDrawables(messageLayout)
+        rippleMaskDrawable.shapeAppearanceModel = shapeAppearanceModel
+    }
+
+    private fun TimelineMessageLayout.Bubble.setConstraintsAndColor() = apply {
         ConstraintSet().apply {
             clone(views.bubbleView)
             clear(R.id.viewStubContainer, ConstraintSet.END)
-            if (messageLayout.timestampAsOverlay) {
+            if (timestampAsOverlay) {
                 val timeColor = ContextCompat.getColor(context, R.color.palette_white)
                 views.messageTimeView.setTextColor(timeColor)
                 connect(R.id.viewStubContainer, ConstraintSet.END, R.id.parent, ConstraintSet.END, 0)
@@ -113,17 +136,26 @@ class MessageBubbleView @JvmOverloads constructor(context: Context, attrs: Attri
             }
             applyTo(views.bubbleView)
         }
-        if (messageLayout.timestampAsOverlay) {
+    }
+
+    private fun TimelineMessageLayout.Bubble.toggleMessageOverlay() = apply {
+        if (timestampAsOverlay) {
             views.messageOverlayView.isVisible = true
-            (views.messageOverlayView.background as? GradientDrawable)?.cornerRadii = messageLayout.cornersRadius.toFloatArray()
+            (views.messageOverlayView.background as? GradientDrawable)?.cornerRadii = cornersRadius.toFloatArray()
         } else {
             views.messageOverlayView.isVisible = false
         }
-        if (messageLayout.isPseudoBubble && messageLayout.timestampAsOverlay) {
+    }
+
+    private fun TimelineMessageLayout.Bubble.setPadding() = apply {
+        if (isPseudoBubble && timestampAsOverlay) {
             views.viewStubContainer.root.setPadding(0, 0, 0, 0)
         } else {
             views.viewStubContainer.root.setPadding(horizontalStubPadding, verticalStubPadding, horizontalStubPadding, verticalStubPadding)
         }
+    }
+
+    private fun TimelineMessageLayout.Bubble.setMargins() = apply {
         if (isIncoming) {
             views.messageEndGuideline.updateLayoutParams<LayoutParams> {
                 marginEnd = resources.getDimensionPixelSize(R.dimen.chat_bubble_margin_end)
@@ -139,26 +171,13 @@ class MessageBubbleView @JvmOverloads constructor(context: Context, attrs: Attri
                 marginStart = resources.getDimensionPixelSize(R.dimen.chat_bubble_margin_end)
             }
         }
+    }
 
-        views.additionalTopSpace.isVisible = messageLayout.addTopMargin
+    private fun TimelineMessageLayout.Bubble.setAdditionalTopSpace() = apply {
+        views.additionalTopSpace.isVisible = addTopMargin
     }
 
     private fun TimelineMessageLayout.Bubble.CornersRadius.toFloatArray(): FloatArray {
         return floatArrayOf(topStartRadius, topStartRadius, topEndRadius, topEndRadius, bottomEndRadius, bottomEndRadius, bottomStartRadius, bottomStartRadius)
-    }
-
-    private fun updateDrawables(messageLayout: TimelineMessageLayout.Bubble) {
-        val shapeAppearanceModel = messageLayout.cornersRadius.shapeAppearanceModel()
-        bubbleDrawable.apply {
-            this.shapeAppearanceModel = shapeAppearanceModel
-            this.fillColor = if (messageLayout.isPseudoBubble) {
-                ColorStateList.valueOf(Color.TRANSPARENT)
-            } else {
-                val backgroundColorAttr = if (isIncoming) R.attr.vctr_message_bubble_inbound else R.attr.vctr_message_bubble_outbound
-                val backgroundColor = ThemeUtils.getColor(context, backgroundColorAttr)
-                ColorStateList.valueOf(backgroundColor)
-            }
-        }
-        rippleMaskDrawable.shapeAppearanceModel = shapeAppearanceModel
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/view/MessageBubbleView.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/view/MessageBubbleView.kt
@@ -139,6 +139,8 @@ class MessageBubbleView @JvmOverloads constructor(context: Context, attrs: Attri
                 marginStart = resources.getDimensionPixelSize(R.dimen.chat_bubble_margin_end)
             }
         }
+
+        views.additionalTopSpace.isVisible = messageLayout.addTopMargin
     }
 
     private fun TimelineMessageLayout.Bubble.CornersRadius.toFloatArray(): FloatArray {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes a crash due to a view with id R.id.additionalTopSpace not being found in the base timeline view. This is a view that's only being used in bubbles

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/5535 and https://github.com/matrix-org/element-android-rageshakes/issues/35624

The additionalTopSpace view is only being used in bubbles so I reduced its scope to only the bubbles view rather than the base timeline view.

I also included some slight refactoring of the bubbles view class for readability

## Screenshots / GIFs

No UI changes but simple confirmation that top space above bubbles works as expected

![image](https://user-images.githubusercontent.com/20701752/158182964-5fd6e82b-a7d3-44f9-997a-f0993545166c.png)

## Tests

<!-- Explain how you tested your development -->

- Open timeline. Observe no crash
- Observe top margin behaviour added [in this PR](https://github.com/vector-im/element-android/pull/5384) is still present

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 10

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
