### PR TITLE
Small doc udpate

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -18,6 +18,7 @@ body:
 
         - [ ] Weblate sync, fix lint issue if any (in a dedicated PR)
         - [ ] Check the update of the store descriptions (using Google Translate if necessary) to ensure that the changes are acceptable to be published to the stores.
+        - [ ] While Weblate is locked, and after the PR from Weblate has been merged, handle all the TODOs in the main `strings.xml` file
         - [ ] Run the script `./tools/release/pushPlayStoreMetaData.sh`. You can check in the GooglePlay console the Activity log to check the effect.
 
         ### Do the release

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,17 @@
 
 ## Screenshots / GIFs
 
-<!-- Only if UI have been changed -->
+<!-- Only if UI have been changed
+You can use a table like this to show screenshots comparison.
+Uncomment this markdown table below and edit the last line `|||`:
+|copy screenshot of before here|copy screenshot of after here|
+-->
+
+<!--
+|Before|After|
+|-|-|
+|||
+ -->
 
 ## Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,8 @@ Instead, please comment the original string with:
 ```xml
 <!-- TODO TO BE REMOVED -->
 ```
+And add `tools:ignore="UnusedResources"` to the string, to let lint ignore that the string is not used.
+
 The string will be removed during the next sync with Weblate.
 
 ### Accessibility


### PR DESCRIPTION
Small changes in the doc:
- Add a reminder for the strings cleanup
- Add a handy markdown table in the PR template
- Add a step when scheduling a String to be removed