### PR TITLE
Potentially fixes intermittent crashing from sending gallery images

### DIFF
--- a/changelog.d/5652.bugfix
+++ b/changelog.d/5652.bugfix
@@ -1,0 +1,1 @@
+Tentative fix of images crashing when being sent or shared from gallery

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/CameraPicker.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/CameraPicker.kt
@@ -23,11 +23,9 @@ import android.provider.MediaStore
 import androidx.activity.result.ActivityResultLauncher
 import androidx.core.content.FileProvider
 import im.vector.lib.multipicker.entity.MultiPickerImageType
+import im.vector.lib.multipicker.utils.MediaFileUtils.MediaType.IMAGE
+import im.vector.lib.multipicker.utils.MediaFileUtils.createTemporaryMediaFile
 import im.vector.lib.multipicker.utils.toMultiPickerImageType
-import java.io.File
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 
 /**
  * Implementation of taking a photo with Camera
@@ -38,7 +36,7 @@ class CameraPicker {
      * Start camera by using a ActivityResultLauncher
      * @return Uri of taken photo or null if the operation is cancelled.
      */
-    fun startWithExpectingFile(context: Context, activityResultLauncher: ActivityResultLauncher<Intent>): Uri? {
+    fun startWithExpectingFile(context: Context, activityResultLauncher: ActivityResultLauncher<Intent>): Uri {
         val photoUri = createPhotoUri(context)
         val intent = createIntent().apply {
             putExtra(MediaStore.EXTRA_OUTPUT, photoUri)
@@ -63,19 +61,9 @@ class CameraPicker {
 
     companion object {
         fun createPhotoUri(context: Context): Uri {
-            val file = createImageFile(context)
+            val file = createTemporaryMediaFile(context, IMAGE)
             val authority = context.packageName + ".multipicker.fileprovider"
             return FileProvider.getUriForFile(context, authority, file)
-        }
-
-        private fun createImageFile(context: Context): File {
-            val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
-            val storageDir: File = context.filesDir
-            return File.createTempFile(
-                    "${timeStamp}_", /* prefix */
-                    ".jpg", /* suffix */
-                    storageDir /* directory */
-            )
         }
     }
 }

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/CameraPicker.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/CameraPicker.kt
@@ -23,8 +23,8 @@ import android.provider.MediaStore
 import androidx.activity.result.ActivityResultLauncher
 import androidx.core.content.FileProvider
 import im.vector.lib.multipicker.entity.MultiPickerImageType
-import im.vector.lib.multipicker.utils.MediaFileUtils.MediaType.IMAGE
-import im.vector.lib.multipicker.utils.MediaFileUtils.createTemporaryMediaFile
+import im.vector.lib.multipicker.utils.MediaType
+import im.vector.lib.multipicker.utils.createTemporaryMediaFile
 import im.vector.lib.multipicker.utils.toMultiPickerImageType
 
 /**
@@ -61,7 +61,7 @@ class CameraPicker {
 
     companion object {
         fun createPhotoUri(context: Context): Uri {
-            val file = createTemporaryMediaFile(context, IMAGE)
+            val file = createTemporaryMediaFile(context, MediaType.IMAGE)
             val authority = context.packageName + ".multipicker.fileprovider"
             return FileProvider.getUriForFile(context, authority, file)
         }

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/CameraVideoPicker.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/CameraVideoPicker.kt
@@ -23,8 +23,8 @@ import android.provider.MediaStore
 import androidx.activity.result.ActivityResultLauncher
 import androidx.core.content.FileProvider
 import im.vector.lib.multipicker.entity.MultiPickerVideoType
-import im.vector.lib.multipicker.utils.MediaFileUtils.MediaType.VIDEO
-import im.vector.lib.multipicker.utils.MediaFileUtils.createTemporaryMediaFile
+import im.vector.lib.multipicker.utils.MediaType
+import im.vector.lib.multipicker.utils.createTemporaryMediaFile
 import im.vector.lib.multipicker.utils.toMultiPickerVideoType
 
 /**
@@ -61,7 +61,7 @@ class CameraVideoPicker {
 
     companion object {
         fun createVideoUri(context: Context): Uri {
-            val file = createTemporaryMediaFile(context, VIDEO)
+            val file = createTemporaryMediaFile(context, MediaType.VIDEO)
             val authority = context.packageName + ".multipicker.fileprovider"
             return FileProvider.getUriForFile(context, authority, file)
         }

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/CameraVideoPicker.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/CameraVideoPicker.kt
@@ -23,11 +23,9 @@ import android.provider.MediaStore
 import androidx.activity.result.ActivityResultLauncher
 import androidx.core.content.FileProvider
 import im.vector.lib.multipicker.entity.MultiPickerVideoType
+import im.vector.lib.multipicker.utils.MediaFileUtils.MediaType.VIDEO
+import im.vector.lib.multipicker.utils.MediaFileUtils.createTemporaryMediaFile
 import im.vector.lib.multipicker.utils.toMultiPickerVideoType
-import java.io.File
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 
 /**
  * Implementation of taking a video with Camera
@@ -38,7 +36,7 @@ class CameraVideoPicker {
      * Start camera by using a ActivityResultLauncher
      * @return Uri of taken photo or null if the operation is cancelled.
      */
-    fun startWithExpectingFile(context: Context, activityResultLauncher: ActivityResultLauncher<Intent>): Uri? {
+    fun startWithExpectingFile(context: Context, activityResultLauncher: ActivityResultLauncher<Intent>): Uri {
         val videoUri = createVideoUri(context)
         val intent = createIntent().apply {
             putExtra(MediaStore.EXTRA_OUTPUT, videoUri)
@@ -63,19 +61,9 @@ class CameraVideoPicker {
 
     companion object {
         fun createVideoUri(context: Context): Uri {
-            val file = createVideoFile(context)
+            val file = createTemporaryMediaFile(context, VIDEO)
             val authority = context.packageName + ".multipicker.fileprovider"
             return FileProvider.getUriForFile(context, authority, file)
-        }
-
-        private fun createVideoFile(context: Context): File {
-            val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
-            val storageDir: File = context.filesDir
-            return File.createTempFile(
-                    "${timeStamp}_", /* prefix */
-                    ".mp4", /* suffix */
-                    storageDir /* directory */
-            )
         }
     }
 }

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/MediaFileUtils.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/MediaFileUtils.kt
@@ -22,7 +22,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-fun createTemporaryMediaFile(context: Context, mediaType: MediaType): File {
+internal fun createTemporaryMediaFile(context: Context, mediaType: MediaType): File {
     val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
     val storageDir: File = context.filesDir.also { it.mkdirs() }
     val fileSuffix = when (mediaType) {

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/MediaFileUtils.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/MediaFileUtils.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.lib.multipicker.utils
+
+import android.content.Context
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object MediaFileUtils {
+
+    fun createTemporaryMediaFile(context: Context, mediaType: MediaType): File {
+        val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
+        val storageDir: File = context.filesDir.also { it.mkdirs() }
+        val fileSuffix = when (mediaType) {
+            MediaType.IMAGE -> ".jpg"
+            MediaType.VIDEO -> ".mp4"
+        }
+
+        return File.createTempFile(
+                "${timeStamp}_",
+                fileSuffix,
+                storageDir
+        )
+    }
+
+    enum class MediaType {
+        IMAGE, VIDEO
+    }
+}

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/MediaFileUtils.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/MediaFileUtils.kt
@@ -37,6 +37,6 @@ internal fun createTemporaryMediaFile(context: Context, mediaType: MediaType): F
     )
 }
 
-enum class MediaType {
+internal enum class MediaType {
     IMAGE, VIDEO
 }

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/MediaFileUtils.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/MediaFileUtils.kt
@@ -22,24 +22,21 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-object MediaFileUtils {
-
-    fun createTemporaryMediaFile(context: Context, mediaType: MediaType): File {
-        val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
-        val storageDir: File = context.filesDir.also { it.mkdirs() }
-        val fileSuffix = when (mediaType) {
-            MediaType.IMAGE -> ".jpg"
-            MediaType.VIDEO -> ".mp4"
-        }
-
-        return File.createTempFile(
-                "${timeStamp}_",
-                fileSuffix,
-                storageDir
-        )
+fun createTemporaryMediaFile(context: Context, mediaType: MediaType): File {
+    val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
+    val storageDir: File = context.filesDir.also { it.mkdirs() }
+    val fileSuffix = when (mediaType) {
+        MediaType.IMAGE -> ".jpg"
+        MediaType.VIDEO -> ".mp4"
     }
 
-    enum class MediaType {
-        IMAGE, VIDEO
-    }
+    return File.createTempFile(
+            "${timeStamp}_",
+            fileSuffix,
+            storageDir
+    )
+}
+
+enum class MediaType {
+    IMAGE, VIDEO
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/TemporaryFileCreator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/TemporaryFileCreator.kt
@@ -28,10 +28,8 @@ internal class TemporaryFileCreator @Inject constructor(
 ) {
     suspend fun create(): File {
         return withContext(Dispatchers.IO) {
-            runCatching {
-                File.createTempFile(UUID.randomUUID().toString(), null, context.cacheDir)
-                        .apply { mkdirs() }
-            }.getOrThrow()
+            File.createTempFile(UUID.randomUUID().toString(), null, context.cacheDir)
+                    .apply { mkdirs() }
         }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/TemporaryFileCreator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/TemporaryFileCreator.kt
@@ -28,7 +28,10 @@ internal class TemporaryFileCreator @Inject constructor(
 ) {
     suspend fun create(): File {
         return withContext(Dispatchers.IO) {
-            File.createTempFile(UUID.randomUUID().toString(), null, context.cacheDir)
+            runCatching {
+                File.createTempFile(UUID.randomUUID().toString(), null, context.cacheDir)
+                        .apply { mkdirs() }
+            }.getOrThrow()
         }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Edit: This PR's title and description have been updated as an entirely new solution has been implemented

The suspected cause of the error is that depending on the way the device's gallery caches images to be sent to the Element app, the content resolver may need to access IO operations (network, etc)

Currently, we're accessing the content resolver on the main thread

The way the content resolver works, any exception thrown during this operation would be rethrown as a `FileNotFoundException`, the exception we see in the rageshakes

On this PR, I forced the accessing of the io thread on the content resolver operations that send media from gallery. This does of course affect many other files with coroutine scope and suspend chains.

## Motivation and context

Potentially fixes https://github.com/vector-im/element-android/issues/3119

## Screenshots / GIFs

N/A

## Tests

Test with devices pre and post Android 11
- Go to the timeline and send different media types (image, video, audio). See that they send normally and the app doesn't crash

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): Android 10, 12 (emulator)

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
