### PR TITLE
Fixes voice call button disappearing in DM rooms with more than 2 members

### DIFF
--- a/changelog.d/5548.bugfix
+++ b/changelog.d/5548.bugfix
@@ -1,0 +1,1 @@
+Fixes voice call button disappearing in DM rooms with more than 2 members

--- a/vector/src/main/java/im/vector/app/features/call/conference/RemoveJitsiWidgetView.kt
+++ b/vector/src/main/java/im/vector/app/features/call/conference/RemoveJitsiWidgetView.kt
@@ -88,7 +88,7 @@ import org.matrix.android.sdk.api.session.room.model.Membership
     fun render(roomDetailViewState: RoomDetailViewState) {
         val summary = roomDetailViewState.asyncRoomSummary()
         val newState = if (summary?.membership != Membership.JOIN ||
-                roomDetailViewState.isWebRTCCallOptionAvailable() ||
+                roomDetailViewState.isCallOptionAvailable() ||
                 !roomDetailViewState.isAllowedToManageWidgets ||
                 roomDetailViewState.jitsiState.widgetId == null) {
             State.Unmount

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -31,7 +31,6 @@ import org.matrix.android.sdk.api.session.sync.SyncState
 import org.matrix.android.sdk.api.session.threads.ThreadNotificationBadgeState
 import org.matrix.android.sdk.api.session.widgets.model.Widget
 import org.matrix.android.sdk.api.session.widgets.model.WidgetType
-import timber.log.Timber
 
 sealed class UnreadState {
     object Unknown : UnreadState()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -88,15 +88,7 @@ data class RoomDetailViewState(
             rootThreadEventId = args.threadTimelineArgs?.rootThreadEventId
     )
 
-    // TODO: Add condition here to check that room is DM-based group chat and not group room
-    fun isWebRTCCallOptionAvailable() = asyncRoomSummary.invoke()?.let { roomSummary ->
-        val joinedMembersCount = roomSummary.joinedMembersCount ?: 0
-        val isDirect = roomSummary.isDirect
-        Timber.d("WebRTCTest roomSummary: $roomSummary")
-        Timber.d("WebRTCTest joined members: $joinedMembersCount")
-        Timber.d("WebRTCTest isDirect: $isDirect")
-        joinedMembersCount <= 2
-    } ?: true // if room summary cannot be found, assume call option should be available
+    fun isWebRTCCallOptionAvailable() = asyncRoomSummary.invoke()?.isDirect ?: true
 
     fun isSearchAvailable() = asyncRoomSummary()?.isEncrypted == false
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -31,6 +31,7 @@ import org.matrix.android.sdk.api.session.sync.SyncState
 import org.matrix.android.sdk.api.session.threads.ThreadNotificationBadgeState
 import org.matrix.android.sdk.api.session.widgets.model.Widget
 import org.matrix.android.sdk.api.session.widgets.model.WidgetType
+import timber.log.Timber
 
 sealed class UnreadState {
     object Unknown : UnreadState()
@@ -87,7 +88,15 @@ data class RoomDetailViewState(
             rootThreadEventId = args.threadTimelineArgs?.rootThreadEventId
     )
 
-    fun isWebRTCCallOptionAvailable() = (asyncRoomSummary.invoke()?.joinedMembersCount ?: 0) <= 2
+    // TODO: Add condition here to check that room is DM-based group chat and not group room
+    fun isWebRTCCallOptionAvailable() = asyncRoomSummary.invoke()?.let { roomSummary ->
+        val joinedMembersCount = roomSummary.joinedMembersCount ?: 0
+        val isDirect = roomSummary.isDirect
+        Timber.d("WebRTCTest roomSummary: $roomSummary")
+        Timber.d("WebRTCTest joined members: $joinedMembersCount")
+        Timber.d("WebRTCTest isDirect: $isDirect")
+        joinedMembersCount <= 2
+    }
 
     fun isSearchAvailable() = asyncRoomSummary()?.isEncrypted == false
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -87,7 +87,7 @@ data class RoomDetailViewState(
             rootThreadEventId = args.threadTimelineArgs?.rootThreadEventId
     )
 
-    fun isWebRTCCallOptionAvailable() = asyncRoomSummary.invoke()?.isDirect ?: true
+    fun isCallOptionAvailable() = asyncRoomSummary.invoke()?.isDirect ?: true
 
     fun isSearchAvailable() = asyncRoomSummary()?.isEncrypted == false
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -96,7 +96,7 @@ data class RoomDetailViewState(
         Timber.d("WebRTCTest joined members: $joinedMembersCount")
         Timber.d("WebRTCTest isDirect: $isDirect")
         joinedMembersCount <= 2
-    }
+    } ?: true // if room summary cannot be found, assume call option should be available
 
     fun isSearchAvailable() = asyncRoomSummary()?.isEncrypted == false
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -714,10 +714,10 @@ class TimelineViewModel @AssistedInject constructor(
                 R.id.timeline_setting          -> true
                 R.id.invite                    -> state.canInvite
                 R.id.open_matrix_apps          -> true
-                R.id.voice_call                -> state.isWebRTCCallOptionAvailable()
-                R.id.video_call                -> state.isWebRTCCallOptionAvailable() || state.jitsiState.confId == null || state.jitsiState.hasJoined
+                R.id.voice_call                -> state.isCallOptionAvailable()
+                R.id.video_call                -> state.isCallOptionAvailable() || state.jitsiState.confId == null || state.jitsiState.hasJoined
                 // Show Join conference button only if there is an active conf id not joined. Otherwise fallback to default video disabled. ^
-                R.id.join_conference           -> !state.isWebRTCCallOptionAvailable() && state.jitsiState.confId != null && !state.jitsiState.hasJoined
+                R.id.join_conference           -> !state.isCallOptionAvailable() && state.jitsiState.confId != null && !state.jitsiState.hasJoined
                 R.id.search                    -> state.isSearchAvailable()
                 R.id.menu_timeline_thread_list -> vectorPreferences.areThreadMessagesEnabled()
                 R.id.dev_tools                 -> vectorPreferences.developerMode()

--- a/vector/src/main/res/menu/menu_timeline.xml
+++ b/vector/src/main/res/menu/menu_timeline.xml
@@ -25,7 +25,7 @@
         android:title="@string/action_video_call"
         android:visible="false"
         app:iconTint="?colorPrimary"
-        app:showAsAction="always"
+        app:showAsAction="ifRoom"
         tools:visible="true" />
 
     <item
@@ -34,7 +34,7 @@
         android:title="@string/call"
         android:visible="false"
         app:iconTint="?colorPrimary"
-        app:showAsAction="always"
+        app:showAsAction="ifRoom"
         tools:visible="true" />
 
     <item
@@ -43,7 +43,7 @@
         android:visible="false"
         app:iconTint="?colorPrimary"
         app:actionLayout="@layout/view_thread_notification_badge"
-        app:showAsAction="always"
+        app:showAsAction="ifRoom"
         tools:visible="true" />
 
     <item android:id="@+id/join_conference"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Changes the condition for the voice call option on the action bar showing from being in a room of 2 or less people to simply being in a direct message room.

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/4762

Quoting conversation in the issue (re current behaviour of voice call not showing):

"this is not a normal behaviour for a DM based group chat (using native VoIP system). We should have both voice and video calls displayed.
For "group rooms" e.g: the large Matrix community room, we currently use Jitsi and so only conference calls should be displayed with a video button. The conference calls are controlled by admins with permissions."

## Screenshots / GIFs

| 1:1 DM | Group DM | Non-direct chatroom |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/20701752/158458995-18f203af-5dcc-44f9-85a1-c6792b29c8d1.png) | ![image](https://user-images.githubusercontent.com/20701752/158459104-381e74e9-5241-49e5-ad05-59cabcb55e25.png) | ![image](https://user-images.githubusercontent.com/20701752/158459308-d6895351-ec55-4a0c-be46-62b81c5658ca.png) |

## Tests

<!-- Explain how you tested your development -->

- Go to a DM room with 1 other member. See VoIP button visible
- Go to a DM room with at least 2 other members. See VoIP button visible
- Go to a non-direct room. See VoIP button hidden

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 10

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
