### PR TITLE
Moving live location sharing permission to debug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,4 @@
-Changes in Element v1.4.7 (2022-03-24)
-======================================
-
-Bugfixes 🐛
-----------
- - Fix inconsistencies between the arrow visibility and the collapse action on the room sections ([#5616](https://github.com/vector-im/element-android/issues/5616))
- - Fix room list header count flickering
-
-Changes in Element v1.4.6 (2022-03-23)
+Changes in Element v1.4.8 (2022-03-28)
 ======================================
 
 Features ✨
@@ -59,6 +51,7 @@ Other changes
  - Added online presence indicator attribute online to match offline styling ([#5513](https://github.com/vector-im/element-android/issues/5513))
  - Add a presence sync enabling build config ([#5563](https://github.com/vector-im/element-android/issues/5563))
  - Show stickers on click ([#5572](https://github.com/vector-im/element-android/issues/5572))
+ - Moving live location sharing permission to debug only builds whilst it is WIP ([#5636](https://github.com/vector-im/element-android/issues/5636))
 
 
 Changes in Element v1.4.4 (2022-03-09)

--- a/changelog.d/5636.misc
+++ b/changelog.d/5636.misc
@@ -1,0 +1,1 @@
+Moving live location sharing permission to debug only builds whilst it is WIP

--- a/changelog.d/5636.misc
+++ b/changelog.d/5636.misc
@@ -1,1 +1,0 @@
-Moving live location sharing permission to debug only builds whilst it is WIP

--- a/fastlane/metadata/android/en-US/changelogs/40104080.txt
+++ b/fastlane/metadata/android/en-US/changelogs/40104080.txt
@@ -1,0 +1,2 @@
+Main changes in this version: Thread timeline are now live and faster. Various bug fixes and stability improvements.
+Full changelog: https://github.com/vector-im/element-android/releases

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -31,7 +31,7 @@ android {
         // that the app's state is completely cleared between tests.
         testInstrumentationRunnerArguments clearPackageData: 'true'
 
-        buildConfigField "String", "SDK_VERSION", "\"1.4.7\""
+        buildConfigField "String", "SDK_VERSION", "\"1.4.8\""
 
         buildConfigField "String", "GIT_SDK_REVISION", "\"${gitRevision()}\""
         buildConfigField "String", "GIT_SDK_REVISION_UNIX_DATE", "\"${gitRevisionUnixDate()}\""

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -18,7 +18,7 @@ ext.versionMinor = 4
 // Note: even values are reserved for regular release, odd values for hotfix release.
 // When creating a hotfix, you should decrease the value, since the current value
 // is the value for the next regular release.
-ext.versionPatch = 7
+ext.versionPatch = 8
 
 static def getGitTimestamp() {
     def cmd = 'git show -s --format=%ct'

--- a/vector/src/debug/AndroidManifest.xml
+++ b/vector/src/debug/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="im.vector.app">
 
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+
     <application>
         <activity android:name=".features.debug.TestLinkifyActivity" />
         <activity android:name=".features.debug.DebugPermissionActivity" />

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -45,7 +45,8 @@
     <!-- Location Sharing -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <!--  Debug only whilst live location sharing is WIP -->
+    <!--<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />-->
 
     <!-- Jitsi SDK is now API23+ -->
     <uses-sdk tools:overrideLibrary="org.jitsi.meet.sdk,com.oney.WebRTCModule,com.learnium.RNDeviceInfo,com.reactnativecommunity.asyncstorage,com.ocetnik.timer,com.calendarevents,com.reactnativecommunity.netinfo,com.kevinresol.react_native_default_preference,com.rnimmersive,com.corbt.keepawake,com.BV.LinearGradient,com.horcrux.svg,com.oblador.performance,com.reactnativecommunity.slider,com.brentvatne.react" />


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Moves the `ACCESS_BACKGROUND_LOCATION` permission to the debug `AndroidManifest`, as including it in the main/release build requires additional steps wen releasing on the Google Play store #5635 

Once the feature is complete we can promote it back to the main/release manifest

## Motivation and context

Fixes #5636 by matching the current live location build flag (debug only)

## Screenshots / GIFs

No UI changes!

## Tests

- Upload to the play store
- See warning message `You must provide information about how your app uses background location permissions, or your app may be removed from Google Play`
## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 10

