### PR TITLE
Fixing crash when navigating the app whilst room keys are being processed 

### DIFF
--- a/changelog.d/5746.bugfix
+++ b/changelog.d/5746.bugfix
@@ -1,0 +1,1 @@
+Fixes crash when navigating the app whilst processing new room keys

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/RoomDecryptorProvider.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/RoomDecryptorProvider.kt
@@ -74,7 +74,7 @@ internal class RoomDecryptorProvider @Inject constructor(
                     this.newSessionListener = object : NewSessionListener {
                         override fun onNewSession(roomId: String?, senderKey: String, sessionId: String) {
                             // PR reviewer: the parameter has been renamed so is now in conflict with the parameter of getOrCreateRoomDecryptor
-                            newSessionListeners.forEach {
+                            newSessionListeners.toList().forEach {
                                 try {
                                     it.onNewSession(roomId, senderKey, sessionId)
                                 } catch (e: Throwable) {


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes #5746

Copies the `onNewSession` listener list to avoid concurrent modification exceptions as the `onNewSession` function is called from the `Cypto Thread` whereas adding and removing which happens when navigating around the app happens on the `Main Thread`

## Motivation and context

To fix the crash!

## Screenshots / GIFs

*With a hardcoded bottleneck `Thread.sleep(5000)` [here](https://github.com/vector-im/element-android/blob/develop/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt#L94)  

| BEFORE | AFTER | 
| --- | --- |
![before-concurrent](https://user-images.githubusercontent.com/1848238/163015517-df852b0f-be66-4dbf-b85e-2819fa2bcfe0.gif)|![after-concurrent](https://user-images.githubusercontent.com/1848238/163015512-dcb88256-4d4d-4de4-add0-be90554cd889.gif)

## Tests

*with the hardcoded bottleneck

- in element web /discard session
- in element android launch the app via launcher icon
- open room with discarded session
- in element web send new message (which in turn creates a new session)
- receive the message on element android and press back
- once the timeout completes, notice a crash


## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 29

