### PR TITLE
Prune the content of deleted events completely

### DIFF
--- a/changelog.d/5707.bugfix
+++ b/changelog.d/5707.bugfix
@@ -1,0 +1,1 @@
+Redacted events are no longer visible.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/prune/RedactionEventProcessor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/prune/RedactionEventProcessor.kt
@@ -86,9 +86,9 @@ internal class RedactionEventProcessor @Inject constructor() : EventInsertLivePr
 //                    }
 
                     val modified = unsignedData.copy(redactedEvent = redactionEvent)
-                    // I Commented the line below, it should not be empty while we lose all the previous info about
-                    // the redacted event
-//                    eventToPrune.content = ContentMapper.map(emptyMap())
+                    // Deleting the content of a thread message will result to delete the thread relation, however threads are now dynamic
+                    // so there is not much of a problem
+                    eventToPrune.content = ContentMapper.map(emptyMap())
                     eventToPrune.unsignedData = MoshiProvider.providesMoshi().adapter(UnsignedData::class.java).toJson(modified)
                     eventToPrune.decryptionResultJson = null
                     eventToPrune.decryptionErrorCode = null


### PR DESCRIPTION
We can prune completely redacted events again.

The reason why we kept the content of redacted events was due to the fact that relations are within the content. So after an event redaction we couldn't know if the event was a thread or a normal event.

Hopefully threads are now dynamic, so the problem is minimised. To further optimise this behaviour backend actions are needed to exclude relations from within the content.

Related [MSC](https://github.com/matrix-org/matrix-spec-proposals/pull/3389)

Closes #5682