### PR TITLE
Fixing onboarding confetti Z order

### DIFF
--- a/changelog.d/5735.bugfix
+++ b/changelog.d/5735.bugfix
@@ -1,0 +1,1 @@
+Fixes the onboarding confetti rendering behind the content instead of in-front

--- a/vector/src/main/res/layout/fragment_ftue_account_created.xml
+++ b/vector/src/main/res/layout/fragment_ftue_account_created.xml
@@ -6,12 +6,6 @@
     android:layout_height="match_parent"
     android:background="?colorSecondary">
 
-    <nl.dionsegijn.konfetti.xml.KonfettiView
-        android:id="@+id/viewKonfetti"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone" />
-
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/ftueAuthGutterStart"
         android:layout_width="wrap_content"
@@ -167,5 +161,11 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHeight_percent="0.05"
         app:layout_constraintTop_toBottomOf="@id/ctaBottomBarrier" />
+
+    <nl.dionsegijn.konfetti.xml.KonfettiView
+        android:id="@+id/viewKonfetti"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/main/res/layout/fragment_ftue_personalization_complete.xml
+++ b/vector/src/main/res/layout/fragment_ftue_personalization_complete.xml
@@ -4,12 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <nl.dionsegijn.konfetti.xml.KonfettiView
-        android:id="@+id/viewKonfetti"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone" />
-
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/ftueAuthGutterStart"
         android:layout_width="wrap_content"
@@ -111,5 +105,11 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHeight_percent="0.05"
         app:layout_constraintTop_toBottomOf="@id/personalizationCompleteCta" />
+
+    <nl.dionsegijn.konfetti.xml.KonfettiView
+        android:id="@+id/viewKonfetti"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other : 

## Content

Fixes #5735 

The rendering of the onboarding celebratory confetti is occurring behind the page content, whereas it should be in front.

## Screenshots / GIFs

|Before|After|
|-|-|
|![before-confetti](https://user-images.githubusercontent.com/1848238/162737462-19799f5a-9dd8-41fc-975d-6cfff08aeb48.gif)|![after-confetti](https://user-images.githubusercontent.com/1848238/162737483-285dba0e-f3ae-4c5f-89b2-5f3ce53b2bd3.gif)|

## Tests

- Create an account
- Notice the confetti renders behind the avatar/text

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 31
