### PR TITLE
Improved thread rendering in the main timeline

### DIFF
--- a/changelog.d/5151.misc
+++ b/changelog.d/5151.misc
@@ -1,0 +1,1 @@
+Improve main timeline thread summary rendering

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/style/TimelineMessageLayoutFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/style/TimelineMessageLayoutFactory.kt
@@ -31,6 +31,7 @@ import org.matrix.android.sdk.api.session.room.model.message.MessageVerification
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
 import org.matrix.android.sdk.api.session.room.timeline.getLastMessageContent
 import org.matrix.android.sdk.api.session.room.timeline.isEdition
+import org.matrix.android.sdk.api.session.room.timeline.isRootThread
 import javax.inject.Inject
 
 class TimelineMessageLayoutFactory @Inject constructor(private val session: Session,
@@ -91,6 +92,7 @@ class TimelineMessageLayoutFactory @Inject constructor(private val session: Sess
                 nextDisplayableEvent.root.getClearType() !in listOf(EventType.MESSAGE, EventType.STICKER, EventType.ENCRYPTED) ||
                 isNextMessageReceivedMoreThanOneHourAgo ||
                 isTileTypeMessage(nextDisplayableEvent) ||
+                event.isRootThread() ||
                 nextDisplayableEvent.isEdition()
 
         val messageLayout = when (layoutSettingsProvider.getLayoutSettings()) {


### PR DESCRIPTION
Currently, when there are multiple consecutive messages by the same author we group them as a single block in the main timeline.

If any of those messages, except for the last one, gets converted to a thread then there's no clear relationship between thread summaries and root messages anymore. This affects all layout modes, but can be especially problematic when Message Bubbles are enabled.

Below you can see the expected result, each root message should have the icon displayed

|Before | After |
|---|---|
|![Screenshot_20220404-115145_Element dbg](https://user-images.githubusercontent.com/60798129/161513395-bf1438f0-b08c-440d-be34-de41d7c9867a.jpg)|![Screenshot_20220404-120227_Element dbg](https://user-images.githubusercontent.com/60798129/161513436-f68b163e-28b9-4cd9-8e2f-d9eb04bec57b.jpg)|

Closes #5151
