### PR TITLE
[MergedRoomCreationItem] DM: RoomDescriptionText use the roomName instead of memberName

### DIFF
--- a/changelog.d/5570.bugfix
+++ b/changelog.d/5570.bugfix
@@ -1,0 +1,1 @@
+[MergedRoomCreationItem] DM: RoomDescriptionText use the roomName instead of memberName

--- a/changelog.d/5570.bugfix
+++ b/changelog.d/5570.bugfix
@@ -1,1 +1,1 @@
-[MergedRoomCreationItem] DM: RoomDescriptionText use the roomName instead of memberName
+Use member name instead of room name in DM creation item

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MergedRoomCreationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MergedRoomCreationItem.kt
@@ -133,7 +133,10 @@ abstract class MergedRoomCreationItem : BasedMergedItem<MergedRoomCreationItem.H
         val membersCount = roomSummary?.otherMemberIds?.size ?: 0
 
         if (isDirect) {
-            holder.roomDescriptionText.text = holder.view.resources.getString(R.string.this_is_the_beginning_of_dm, roomSummary?.displayName ?: "")
+            holder.roomDescriptionText.text = holder.view.resources.getString(
+                    R.string.this_is_the_beginning_of_dm,
+                    distinctMergeData.lastOrNull()?.memberName ?: ""
+            )
         } else if (roomDisplayName.isNullOrBlank() || roomSummary.name.isBlank()) {
             holder.roomDescriptionText.text = holder.view.resources.getString(R.string.this_is_the_beginning_of_room_no_name)
         } else {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context
#5570 
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
![Screenshot_1649246922](https://user-images.githubusercontent.com/15031750/161971364-e16f451e-703c-47cb-b136-7a69858d250b.png)

<!-- Only if UI have been changed -->

## Tests
- Create a DM 
-  Update the room name
- Check the Room creation item

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [X] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
