### PR TITLE
Thread redaction will now update the thread summary counter

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/UnsignedData.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/UnsignedData.kt
@@ -46,3 +46,5 @@ data class UnsignedData(
         @Json(name = "replaces_state") val replacesState: String? = null
 
 )
+
+fun UnsignedData?.isRedacted() = this?.redactedEvent != null

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ThreadEventsHelper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ThreadEventsHelper.kt
@@ -16,9 +16,12 @@
 
 package org.matrix.android.sdk.internal.database.helper
 
+import com.squareup.moshi.JsonDataException
 import io.realm.Realm
 import io.realm.RealmQuery
 import io.realm.Sort
+import org.matrix.android.sdk.api.session.events.model.UnsignedData
+import org.matrix.android.sdk.api.session.events.model.isRedacted
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
 import org.matrix.android.sdk.api.session.threads.ThreadNotificationState
 import org.matrix.android.sdk.internal.database.mapper.asDomain
@@ -33,6 +36,8 @@ import org.matrix.android.sdk.internal.database.query.findIncludingEvent
 import org.matrix.android.sdk.internal.database.query.findLastForwardChunkOfRoom
 import org.matrix.android.sdk.internal.database.query.where
 import org.matrix.android.sdk.internal.database.query.whereRoomId
+import org.matrix.android.sdk.internal.di.MoshiProvider
+import timber.log.Timber
 
 private typealias Summary = Pair<Int, TimelineEventEntity>?
 
@@ -90,19 +95,18 @@ internal fun EventEntity.markEventAsRoot(
 
 /**
  * Count the number of threads for the provided root thread eventId, and finds the latest event message
+ * note: Redactions are handled by RedactionEventProcessor
  * @param rootThreadEventId The root eventId that will find the number of threads
  * @return A ThreadSummary containing the counted threads and the latest event message
  */
 internal fun EventEntity.threadSummaryInThread(realm: Realm, rootThreadEventId: String, chunkEntity: ChunkEntity?): Summary {
-    // Number of messages
-    val messages = TimelineEventEntity
-            .whereRoomId(realm, roomId = roomId)
-            .equalTo(TimelineEventEntityFields.ROOT.ROOT_THREAD_EVENT_ID, rootThreadEventId)
-            .distinct(TimelineEventEntityFields.ROOT.EVENT_ID)
-            .count()
-            .toInt()
+    val numberOfThread = countThreads(
+            realm = realm,
+            roomId = roomId,
+            rootThreadEventId = rootThreadEventId
+    ) ?: return null
 
-    if (messages <= 0) return null
+    if (numberOfThread <= 0) return null
 
     // Find latest thread event, we know it exists
     var chunk = ChunkEntity.findLastForwardChunkOfRoom(realm, roomId) ?: chunkEntity ?: return null
@@ -124,8 +128,37 @@ internal fun EventEntity.threadSummaryInThread(realm: Realm, rootThreadEventId: 
 
     result ?: return null
 
-    return Summary(messages, result)
+    return Summary(numberOfThread, result)
 }
+
+/**
+ * Counts the number of threads in the main timeline thread summary,
+ * with respect to redactions.
+ */
+internal fun countThreads(realm: Realm, roomId: String, rootThreadEventId: String): Int? =
+        TimelineEventEntity
+                .whereRoomId(realm, roomId = roomId)
+                .equalTo(TimelineEventEntityFields.ROOT.ROOT_THREAD_EVENT_ID, rootThreadEventId)
+                .distinct(TimelineEventEntityFields.ROOT.EVENT_ID)
+                .findAll()
+                ?.filterNot { timelineEvent ->
+                    timelineEvent.root
+                            ?.unsignedData
+                            ?.takeIf { it.isNotBlank() }
+                            ?.toUnsignedData()
+                            .isRedacted()
+                }?.size
+
+/**
+ * Mapping string to UnsignedData using Moshi
+ */
+private fun String.toUnsignedData(): UnsignedData? =
+        try {
+            MoshiProvider.providesMoshi().adapter(UnsignedData::class.java).fromJson(this)
+        } catch (ex: JsonDataException) {
+            Timber.e(ex, "Failed to parse UnsignedData")
+            null
+        }
 
 /**
  * Lets compare them in case user is moving forward in the timeline and we cannot know the

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ThreadEventsHelper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ThreadEventsHelper.kt
@@ -100,7 +100,7 @@ internal fun EventEntity.markEventAsRoot(
  * @return A ThreadSummary containing the counted threads and the latest event message
  */
 internal fun EventEntity.threadSummaryInThread(realm: Realm, rootThreadEventId: String, chunkEntity: ChunkEntity?): Summary {
-    val numberOfThread = countThreads(
+    val numberOfThread = countThreadReplies(
             realm = realm,
             roomId = roomId,
             rootThreadEventId = rootThreadEventId
@@ -135,7 +135,7 @@ internal fun EventEntity.threadSummaryInThread(realm: Realm, rootThreadEventId: 
  * Counts the number of threads in the main timeline thread summary,
  * with respect to redactions.
  */
-internal fun countThreads(realm: Realm, roomId: String, rootThreadEventId: String): Int? =
+internal fun countThreadReplies(realm: Realm, roomId: String, rootThreadEventId: String): Int? =
         TimelineEventEntity
                 .whereRoomId(realm, roomId = roomId)
                 .equalTo(TimelineEventEntityFields.ROOT.ROOT_THREAD_EVENT_ID, rootThreadEventId)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/EventEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/EventEntity.kt
@@ -44,6 +44,7 @@ internal open class EventEntity(@Index var eventId: String = "",
         // Thread related, no need to create a new Entity for performance
                                 @Index var isRootThread: Boolean = false,
                                 @Index var rootThreadEventId: String? = null,
+        // Number messages within the thread
                                 var numberOfThreads: Int = 0,
                                 var threadSummaryLatestMessage: TimelineEventEntity? = null
 ) : RealmObject() {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/prune/RedactionEventProcessor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/prune/RedactionEventProcessor.kt
@@ -21,11 +21,14 @@ import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.LocalEcho
 import org.matrix.android.sdk.api.session.events.model.UnsignedData
+import org.matrix.android.sdk.internal.database.helper.countThreads
+import org.matrix.android.sdk.internal.database.helper.findRootThreadEvent
 import org.matrix.android.sdk.internal.database.mapper.ContentMapper
 import org.matrix.android.sdk.internal.database.mapper.EventMapper
 import org.matrix.android.sdk.internal.database.model.EventEntity
 import org.matrix.android.sdk.internal.database.model.EventInsertType
 import org.matrix.android.sdk.internal.database.model.TimelineEventEntity
+import org.matrix.android.sdk.internal.database.model.threads.ThreadSummaryEntity
 import org.matrix.android.sdk.internal.database.query.findWithSenderMembershipEvent
 import org.matrix.android.sdk.internal.database.query.where
 import org.matrix.android.sdk.internal.di.MoshiProvider
@@ -89,6 +92,8 @@ internal class RedactionEventProcessor @Inject constructor() : EventInsertLivePr
                     eventToPrune.unsignedData = MoshiProvider.providesMoshi().adapter(UnsignedData::class.java).toJson(modified)
                     eventToPrune.decryptionResultJson = null
                     eventToPrune.decryptionErrorCode = null
+
+                    handleTimelineThreadSummaryIfNeeded(realm, eventToPrune, isLocalEcho)
                 }
 //                EventType.REACTION -> {
 //                    eventRelationsAggregationUpdater.handleReactionRedact(eventToPrune, realm, userId)
@@ -100,6 +105,39 @@ internal class RedactionEventProcessor @Inject constructor() : EventInsertLivePr
                 it.senderName = null
                 it.isUniqueDisplayName = false
                 it.senderAvatar = null
+            }
+        }
+    }
+
+    /**
+     * Invalidates the number of threads in the main timeline thread summary,
+     * with respect to redactions.
+     */
+    private fun handleTimelineThreadSummaryIfNeeded(
+            realm: Realm,
+            eventToPrune: EventEntity,
+            isLocalEcho: Boolean,
+    ) {
+        if (eventToPrune.isThread() && !isLocalEcho) {
+            val roomId = eventToPrune.roomId
+            val rootThreadEvent = eventToPrune.findRootThreadEvent() ?: return
+            val rootThreadEventId = eventToPrune.rootThreadEventId ?: return
+
+            val numberOfThreads = countThreads(
+                    realm = realm,
+                    roomId = roomId,
+                    rootThreadEventId = rootThreadEventId
+            ) ?: return
+
+            rootThreadEvent.numberOfThreads = numberOfThreads
+            if (numberOfThreads == 0) {
+                // We should also clear the thread summary list
+                rootThreadEvent.isRootThread = false
+                rootThreadEvent.threadSummaryLatestMessage = null
+                ThreadSummaryEntity
+                        .where(realm, roomId = roomId, rootThreadEventId)
+                        .findFirst()
+                        ?.deleteFromRealm()
             }
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/prune/RedactionEventProcessor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/prune/RedactionEventProcessor.kt
@@ -21,7 +21,7 @@ import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.LocalEcho
 import org.matrix.android.sdk.api.session.events.model.UnsignedData
-import org.matrix.android.sdk.internal.database.helper.countThreadReplies
+import org.matrix.android.sdk.internal.database.helper.countInThreadMessages
 import org.matrix.android.sdk.internal.database.helper.findRootThreadEvent
 import org.matrix.android.sdk.internal.database.mapper.ContentMapper
 import org.matrix.android.sdk.internal.database.mapper.EventMapper
@@ -123,14 +123,14 @@ internal class RedactionEventProcessor @Inject constructor() : EventInsertLivePr
             val rootThreadEvent = eventToPrune.findRootThreadEvent() ?: return
             val rootThreadEventId = eventToPrune.rootThreadEventId ?: return
 
-            val numberOfThreads = countThreadReplies(
+            val inThreadMessages = countInThreadMessages(
                     realm = realm,
                     roomId = roomId,
                     rootThreadEventId = rootThreadEventId
-            ) ?: return
+            )
 
-            rootThreadEvent.numberOfThreads = numberOfThreads
-            if (numberOfThreads == 0) {
+            rootThreadEvent.numberOfThreads = inThreadMessages
+            if (inThreadMessages == 0) {
                 // We should also clear the thread summary list
                 rootThreadEvent.isRootThread = false
                 rootThreadEvent.threadSummaryLatestMessage = null

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/prune/RedactionEventProcessor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/prune/RedactionEventProcessor.kt
@@ -21,7 +21,7 @@ import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.LocalEcho
 import org.matrix.android.sdk.api.session.events.model.UnsignedData
-import org.matrix.android.sdk.internal.database.helper.countThreads
+import org.matrix.android.sdk.internal.database.helper.countThreadReplies
 import org.matrix.android.sdk.internal.database.helper.findRootThreadEvent
 import org.matrix.android.sdk.internal.database.mapper.ContentMapper
 import org.matrix.android.sdk.internal.database.mapper.EventMapper
@@ -123,7 +123,7 @@ internal class RedactionEventProcessor @Inject constructor() : EventInsertLivePr
             val rootThreadEvent = eventToPrune.findRootThreadEvent() ?: return
             val rootThreadEventId = eventToPrune.rootThreadEventId ?: return
 
-            val numberOfThreads = countThreads(
+            val numberOfThreads = countThreadReplies(
                     realm = realm,
                     roomId = roomId,
                     rootThreadEventId = rootThreadEventId


### PR DESCRIPTION
## Type of change

- [x] Bugfix
## Content

- When there is an empty thread after a thread event redaction, thread summary should be gone and thread list should remove that root thread record
- Redaction of a thread event should reduce the thread counter in main timeline thread summary

|Before redaction|After redaction|
| --- | --- | 
|![Screenshot_20220324-170027_Element dbg](https://user-images.githubusercontent.com/60798129/159946431-5e4ff86c-b035-4503-9193-eb9dc6f1d8f5.jpg)|![Screenshot_20220324-170045_Element dbg](https://user-images.githubusercontent.com/60798129/159946448-c33ecc01-a413-47e6-8f9e-47ea6f37c451.jpg)|



Closes #5598
Closes #5625