### PR TITLE
Restore #5580 "Do not suggest collapse if there is only one section"

### DIFF
--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -295,7 +295,8 @@ class RoomListFragment @Inject constructor(
                                         section.notificationCount.observe(viewLifecycleOwner) { counts ->
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     notificationCount = counts.totalCount,
-                                                    isHighlighted = counts.isHighlight
+                                                    isHighlighted = counts.isHighlight,
+                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
                                             ))
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
@@ -329,14 +330,17 @@ class RoomListFragment @Inject constructor(
                                             controller.setData(list)
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     isHidden = list.isEmpty(),
-                                                    isLoading = false))
+                                                    isLoading = false,
+                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
+                                            ))
                                             checkEmptyState()
                                         }
                                         observeItemCount(section, sectionAdapter)
                                         section.notificationCount.observe(viewLifecycleOwner) { counts ->
                                             sectionAdapter.updateSection(sectionAdapter.roomsSectionData.copy(
                                                     notificationCount = counts.totalCount,
-                                                    isHighlighted = counts.isHighlight
+                                                    isHighlighted = counts.isHighlight,
+                                                    shouldShowExpandedArrow = shouldShowExpendedArrow()
                                             ))
                                         }
                                         section.isExpanded.observe(viewLifecycleOwner) { _ ->
@@ -442,6 +446,10 @@ class RoomListFragment @Inject constructor(
 
     override fun invalidate() = withState(roomListViewModel) { state ->
         footerController.setData(state)
+    }
+
+    private fun shouldShowExpendedArrow(): Boolean {
+        return adapterInfosList.filter { !it.sectionHeaderAdapter.roomsSectionData.isHidden }.size >= 2
     }
 
     private fun checkEmptyState() {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/SectionHeaderAdapter.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/SectionHeaderAdapter.kt
@@ -17,6 +17,7 @@
 package im.vector.app.features.home.room.list
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
@@ -39,7 +40,8 @@ class SectionHeaderAdapter constructor(
             val isHighlighted: Boolean = false,
             val isHidden: Boolean = true,
             // This will be false until real data has been submitted once
-            val isLoading: Boolean = true
+            val isLoading: Boolean = true,
+            val shouldShowExpandedArrow: Boolean = false
     )
 
     lateinit var roomsSectionData: RoomsSectionData
@@ -82,11 +84,16 @@ class SectionHeaderAdapter constructor(
         fun bind(roomsSectionData: RoomsSectionData) {
             binding.roomCategoryTitleView.text = roomsSectionData.name
             val tintColor = ThemeUtils.getColor(binding.root.context, R.attr.vctr_content_secondary)
-            val expandedArrowDrawableRes = if (roomsSectionData.isExpanded) R.drawable.ic_expand_more else R.drawable.ic_expand_less
-            val expandedArrowDrawable = ContextCompat.getDrawable(binding.root.context, expandedArrowDrawableRes)?.also {
-                DrawableCompat.setTint(it, tintColor)
+            if (roomsSectionData.shouldShowExpandedArrow) {
+                binding.roomCategoryCounterView.visibility = View.VISIBLE
+                val expandedArrowDrawableRes = if (roomsSectionData.isExpanded) R.drawable.ic_expand_more else R.drawable.ic_expand_less
+                val expandedArrowDrawable = ContextCompat.getDrawable(binding.root.context, expandedArrowDrawableRes)?.also {
+                    DrawableCompat.setTint(it, tintColor)
+                }
+                binding.roomCategoryCounterView.setCompoundDrawablesWithIntrinsicBounds(null, null, expandedArrowDrawable, null)
+            } else {
+                binding.roomCategoryCounterView.visibility = View.GONE
             }
-            binding.roomCategoryCounterView.setCompoundDrawablesWithIntrinsicBounds(null, null, expandedArrowDrawable, null)
             binding.roomCategoryCounterView.text = roomsSectionData.itemCount.takeIf { it > 0 }?.toString().orEmpty()
             binding.roomCategoryUnreadCounterBadgeView.render(UnreadCounterBadgeView.State(roomsSectionData.notificationCount, roomsSectionData.isHighlighted))
         }


### PR DESCRIPTION
This PR restore the changes made in #5580 which was reverted in the Element release 1.4.6 because of some UI and functional issues. The issues are fixed in #5616.