### PR TITLE
fix: increase font size for messages

### DIFF
--- a/changelog.d/5717.misc
+++ b/changelog.d/5717.misc
@@ -1,0 +1,1 @@
+fix: increase font size for messages

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -85,7 +85,7 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
         if (useBigFont) {
             holder.messageView.textSize = 44F
         } else {
-            holder.messageView.textSize = 14F
+            holder.messageView.textSize = 15.5F
         }
         if (searchForPills) {
             message?.charSequence?.findPillsAndProcess(coroutineScope) {


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [X] Other : Style tweaks

## Content

Increased font size for messages

## Motivation and context

On phones with a rather large screen, the given font sizing is
small even for the default theme. Increasing the size helps with
readability and reduces strain on the eyes.

Should fix #5160.
## Tested devices

- [X] Physical
- [X] Emulator

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [X] UI change has been tested on both light and dark themes
- [X] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [X] Pull request includes screenshots or videos if containing UI changes
- [X] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [X] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
