### PR TITLE
The string `ftue_auth_carousel_workplace_body` was declared not translatable

### DIFF
--- a/changelog.d/5262.bugfix
+++ b/changelog.d/5262.bugfix
@@ -1,0 +1,1 @@
+The string `ftue_auth_carousel_workplace_body` was declared not translatable by mistake

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1862,7 +1862,7 @@
     <string name="ftue_auth_carousel_control_body">Choose where your conversations are kept, giving you control and independence. Connected via Matrix.</string>
     <string name="ftue_auth_carousel_encrypted_body">End-to-end encrypted and no phone number required. No ads or datamining.</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
-    <string name="ftue_auth_carousel_workplace_body" translatable="false">${app_name} is also great for the workplace. It’s trusted by the world’s most secure organisations.</string>
+    <string name="ftue_auth_carousel_workplace_body">${app_name} is also great for the workplace. It’s trusted by the world’s most secure organisations.</string>
 
     <string name="ftue_auth_use_case_title">Who will you chat to the most?</string>
     <string name="ftue_auth_use_case_subtitle">We\'ll help you get connected.</string>


### PR DESCRIPTION
Fixes #5262 

I do not know why the tag had this attribute, probably some historical reason.