### PR TITLE
Don't wrongly show non-space invites in the space panel

### DIFF
--- a/changelog.d/5731.bugfix
+++ b/changelog.d/5731.bugfix
@@ -1,0 +1,1 @@
+Don't wrongly show non-space invites in the space panel.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 11 10:26:55 BST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionSha256Sum=e6d864e3b5bc05cc62041842b306383fc1fefcec359e70cebb1d470a6094ca82
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
+#Mon Apr 11 10:26:55 BST 2022
 distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-distributionSha256Sum=e6d864e3b5bc05cc62041842b306383fc1fefcec359e70cebb1d470a6094ca82
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
-zipStoreBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceListViewModel.kt
@@ -54,6 +54,7 @@ import org.matrix.android.sdk.api.session.group.groupSummaryQueryParams
 import org.matrix.android.sdk.api.session.room.RoomSortOrder
 import org.matrix.android.sdk.api.session.room.accountdata.RoomAccountDataTypes
 import org.matrix.android.sdk.api.session.room.model.Membership
+import org.matrix.android.sdk.api.session.room.model.RoomType
 import org.matrix.android.sdk.api.session.room.roomSummaryQueryParams
 import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
 import org.matrix.android.sdk.api.session.space.SpaceOrderUtils
@@ -275,8 +276,7 @@ class SpaceListViewModel @AssistedInject constructor(@Assisted initialState: Spa
         val spaceSummaryQueryParams = roomSummaryQueryParams {
             memberships = listOf(Membership.JOIN, Membership.INVITE)
             displayName = QueryStringValue.IsNotEmpty
-            excludeType = listOf(/**RoomType.MESSAGING,$*/
-                    null)
+            includeType = listOf(RoomType.SPACE)
         }
 
         val flowSession = session.flow()

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceListViewModel.kt
@@ -54,8 +54,8 @@ import org.matrix.android.sdk.api.session.group.groupSummaryQueryParams
 import org.matrix.android.sdk.api.session.room.RoomSortOrder
 import org.matrix.android.sdk.api.session.room.accountdata.RoomAccountDataTypes
 import org.matrix.android.sdk.api.session.room.model.Membership
-import org.matrix.android.sdk.api.session.room.model.RoomType
 import org.matrix.android.sdk.api.session.room.roomSummaryQueryParams
+import org.matrix.android.sdk.api.session.room.spaceSummaryQueryParams
 import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
 import org.matrix.android.sdk.api.session.space.SpaceOrderUtils
 import org.matrix.android.sdk.api.session.space.model.SpaceOrderContent
@@ -273,10 +273,9 @@ class SpaceListViewModel @AssistedInject constructor(@Assisted initialState: Spa
     }
 
     private fun observeSpaceSummaries() {
-        val spaceSummaryQueryParams = roomSummaryQueryParams {
+        val params = spaceSummaryQueryParams {
             memberships = listOf(Membership.JOIN, Membership.INVITE)
             displayName = QueryStringValue.IsNotEmpty
-            includeType = listOf(RoomType.SPACE)
         }
 
         val flowSession = session.flow()
@@ -288,7 +287,7 @@ class SpaceListViewModel @AssistedInject constructor(@Assisted initialState: Spa
                             it.getOrNull()
                         },
                 flowSession
-                        .liveSpaceSummaries(spaceSummaryQueryParams),
+                        .liveSpaceSummaries(params),
                 session
                         .accountDataService()
                         .getLiveRoomAccountDataEvents(setOf(RoomAccountDataTypes.EVENT_TYPE_SPACE_ORDER))


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

Prevents invites to non-space non-null room types from showing up wrongly in the Space panel


## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/2403652/162721016-d4002bb2-01ed-4014-a576-0bbb6dd68b98.png)|![image](https://user-images.githubusercontent.com/2403652/162722406-46ab88a1-ad8a-4db7-ab9e-cb68a5553f86.png)|

## Tests

<!-- Explain how you tested your development -->

- Invited test account to video room
- Checked if invite was (wrongly) visible in the space panel

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): API 22

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] You've made a self review of your PR
