### PR TITLE
Fixes myRoomNick changing Display Name

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/RoomMemberEventHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/RoomMemberEventHandler.kt
@@ -26,7 +26,6 @@ import org.matrix.android.sdk.internal.database.query.where
 import org.matrix.android.sdk.internal.di.UserId
 import org.matrix.android.sdk.internal.session.events.getFixedRoomMemberContent
 import org.matrix.android.sdk.internal.session.sync.SyncResponsePostTreatmentAggregator
-import org.matrix.android.sdk.internal.session.user.UserEntityFactory
 import javax.inject.Inject
 
 internal class RoomMemberEventHandler @Inject constructor(
@@ -58,10 +57,6 @@ internal class RoomMemberEventHandler @Inject constructor(
                 // but we want to preserve presence record value and not replace it with null
                 getExistingPresenceState(realm, roomId, userId))
         realm.insertOrUpdate(roomMemberEntity)
-        if (roomMember.membership.isActive()) {
-            val userEntity = UserEntityFactory.create(userId, roomMember)
-            realm.insertOrUpdate(userEntity)
-        }
 
         // check whether this new room member event may be used to update the directs dictionary in account data
         // this is required to handle correctly invite by email in DM


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Removes a user entity update when changing your nickname for a single room using the command `/myRoomNick`

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/5321

When entering the above command to change the nickname, it updates both the Room Member Entity and the User Entity. It's clear why the Room Member Entity update needs to be made (this actually updates the nickname of that room member), but it's very unclear if the User Entity update is needed at all. This being updated is the source of this bug.

Additionally, changing your nickname in the room changed your display name across the app. You would even see this reflected beside your avatar in the navigation drawer.

## Screenshots / GIFs

<!-- Only if UI have been changed -->

## Tests

<!-- Explain how you tested your development -->

- In any room type the command `/myRoomNick [name]` to change your nickname for that room
- Send a message in the room and see that your nickname in that room is successfully changed
- See that your display name on the navigation drawer is as normal and not your newly set room nickname
- On another account, create a new room and go to the invite page and search for your account that set the nickname in a room. See that the display name is as normal and not the previously set room nickname

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
