### PR TITLE
Replace "open settings" button by "disable" action in RageShake dialog if there is no session

### DIFF
--- a/changelog.d/4445.bugfix
+++ b/changelog.d/4445.bugfix
@@ -1,0 +1,1 @@
+Replace "open settings" button by "disable" action in RageShake dialog if there is no session

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -866,6 +866,17 @@ class VectorPreferences @Inject constructor(private val context: Context) {
     }
 
     /**
+     * Update the rage shake enabled status.
+     *
+     * @param isEnabled true to enable rage shake.
+     */
+    fun setRageshakeEnabled(isEnabled: Boolean) {
+        defaultPrefs.edit {
+            putBoolean(SETTINGS_USE_RAGE_SHAKE_KEY, isEnabled)
+        }
+    }
+
+    /**
      * Tells if the rage shake is used.
      *
      * @return true if the rage shake is used

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -358,6 +358,7 @@
     <string name="action_switch">Switch</string>
     <string name="action_unpublish">Unpublish</string>
     <string name="action_enable">Enable</string>
+    <string name="action_disable">Disable</string>
     <string name="action_not_now">Not now</string>
     <string name="action_agree">Agree</string>
     <string name="action_change">"Change"</string>


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

The "settings" button is replaced by a "disable" button when there is no session. Clicking on this button will disable the rage shake feature until the user manually reactive it by opening the application settings from a new session. 

## Motivation and context

Fix #4445 

## Screenshots / GIFs

<img width="860" alt="image" src="https://user-images.githubusercontent.com/11990514/161276788-ab4e58de-c307-42c1-894c-3873fcd548ec.png">

## Tests

Tested by triggering the rageshake dialog in both states (connected & disconnected).

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [X] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
