### PR TITLE
Fixing crash when tapping timeline verification item

### DIFF
--- a/changelog.d/5540.bugfix
+++ b/changelog.d/5540.bugfix
@@ -1,0 +1,1 @@
+Fixes crash when tapping the timeline verification surround box instead of the buttons

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1771,13 +1771,11 @@ class TimelineFragment @Inject constructor(
             }
             is RoomDetailAction.ResumeVerification        -> {
                 val otherUserId = data.otherUserId ?: return
-                VerificationBottomSheet().apply {
-                    setArguments(VerificationBottomSheet.VerificationArgs(
-                            otherUserId = otherUserId,
-                            verificationId = data.transactionId,
-                            roomId = timelineArgs.roomId
-                    ))
-                }.show(parentFragmentManager, "REQ")
+                VerificationBottomSheet.withArgs(
+                        roomId = timelineArgs.roomId,
+                        otherUserId = otherUserId,
+                        transactionId = data.transactionId,
+                ).show(parentFragmentManager, "REQ")
             }
         }
     }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes the wrong `setArguments`  being called when triggering the verification bottom sheet

## Motivation and context
Fixes a crash when tapping the item area instead of the buttons #5540 

## Screenshots / GIFs

| BEFORE | AFTER | 
| --- | --- |
|![crash](https://user-images.githubusercontent.com/1848238/158636672-ad0056e2-7f0d-4384-be79-16c476412537.gif)|![after-verify](https://user-images.githubusercontent.com/1848238/158637187-6c26c21b-8050-416c-bd34-d168f4f24de3.gif)

## Tests

- From web, verify another user
- On mobile as the other user, tap the area surrounding the verification buttons

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 31 Sv2
