### PR TITLE
Updating posthog dev environment credentials

### DIFF
--- a/changelog.d/5732.misc
+++ b/changelog.d/5732.misc
@@ -1,0 +1,1 @@
+Updates the posthog dev environment url and api key

--- a/vector/src/debug/java/im/vector/app/config/AnalyticsConfig.kt
+++ b/vector/src/debug/java/im/vector/app/config/AnalyticsConfig.kt
@@ -21,7 +21,7 @@ import im.vector.app.features.analytics.AnalyticsConfig
 
 val analyticsConfig: AnalyticsConfig = object : AnalyticsConfig {
     override val isEnabled = BuildConfig.APPLICATION_ID == "im.vector.app.debug"
-    override val postHogHost = "https://posthog-poc.lab.element.dev"
-    override val postHogApiKey = "rs-pJjsYJTuAkXJfhaMmPUNBhWliDyTKLOOxike6ck8"
+    override val postHogHost = "https://posthog.element.dev"
+    override val postHogApiKey = "phc_VtA1L35nw3aeAtHIx1ayrGdzGkss7k1xINeXcoIQzXN"
     override val policyLink = "https://element.io/cookie-policy"
 }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Fixes #5732

Updates the posthog dev environment credentials as they were changed when the instance was migrated

## Screenshots / GIFs

![2022-04-11T11:57:28,943441524+01:00](https://user-images.githubusercontent.com/1848238/162726261-e8c7f245-e471-476b-b2dd-10bf8a1993a9.png)

## Tests

- Sign up/in
- Enable analytics 
- Monitor the events in https://posthog.element.dev/events

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 29
