### PR TITLE
Fix rooms section collapsing

### DIFF
--- a/changelog.d/5616.bugfix
+++ b/changelog.d/5616.bugfix
@@ -1,0 +1,1 @@
+Fix inconsistencies between the arrow visibility and the collapse action on the room sections

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -148,9 +148,10 @@ class RoomListFragment @Inject constructor(
     }
 
     private fun refreshCollapseStates() {
+        val sectionsCount = adapterInfosList.count { !it.sectionHeaderAdapter.roomsSectionData.isHidden }
         roomListViewModel.sections.forEachIndexed { index, roomsSection ->
             val actualBlock = adapterInfosList[index]
-            val isRoomSectionExpanded = roomsSection.isExpanded.value.orTrue()
+            val isRoomSectionExpanded = roomsSection.isExpanded.value.orTrue() || sectionsCount == 1
             if (actualBlock.section.isExpanded && !isRoomSectionExpanded) {
                 // mark controller as collapsed
                 actualBlock.contentEpoxyController.setCollapsed(true)
@@ -162,7 +163,10 @@ class RoomListFragment @Inject constructor(
                     isExpanded = isRoomSectionExpanded
             )
             actualBlock.sectionHeaderAdapter.updateSection(
-                    actualBlock.sectionHeaderAdapter.roomsSectionData.copy(isExpanded = isRoomSectionExpanded)
+                    actualBlock.sectionHeaderAdapter.roomsSectionData.copy(
+                            isExpanded = isRoomSectionExpanded,
+                            shouldShowExpandedArrow = sectionsCount > 1
+                    )
             )
         }
     }
@@ -289,6 +293,7 @@ class RoomListFragment @Inject constructor(
                                                     isHidden = pl.isEmpty(),
                                                     isLoading = false
                                             ))
+                                            refreshCollapseStates()
                                             checkEmptyState()
                                         }
                                         observeItemCount(section, sectionAdapter)
@@ -296,7 +301,6 @@ class RoomListFragment @Inject constructor(
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     notificationCount = counts.totalCount,
                                                     isHighlighted = counts.isHighlight,
-                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
                                             ))
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
@@ -314,6 +318,7 @@ class RoomListFragment @Inject constructor(
                                                     isHidden = info.rooms.isEmpty(),
                                                     isLoading = false
                                             ))
+                                            refreshCollapseStates()
                                             checkEmptyState()
                                         }
                                         observeItemCount(section, sectionAdapter)
@@ -331,16 +336,15 @@ class RoomListFragment @Inject constructor(
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     isHidden = list.isEmpty(),
                                                     isLoading = false,
-                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
                                             ))
+                                            refreshCollapseStates()
                                             checkEmptyState()
                                         }
                                         observeItemCount(section, sectionAdapter)
                                         section.notificationCount.observe(viewLifecycleOwner) { counts ->
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     notificationCount = counts.totalCount,
-                                                    isHighlighted = counts.isHighlight,
-                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
+                                                    isHighlighted = counts.isHighlight
                                             ))
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
@@ -446,10 +450,6 @@ class RoomListFragment @Inject constructor(
 
     override fun invalidate() = withState(roomListViewModel) { state ->
         footerController.setData(state)
-    }
-
-    private fun shouldShowExpendedArrow(): Boolean {
-        return adapterInfosList.filter { !it.sectionHeaderAdapter.roomsSectionData.isHidden }.size >= 2
     }
 
     private fun checkEmptyState() {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -162,12 +162,12 @@ class RoomListFragment @Inject constructor(
             actualBlock.section = actualBlock.section.copy(
                     isExpanded = isRoomSectionExpanded
             )
-            actualBlock.sectionHeaderAdapter.updateSection(
-                    actualBlock.sectionHeaderAdapter.roomsSectionData.copy(
-                            isExpanded = isRoomSectionExpanded,
-                            shouldShowExpandedArrow = sectionsCount > 1
-                    )
-            )
+            actualBlock.sectionHeaderAdapter.updateSection {
+                it.copy(
+                        isExpanded = isRoomSectionExpanded,
+                        shouldShowExpandedArrow = sectionsCount > 1
+                )
+            }
         }
     }
 
@@ -276,32 +276,34 @@ class RoomListFragment @Inject constructor(
         val concatAdapter = ConcatAdapter()
 
         roomListViewModel.sections.forEach { section ->
-            val sectionAdapter = SectionHeaderAdapter {
+            val sectionAdapter = SectionHeaderAdapter(SectionHeaderAdapter.RoomsSectionData(section.sectionName)) {
                 roomListViewModel.handle(RoomListAction.ToggleSection(section))
-            }.also {
-                it.updateSection(SectionHeaderAdapter.RoomsSectionData(section.sectionName))
             }
 
             val contentAdapter =
                     when {
-                        section.livePages != null     -> {
+                        section.livePages != null -> {
                             pagedControllerFactory.createRoomSummaryPagedController()
                                     .also { controller ->
                                         section.livePages.observe(viewLifecycleOwner) { pl ->
                                             controller.submitList(pl)
-                                            sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
-                                                    isHidden = pl.isEmpty(),
-                                                    isLoading = false
-                                            ))
+                                            sectionAdapter.updateSection {
+                                                it.copy(
+                                                        isHidden = pl.isEmpty(),
+                                                        isLoading = false
+                                                )
+                                            }
                                             refreshCollapseStates()
                                             checkEmptyState()
                                         }
                                         observeItemCount(section, sectionAdapter)
                                         section.notificationCount.observe(viewLifecycleOwner) { counts ->
-                                            sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
-                                                    notificationCount = counts.totalCount,
-                                                    isHighlighted = counts.isHighlight,
-                                            ))
+                                            sectionAdapter.updateSection {
+                                                it.copy(
+                                                        notificationCount = counts.totalCount,
+                                                        isHighlighted = counts.isHighlight,
+                                                )
+                                            }
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
                                             refreshCollapseStates()
@@ -314,10 +316,12 @@ class RoomListFragment @Inject constructor(
                                     .also { controller ->
                                         section.liveSuggested.observe(viewLifecycleOwner) { info ->
                                             controller.setData(info)
-                                            sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
-                                                    isHidden = info.rooms.isEmpty(),
-                                                    isLoading = false
-                                            ))
+                                            sectionAdapter.updateSection {
+                                                it.copy(
+                                                        isHidden = info.rooms.isEmpty(),
+                                                        isLoading = false
+                                                )
+                                            }
                                             refreshCollapseStates()
                                             checkEmptyState()
                                         }
@@ -333,19 +337,23 @@ class RoomListFragment @Inject constructor(
                                     .also { controller ->
                                         section.liveList?.observe(viewLifecycleOwner) { list ->
                                             controller.setData(list)
-                                            sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
-                                                    isHidden = list.isEmpty(),
-                                                    isLoading = false,
-                                            ))
+                                            sectionAdapter.updateSection {
+                                                it.copy(
+                                                        isHidden = list.isEmpty(),
+                                                        isLoading = false,
+                                                )
+                                            }
                                             refreshCollapseStates()
                                             checkEmptyState()
                                         }
                                         observeItemCount(section, sectionAdapter)
                                         section.notificationCount.observe(viewLifecycleOwner) { counts ->
-                                            sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
-                                                    notificationCount = counts.totalCount,
-                                                    isHighlighted = counts.isHighlight
-                                            ))
+                                            sectionAdapter.updateSection {
+                                                it.copy(
+                                                        notificationCount = counts.totalCount,
+                                                        isHighlighted = counts.isHighlight
+                                                )
+                                            }
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
                                             refreshCollapseStates()
@@ -393,9 +401,9 @@ class RoomListFragment @Inject constructor(
             section.itemCount
                     .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
                     .collect { count ->
-                        sectionAdapter.updateSection(
-                                sectionAdapter.roomsSectionData.copy(itemCount = count)
-                        )
+                        sectionAdapter.updateSection {
+                            it.copy(itemCount = count)
+                        }
                     }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/SectionHeaderAdapter.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/SectionHeaderAdapter.kt
@@ -29,6 +29,7 @@ import im.vector.app.databinding.ItemRoomCategoryBinding
 import im.vector.app.features.themes.ThemeUtils
 
 class SectionHeaderAdapter constructor(
+        roomsSectionData: RoomsSectionData,
         private val onClickAction: ClickListener
 ) : RecyclerView.Adapter<SectionHeaderAdapter.VH>() {
 
@@ -44,11 +45,12 @@ class SectionHeaderAdapter constructor(
             val shouldShowExpandedArrow: Boolean = false
     )
 
-    lateinit var roomsSectionData: RoomsSectionData
+    var roomsSectionData: RoomsSectionData = roomsSectionData
         private set
 
-    fun updateSection(newRoomsSectionData: RoomsSectionData) {
-        if (!::roomsSectionData.isInitialized || newRoomsSectionData != roomsSectionData) {
+    fun updateSection(block: (RoomsSectionData) -> RoomsSectionData) {
+        val newRoomsSectionData = block(roomsSectionData)
+        if (roomsSectionData != newRoomsSectionData) {
             roomsSectionData = newRoomsSectionData
             notifyDataSetChanged()
         }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/SectionHeaderAdapter.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/SectionHeaderAdapter.kt
@@ -42,7 +42,7 @@ class SectionHeaderAdapter constructor(
             val isHidden: Boolean = true,
             // This will be false until real data has been submitted once
             val isLoading: Boolean = true,
-            val shouldShowExpandedArrow: Boolean = false
+            val isCollapsable: Boolean = false
     )
 
     var roomsSectionData: RoomsSectionData = roomsSectionData
@@ -86,7 +86,7 @@ class SectionHeaderAdapter constructor(
         fun bind(roomsSectionData: RoomsSectionData) {
             binding.roomCategoryTitleView.text = roomsSectionData.name
             val tintColor = ThemeUtils.getColor(binding.root.context, R.attr.vctr_content_secondary)
-            if (roomsSectionData.shouldShowExpandedArrow) {
+            if (roomsSectionData.isCollapsable) {
                 binding.roomCategoryCounterView.visibility = View.VISIBLE
                 val expandedArrowDrawableRes = if (roomsSectionData.isExpanded) R.drawable.ic_expand_more else R.drawable.ic_expand_less
                 val expandedArrowDrawable = ContextCompat.getDrawable(binding.root.context, expandedArrowDrawableRes)?.also {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fix inconsistencies between the arrow visibility and the collapse action by clicking on a room section header.

## Motivation and context

The sections were always collapsible even if the arrow was not visible. Adding favourites in both DM and Rooms tab was causing issues on the arrow visibility for this section.

## Screenshots / GIFs

## Tests

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
