### PR TITLE
Build Speed - using static git information for debug build config

### DIFF
--- a/changelog.d/5668.misc
+++ b/changelog.d/5668.misc
@@ -1,1 +1,1 @@
-Improving build speed after committing or changes branches by removing git sha information from debug builds
+Improving build speed after committing or changing branches by removing git sha information from debug builds

--- a/changelog.d/5668.misc
+++ b/changelog.d/5668.misc
@@ -1,0 +1,1 @@
+Improving build speed after committing or changes branches by removing git sha information from debug builds

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -33,10 +33,6 @@ android {
 
         buildConfigField "String", "SDK_VERSION", "\"1.4.10\""
 
-        buildConfigField "String", "GIT_SDK_REVISION", "\"${gitRevision()}\""
-        buildConfigField "String", "GIT_SDK_REVISION_UNIX_DATE", "\"${gitRevisionUnixDate()}\""
-        buildConfigField "String", "GIT_SDK_REVISION_DATE", "\"${gitRevisionDate()}\""
-
         defaultConfig {
             consumerProguardFiles 'proguard-rules.pro'
         }
@@ -53,11 +49,19 @@ android {
             buildConfigField "boolean", "LOG_PRIVATE_DATA", project.property("vector.debugPrivateData")
             // Set to BODY instead of NONE to enable logging
             buildConfigField "okhttp3.logging.HttpLoggingInterceptor.Level", "OKHTTP_LOGGING_LEVEL", "okhttp3.logging.HttpLoggingInterceptor.Level." + project.property("vector.httpLogLevel")
+
+            buildConfigField "String", "GIT_SDK_REVISION", "\"dev\""
+            buildConfigField "String", "GIT_SDK_REVISION_UNIX_DATE", "\"dev\""
+            buildConfigField "String", "GIT_SDK_REVISION_DATE", "\"dev\""
         }
 
         release {
             buildConfigField "boolean", "LOG_PRIVATE_DATA", "false"
             buildConfigField "okhttp3.logging.HttpLoggingInterceptor.Level", "OKHTTP_LOGGING_LEVEL", "okhttp3.logging.HttpLoggingInterceptor.Level.BASIC"
+
+            buildConfigField "String", "GIT_SDK_REVISION", "\"${gitRevision()}\""
+            buildConfigField "String", "GIT_SDK_REVISION_UNIX_DATE", "\"${gitRevisionUnixDate()}\""
+            buildConfigField "String", "GIT_SDK_REVISION_DATE", "\"${gitRevisionDate()}\""
         }
     }
 

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -131,14 +131,6 @@ android {
         // Required for sonar analysis
         versionName "${versionMajor}.${versionMinor}.${versionPatch}-sonar"
 
-        // Generate a random app task affinity
-        manifestPlaceholders = [appTaskAffinitySuffix:"H_${gitRevision()}"]
-
-        buildConfigField "String", "GIT_REVISION", "\"${gitRevision()}\""
-        buildConfigField "String", "GIT_REVISION_DATE", "\"${gitRevisionDate()}\""
-        buildConfigField "String", "GIT_BRANCH_NAME", "\"${gitBranchName()}\""
-        buildConfigField "String", "BUILD_NUMBER", "\"${buildNumber}\""
-
         buildConfigField "im.vector.app.features.VectorFeatures.OnboardingVariant", "ONBOARDING_VARIANT", "im.vector.app.features.VectorFeatures.OnboardingVariant.FTUE_AUTH"
 
         buildConfigField "im.vector.app.features.crypto.keysrequest.OutboundSessionKeySharingStrategy", "outboundSessionKeySharingStrategy", "im.vector.app.features.crypto.keysrequest.OutboundSessionKeySharingStrategy.WhenTyping"
@@ -232,6 +224,13 @@ android {
             buildConfigField "boolean", "ENABLE_STRICT_MODE_LOGS", "false"
             buildConfigField "Boolean", "ENABLE_LIVE_LOCATION_SHARING", "true"
 
+            // using static values to avoid cache misses on new commits
+            manifestPlaceholders = [appTaskAffinitySuffix: "H_aaaaaa"]
+            buildConfigField "String", "GIT_REVISION", "\"dev\""
+            buildConfigField "String", "GIT_REVISION_DATE", "\"dev\""
+            buildConfigField "String", "GIT_BRANCH_NAME", "\"dev\""
+            buildConfigField "String", "BUILD_NUMBER", "\"dev\""
+
             signingConfig signingConfigs.debug
         }
 
@@ -241,6 +240,13 @@ android {
             buildConfigField "boolean", "LOW_PRIVACY_LOG_ENABLE", "false"
             buildConfigField "boolean", "ENABLE_STRICT_MODE_LOGS", "false"
             buildConfigField "Boolean", "ENABLE_LIVE_LOCATION_SHARING", "false"
+
+            manifestPlaceholders = [appTaskAffinitySuffix:"H_${gitRevision()}"]
+
+            buildConfigField "String", "GIT_REVISION", "\"${gitRevision()}\""
+            buildConfigField "String", "GIT_REVISION_DATE", "\"${gitRevisionDate()}\""
+            buildConfigField "String", "GIT_BRANCH_NAME", "\"${gitBranchName()}\""
+            buildConfigField "String", "BUILD_NUMBER", "\"${buildNumber}\""
 
             postprocessing {
                 removeUnusedCode true


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Only applies the git meta information to release builds, by dynamically including it in all build types we end up invalidating our local caches causing cascading compilation across the modules   

## Motivation and context

To speed up the build when no code changes have been made

## Screenshots / GIFs

Notice the `dev` mentions instead of the current git sha for the debug build

| ONBOARDING | ABOUT |
| --- | --- | 
![Screenshot_20220330_133854](https://user-images.githubusercontent.com/1848238/160836199-cc5a222c-6ca0-49de-80bd-9db8b70874c7.png)|![Screenshot_20220330_133841](https://user-images.githubusercontent.com/1848238/160836204-8f76d64b-0e3f-414e-a218-6f0d6c356e22.png)

## Tests

#### Setup

```
./gradlew assembleGplayDebug  # 3m 30s~
./gradlew assembleGplayDebug  # 1s

git commit -m "empty commit" --allow-empty # or checkout a new branch
 ```

The next build after changing git sha...

#### Before
 
```
./gradlew assembleGplayDebug  # 3m~
```

#### After 

```
./gradlew assembleGplayDebug  # 18s~
```

Hopefully in the future we'll be able to automate this benchmark https://github.com/gradle/gradle-profiler/issues/335 

**note build times are dependent on system specs
 
## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 31 Sv2

