### PR TITLE
#5571: Live location status bar indicator

### DIFF
--- a/changelog.d/5571.feature
+++ b/changelog.d/5571.feature
@@ -1,0 +1,1 @@
+Live location sharing: Adding indicator view when enabled

--- a/library/ui-styles/src/main/res/values/styles_location.xml
+++ b/library/ui-styles/src/main/res/values/styles_location.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Widget.Vector.Button.Text.OnPrimary.LocationLive">
+        <item name="android:background">?selectableItemBackground</item>
+        <item name="android:textSize">12sp</item>
+        <item name="android:padding">0dp</item>
+        <item name="android:gravity">center</item>
+    </style>
+
+</resources>

--- a/vector/src/main/java/im/vector/app/features/location/live/LocationLiveStatusView.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/LocationLiveStatusView.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.location.live
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import android.widget.Button
 import androidx.constraintlayout.widget.ConstraintLayout
 import im.vector.app.databinding.ViewLocationLiveStatusBinding
 
@@ -30,4 +31,7 @@ class LocationLiveStatusView @JvmOverloads constructor(
             LayoutInflater.from(context),
             this
     )
+
+    val stopButton: Button
+        get() = binding.locationLiveStatusStop
 }

--- a/vector/src/main/java/im/vector/app/features/location/live/LocationLiveStatusView.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/LocationLiveStatusView.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.location.live
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.constraintlayout.widget.ConstraintLayout
+import im.vector.app.databinding.ViewLocationLiveStatusBinding
+
+class LocationLiveStatusView @JvmOverloads constructor(
+        context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
+) : ConstraintLayout(context, attrs, defStyleAttr) {
+
+    private val binding = ViewLocationLiveStatusBinding.inflate(
+            LayoutInflater.from(context),
+            this
+    )
+}

--- a/vector/src/main/java/im/vector/app/features/location/live/LocationLiveStatusView.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/LocationLiveStatusView.kt
@@ -24,7 +24,9 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import im.vector.app.databinding.ViewLocationLiveStatusBinding
 
 class LocationLiveStatusView @JvmOverloads constructor(
-        context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0
 ) : ConstraintLayout(context, attrs, defStyleAttr) {
 
     private val binding = ViewLocationLiveStatusBinding.inflate(

--- a/vector/src/main/res/layout/fragment_timeline.xml
+++ b/vector/src/main/res/layout/fragment_timeline.xml
@@ -17,7 +17,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="48dp"
-            android:visibility="gone"/>
+            android:visibility="gone" />
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/roomToolbar"
@@ -46,20 +46,32 @@
 
     <im.vector.app.features.sync.widget.SyncStateView
         android:id="@+id/syncStateView"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/appBarLayout" />
 
+    <im.vector.app.features.location.live.LocationLiveStatusView
+        android:id="@+id/locationLiveStatusIndicator"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/syncStateView"
+        tools:visibility="visible" />
+
     <im.vector.app.features.call.conference.RemoveJitsiWidgetView
         android:id="@+id/removeJitsiWidgetView"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:background="?android:colorBackground"
         android:minHeight="54dp"
         android:visibility="visible"
-        app:layout_constraintTop_toBottomOf="@id/syncStateView" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/locationLiveStatusIndicator" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/timelineRecyclerView"
@@ -86,19 +98,19 @@
         app:closeIcon="@drawable/ic_close_24dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/removeJitsiWidgetView"/>
+        app:layout_constraintTop_toBottomOf="@id/removeJitsiWidgetView" />
 
     <im.vector.app.core.ui.views.TypingMessageView
         android:id="@+id/typingMessageView"
-        app:layout_constraintBottom_toTopOf="@id/composerLayout"
-        app:layout_constraintTop_toBottomOf="@id/timelineRecyclerView"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         android:layout_width="0dp"
+        android:layout_height="20dp"
         android:paddingStart="20dp"
         android:paddingEnd="20dp"
-        tools:visibility="visible"
-        android:layout_height="20dp"/>
+        app:layout_constraintBottom_toTopOf="@id/composerLayout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/timelineRecyclerView"
+        tools:visibility="visible" />
 
     <im.vector.app.core.ui.views.NotificationAreaView
         android:id="@+id/notificationAreaView"
@@ -108,7 +120,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        tools:visibility="visible"/>
+        tools:visibility="visible" />
 
     <ViewStub
         android:id="@+id/failedMessagesWarningStub"
@@ -130,7 +142,7 @@
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent" />
 
     <im.vector.app.features.home.room.detail.composer.voice.VoiceMessageRecorderView
         android:id="@+id/voiceMessageRecorderView"

--- a/vector/src/main/res/layout/view_location_live_status.xml
+++ b/vector/src/main/res/layout/view_location_live_status.xml
@@ -39,14 +39,10 @@
 
     <Button
         android:id="@+id/locationLiveStatusStop"
-        style="Widget.Vector.Button.Text.OnPrimary"
+        style="@style/Widget.Vector.Button.Text.OnPrimary.LocationLive"
         android:layout_width="60dp"
         android:layout_height="0dp"
-        android:background="?selectableItemBackground"
-        android:gravity="center"
-        android:padding="0dp"
         android:text="@string/location_share_live_stop"
-        android:textSize="12sp"
         app:layout_constraintBottom_toBottomOf="@id/locationLiveStatusContainer"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/locationLiveStatusContainer" />

--- a/vector/src/main/res/layout/view_location_live_status.xml
+++ b/vector/src/main/res/layout/view_location_live_status.xml
@@ -39,11 +39,15 @@
 
     <Button
         android:id="@+id/locationLiveStatusStop"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="Widget.Vector.Button.Text.OnPrimary"
+        android:layout_width="60dp"
+        android:layout_height="0dp"
+        android:background="?selectableItemBackground"
+        android:gravity="center"
+        android:padding="0dp"
         android:text="@string/location_share_live_stop"
-        android:visibility="gone"
+        android:textSize="12sp"
+        app:layout_constraintBottom_toBottomOf="@id/locationLiveStatusContainer"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/locationLiveStatusTitle" />
+        app:layout_constraintTop_toTopOf="@id/locationLiveStatusContainer" />
 </merge>

--- a/vector/src/main/res/layout/view_location_live_status.xml
+++ b/vector/src/main/res/layout/view_location_live_status.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
+
+    <androidx.constraintlayout.helper.widget.Flow
+        android:id="@+id/locationLiveStatusContainer"
+        android:layout_width="0dp"
+        android:layout_height="32dp"
+        android:background="?colorPrimary"
+        android:duplicateParentState="true"
+        android:paddingStart="9dp"
+        android:paddingEnd="12dp"
+        app:constraint_referenced_ids="locationLiveStatusIcon,locationLiveStatusTitle"
+        app:flow_horizontalBias="0"
+        app:flow_horizontalGap="8dp"
+        app:flow_horizontalStyle="packed"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <ImageView
+        android:id="@+id/locationLiveStatusIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="13dp"
+        app:srcCompat="@drawable/ic_attachment_location_live_white"
+        tools:ignore="ContentDescription" />
+
+    <TextView
+        android:id="@+id/locationLiveStatusTitle"
+        style="@style/Widget.Vector.TextView.Caption"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/location_share_live_enabled"
+        android:textColor="?colorOnPrimary" />
+
+    <Button
+        android:id="@+id/locationLiveStatusStop"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/location_share_live_stop"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/locationLiveStatusTitle" />
+</merge>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2946,6 +2946,9 @@
     <string name="settings_enable_location_sharing_summary">Once enabled you will be able to send your location to any room</string>
     <string name="labs_render_locations_in_timeline">Render user locations in the timeline</string>
     <string name="location_timeline_failed_to_load_map">Failed to load map</string>
+    <string name="location_share_live_enabled">Live location enabled</string>
+    <!-- TODO use other resources "keys_backup_setup_override_stop" for translations? -->
+    <string name="location_share_live_stop">Stop</string>
 
     <string name="message_bubbles">Show Message bubbles</string>
 

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2947,7 +2947,6 @@
     <string name="labs_render_locations_in_timeline">Render user locations in the timeline</string>
     <string name="location_timeline_failed_to_load_map">Failed to load map</string>
     <string name="location_share_live_enabled">Live location enabled</string>
-    <!-- TODO use other resources "keys_backup_setup_override_stop" for translations? -->
     <string name="location_share_live_stop">Stop</string>
 
     <string name="message_bubbles">Show Message bubbles</string>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Adding a custom view inside the room timeline screen to show a status bar when the live location will be enabled in a room. For now, it is always hidden.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #5571 
When the user will share its live location in a room, the app will show a status bar saying the live location is enabled in the room. A "stop" button enables the user to stop sharing its live location.

## Screenshots / GIFs

<!-- Only if UI have been changed -->
### Examples when the view is visible
Note: I have decided to use upper case for the "Stop" button since I think it is more suitable for this type of button (it is in lower case in Figma): this change will be confirmed and can be modified later if needed.
<img width=300 src="https://user-images.githubusercontent.com/46314705/159017386-c06f6723-5160-4b07-8607-1c1f1d650ee8.png" /> <img width=300 src="https://user-images.githubusercontent.com/46314705/159017432-1e56b76e-fdc6-4c00-b5ac-994ea630b0ea.png" />

## Tests

<!-- Explain how you tested your development -->
If you want to test, you can add this piece of code at the end of the `onViewCreated` method in the `TimelineFragment`:
```kotlin
private fun testLocationLiveStatusIndicator() {
    views.locationLiveStatusIndicator.isVisible = true
    views.locationLiveStatusIndicator.stopButton.setOnClickListener {
        Toast.makeText(requireContext(), "stopped", Toast.LENGTH_SHORT).show()
    }
}
```

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 10

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
