### PR TITLE
Add loader to thread list

### DIFF
--- a/changelog.d/5562.bugfix
+++ b/changelog.d/5562.bugfix
@@ -1,0 +1,1 @@
+Add loader in thread list

--- a/vector/src/main/java/im/vector/app/features/home/room/threads/list/viewmodel/ThreadListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/threads/list/viewmodel/ThreadListViewModel.kt
@@ -113,7 +113,15 @@ class ThreadListViewModel @AssistedInject constructor(@Assisted val initialState
 
     private fun fetchThreadList() {
         viewModelScope.launch {
+            isLoading(true)
             room?.fetchThreadSummaries()
+            isLoading(false)
+        }
+    }
+
+    private fun isLoading(show: Boolean) {
+        setState {
+            copy(isLoading = show)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/threads/list/viewmodel/ThreadListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/threads/list/viewmodel/ThreadListViewModel.kt
@@ -113,15 +113,15 @@ class ThreadListViewModel @AssistedInject constructor(@Assisted val initialState
 
     private fun fetchThreadList() {
         viewModelScope.launch {
-            isLoading(true)
+            setLoading(true)
             room?.fetchThreadSummaries()
-            isLoading(false)
+            setLoading(false)
         }
     }
 
-    private fun isLoading(show: Boolean) {
+    private fun setLoading(isLoading: Boolean) {
         setState {
-            copy(isLoading = show)
+            copy(isLoading = isLoading)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/threads/list/viewmodel/ThreadListViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/threads/list/viewmodel/ThreadListViewState.kt
@@ -27,6 +27,7 @@ data class ThreadListViewState(
         val threadSummaryList: Async<List<ThreadSummary>> = Uninitialized,
         val rootThreadEventList: Async<List<ThreadTimelineEvent>> = Uninitialized,
         val shouldFilterThreads: Boolean = false,
+        val isLoading: Boolean = false,
         val roomId: String
 ) : MavericksState {
     constructor(args: ThreadListArgs) : this(roomId = args.roomId)

--- a/vector/src/main/java/im/vector/app/features/home/room/threads/list/views/ThreadListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/threads/list/views/ThreadListFragment.kt
@@ -104,6 +104,11 @@ class ThreadListFragment @Inject constructor(
     override fun invalidate() = withState(threadListViewModel) { state ->
         renderEmptyStateIfNeeded(state)
         threadListController.update(state)
+        renderLoaderIfNeeded(state)
+    }
+
+    private fun renderLoaderIfNeeded(state: ThreadListViewState) {
+        views.threadListProgressBar.isVisible = state.isLoading
     }
 
     private fun renderToolbar() {

--- a/vector/src/main/res/layout/fragment_thread_list.xml
+++ b/vector/src/main/res/layout/fragment_thread_list.xml
@@ -46,6 +46,7 @@
             android:layout_gravity="center_vertical"
             android:indeterminate="true"
             android:visibility="gone"
+            tools:ignore="NegativeMargin"
             android:layout_marginTop="-6dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/vector/src/main/res/layout/fragment_thread_list.xml
+++ b/vector/src/main/res/layout/fragment_thread_list.xml
@@ -37,6 +37,21 @@
         tools:listitem="@layout/item_thread"
         tools:visibility="gone" />
 
+
+        <ProgressBar
+            android:id="@+id/threadListProgressBar"
+            style="@style/Widget.Vector.ProgressBar.Horizontal"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:indeterminate="true"
+            android:visibility="gone"
+            android:layout_marginTop="-6dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/threadListAppBarLayout"
+            tools:visibility="visible" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/threadListEmptyConstraintLayout"
         android:layout_width="0dp"
@@ -54,7 +69,6 @@
             android:id="@+id/threadListEmptyImageView"
             android:layout_width="64dp"
             android:layout_height="64dp"
-            android:layout_marginStart="8dp"
             android:layout_marginTop="4dp"
             android:layout_marginBottom="24dp"
             android:background="@drawable/bg_rounded_button"
@@ -75,13 +89,13 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginBottom="20dp"
+            android:gravity="center"
+            android:text="@string/thread_list_empty_title"
             android:textColor="?vctr_content_primary"
             app:layout_constraintBottom_toTopOf="@id/threadListEmptySubtitleTextView"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            android:gravity="center"
-            app:layout_constraintTop_toBottomOf="@id/threadListEmptyImageView"
-            android:text="@string/thread_list_empty_title" />
+            app:layout_constraintTop_toBottomOf="@id/threadListEmptyImageView" />
 
         <TextView
             android:id="@+id/threadListEmptySubtitleTextView"
@@ -90,12 +104,12 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="20dp"
             android:gravity="center"
+            android:text="@string/thread_list_empty_subtitle"
             android:textColor="?vctr_content_secondary"
             app:layout_constraintBottom_toTopOf="@id/threadListEmptyNoticeTextView"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/threadListEmptyTitleTextView"
-            android:text="@string/thread_list_empty_subtitle" />
+            app:layout_constraintTop_toBottomOf="@id/threadListEmptyTitleTextView" />
 
         <TextView
             android:id="@+id/threadListEmptyNoticeTextView"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Add loader when user open/load the thread list

## Motivation and context

Especially on large rooms and on initial launch of the thread list, we should show an indicator to the user about the progress

## Screenshots / GIFs
|Before|After|
|---|---|
|![Screenshot_20220330-121034_Element dbg](https://user-images.githubusercontent.com/60798129/160796916-cbd6abbe-de7a-41d8-a4c1-5964ef8a0fc6.jpg)|![Screenshot_20220330-121026_Element dbg](https://user-images.githubusercontent.com/60798129/160796904-0e219d74-217b-4937-8d0b-ebefb091e1b9.jpg)|
<!-- Only if UI have been changed -->

Closes #5562