### PR TITLE
Direct login tests

### DIFF
--- a/changelog.d/5628.misc
+++ b/changelog.d/5628.misc
@@ -1,0 +1,1 @@
+Adds unit tests around the login with matrix id flow

--- a/vector/src/main/java/im/vector/app/features/onboarding/DirectLoginUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/DirectLoginUseCase.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.onboarding
+
+import android.net.Uri
+import im.vector.app.R
+import im.vector.app.core.resources.StringProvider
+import im.vector.app.features.onboarding.OnboardingAction.LoginOrRegister
+import org.matrix.android.sdk.api.MatrixPatterns.getDomain
+import org.matrix.android.sdk.api.auth.AuthenticationService
+import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
+import org.matrix.android.sdk.api.auth.wellknown.WellknownResult
+import org.matrix.android.sdk.api.session.Session
+import javax.inject.Inject
+
+class DirectLoginUseCase @Inject constructor(
+        private val authenticationService: AuthenticationService,
+        private val stringProvider: StringProvider,
+) {
+
+    suspend fun execute(action: LoginOrRegister, homeServerConnectionConfig: HomeServerConnectionConfig?): Result<Session> {
+        return fetchWellKnown(action.username, homeServerConnectionConfig)
+                .andThen { wellKnown -> createSessionFor(wellKnown, action, homeServerConnectionConfig) }
+    }
+
+    private suspend fun fetchWellKnown(matrixId: String, config: HomeServerConnectionConfig?) = runCatching {
+        authenticationService.getWellKnownData(matrixId, config)
+    }
+
+    private suspend fun createSessionFor(data: WellknownResult, action: LoginOrRegister, config: HomeServerConnectionConfig?) = when (data) {
+        is WellknownResult.Prompt     -> loginDirect(action, data, config)
+        is WellknownResult.FailPrompt -> handleFailPrompt(data, action, config)
+        else                          -> onWellKnownError()
+    }
+
+    private suspend fun handleFailPrompt(data: WellknownResult.FailPrompt, action: LoginOrRegister, config: HomeServerConnectionConfig?): Result<Session> {
+        // Relax on IS discovery if homeserver is valid
+        val isMissingInformationToLogin = data.homeServerUrl == null || data.wellKnown == null
+        return when {
+            isMissingInformationToLogin -> onWellKnownError()
+            else                        -> loginDirect(action, WellknownResult.Prompt(data.homeServerUrl!!, null, data.wellKnown!!), config)
+        }
+    }
+
+    private suspend fun loginDirect(action: LoginOrRegister, wellKnownPrompt: WellknownResult.Prompt, config: HomeServerConnectionConfig?): Result<Session> {
+        val alteredHomeServerConnectionConfig = config?.updateWith(wellKnownPrompt) ?: fallbackConfig(action, wellKnownPrompt)
+        return runCatching {
+            authenticationService.directAuthentication(
+                    alteredHomeServerConnectionConfig,
+                    action.username,
+                    action.password,
+                    action.initialDeviceName
+            )
+        }
+    }
+
+    private fun HomeServerConnectionConfig.updateWith(wellKnownPrompt: WellknownResult.Prompt) = copy(
+            homeServerUriBase = Uri.parse(wellKnownPrompt.homeServerUrl),
+            identityServerUri = wellKnownPrompt.identityServerUrl?.let { Uri.parse(it) }
+    )
+
+    private fun fallbackConfig(action: LoginOrRegister, wellKnownPrompt: WellknownResult.Prompt) = HomeServerConnectionConfig(
+            homeServerUri = Uri.parse("https://${action.username.getDomain()}"),
+            homeServerUriBase = Uri.parse(wellKnownPrompt.homeServerUrl),
+            identityServerUri = wellKnownPrompt.identityServerUrl?.let { Uri.parse(it) }
+    )
+
+    private fun onWellKnownError() = Result.failure<Session>(Exception(stringProvider.getString(R.string.autodiscover_well_known_error)))
+}
+
+@Suppress("UNCHECKED_CAST") // We're casting null failure results to R
+private inline fun <T, R> Result<T>.andThen(block: (T) -> Result<R>): Result<R> {
+    return when (val result = getOrNull()) {
+        null -> this as Result<R>
+        else -> block(result)
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/onboarding/UriFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/UriFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Matrix.org Foundation C.I.C.
+ * Copyright (c) 2022 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.matrix.android.sdk.internal.extensions
 
-import org.matrix.android.sdk.api.MatrixCallback
+package im.vector.app.features.onboarding
 
-fun <A> Result<A>.foldToCallback(callback: MatrixCallback<A>): Unit = fold(
-        { callback.onSuccess(it) },
-        { callback.onFailure(it) }
-)
+import android.net.Uri
+import javax.inject.Inject
 
-@Suppress("UNCHECKED_CAST") // We're casting null failure results to R
-inline fun <T, R> Result<T>.andThen(block: (T) -> Result<R>): Result<R> {
-    return when (val result = getOrNull()) {
-        null -> this as Result<R>
-        else -> block(result)
+class UriFactory @Inject constructor() {
+
+    fun parse(value: String): Uri {
+        return Uri.parse(value)
     }
 }

--- a/vector/src/test/java/im/vector/app/features/onboarding/DirectLoginUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/DirectLoginUseCaseTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.onboarding
+
+import im.vector.app.test.fakes.FakeAuthenticationService
+import im.vector.app.test.fakes.FakeSession
+import im.vector.app.test.fakes.FakeStringProvider
+import im.vector.app.test.fakes.FakeUri
+import im.vector.app.test.fakes.FakeUriFactory
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.matrix.android.sdk.api.MatrixPatterns.getDomain
+import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
+import org.matrix.android.sdk.api.auth.data.WellKnown
+import org.matrix.android.sdk.api.auth.wellknown.WellknownResult
+
+private val A_LOGIN_OR_REGISTER_ACTION = OnboardingAction.LoginOrRegister("@a-user:id.org", "a-password", "a-device-name")
+private val A_WELLKNOWN_SUCCESS_RESULT = WellknownResult.Prompt("https://homeserverurl.com", identityServerUrl = null, WellKnown())
+private val A_WELLKNOWN_FAILED_WITH_CONTENT_RESULT = WellknownResult.FailPrompt("https://homeserverurl.com", WellKnown())
+private val NO_HOMESERVER_CONFIG: HomeServerConnectionConfig? = null
+private val A_FALLBACK_CONFIG: HomeServerConnectionConfig = HomeServerConnectionConfig(
+        homeServerUri = FakeUri("https://${A_LOGIN_OR_REGISTER_ACTION.username.getDomain()}").instance,
+        homeServerUriBase = FakeUri(A_WELLKNOWN_SUCCESS_RESULT.homeServerUrl).instance,
+        identityServerUri = null
+)
+
+class DirectLoginUseCaseTest {
+
+    private val fakeAuthenticationService = FakeAuthenticationService()
+    private val fakeStringProvider = FakeStringProvider()
+    private val fakeSession = FakeSession()
+
+    private val useCase = DirectLoginUseCase(fakeAuthenticationService, fakeStringProvider.instance, FakeUriFactory().instance)
+
+    @Test
+    fun `when logging in directly, then returns success with direct session result`() = runTest {
+        fakeAuthenticationService.givenWellKnown(A_LOGIN_OR_REGISTER_ACTION.username, config = NO_HOMESERVER_CONFIG, result = A_WELLKNOWN_SUCCESS_RESULT)
+        val (username, password, initialDeviceName) = A_LOGIN_OR_REGISTER_ACTION
+        fakeAuthenticationService.givenDirectAuthentication(A_FALLBACK_CONFIG, username, password, initialDeviceName, result = fakeSession)
+
+        val result = useCase.execute(A_LOGIN_OR_REGISTER_ACTION, homeServerConnectionConfig = NO_HOMESERVER_CONFIG)
+
+        result shouldBeEqualTo Result.success(fakeSession)
+    }
+
+    @Test
+    fun `given wellknown fails but has content, when logging in directly, then returns success with direct session result`() = runTest {
+        fakeAuthenticationService.givenWellKnown(A_LOGIN_OR_REGISTER_ACTION.username, config = NO_HOMESERVER_CONFIG, result = A_WELLKNOWN_FAILED_WITH_CONTENT_RESULT)
+        val (username, password, initialDeviceName) = A_LOGIN_OR_REGISTER_ACTION
+        fakeAuthenticationService.givenDirectAuthentication(A_FALLBACK_CONFIG, username, password, initialDeviceName, result = fakeSession)
+
+        val result = useCase.execute(A_LOGIN_OR_REGISTER_ACTION, homeServerConnectionConfig = NO_HOMESERVER_CONFIG)
+
+        result shouldBeEqualTo Result.success(fakeSession)
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/onboarding/DirectLoginUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/DirectLoginUseCaseTest.kt
@@ -16,12 +16,15 @@
 
 package im.vector.app.features.onboarding
 
+import im.vector.app.R
 import im.vector.app.test.fakes.FakeAuthenticationService
 import im.vector.app.test.fakes.FakeSession
 import im.vector.app.test.fakes.FakeStringProvider
 import im.vector.app.test.fakes.FakeUri
 import im.vector.app.test.fakes.FakeUriFactory
+import im.vector.app.test.fakes.toTestString
 import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.should
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.matrix.android.sdk.api.MatrixPatterns.getDomain
@@ -32,12 +35,14 @@ import org.matrix.android.sdk.api.auth.wellknown.WellknownResult
 private val A_LOGIN_OR_REGISTER_ACTION = OnboardingAction.LoginOrRegister("@a-user:id.org", "a-password", "a-device-name")
 private val A_WELLKNOWN_SUCCESS_RESULT = WellknownResult.Prompt("https://homeserverurl.com", identityServerUrl = null, WellKnown())
 private val A_WELLKNOWN_FAILED_WITH_CONTENT_RESULT = WellknownResult.FailPrompt("https://homeserverurl.com", WellKnown())
+private val A_WELLKNOWN_FAILED_WITHOUT_CONTENT_RESULT = WellknownResult.FailPrompt(null, null)
 private val NO_HOMESERVER_CONFIG: HomeServerConnectionConfig? = null
 private val A_FALLBACK_CONFIG: HomeServerConnectionConfig = HomeServerConnectionConfig(
         homeServerUri = FakeUri("https://${A_LOGIN_OR_REGISTER_ACTION.username.getDomain()}").instance,
         homeServerUriBase = FakeUri(A_WELLKNOWN_SUCCESS_RESULT.homeServerUrl).instance,
         identityServerUri = null
 )
+private val AN_ERROR = RuntimeException()
 
 class DirectLoginUseCaseTest {
 
@@ -59,7 +64,7 @@ class DirectLoginUseCaseTest {
     }
 
     @Test
-    fun `given wellknown fails but has content, when logging in directly, then returns success with direct session result`() = runTest {
+    fun `given wellknown fails with content, when logging in directly, then returns success with direct session result`() = runTest {
         fakeAuthenticationService.givenWellKnown(A_LOGIN_OR_REGISTER_ACTION.username, config = NO_HOMESERVER_CONFIG, result = A_WELLKNOWN_FAILED_WITH_CONTENT_RESULT)
         val (username, password, initialDeviceName) = A_LOGIN_OR_REGISTER_ACTION
         fakeAuthenticationService.givenDirectAuthentication(A_FALLBACK_CONFIG, username, password, initialDeviceName, result = fakeSession)
@@ -67,5 +72,38 @@ class DirectLoginUseCaseTest {
         val result = useCase.execute(A_LOGIN_OR_REGISTER_ACTION, homeServerConnectionConfig = NO_HOMESERVER_CONFIG)
 
         result shouldBeEqualTo Result.success(fakeSession)
+    }
+
+    @Test
+    fun `given wellknown fails without content, when logging in directly, then returns well known error`() = runTest {
+        fakeAuthenticationService.givenWellKnown(A_LOGIN_OR_REGISTER_ACTION.username, config = NO_HOMESERVER_CONFIG, result = A_WELLKNOWN_FAILED_WITHOUT_CONTENT_RESULT)
+        val (username, password, initialDeviceName) = A_LOGIN_OR_REGISTER_ACTION
+        fakeAuthenticationService.givenDirectAuthentication(A_FALLBACK_CONFIG, username, password, initialDeviceName, result = fakeSession)
+
+        val result = useCase.execute(A_LOGIN_OR_REGISTER_ACTION, homeServerConnectionConfig = NO_HOMESERVER_CONFIG)
+
+        result should { this.isFailure }
+        result should { this.exceptionOrNull() is Exception }
+        result should { this.exceptionOrNull()?.message == R.string.autodiscover_well_known_error.toTestString() }
+    }
+
+    @Test
+    fun `given wellknown throws, when logging in directly, then returns failure result with original cause`() = runTest {
+        fakeAuthenticationService.givenWellKnownThrows(A_LOGIN_OR_REGISTER_ACTION.username, config = NO_HOMESERVER_CONFIG, cause = AN_ERROR)
+
+        val result = useCase.execute(A_LOGIN_OR_REGISTER_ACTION, homeServerConnectionConfig = NO_HOMESERVER_CONFIG)
+
+        result shouldBeEqualTo Result.failure(AN_ERROR)
+    }
+
+    @Test
+    fun `given direct authentication throws, when logging in directly, then returns failure result with original cause`() = runTest {
+        fakeAuthenticationService.givenWellKnown(A_LOGIN_OR_REGISTER_ACTION.username, config = NO_HOMESERVER_CONFIG, result = A_WELLKNOWN_SUCCESS_RESULT)
+        val (username, password, initialDeviceName) = A_LOGIN_OR_REGISTER_ACTION
+        fakeAuthenticationService.givenDirectAuthenticationThrows(A_FALLBACK_CONFIG, username, password, initialDeviceName, cause = AN_ERROR)
+
+        val result = useCase.execute(A_LOGIN_OR_REGISTER_ACTION, homeServerConnectionConfig = NO_HOMESERVER_CONFIG)
+
+        result shouldBeEqualTo Result.failure(AN_ERROR)
     }
 }

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -139,6 +139,26 @@ class OnboardingViewModelTest {
     }
 
     @Test
+    fun `given has sign in with matrix id sign mode, when handling login or register action fails, then emits error`() = runTest {
+        val initialState = initialState.copy(signMode = SignMode.SignInWithMatrixId)
+        viewModel = createViewModel(initialState)
+        fakeDirectLoginUseCase.givenFailureResult(A_LOGIN_OR_REGISTER_ACTION, config = null, cause = AN_ERROR)
+        givenInitialisesSession(fakeSession)
+        val test = viewModel.test()
+
+        viewModel.handle(A_LOGIN_OR_REGISTER_ACTION)
+
+        test
+                .assertStatesChanges(
+                        initialState,
+                        { copy(isLoading = true) },
+                        { copy(isLoading = false) }
+                )
+                .assertEvents(OnboardingViewEvents.Failure(AN_ERROR))
+                .finish()
+    }
+
+    @Test
     fun `when handling SignUp then sets sign mode to sign up and starts registration`() = runTest {
         givenRegistrationResultFor(RegisterAction.StartRegistration, ANY_CONTINUING_REGISTRATION_RESULT)
         val test = viewModel.test()

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
@@ -43,7 +43,15 @@ class FakeAuthenticationService : AuthenticationService by mockk() {
         coEvery { getWellKnownData(matrixId, config) } returns result
     }
 
+    fun givenWellKnownThrows(matrixId: String, config: HomeServerConnectionConfig?, cause: Throwable) {
+        coEvery { getWellKnownData(matrixId, config) } throws cause
+    }
+
     fun givenDirectAuthentication(config: HomeServerConnectionConfig, matrixId: String, password: String, deviceName: String, result: FakeSession) {
         coEvery { directAuthentication(config, matrixId, password, deviceName) } returns result
+    }
+
+    fun givenDirectAuthenticationThrows(config: HomeServerConnectionConfig, matrixId: String, password: String, deviceName: String, cause: Throwable) {
+        coEvery { directAuthentication(config, matrixId, password, deviceName) } throws  cause
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
@@ -16,11 +16,14 @@
 
 package im.vector.app.test.fakes
 
+import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.every
 import io.mockk.mockk
 import org.matrix.android.sdk.api.auth.AuthenticationService
+import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
 import org.matrix.android.sdk.api.auth.registration.RegistrationWizard
+import org.matrix.android.sdk.api.auth.wellknown.WellknownResult
 
 class FakeAuthenticationService : AuthenticationService by mockk() {
 
@@ -34,5 +37,13 @@ class FakeAuthenticationService : AuthenticationService by mockk() {
 
     fun expectReset() {
         coJustRun { reset() }
+    }
+
+    fun givenWellKnown(matrixId: String, config: HomeServerConnectionConfig?, result: WellknownResult) {
+        coEvery { getWellKnownData(matrixId, config) } returns result
+    }
+
+    fun givenDirectAuthentication(config: HomeServerConnectionConfig, matrixId: String, password: String, deviceName: String, result: FakeSession) {
+        coEvery { directAuthentication(config, matrixId, password, deviceName) } returns result
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeDirectLoginUseCase.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeDirectLoginUseCase.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import im.vector.app.features.onboarding.DirectLoginUseCase
+import im.vector.app.features.onboarding.OnboardingAction
+import io.mockk.coEvery
+import io.mockk.mockk
+import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
+
+class FakeDirectLoginUseCase {
+    val instance = mockk<DirectLoginUseCase>()
+
+    fun givenSuccessResult(action: OnboardingAction.LoginOrRegister, config: HomeServerConnectionConfig?, result: FakeSession) {
+        coEvery { instance.execute(action, config) } returns Result.success(result)
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeDirectLoginUseCase.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeDirectLoginUseCase.kt
@@ -28,4 +28,8 @@ class FakeDirectLoginUseCase {
     fun givenSuccessResult(action: OnboardingAction.LoginOrRegister, config: HomeServerConnectionConfig?, result: FakeSession) {
         coEvery { instance.execute(action, config) } returns Result.success(result)
     }
+
+    fun givenFailureResult(action: OnboardingAction.LoginOrRegister, config: HomeServerConnectionConfig?, cause: Throwable) {
+        coEvery { instance.execute(action, config) } returns Result.failure(cause)
+    }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeStringProvider.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeStringProvider.kt
@@ -30,3 +30,5 @@ class FakeStringProvider {
         }
     }
 }
+
+fun Int.toTestString() = "test-$this"

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeUri.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeUri.kt
@@ -20,8 +20,13 @@ import android.net.Uri
 import io.mockk.every
 import io.mockk.mockk
 
-class FakeUri {
+class FakeUri(contentEquals: String? = null) {
+
     val instance = mockk<Uri>()
+
+    init {
+        contentEquals?.let { givenEquals(it) }
+    }
 
     fun givenNonHierarchical() {
         givenContent(schema = "mail", path = null)
@@ -30,5 +35,13 @@ class FakeUri {
     fun givenContent(schema: String, path: String?) {
         every { instance.scheme } returns schema
         every { instance.path } returns path
+    }
+
+    @Suppress("ReplaceCallWithBinaryOperator")
+    fun givenEquals(content: String) {
+        every { instance.equals(any()) } answers {
+            it.invocation.args.first() == content
+        }
+        every { instance.hashCode() } answers { content.hashCode() }
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeUriFactory.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeUriFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Matrix.org Foundation C.I.C.
+ * Copyright (c) 2022 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.matrix.android.sdk.internal.extensions
 
-import org.matrix.android.sdk.api.MatrixCallback
+package im.vector.app.test.fakes
 
-fun <A> Result<A>.foldToCallback(callback: MatrixCallback<A>): Unit = fold(
-        { callback.onSuccess(it) },
-        { callback.onFailure(it) }
-)
+import im.vector.app.features.onboarding.UriFactory
+import io.mockk.every
+import io.mockk.mockk
 
-@Suppress("UNCHECKED_CAST") // We're casting null failure results to R
-inline fun <T, R> Result<T>.andThen(block: (T) -> Result<R>): Result<R> {
-    return when (val result = getOrNull()) {
-        null -> this as Result<R>
-        else -> block(result)
+class FakeUriFactory {
+
+    val instance = mockk<UriFactory>().also {
+        every { it.parse(any()) } answers {
+            val input = it.invocation.args.first() as String
+            FakeUri().also { it.givenEquals(input) }.instance
+        }
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Adds unit tests around the direct login flow via the `OnboardingViewModel` and the happy paths of the extracted `DirectLoginUseCase`

## Motivation and context

To ensure the direct login flow is treated as a sign in and avoid regressions such as #5623 

## Screenshots / GIFs

| WRONG ID | WRONG CREDENTIALS | OFFLINE | 404 HOMESERVER | 
| --- | --- | --- | --- |
|![after-wrong-id](https://user-images.githubusercontent.com/1848238/159958038-a310d989-ddf0-4f1a-8914-cddc9f23de83.gif)|![after-wrong-credentials](https://user-images.githubusercontent.com/1848238/159958312-06c4b005-3a1f-45a0-b837-a1c43e7cae27.gif)|![after-offline](https://user-images.githubusercontent.com/1848238/159958046-127bc745-1030-4059-811a-dee154eac620.gif)|![after-404-hs](https://user-images.githubusercontent.com/1848238/159958043-ec70da04-24ff-4471-9afa-b18ef61d6db2.gif)

## Tests

- Via the sign in flow - 
- Sign in with matrix id

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 10


