### PR TITLE
Fixing missing :vector test coverage in Jacoco report

### DIFF
--- a/coverage.gradle
+++ b/coverage.gradle
@@ -17,7 +17,7 @@ def initializeReport(report, projects, classExcludes) {
         projects.each { project ->
             switch (project) {
                 case { project.plugins.hasPlugin("com.android.application") }:
-                    androidClassDirs.add("${project.buildDir}/tmp/kotlin-classes/debug")
+                    androidClassDirs.add("${project.buildDir}/tmp/kotlin-classes/gplayDebug")
                     androidSourceDirs.add("${project.projectDir}/src/main/kotlin")
                     androidSourceDirs.add("${project.projectDir}/src/main/java")
                     break


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Fixes the `:vector` module coverage not being pulled into the jacoco report, this is due to the classes being under the variant name directory `gplayDebug`

## Motivation and context

To include missing coverage

## Screenshots / GIFs

For example the onboarding package was not being picked up. With the change...

![2022-04-13T14:18:14,985297979+01:00](https://user-images.githubusercontent.com/1848238/163189100-bd36b1c3-e6dd-4c4b-82ef-ba35bc74cf46.png)

## Tests

- Run ./gradlew allCodeCoverageReport

## Tested devices

N/A