### PR TITLE
Move to using hookshot to send notifications, rather than using matrix client directly.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -330,10 +330,9 @@ jobs:
     if: always() && github.event_name != 'workflow_dispatch'
     # No concurrency required, runs every time on a schedule.
     steps:
-      - uses: michaelkaye/matrix-hookshot-action@v0.3.0
+      - uses: michaelkaye/matrix-hookshot-action@v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          matrix_access_token: ${{ secrets.ELEMENT_ANDROID_NOTIFICATION_ACCESS_TOKEN }}
-          matrix_room_id: ${{ secrets.ELEMENT_ANDROID_INTERNAL_ROOM_ID }}
+          hookshot_url: ${{ secrets.ELEMENT_ANDROID_HOOKSHOT_URL }}
           text_template: "{{#if '${{ github.event_name }}' == 'schedule' }}Nightly test run{{else}}Test run (on ${{ github.ref }}){{/if }}: {{#each job_statuses }}{{#with this }}{{#if completed }}  {{name}} {{conclusion}} at {{completed_at}}, {{/if}}{{/with}}{{/each}}"
           html_template: "{{#if '${{ github.event_name }}' == 'schedule' }}Nightly test run{{else}}Test run (on ${{ github.ref }}){{/if }}: {{#each job_statuses }}{{#with this }}{{#if completed }}<br />{{icon conclusion}} {{name}} <font color='{{color conclusion}}'>{{conclusion}} at {{completed_at}} <a href=\"{{html_url}}\">[details]</a></font>{{/if}}{{/with}}{{/each}}"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [X] Other notifications

## Content

<!-- Describe shortly what has been changed -->

With v1.0.0 of matrix-hookshot-action we can use hookshoot to send notifications via generic webhook, rather than embedding an access token with read/write access to the room. Otherwise there's no changes in the new hookshot-action version.

## Motivation and context

Neatness; avoiding risk of access token to the room leaking.
