### PR TITLE
Use truncate mode to replace the contents of existing files

### DIFF
--- a/changelog.d/5663.bugfix
+++ b/changelog.d/5663.bugfix
@@ -1,0 +1,1 @@
+Fixed key export when overwriting existing files

--- a/vector/src/main/java/im/vector/app/core/extensions/Context.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/Context.kt
@@ -18,6 +18,7 @@ package im.vector.app.core.extensions
 
 import android.content.Context
 import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.ImageSpan
@@ -31,6 +32,7 @@ import androidx.datastore.preferences.core.Preferences
 import dagger.hilt.EntryPoints
 import im.vector.app.core.datastore.dataStoreProvider
 import im.vector.app.core.di.SingletonEntryPoint
+import java.io.OutputStream
 import kotlin.math.roundToInt
 
 fun Context.singletonEntryPoint(): SingletonEntryPoint {
@@ -68,3 +70,10 @@ private fun Float.toAndroidAlpha(): Int {
 }
 
 val Context.dataStoreProvider: (String) -> DataStore<Preferences> by dataStoreProvider()
+
+/**
+ * Open Uri in truncate mode to make sure we don't partially overwrite content when we get passed a Uri to an existing file.
+ */
+fun Context.safeOpenOutputStream(uri: Uri): OutputStream? {
+    return contentResolver.openOutputStream(uri, "wt")
+}

--- a/vector/src/main/java/im/vector/app/features/crypto/keys/KeysExporter.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keys/KeysExporter.kt
@@ -34,7 +34,7 @@ class KeysExporter @Inject constructor(
     suspend fun export(password: String, uri: Uri) {
         withContext(dispatchers.io) {
             val data = session.cryptoService().exportRoomKeys(password)
-            context.contentResolver.openOutputStream(uri)
+            context.contentResolver.openOutputStream(uri, "wt")
                     ?.use { it.write(data) }
                     ?: throw IllegalStateException("Unable to open file for writing")
             verifyExportedKeysOutputFileSize(uri, expectedSize = data.size.toLong())

--- a/vector/src/main/java/im/vector/app/features/crypto/keys/KeysExporter.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keys/KeysExporter.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.crypto.keys
 import android.content.Context
 import android.net.Uri
 import im.vector.app.core.dispatchers.CoroutineDispatchers
+import im.vector.app.core.extensions.safeOpenOutputStream
 import kotlinx.coroutines.withContext
 import org.matrix.android.sdk.api.session.Session
 import javax.inject.Inject
@@ -34,7 +35,7 @@ class KeysExporter @Inject constructor(
     suspend fun export(password: String, uri: Uri) {
         withContext(dispatchers.io) {
             val data = session.cryptoService().exportRoomKeys(password)
-            context.contentResolver.openOutputStream(uri, "wt")
+            context.safeOpenOutputStream(uri)
                     ?.use { it.write(data) }
                     ?: throw IllegalStateException("Unable to open file for writing")
             verifyExportedKeysOutputFileSize(uri, expectedSize = data.size.toLong())

--- a/vector/src/main/java/im/vector/app/features/crypto/keysbackup/setup/KeysBackupSetupStep3Fragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysbackup/setup/KeysBackupSetupStep3Fragment.kt
@@ -30,6 +30,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import im.vector.app.R
 import im.vector.app.core.extensions.registerStartForActivityResult
+import im.vector.app.core.extensions.safeOpenOutputStream
 import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.core.utils.LiveEvent
 import im.vector.app.core.utils.copyToClipboard
@@ -165,7 +166,7 @@ class KeysBackupSetupStep3Fragment @Inject constructor() : VectorBaseFragment<Fr
         lifecycleScope.launch(Dispatchers.Main) {
             Try {
                 withContext(Dispatchers.IO) {
-                    requireContext().contentResolver.openOutputStream(uri, "wt")
+                    requireContext().safeOpenOutputStream(uri)
                             ?.use { os ->
                                 os.write(data.toByteArray())
                                 os.flush()

--- a/vector/src/main/java/im/vector/app/features/crypto/keysbackup/setup/KeysBackupSetupStep3Fragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysbackup/setup/KeysBackupSetupStep3Fragment.kt
@@ -165,7 +165,7 @@ class KeysBackupSetupStep3Fragment @Inject constructor() : VectorBaseFragment<Fr
         lifecycleScope.launch(Dispatchers.Main) {
             Try {
                 withContext(Dispatchers.IO) {
-                    requireContext().contentResolver.openOutputStream(uri)
+                    requireContext().contentResolver.openOutputStream(uri, "wt")
                             ?.use { os ->
                                 os.write(data.toByteArray())
                                 os.flush()

--- a/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapSaveRecoveryKeyFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapSaveRecoveryKeyFragment.kt
@@ -29,6 +29,7 @@ import com.airbnb.mvrx.parentFragmentViewModel
 import com.airbnb.mvrx.withState
 import im.vector.app.R
 import im.vector.app.core.extensions.registerStartForActivityResult
+import im.vector.app.core.extensions.safeOpenOutputStream
 import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.utils.startSharePlainTextIntent
@@ -81,7 +82,7 @@ class BootstrapSaveRecoveryKeyFragment @Inject constructor(
             val uri = activityResult.data?.data ?: return@registerStartForActivityResult
             lifecycleScope.launch(Dispatchers.IO) {
                 try {
-                    sharedViewModel.handle(BootstrapActions.SaveKeyToUri(requireContext().contentResolver!!.openOutputStream(uri, "wt")!!))
+                    sharedViewModel.handle(BootstrapActions.SaveKeyToUri(requireContext().safeOpenOutputStream(uri)!!))
                 } catch (failure: Throwable) {
                     sharedViewModel.handle(BootstrapActions.SaveReqFailed)
                 }

--- a/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapSaveRecoveryKeyFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapSaveRecoveryKeyFragment.kt
@@ -81,7 +81,7 @@ class BootstrapSaveRecoveryKeyFragment @Inject constructor(
             val uri = activityResult.data?.data ?: return@registerStartForActivityResult
             lifecycleScope.launch(Dispatchers.IO) {
                 try {
-                    sharedViewModel.handle(BootstrapActions.SaveKeyToUri(requireContext().contentResolver!!.openOutputStream(uri)!!))
+                    sharedViewModel.handle(BootstrapActions.SaveKeyToUri(requireContext().contentResolver!!.openOutputStream(uri, "wt")!!))
                 } catch (failure: Throwable) {
                     sharedViewModel.handle(BootstrapActions.SaveReqFailed)
                 }

--- a/vector/src/main/java/im/vector/app/features/settings/devtools/KeyRequestsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devtools/KeyRequestsFragment.kt
@@ -106,7 +106,7 @@ class KeyRequestsFragment @Inject constructor() : VectorBaseFragment<FragmentDev
             when (it) {
                 is KeyRequestEvents.SaveAudit -> {
                     tryOrNull {
-                        requireContext().contentResolver?.openOutputStream(it.uri)
+                        requireContext().contentResolver?.openOutputStream(it.uri, "wt")
                                 ?.use { os -> os.write(it.raw.toByteArray()) }
                     }
                 }

--- a/vector/src/main/java/im/vector/app/features/settings/devtools/KeyRequestsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devtools/KeyRequestsFragment.kt
@@ -34,6 +34,7 @@ import com.airbnb.mvrx.withState
 import com.google.android.material.tabs.TabLayoutMediator
 import im.vector.app.R
 import im.vector.app.core.extensions.registerStartForActivityResult
+import im.vector.app.core.extensions.safeOpenOutputStream
 import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.core.utils.selectTxtFileToWrite
 import im.vector.app.databinding.FragmentDevtoolKeyrequestsBinding
@@ -106,7 +107,7 @@ class KeyRequestsFragment @Inject constructor() : VectorBaseFragment<FragmentDev
             when (it) {
                 is KeyRequestEvents.SaveAudit -> {
                     tryOrNull {
-                        requireContext().contentResolver?.openOutputStream(it.uri, "wt")
+                        requireContext().safeOpenOutputStream(it.uri)
                                 ?.use { os -> os.write(it.raw.toByteArray()) }
                     }
                 }

--- a/vector/src/test/java/im/vector/app/features/crypto/keys/KeysExporterTest.kt
+++ b/vector/src/test/java/im/vector/app/features/crypto/keys/KeysExporterTest.kt
@@ -53,7 +53,7 @@ class KeysExporterTest {
     @Test
     fun `when exporting then writes exported keys to context output stream`() {
         givenFileDescriptorWithSize(size = A_ROOM_KEYS_EXPORT.size.toLong())
-        val outputStream = context.givenOutputStreamFor(A_URI)
+        val outputStream = context.givenOutputStreamFor(A_URI, mode = "wt")
 
         runTest { keysExporter.export(A_PASSWORD, A_URI) }
 
@@ -63,7 +63,7 @@ class KeysExporterTest {
     @Test
     fun `given different file size returned for export when exporting then throws UnexpectedExportKeysFileSizeException`() {
         givenFileDescriptorWithSize(size = 110)
-        context.givenOutputStreamFor(A_URI)
+        context.givenOutputStreamFor(A_URI, mode = "wt")
 
         assertFailsWith<UnexpectedExportKeysFileSizeException> {
             runTest { keysExporter.export(A_PASSWORD, A_URI) }
@@ -72,7 +72,7 @@ class KeysExporterTest {
 
     @Test
     fun `given output stream is unavailable for exporting to when exporting then throws IllegalStateException`() {
-        context.givenMissingOutputStreamFor(A_URI)
+        context.givenMissingOutputStreamFor(A_URI, mode = "wt")
 
         assertFailsWith<IllegalStateException>(message = "Unable to open file for writing") {
             runTest { keysExporter.export(A_PASSWORD, A_URI) }
@@ -82,7 +82,7 @@ class KeysExporterTest {
     @Test
     fun `given exported file is missing after export when exporting then throws IllegalStateException`() {
         context.givenFileDescriptor(A_URI, mode = "r") { null }
-        context.givenOutputStreamFor(A_URI)
+        context.givenOutputStreamFor(A_URI, mode = "wt")
 
         assertFailsWith<IllegalStateException>(message = "Exported file not found") {
             runTest { keysExporter.export(A_PASSWORD, A_URI) }

--- a/vector/src/test/java/im/vector/app/features/crypto/keys/KeysExporterTest.kt
+++ b/vector/src/test/java/im/vector/app/features/crypto/keys/KeysExporterTest.kt
@@ -53,7 +53,7 @@ class KeysExporterTest {
     @Test
     fun `when exporting then writes exported keys to context output stream`() {
         givenFileDescriptorWithSize(size = A_ROOM_KEYS_EXPORT.size.toLong())
-        val outputStream = context.givenOutputStreamFor(A_URI, mode = "wt")
+        val outputStream = context.givenSafeOutputStreamFor(A_URI)
 
         runTest { keysExporter.export(A_PASSWORD, A_URI) }
 
@@ -63,7 +63,7 @@ class KeysExporterTest {
     @Test
     fun `given different file size returned for export when exporting then throws UnexpectedExportKeysFileSizeException`() {
         givenFileDescriptorWithSize(size = 110)
-        context.givenOutputStreamFor(A_URI, mode = "wt")
+        context.givenSafeOutputStreamFor(A_URI)
 
         assertFailsWith<UnexpectedExportKeysFileSizeException> {
             runTest { keysExporter.export(A_PASSWORD, A_URI) }
@@ -72,7 +72,7 @@ class KeysExporterTest {
 
     @Test
     fun `given output stream is unavailable for exporting to when exporting then throws IllegalStateException`() {
-        context.givenMissingOutputStreamFor(A_URI, mode = "wt")
+        context.givenMissingSafeOutputStreamFor(A_URI)
 
         assertFailsWith<IllegalStateException>(message = "Unable to open file for writing") {
             runTest { keysExporter.export(A_PASSWORD, A_URI) }
@@ -82,7 +82,7 @@ class KeysExporterTest {
     @Test
     fun `given exported file is missing after export when exporting then throws IllegalStateException`() {
         context.givenFileDescriptor(A_URI, mode = "r") { null }
-        context.givenOutputStreamFor(A_URI, mode = "wt")
+        context.givenSafeOutputStreamFor(A_URI)
 
         assertFailsWith<IllegalStateException>(message = "Exported file not found") {
             runTest { keysExporter.export(A_PASSWORD, A_URI) }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeContext.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeContext.kt
@@ -39,13 +39,13 @@ class FakeContext(
         every { contentResolver.openFileDescriptor(uri, mode, null) } returns fileDescriptor
     }
 
-    fun givenOutputStreamFor(uri: Uri, mode: String): OutputStream {
+    fun givenSafeOutputStreamFor(uri: Uri): OutputStream {
         val outputStream = mockk<OutputStream>(relaxed = true)
-        every { contentResolver.openOutputStream(uri, mode) } returns outputStream
+        every { contentResolver.openOutputStream(uri, "wt") } returns outputStream
         return outputStream
     }
 
-    fun givenMissingOutputStreamFor(uri: Uri, mode: String) {
-        every { contentResolver.openOutputStream(uri, mode) } returns null
+    fun givenMissingSafeOutputStreamFor(uri: Uri) {
+        every { contentResolver.openOutputStream(uri, "wt") } returns null
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeContext.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeContext.kt
@@ -39,13 +39,13 @@ class FakeContext(
         every { contentResolver.openFileDescriptor(uri, mode, null) } returns fileDescriptor
     }
 
-    fun givenOutputStreamFor(uri: Uri): OutputStream {
+    fun givenOutputStreamFor(uri: Uri, mode: String): OutputStream {
         val outputStream = mockk<OutputStream>(relaxed = true)
-        every { contentResolver.openOutputStream(uri) } returns outputStream
+        every { contentResolver.openOutputStream(uri, mode) } returns outputStream
         return outputStream
     }
 
-    fun givenMissingOutputStreamFor(uri: Uri) {
-        every { contentResolver.openOutputStream(uri) } returns null
+    fun givenMissingOutputStreamFor(uri: Uri, mode: String) {
+        every { contentResolver.openOutputStream(uri, mode) } returns null
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Instances where `ContentResolver.openOutputStream(Uri)` is used to potentially open existing files for writing have been fixed.

## Motivation and context

`ContentResolver.openOutputStream(Uri)` does not truncate existing files. If the amount of data written is smaller than the file size, you end up with new data at the beginning of the file followed by old data at the end of the file.

Some places where `ContentResolver.openOutputStream(Uri)` is used have not been changed because they only deal with newly created files and are thus not a problem.

## Tests

1. Create a large text file with arbitrary content on your Android device (1 MB should do)
2. Go to *Settings → Security & Privacy*
3. Select *Export E2E room keys*
4. In the system file picker, select the file created in step 1, confirm that you want to overwrite the file
5. Complete the export flow (enter passwords, etc)
6. Notice that the file size hasn't changed. Only the beginning of the file has been overwritten with the exported data.

The other export functionality can be tested in a similar way.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 12

## Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

```
Signed-off-by: cketti <ck@cketti.de>
```