### PR TITLE
Fix mentions using matrix.to rather than client defined permalink base url

### DIFF
--- a/changelog.d/5521.bugfix
+++ b/changelog.d/5521.bugfix
@@ -1,0 +1,1 @@
+Fix mentions using matrix.to rather than client defined permalink base url

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/MarkdownParserTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/MarkdownParserTest.kt
@@ -61,10 +61,8 @@ class MarkdownParserTest : InstrumentedTest {
                                     roomDisplayNameFallbackProvider = TestRoomDisplayNameFallbackProvider()
                             )
                     ),
-                    MatrixConfiguration(
-                            applicationFlavor = "TestFlavor",
-                            roomDisplayNameFallbackProvider = TestRoomDisplayNameFallbackProvider()
-                    ))
+                    TestPermalinkService()
+            )
     )
 
     @Test

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/MarkdownParserTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/MarkdownParserTest.kt
@@ -60,6 +60,10 @@ class MarkdownParserTest : InstrumentedTest {
                                     applicationFlavor = "TestFlavor",
                                     roomDisplayNameFallbackProvider = TestRoomDisplayNameFallbackProvider()
                             )
+                    ),
+                    MatrixConfiguration(
+                            applicationFlavor = "TestFlavor",
+                            roomDisplayNameFallbackProvider = TestRoomDisplayNameFallbackProvider()
                     ))
     )
 

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/TestPermalinkService.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/TestPermalinkService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/TestPermalinkService.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/TestPermalinkService.kt
@@ -18,6 +18,7 @@ package org.matrix.android.sdk.internal.session.room.send
 
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService
+import org.matrix.android.sdk.api.session.permalinks.PermalinkService.SpanTemplateType.*
 
 class TestPermalinkService : PermalinkService {
     override fun createPermalink(event: Event, forceMatrixTo: Boolean): String? {
@@ -40,11 +41,10 @@ class TestPermalinkService : PermalinkService {
         return null
     }
 
-    override fun createHtmlMentionSpanTemplate(forceMatrixTo: Boolean): String {
-        return "<a href=\"https://matrix.to/#/%1\$s\">%2\$s</a>"
-    }
-
-    override fun createMdMentionSpanTemplate(forceMatrixTo: Boolean): String {
-        return "[%2\$s](https://matrix.to/#/%1\$s)"
+    override fun createMentionSpanTemplate(type: PermalinkService.SpanTemplateType, forceMatrixTo: Boolean): String {
+        return when (type) {
+            HTML     -> "<a href=\"https://matrix.to/#/%1\$s\">%2\$s</a>"
+            MARKDOWN -> "[%2\$s](https://matrix.to/#/%1\$s)"
+        }
     }
 }

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/TestPermalinkService.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/TestPermalinkService.kt
@@ -19,7 +19,7 @@ package org.matrix.android.sdk.internal.session.room.send
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService
 
-class TestPermalinkService: PermalinkService {
+class TestPermalinkService : PermalinkService {
     override fun createPermalink(event: Event, forceMatrixTo: Boolean): String? {
         return null
     }

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/TestPermalinkService.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/TestPermalinkService.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.room.send
+
+import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.api.session.permalinks.PermalinkService
+
+class TestPermalinkService: PermalinkService {
+    override fun createPermalink(event: Event, forceMatrixTo: Boolean): String? {
+        return null
+    }
+
+    override fun createPermalink(id: String, forceMatrixTo: Boolean): String? {
+        return ""
+    }
+
+    override fun createPermalink(roomId: String, eventId: String, forceMatrixTo: Boolean): String {
+        return ""
+    }
+
+    override fun createRoomPermalink(roomId: String, viaServers: List<String>?, forceMatrixTo: Boolean): String? {
+        return null
+    }
+
+    override fun getLinkedId(url: String): String? {
+        return null
+    }
+
+    override fun createHtmlMentionSpanTemplate(forceMatrixTo: Boolean): String {
+        return "<a href=\"https://matrix.to/#/%1\$s\">%2\$s</a>"
+    }
+
+    override fun createMdMentionSpanTemplate(forceMatrixTo: Boolean): String {
+        return "[%2\$s](https://matrix.to/#/%1\$s)"
+    }
+}

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/TestPermalinkService.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/session/room/send/TestPermalinkService.kt
@@ -18,7 +18,8 @@ package org.matrix.android.sdk.internal.session.room.send
 
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService
-import org.matrix.android.sdk.api.session.permalinks.PermalinkService.SpanTemplateType.*
+import org.matrix.android.sdk.api.session.permalinks.PermalinkService.SpanTemplateType.HTML
+import org.matrix.android.sdk.api.session.permalinks.PermalinkService.SpanTemplateType.MARKDOWN
 
 class TestPermalinkService : PermalinkService {
     override fun createPermalink(event: Event, forceMatrixTo: Boolean): String? {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/permalinks/PermalinkService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/permalinks/PermalinkService.kt
@@ -97,7 +97,7 @@ interface PermalinkService {
      *
      * @param forceMatrixTo whether we should force using matrix.to base URL
      *
-     * @return the HTML template
+     * @return the Markdown template
      */
     fun createMdMentionSpanTemplate(forceMatrixTo: Boolean = false): String
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/permalinks/PermalinkService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/permalinks/PermalinkService.kt
@@ -17,7 +17,6 @@
 package org.matrix.android.sdk.api.session.permalinks
 
 import org.matrix.android.sdk.api.session.events.model.Event
-import org.matrix.android.sdk.internal.session.permalinks.PermalinkFactory
 
 /**
  * Useful methods to create permalink (like matrix.to links or client permalinks).

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/permalinks/PermalinkService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/permalinks/PermalinkService.kt
@@ -17,6 +17,7 @@
 package org.matrix.android.sdk.api.session.permalinks
 
 import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.internal.session.permalinks.PermalinkFactory
 
 /**
  * Useful methods to create permalink (like matrix.to links or client permalinks).
@@ -80,4 +81,24 @@ interface PermalinkService {
      * @return the id from the url, ex: "@benoit:matrix.org", or null if the url is not a permalink
      */
     fun getLinkedId(url: String): String?
+
+    /**
+     * Creates a HTML mention span template. Can be used to replace a mention with a permalink to mentioned user.
+     * Ex: "<a href=\"https://matrix.to/#/%1\$s\">%2\$s</a>"
+     *
+     * @param forceMatrixTo whether we should force using matrix.to base URL
+     *
+     * @return the HTML template
+     */
+    fun createHtmlMentionSpanTemplate(forceMatrixTo: Boolean = false): String
+
+    /**
+     * Creates a Markdown mention span template. Can be used to replace a mention with a permalink to mentioned user.
+     * Ex: "[%2\$s](https://matrix.to/#/%1\$s)"
+     *
+     * @param forceMatrixTo whether we should force using matrix.to base URL
+     *
+     * @return the HTML template
+     */
+    fun createMdMentionSpanTemplate(forceMatrixTo: Boolean = false): String
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/permalinks/PermalinkService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/permalinks/PermalinkService.kt
@@ -28,6 +28,11 @@ interface PermalinkService {
         const val MATRIX_TO_URL_BASE = "https://matrix.to/#/"
     }
 
+    enum class SpanTemplateType {
+        HTML,
+        MARKDOWN
+    }
+
     /**
      * Creates a permalink for an event.
      * Ex: "https://matrix.to/#/!nbzmcXAqpxBXjAdgoX:matrix.org/$1531497316352799BevdV:matrix.org"
@@ -82,22 +87,13 @@ interface PermalinkService {
     fun getLinkedId(url: String): String?
 
     /**
-     * Creates a HTML mention span template. Can be used to replace a mention with a permalink to mentioned user.
-     * Ex: "<a href=\"https://matrix.to/#/%1\$s\">%2\$s</a>"
+     * Creates a HTML or Markdown mention span template. Can be used to replace a mention with a permalink to mentioned user.
+     * Ex: "<a href=\"https://matrix.to/#/%1\$s\">%2\$s</a>" or "[%2\$s](https://matrix.to/#/%1\$s)"
      *
+     * @param type: type of template to create
      * @param forceMatrixTo whether we should force using matrix.to base URL
      *
-     * @return the HTML template
+     * @return the created template
      */
-    fun createHtmlMentionSpanTemplate(forceMatrixTo: Boolean = false): String
-
-    /**
-     * Creates a Markdown mention span template. Can be used to replace a mention with a permalink to mentioned user.
-     * Ex: "[%2\$s](https://matrix.to/#/%1\$s)"
-     *
-     * @param forceMatrixTo whether we should force using matrix.to base URL
-     *
-     * @return the Markdown template
-     */
-    fun createMdMentionSpanTemplate(forceMatrixTo: Boolean = false): String
+    fun createMentionSpanTemplate(type: SpanTemplateType, forceMatrixTo: Boolean = false): String
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/DefaultPermalinkService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/DefaultPermalinkService.kt
@@ -43,4 +43,12 @@ internal class DefaultPermalinkService @Inject constructor(
     override fun getLinkedId(url: String): String? {
         return permalinkFactory.getLinkedId(url)
     }
+
+    override fun createHtmlMentionSpanTemplate(forceMatrixTo: Boolean): String {
+        return permalinkFactory.createHtmlMentionSpanTemplate(forceMatrixTo)
+    }
+
+    override fun createMdMentionSpanTemplate(forceMatrixTo: Boolean): String {
+        return permalinkFactory.createMdMentionSpanTemplate(forceMatrixTo)
+    }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/DefaultPermalinkService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/DefaultPermalinkService.kt
@@ -44,11 +44,7 @@ internal class DefaultPermalinkService @Inject constructor(
         return permalinkFactory.getLinkedId(url)
     }
 
-    override fun createHtmlMentionSpanTemplate(forceMatrixTo: Boolean): String {
-        return permalinkFactory.createHtmlMentionSpanTemplate(forceMatrixTo)
-    }
-
-    override fun createMdMentionSpanTemplate(forceMatrixTo: Boolean): String {
-        return permalinkFactory.createMdMentionSpanTemplate(forceMatrixTo)
+    override fun createMentionSpanTemplate(type: PermalinkService.SpanTemplateType, forceMatrixTo: Boolean): String {
+        return permalinkFactory.createMentionSpanTemplate(type, forceMatrixTo)
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/PermalinkFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/PermalinkFactory.kt
@@ -21,7 +21,9 @@ import org.matrix.android.sdk.api.MatrixPatterns
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.permalinks.PermalinkData
 import org.matrix.android.sdk.api.session.permalinks.PermalinkParser
+import org.matrix.android.sdk.api.session.permalinks.PermalinkService
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService.Companion.MATRIX_TO_URL_BASE
+import org.matrix.android.sdk.api.session.permalinks.PermalinkService.SpanTemplateType.*
 import org.matrix.android.sdk.internal.di.UserId
 import javax.inject.Inject
 
@@ -105,25 +107,20 @@ internal class PermalinkFactory @Inject constructor(
                 ?.substringBeforeLast("?")
     }
 
-    fun createHtmlMentionSpanTemplate(forceMatrixTo: Boolean): String {
+    fun createMentionSpanTemplate(type: PermalinkService.SpanTemplateType, forceMatrixTo: Boolean): String {
         return buildString {
-            append(MENTION_SPAN_TO_HTML_TEMPLATE_BEGIN)
+            when (type) {
+                HTML     -> append(MENTION_SPAN_TO_HTML_TEMPLATE_BEGIN)
+                MARKDOWN -> append(MENTION_SPAN_TO_MD_TEMPLATE_BEGIN)
+            }
             append(baseUrl(forceMatrixTo))
             if (useClientFormat(forceMatrixTo)) {
                 append(USER_PATH)
             }
-            append(MENTION_SPAN_TO_HTML_TEMPLATE_END)
-        }
-    }
-
-    fun createMdMentionSpanTemplate(forceMatrixTo: Boolean): String {
-        return buildString {
-            append(MENTION_SPAN_TO_MD_TEMPLATE_BEGIN)
-            append(baseUrl(forceMatrixTo))
-            if (useClientFormat(forceMatrixTo)) {
-                append(USER_PATH)
+            when (type) {
+                HTML     -> append(MENTION_SPAN_TO_HTML_TEMPLATE_END)
+                MARKDOWN -> append(MENTION_SPAN_TO_MD_TEMPLATE_END)
             }
-            append(MENTION_SPAN_TO_MD_TEMPLATE_END)
         }
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/PermalinkFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/PermalinkFactory.kt
@@ -145,7 +145,7 @@ internal class PermalinkFactory @Inject constructor(
 
     companion object {
         private const val ROOM_PATH = "room/"
-        private const val USER_PATH = "user/"
+        const val USER_PATH = "user/"
         private const val GROUP_PATH = "group/"
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/PermalinkFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/PermalinkFactory.kt
@@ -105,6 +105,28 @@ internal class PermalinkFactory @Inject constructor(
                 ?.substringBeforeLast("?")
     }
 
+    fun createHtmlMentionSpanTemplate(forceMatrixTo: Boolean): String {
+        return buildString {
+            append(MENTION_SPAN_TO_HTML_TEMPLATE_BEGIN)
+            append(baseUrl(forceMatrixTo))
+            if (useClientFormat(forceMatrixTo)) {
+                append(USER_PATH)
+            }
+            append(MENTION_SPAN_TO_HTML_TEMPLATE_END)
+        }
+    }
+
+    fun createMdMentionSpanTemplate(forceMatrixTo: Boolean): String {
+        return buildString {
+            append(MENTION_SPAN_TO_MD_TEMPLATE_BEGIN)
+            append(baseUrl(forceMatrixTo))
+            if (useClientFormat(forceMatrixTo)) {
+                append(USER_PATH)
+            }
+            append(MENTION_SPAN_TO_MD_TEMPLATE_END)
+        }
+    }
+
     /**
      * Escape '/' in id, because it is used as a separator
      *
@@ -145,7 +167,11 @@ internal class PermalinkFactory @Inject constructor(
 
     companion object {
         private const val ROOM_PATH = "room/"
-        const val USER_PATH = "user/"
+        private const val USER_PATH = "user/"
         private const val GROUP_PATH = "group/"
+        private const val MENTION_SPAN_TO_HTML_TEMPLATE_BEGIN = "<a href=\""
+        private const val MENTION_SPAN_TO_HTML_TEMPLATE_END = "%1\$s\">%2\$s</a>"
+        private const val MENTION_SPAN_TO_MD_TEMPLATE_BEGIN = "[%2\$s]("
+        private const val MENTION_SPAN_TO_MD_TEMPLATE_END = "%1\$s)"
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/PermalinkFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/permalinks/PermalinkFactory.kt
@@ -23,7 +23,8 @@ import org.matrix.android.sdk.api.session.permalinks.PermalinkData
 import org.matrix.android.sdk.api.session.permalinks.PermalinkParser
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService.Companion.MATRIX_TO_URL_BASE
-import org.matrix.android.sdk.api.session.permalinks.PermalinkService.SpanTemplateType.*
+import org.matrix.android.sdk.api.session.permalinks.PermalinkService.SpanTemplateType.HTML
+import org.matrix.android.sdk.api.session.permalinks.PermalinkService.SpanTemplateType.MARKDOWN
 import org.matrix.android.sdk.internal.di.UserId
 import javax.inject.Inject
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/pills/TextPillsUtils.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/pills/TextPillsUtils.kt
@@ -38,7 +38,7 @@ internal class TextPillsUtils @Inject constructor(
      * @return the transformed String or null if no Span found
      */
     fun processSpecialSpansToHtml(text: CharSequence): String? {
-        return transformPills(text, permalinkService.createHtmlMentionSpanTemplate())
+        return transformPills(text, permalinkService.createMentionSpanTemplate(PermalinkService.SpanTemplateType.HTML))
     }
 
     /**
@@ -46,7 +46,7 @@ internal class TextPillsUtils @Inject constructor(
      * @return the transformed String or null if no Span found
      */
     fun processSpecialSpansToMarkdown(text: CharSequence): String? {
-        return transformPills(text, permalinkService.createMdMentionSpanTemplate())
+        return transformPills(text, permalinkService.createMentionSpanTemplate(PermalinkService.SpanTemplateType.MARKDOWN))
     }
 
     private fun transformPills(text: CharSequence, template: String): String? {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/pills/TextPillsUtils.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/pills/TextPillsUtils.kt
@@ -17,6 +17,7 @@ package org.matrix.android.sdk.internal.session.room.send.pills
 
 import android.text.SpannableString
 import org.matrix.android.sdk.api.MatrixConfiguration
+import org.matrix.android.sdk.api.session.permalinks.PermalinkService
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService.Companion.MATRIX_TO_URL_BASE
 import org.matrix.android.sdk.api.session.room.send.MatrixItemSpan
 import org.matrix.android.sdk.api.util.MatrixItem
@@ -32,7 +33,7 @@ import javax.inject.Inject
 internal class TextPillsUtils @Inject constructor(
         private val mentionLinkSpecComparator: MentionLinkSpecComparator,
         private val displayNameResolver: DisplayNameResolver,
-        private val matrixConfiguration: MatrixConfiguration
+        private val permalinkService: PermalinkService
 ) {
 
     /**
@@ -40,7 +41,7 @@ internal class TextPillsUtils @Inject constructor(
      * @return the transformed String or null if no Span found
      */
     fun processSpecialSpansToHtml(text: CharSequence): String? {
-        return transformPills(text, createHtmlMentionSpanTemplate(forceMatrixTo = false))
+        return transformPills(text, permalinkService.createHtmlMentionSpanTemplate())
     }
 
     /**
@@ -48,7 +49,7 @@ internal class TextPillsUtils @Inject constructor(
      * @return the transformed String or null if no Span found
      */
     fun processSpecialSpansToMarkdown(text: CharSequence): String? {
-        return transformPills(text, createMdMentionSpanTemplate(forceMatrixTo = false))
+        return transformPills(text, permalinkService.createMdMentionSpanTemplate())
     }
 
     private fun transformPills(text: CharSequence, template: String): String? {
@@ -111,44 +112,5 @@ internal class TextPillsUtils @Inject constructor(
             }
             i++
         }
-    }
-
-    private fun baseUrl(forceMatrixTo: Boolean): String {
-        return matrixConfiguration.clientPermalinkBaseUrl
-                ?.takeUnless { forceMatrixTo }
-                ?: MATRIX_TO_URL_BASE
-    }
-
-    private fun useClientFormat(forceMatrixTo: Boolean): Boolean {
-        return !forceMatrixTo && matrixConfiguration.clientPermalinkBaseUrl != null
-    }
-
-    private fun createHtmlMentionSpanTemplate(forceMatrixTo: Boolean): String {
-        return buildString {
-            append(MENTION_SPAN_TO_HTML_TEMPLATE_BEGIN)
-            append(baseUrl(forceMatrixTo))
-            if (useClientFormat(forceMatrixTo)) {
-                append(PermalinkFactory.USER_PATH)
-            }
-            append(MENTION_SPAN_TO_HTML_TEMPLATE_END)
-        }
-    }
-
-    private fun createMdMentionSpanTemplate(forceMatrixTo: Boolean): String {
-        return buildString {
-            append(MENTION_SPAN_TO_MD_TEMPLATE_BEGIN)
-            append(baseUrl(forceMatrixTo))
-            if (useClientFormat(forceMatrixTo)) {
-                append(PermalinkFactory.USER_PATH)
-            }
-            append(MENTION_SPAN_TO_MD_TEMPLATE_END)
-        }
-    }
-
-    companion object {
-        private const val MENTION_SPAN_TO_HTML_TEMPLATE_BEGIN = "<a href=\""
-        private const val MENTION_SPAN_TO_HTML_TEMPLATE_END = "%1\$s\">%2\$s</a>"
-        private const val MENTION_SPAN_TO_MD_TEMPLATE_BEGIN = "[%2\$s]("
-        private const val MENTION_SPAN_TO_MD_TEMPLATE_END = "%1\$s)"
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/pills/TextPillsUtils.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/pills/TextPillsUtils.kt
@@ -16,13 +16,10 @@
 package org.matrix.android.sdk.internal.session.room.send.pills
 
 import android.text.SpannableString
-import org.matrix.android.sdk.api.MatrixConfiguration
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService
-import org.matrix.android.sdk.api.session.permalinks.PermalinkService.Companion.MATRIX_TO_URL_BASE
 import org.matrix.android.sdk.api.session.room.send.MatrixItemSpan
 import org.matrix.android.sdk.api.util.MatrixItem
 import org.matrix.android.sdk.internal.session.displayname.DisplayNameResolver
-import org.matrix.android.sdk.internal.session.permalinks.PermalinkFactory
 import java.util.Collections
 import javax.inject.Inject
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Mentions permalinks are now based on the client defined permalink base url if available rather than using matrix.to (default).

## Motivation and context

Fixes #5521 

## Tests

<!-- Explain how you tested your development -->

- Step 1: Define clientPermalinkBaseUrl in MatrixConfiguration (don't forget to add it to permalink_supported_hosts as well)
- Step 2: Test communication with another client with the same configuration and the usability of created permalinks (ideally with iOS and/or Web)

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
