### PR TITLE
Sanity test getting stuck on account created screen

### DIFF
--- a/vector/src/androidTest/java/im/vector/app/ui/robot/OnboardingRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/OnboardingRobot.kt
@@ -21,6 +21,7 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.adevinta.android.barista.assertion.BaristaEnabledAssertions.assertDisabled
 import com.adevinta.android.barista.assertion.BaristaEnabledAssertions.assertEnabled
 import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
@@ -55,6 +56,8 @@ class OnboardingRobot {
 
     fun createAccount(userId: String, password: String = "password", homeServerUrl: String = "http://10.0.2.2:8080") {
         initSession(true, userId, password, homeServerUrl)
+        waitUntilViewVisible(withText(R.string.ftue_account_created_congratulations_title))
+        clickOn(R.string.ftue_account_created_take_me_home)
     }
 
     fun login(userId: String, password: String = "password", homeServerUrl: String = "http://10.0.2.2:8080") {


### PR DESCRIPTION
 ## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Updates the account creation flow in the sanity test, taking into account the new account created (congratulations!) screen

## Motivation and context

originally part of https://github.com/vector-im/element-android/pull/5519

## Screenshots / GIFs

| GIF |
| --- |
|![after-account-creation](https://user-images.githubusercontent.com/1848238/159662573-5dbe18b7-3176-4b29-8ad7-7a928c47b89b.gif)

## Tests

- Run the sanity tests 
- See the tests get stuck on the account created screen

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 32 Sv2
