### PR TITLE
Fix regression from #4471

### DIFF
--- a/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomActivity.kt
@@ -28,7 +28,6 @@ import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
-import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.viewModel
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
@@ -167,10 +166,10 @@ class CreateDirectRoomActivity : SimpleFragmentActivity() {
 
     private fun renderCreateAndInviteState(state: Async<String>) {
         when (state) {
-            Uninitialized,
             is Loading -> renderCreationLoading()
             is Success -> renderCreationSuccess(state())
             is Fail    -> renderCreationFailure(state.error)
+            else       -> Unit
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/discovery/DiscoverySettingsController.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/DiscoverySettingsController.kt
@@ -50,7 +50,6 @@ class DiscoverySettingsController @Inject constructor(
 
     override fun buildModels(data: DiscoverySettingsState) {
         when (data.identityServer) {
-            Uninitialized,
             is Loading -> {
                 loadingItem {
                     id("identityServerLoading")
@@ -71,6 +70,7 @@ class DiscoverySettingsController @Inject constructor(
                     buildMsisdnSection(data.phoneNumbersList)
                 }
             }
+            else       -> Unit
         }
     }
 
@@ -356,7 +356,6 @@ class DiscoverySettingsController @Inject constructor(
             colorProvider(host.colorProvider)
             stringProvider(host.stringProvider)
             when (pidInfo.isShared) {
-                Uninitialized,
                 is Loading -> {
                     buttonIndeterminate(true)
                 }
@@ -390,6 +389,7 @@ class DiscoverySettingsController @Inject constructor(
                     }
                     null                            -> Unit
                 }
+                else       -> Unit
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchFragment.kt
@@ -26,7 +26,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
-import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.args
 import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.withState
@@ -89,7 +88,6 @@ class SearchFragment @Inject constructor(
     override fun invalidate() = withState(searchViewModel) { state ->
         if (state.searchResult.isNullOrEmpty()) {
             when (state.asyncSearchRequest) {
-                Uninitialized,
                 is Loading -> {
                     views.stateView.state = StateView.State.Loading
                 }
@@ -101,6 +99,7 @@ class SearchFragment @Inject constructor(
                             title = getString(R.string.search_no_results),
                             image = ContextCompat.getDrawable(requireContext(), R.drawable.ic_search_no_results))
                 }
+                else       -> Unit
             }
         } else {
             controller.setData(state)

--- a/vector/src/main/java/im/vector/app/features/login/LoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginFragment.kt
@@ -28,8 +28,6 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
-import com.airbnb.mvrx.Success
-import com.airbnb.mvrx.Uninitialized
 import im.vector.app.R
 import im.vector.app.core.extensions.hideKeyboard
 import im.vector.app.core.extensions.hidePassword
@@ -269,7 +267,6 @@ class LoginFragment @Inject constructor() : AbstractSSOLoginFragment<FragmentLog
         setupButtons(state)
 
         when (state.asyncLoginAction) {
-            Uninitialized,
             is Loading -> {
                 // Ensure password is hidden
                 views.passwordField.hidePassword()
@@ -292,7 +289,7 @@ class LoginFragment @Inject constructor() : AbstractSSOLoginFragment<FragmentLog
                 }
             }
             // Success is handled by the LoginActivity
-            is Success -> Unit
+            else       -> Unit
         }
 
         when (state.asyncRegistration) {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/uploads/files/RoomUploadsFilesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/uploads/files/RoomUploadsFilesFragment.kt
@@ -24,7 +24,6 @@ import androidx.core.content.ContextCompat
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
-import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.parentFragmentViewModel
 import com.airbnb.mvrx.withState
 import im.vector.app.R
@@ -92,7 +91,6 @@ class RoomUploadsFilesFragment @Inject constructor(
     override fun invalidate() = withState(uploadsViewModel) { state ->
         if (state.fileEvents.isEmpty()) {
             when (state.asyncEventsRequest) {
-                Uninitialized,
                 is Loading -> {
                     views.genericStateViewListStateView.state = StateView.State.Loading
                 }
@@ -110,6 +108,7 @@ class RoomUploadsFilesFragment @Inject constructor(
                         )
                     }
                 }
+                else       -> Unit
             }
         } else {
             views.genericStateViewListStateView.state = StateView.State.Content

--- a/vector/src/main/java/im/vector/app/features/roomprofile/uploads/media/RoomUploadsMediaFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/uploads/media/RoomUploadsMediaFragment.kt
@@ -29,7 +29,6 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
-import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.parentFragmentViewModel
 import com.airbnb.mvrx.withState
 import com.google.android.material.appbar.AppBarLayout
@@ -189,7 +188,6 @@ class RoomUploadsMediaFragment @Inject constructor(
     override fun invalidate() = withState(uploadsViewModel) { state ->
         if (state.mediaEvents.isEmpty()) {
             when (state.asyncEventsRequest) {
-                Uninitialized,
                 is Loading -> {
                     views.genericStateViewListStateView.state = StateView.State.Loading
                 }
@@ -207,6 +205,7 @@ class RoomUploadsMediaFragment @Inject constructor(
                         )
                     }
                 }
+                else       -> Unit
             }
         } else {
             views.genericStateViewListStateView.state = StateView.State.Content

--- a/vector/src/main/java/im/vector/app/features/settings/devtools/AccountDataEpoxyController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devtools/AccountDataEpoxyController.kt
@@ -21,7 +21,6 @@ import com.airbnb.epoxy.TypedEpoxyController
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
-import com.airbnb.mvrx.Uninitialized
 import im.vector.app.R
 import im.vector.app.core.epoxy.loadingItem
 import im.vector.app.core.resources.StringProvider
@@ -46,7 +45,6 @@ class AccountDataEpoxyController @Inject constructor(
         if (data == null) return
         val host = this
         when (data.accountData) {
-            Uninitialized,
             is Loading -> {
                 loadingItem {
                     id("loading")
@@ -82,6 +80,7 @@ class AccountDataEpoxyController @Inject constructor(
                     }
                 }
             }
+            else       -> Unit
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/threepids/ThreePidsSettingsController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/threepids/ThreePidsSettingsController.kt
@@ -21,7 +21,6 @@ import com.airbnb.epoxy.TypedEpoxyController
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
-import com.airbnb.mvrx.Uninitialized
 import im.vector.app.R
 import im.vector.app.core.epoxy.loadingItem
 import im.vector.app.core.epoxy.noResultItem
@@ -78,7 +77,6 @@ class ThreePidsSettingsController @Inject constructor(
         }
 
         when (data.threePids) {
-            Uninitialized,
             is Loading -> {
                 loadingItem {
                     id("loading")
@@ -95,6 +93,7 @@ class ThreePidsSettingsController @Inject constructor(
                 val dataList = data.threePids.invoke()
                 buildThreePids(dataList, data)
             }
+            else       -> Unit
         }
     }
 


### PR DESCRIPTION
`is Loading` has been replaced by `Uninitialized, is Loading` in `when` statements, which is not strictly equivalent

This commit revert those changes.

Related: #4471

This PR fixes regressions on:
- create DM screen
- search message screen

Other places were not regression (`is Incomplete` may have been used previously instead of `is Loading`), but I prefer PR #4471 be strictly equivalent to the previous code.