### PR TITLE
#5347 Do not suggest collapse if there is only one section

### DIFF
--- a/changelog.d/5347.misc
+++ b/changelog.d/5347.misc
@@ -1,0 +1,1 @@
+[Rooms list] Do not suggest collapse the unique section

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -166,7 +166,7 @@ class RoomListFragment @Inject constructor(
             )
         }
     }
-    
+
     override fun showFailure(throwable: Throwable) {
         showErrorInSnackbar(throwable)
     }
@@ -287,8 +287,7 @@ class RoomListFragment @Inject constructor(
                                             controller.submitList(pl)
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     isHidden = pl.isEmpty(),
-                                                    isLoading = false,
-                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
+                                                    isLoading = false
                                             ))
                                             checkEmptyState()
                                         }
@@ -296,9 +295,9 @@ class RoomListFragment @Inject constructor(
                                         section.notificationCount.observe(viewLifecycleOwner) { counts ->
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     notificationCount = counts.totalCount,
-                                                    isHighlighted = counts.isHighlight,
-                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
+                                                    isHighlighted = counts.isHighlight
                                             ))
+                                            setUpCollapse()
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
                                             refreshCollapseStates()
@@ -313,8 +312,7 @@ class RoomListFragment @Inject constructor(
                                             controller.setData(info)
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     isHidden = info.rooms.isEmpty(),
-                                                    isLoading = false,
-                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
+                                                    isLoading = false
                                             ))
                                             checkEmptyState()
                                         }
@@ -332,18 +330,18 @@ class RoomListFragment @Inject constructor(
                                             controller.setData(list)
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     isHidden = list.isEmpty(),
-                                                    isLoading = false,
-                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
+                                                    isLoading = false
                                             ))
                                             checkEmptyState()
+                                            setUpCollapse()
                                         }
                                         observeItemCount(section, sectionAdapter)
                                         section.notificationCount.observe(viewLifecycleOwner) { counts ->
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     notificationCount = counts.totalCount,
-                                                    isHighlighted = counts.isHighlight,
-                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
+                                                    isHighlighted = counts.isHighlight
                                             ))
+                                            setUpCollapse()
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
                                             refreshCollapseStates()

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -166,16 +166,7 @@ class RoomListFragment @Inject constructor(
             )
         }
     }
-
-    private fun setUpCollapse() {
-        roomListViewModel.sections.forEachIndexed { index, _ ->
-            val actualBlock = adapterInfosList[index]
-            actualBlock.sectionHeaderAdapter.updateSection(
-                    actualBlock.sectionHeaderAdapter.roomsSectionData.copy(shouldShowExpandedArrow = shouldShowExpendedArrow())
-            )
-        }
-    }
-
+    
     override fun showFailure(throwable: Throwable) {
         showErrorInSnackbar(throwable)
     }
@@ -296,7 +287,8 @@ class RoomListFragment @Inject constructor(
                                             controller.submitList(pl)
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     isHidden = pl.isEmpty(),
-                                                    isLoading = false
+                                                    isLoading = false,
+                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
                                             ))
                                             checkEmptyState()
                                         }
@@ -304,9 +296,9 @@ class RoomListFragment @Inject constructor(
                                         section.notificationCount.observe(viewLifecycleOwner) { counts ->
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     notificationCount = counts.totalCount,
-                                                    isHighlighted = counts.isHighlight
+                                                    isHighlighted = counts.isHighlight,
+                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
                                             ))
-                                            setUpCollapse()
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
                                             refreshCollapseStates()
@@ -321,7 +313,8 @@ class RoomListFragment @Inject constructor(
                                             controller.setData(info)
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     isHidden = info.rooms.isEmpty(),
-                                                    isLoading = false
+                                                    isLoading = false,
+                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
                                             ))
                                             checkEmptyState()
                                         }
@@ -339,18 +332,18 @@ class RoomListFragment @Inject constructor(
                                             controller.setData(list)
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     isHidden = list.isEmpty(),
-                                                    isLoading = false
+                                                    isLoading = false,
+                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
                                             ))
                                             checkEmptyState()
-                                            setUpCollapse()
                                         }
                                         observeItemCount(section, sectionAdapter)
                                         section.notificationCount.observe(viewLifecycleOwner) { counts ->
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     notificationCount = counts.totalCount,
-                                                    isHighlighted = counts.isHighlight
+                                                    isHighlighted = counts.isHighlight,
+                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
                                             ))
-                                            setUpCollapse()
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
                                             refreshCollapseStates()

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -295,9 +295,9 @@ class RoomListFragment @Inject constructor(
                                         section.notificationCount.observe(viewLifecycleOwner) { counts ->
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     notificationCount = counts.totalCount,
-                                                    isHighlighted = counts.isHighlight
+                                                    isHighlighted = counts.isHighlight,
+                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
                                             ))
-                                            setUpCollapse()
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
                                             refreshCollapseStates()
@@ -330,18 +330,18 @@ class RoomListFragment @Inject constructor(
                                             controller.setData(list)
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     isHidden = list.isEmpty(),
-                                                    isLoading = false
+                                                    isLoading = false,
+                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
                                             ))
                                             checkEmptyState()
-                                            setUpCollapse()
                                         }
                                         observeItemCount(section, sectionAdapter)
                                         section.notificationCount.observe(viewLifecycleOwner) { counts ->
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     notificationCount = counts.totalCount,
-                                                    isHighlighted = counts.isHighlight
+                                                    isHighlighted = counts.isHighlight,
+                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
                                             ))
-                                            setUpCollapse()
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
                                             refreshCollapseStates()

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -167,6 +167,15 @@ class RoomListFragment @Inject constructor(
         }
     }
 
+    private fun setUpCollapse() {
+        roomListViewModel.sections.forEachIndexed { index, _ ->
+            val actualBlock = adapterInfosList[index]
+            actualBlock.sectionHeaderAdapter.updateSection(
+                    actualBlock.sectionHeaderAdapter.roomsSectionData.copy(shouldShowExpandedArrow = shouldShowExpendedArrow())
+            )
+        }
+    }
+
     override fun showFailure(throwable: Throwable) {
         showErrorInSnackbar(throwable)
     }
@@ -297,6 +306,7 @@ class RoomListFragment @Inject constructor(
                                                     notificationCount = counts.totalCount,
                                                     isHighlighted = counts.isHighlight
                                             ))
+                                            setUpCollapse()
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
                                             refreshCollapseStates()
@@ -329,8 +339,10 @@ class RoomListFragment @Inject constructor(
                                             controller.setData(list)
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     isHidden = list.isEmpty(),
-                                                    isLoading = false))
+                                                    isLoading = false
+                                            ))
                                             checkEmptyState()
+                                            setUpCollapse()
                                         }
                                         observeItemCount(section, sectionAdapter)
                                         section.notificationCount.observe(viewLifecycleOwner) { counts ->
@@ -338,6 +350,7 @@ class RoomListFragment @Inject constructor(
                                                     notificationCount = counts.totalCount,
                                                     isHighlighted = counts.isHighlight
                                             ))
+                                            setUpCollapse()
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
                                             refreshCollapseStates()
@@ -442,6 +455,10 @@ class RoomListFragment @Inject constructor(
 
     override fun invalidate() = withState(roomListViewModel) { state ->
         footerController.setData(state)
+    }
+
+    private fun shouldShowExpendedArrow(): Boolean {
+        return adapterInfosList.filter { !it.sectionHeaderAdapter.roomsSectionData.isHidden }.size >= 2
     }
 
     private fun checkEmptyState() {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/SectionHeaderAdapter.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/SectionHeaderAdapter.kt
@@ -17,6 +17,7 @@
 package im.vector.app.features.home.room.list
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
@@ -39,7 +40,8 @@ class SectionHeaderAdapter constructor(
             val isHighlighted: Boolean = false,
             val isHidden: Boolean = true,
             // This will be false until real data has been submitted once
-            val isLoading: Boolean = true
+            val isLoading: Boolean = true,
+            val shouldShowExpandedArrow: Boolean = false
     )
 
     lateinit var roomsSectionData: RoomsSectionData
@@ -82,11 +84,16 @@ class SectionHeaderAdapter constructor(
         fun bind(roomsSectionData: RoomsSectionData) {
             binding.roomCategoryTitleView.text = roomsSectionData.name
             val tintColor = ThemeUtils.getColor(binding.root.context, R.attr.vctr_content_secondary)
-            val expandedArrowDrawableRes = if (roomsSectionData.isExpanded) R.drawable.ic_expand_more else R.drawable.ic_expand_less
-            val expandedArrowDrawable = ContextCompat.getDrawable(binding.root.context, expandedArrowDrawableRes)?.also {
-                DrawableCompat.setTint(it, tintColor)
+            if (roomsSectionData.shouldShowExpandedArrow) {
+                binding.roomCategoryCounterView.visibility = View.VISIBLE
+                val expandedArrowDrawableRes = if (roomsSectionData.isExpanded) R.drawable.ic_expand_more else R.drawable.ic_expand_less
+                val expandedArrowDrawable = ContextCompat.getDrawable(binding.root.context, expandedArrowDrawableRes)?.also {
+                    DrawableCompat.setTint(it, tintColor)
+                }
+                binding.roomCategoryCounterView.setCompoundDrawablesWithIntrinsicBounds(null, null, expandedArrowDrawable, null)
+            } else {
+                binding.roomCategoryCounterView.visibility = View.GONE
             }
-            binding.roomCategoryCounterView.setCompoundDrawablesWithIntrinsicBounds(null, null, expandedArrowDrawable, null)
             binding.roomCategoryCounterView.text = roomsSectionData.itemCount.takeIf { it > 0 }?.toString().orEmpty()
             binding.roomCategoryUnreadCounterBadgeView.render(UnreadCounterBadgeView.State(roomsSectionData.notificationCount, roomsSectionData.isHighlighted))
         }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [X] Other :

## Content
In room list fragment disable collapse section if there is only section.
<!-- Describe shortly what has been changed -->

## Motivation and context
#5347 
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
