### PR TITLE
add text to spinner when click on space member (dm)

### DIFF
--- a/changelog.d/4305.bugfix
+++ b/changelog.d/4305.bugfix
@@ -1,0 +1,1 @@
+Added text next to spinner when loading information after user is clicked on space members screen

--- a/vector/src/main/java/im/vector/app/features/spaces/people/SpacePeopleActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/people/SpacePeopleActivity.kt
@@ -24,6 +24,7 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.airbnb.mvrx.Mavericks
 import dagger.hilt.android.AndroidEntryPoint
+import im.vector.app.R
 import im.vector.app.core.extensions.hideKeyboard
 import im.vector.app.core.extensions.replaceFragment
 import im.vector.app.core.platform.GenericIdArgs
@@ -79,7 +80,7 @@ class SpacePeopleActivity : VectorBaseActivity<ActivitySimpleLoadingBinding>() {
                         is SpacePeopleSharedAction.NavigateToRoom   -> navigateToRooms(sharedAction)
                         SpacePeopleSharedAction.HideModalLoading    -> hideWaitingView()
                         SpacePeopleSharedAction.ShowModalLoading    -> {
-                            showWaitingView()
+                            showWaitingView(getString(R.string.please_wait))
                         }
                         is SpacePeopleSharedAction.NavigateToInvite -> {
                             ShareSpaceBottomSheet.show(supportFragmentManager, sharedAction.spaceId)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [] Other :

## Content

add text to spinner when selecting person to start dm via space people list 

## Motivation and context

closes #4305

## Screenshots / GIFs

![Screenshot 2022-04-04 at 9 49 09](https://user-images.githubusercontent.com/66663241/161500572-43e6ab6f-f2b5-4039-9360-075d47bd14ca.png)


## Tests

- select space
- select "people" tab
- press fab
- select a person (there shouldn't be already created dm with this person)


## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
