### PR TITLE
[Notification mode] Wrong mode is displayed when the mention only is selected on the web client

### DIFF
--- a/changelog.d/5547.bugfix
+++ b/changelog.d/5547.bugfix
@@ -1,0 +1,1 @@
+[Notification mode] Wrong mode is displayed when the mention only is selected on the web client

--- a/vector/src/main/java/im/vector/app/features/roomprofile/notifications/RoomNotificationSettingsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/notifications/RoomNotificationSettingsViewState.kt
@@ -40,14 +40,17 @@ data class RoomNotificationSettingsViewState(
  */
 val RoomNotificationSettingsViewState.notificationStateMapped: Async<RoomNotificationState>
     get() {
-        if ((roomSummary()?.isEncrypted == true && notificationState() == RoomNotificationState.MENTIONS_ONLY)) {
+        return when {
             /**
              * if in an encrypted room, mentions notifications are not supported so show "None" as selected.
              * Also in the new settings there is no notion of notifications without sound so it maps to noisy also
              */
-            return Success(RoomNotificationState.MUTE)
+            (roomSummary()?.isEncrypted == true && notificationState() == RoomNotificationState.MENTIONS_ONLY)
+                 -> Success(RoomNotificationState.MUTE)
+            (roomSummary()?.isEncrypted == true && notificationState() == RoomNotificationState.ALL_MESSAGES)
+                 -> Success(RoomNotificationState.ALL_MESSAGES_NOISY)
+            else -> notificationState
         }
-        return  notificationState
     }
 
 /**

--- a/vector/src/main/java/im/vector/app/features/roomprofile/notifications/RoomNotificationSettingsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/notifications/RoomNotificationSettingsViewState.kt
@@ -46,10 +46,9 @@ val RoomNotificationSettingsViewState.notificationStateMapped: Async<RoomNotific
              * Also in the new settings there is no notion of notifications without sound so it maps to noisy also
              */
             (roomSummary()?.isEncrypted == true && notificationState() == RoomNotificationState.MENTIONS_ONLY)
-                 -> Success(RoomNotificationState.MUTE)
-            (roomSummary()?.isEncrypted == true && notificationState() == RoomNotificationState.ALL_MESSAGES)
-                 -> Success(RoomNotificationState.ALL_MESSAGES_NOISY)
-            else -> notificationState
+                                                                      -> Success(RoomNotificationState.MUTE)
+            notificationState() == RoomNotificationState.ALL_MESSAGES -> Success(RoomNotificationState.ALL_MESSAGES_NOISY)
+            else                                                      -> notificationState
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/roomprofile/notifications/RoomNotificationSettingsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/notifications/RoomNotificationSettingsViewState.kt
@@ -40,12 +40,12 @@ data class RoomNotificationSettingsViewState(
  */
 val RoomNotificationSettingsViewState.notificationStateMapped: Async<RoomNotificationState>
     get() {
-        if ((roomSummary()?.isEncrypted == true && notificationState() == RoomNotificationState.MENTIONS_ONLY) ||
-                notificationState() == RoomNotificationState.ALL_MESSAGES) {
-            /** if in an encrypted room, mentions notifications are not supported so show "All Messages" as selected.
+        if ((roomSummary()?.isEncrypted == true && notificationState() == RoomNotificationState.MENTIONS_ONLY)) {
+            /**
+             * if in an encrypted room, mentions notifications are not supported so show "None" as selected.
              * Also in the new settings there is no notion of notifications without sound so it maps to noisy also
              */
-            return Success(RoomNotificationState.ALL_MESSAGES_NOISY)
+            return Success(RoomNotificationState.MUTE)
         }
         return  notificationState
     }


### PR DESCRIPTION
 ## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context
Use none in android application when all messages or mentions only is selected in the web application.
https://github.com/tchapgouv/tchap-android-v2/issues/464

## Screenshots / GIFs
Android:
![Screenshot_20220315-145528_Element](https://user-images.githubusercontent.com/15031750/158393808-9a0fca35-7378-4930-8df1-2f0603682166.jpg)

Web:
<img width="446" alt="Capture d’écran 2022-03-15 à 14 56 00" src="https://user-images.githubusercontent.com/15031750/158393655-7810660b-2363-4845-8245-3d20583929d6.png">

## Tests

<!-- Explain how you tested your development -->

- Update Notification settings in web application to mention only
- Check if in Android application the notifications preference is equal to None.

## Tested devices

- [X] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [X] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [X] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
