### PR TITLE
FTUE - Server selection errors

### DIFF
--- a/changelog.d/5749.wip
+++ b/changelog.d/5749.wip
@@ -1,0 +1,1 @@
+Adds error handling within the new FTUE server selection screen

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
@@ -25,32 +25,26 @@ import java.io.IOException
 import java.net.UnknownHostException
 import javax.net.ssl.HttpsURLConnection
 
-fun Throwable.is401() =
-        this is Failure.ServerError &&
-                httpCode == HttpsURLConnection.HTTP_UNAUTHORIZED && /* 401 */
-                error.code == MatrixError.M_UNAUTHORIZED
+fun Throwable.is401() = this is Failure.ServerError &&
+        httpCode == HttpsURLConnection.HTTP_UNAUTHORIZED && /* 401 */
+        error.code == MatrixError.M_UNAUTHORIZED
 
-fun Throwable.is404() =
-        this is Failure.ServerError &&
-                httpCode == HttpsURLConnection.HTTP_NOT_FOUND && /* 404 */
-                error.code == MatrixError.M_NOT_FOUND
+fun Throwable.is404() = this is Failure.ServerError &&
+        httpCode == HttpsURLConnection.HTTP_NOT_FOUND && /* 404 */
+        error.code == MatrixError.M_NOT_FOUND
 
-fun Throwable.isTokenError() =
-        this is Failure.ServerError &&
-                (error.code == MatrixError.M_UNKNOWN_TOKEN ||
-                        error.code == MatrixError.M_MISSING_TOKEN ||
-                        error.code == MatrixError.ORG_MATRIX_EXPIRED_ACCOUNT)
+fun Throwable.isTokenError() = this is Failure.ServerError &&
+        (error.code == MatrixError.M_UNKNOWN_TOKEN ||
+                error.code == MatrixError.M_MISSING_TOKEN ||
+                error.code == MatrixError.ORG_MATRIX_EXPIRED_ACCOUNT)
 
-fun Throwable.isLimitExceededError() =
-        this is Failure.ServerError &&
-                httpCode == 429 &&
-                error.code == MatrixError.M_LIMIT_EXCEEDED
+fun Throwable.isLimitExceededError() = this is Failure.ServerError &&
+        httpCode == 429 &&
+        error.code == MatrixError.M_LIMIT_EXCEEDED
 
-fun Throwable.shouldBeRetried(): Boolean {
-    return this is Failure.NetworkConnection ||
-            this is IOException ||
-            this.isLimitExceededError()
-}
+fun Throwable.shouldBeRetried() = this is Failure.NetworkConnection ||
+        this is IOException ||
+        isLimitExceededError()
 
 /**
  * Get the retry delay in case of rate limit exceeded error, adding 100 ms, of defaultValue otherwise
@@ -64,46 +58,33 @@ fun Throwable.getRetryDelay(defaultValue: Long): Long {
             ?: defaultValue
 }
 
-fun Throwable.isUsernameInUse(): Boolean {
-    return this is Failure.ServerError && error.code == MatrixError.M_USER_IN_USE
-}
+fun Throwable.isUsernameInUse() = this is Failure.ServerError &&
+        error.code == MatrixError.M_USER_IN_USE
 
-fun Throwable.isInvalidUsername(): Boolean {
-    return this is Failure.ServerError &&
-            error.code == MatrixError.M_INVALID_USERNAME
-}
+fun Throwable.isInvalidUsername() = this is Failure.ServerError &&
+        error.code == MatrixError.M_INVALID_USERNAME
 
-fun Throwable.isInvalidPassword(): Boolean {
-    return this is Failure.ServerError &&
-            error.code == MatrixError.M_FORBIDDEN &&
-            error.message == "Invalid password"
-}
+fun Throwable.isInvalidPassword() = this is Failure.ServerError &&
+        error.code == MatrixError.M_FORBIDDEN &&
+        error.message == "Invalid password"
 
-fun Throwable.isRegistrationDisabled(): Boolean {
-    return this is Failure.ServerError && error.code == MatrixError.M_FORBIDDEN &&
-            httpCode == HttpsURLConnection.HTTP_FORBIDDEN
-}
+fun Throwable.isRegistrationDisabled() = this is Failure.ServerError &&
+        error.code == MatrixError.M_FORBIDDEN &&
+        httpCode == HttpsURLConnection.HTTP_FORBIDDEN
 
-fun Throwable.isWeakPassword(): Boolean {
-    return this is Failure.ServerError && error.code == MatrixError.M_WEAK_PASSWORD
-}
+fun Throwable.isWeakPassword() = this is Failure.ServerError &&
+        error.code == MatrixError.M_WEAK_PASSWORD
 
-fun Throwable.isLoginEmailUnknown(): Boolean {
-    return this is Failure.ServerError &&
-            error.code == MatrixError.M_FORBIDDEN &&
-            error.message.isEmpty()
-}
+fun Throwable.isLoginEmailUnknown() = this is Failure.ServerError &&
+        error.code == MatrixError.M_FORBIDDEN &&
+        error.message.isEmpty()
 
-fun Throwable.isInvalidUIAAuth(): Boolean {
-    return this is Failure.ServerError &&
-            error.code == MatrixError.M_FORBIDDEN &&
-            error.flows != null
-}
+fun Throwable.isInvalidUIAAuth() = this is Failure.ServerError &&
+        error.code == MatrixError.M_FORBIDDEN &&
+        error.flows != null
 
-fun Throwable.isHomeserverUnavailable(): Boolean {
-    return this is Failure.NetworkConnection &&
-            this.ioException is UnknownHostException
-}
+fun Throwable.isHomeserverUnavailable() = this is Failure.NetworkConnection &&
+        this.ioException is UnknownHostException
 
 /**
  * Try to convert to a RegistrationFlowResponse. Return null in the cases it's not possible
@@ -135,13 +116,11 @@ fun Throwable.toRegistrationFlowResponse(): RegistrationFlowResponse? {
     }
 }
 
-fun Throwable.isRegistrationAvailabilityError(): Boolean {
-    return this is Failure.ServerError &&
-            httpCode == HttpsURLConnection.HTTP_BAD_REQUEST && /* 400 */
-            (error.code == MatrixError.M_USER_IN_USE ||
-                    error.code == MatrixError.M_INVALID_USERNAME ||
-                    error.code == MatrixError.M_EXCLUSIVE)
-}
+fun Throwable.isRegistrationAvailabilityError() = this is Failure.ServerError &&
+        httpCode == HttpsURLConnection.HTTP_BAD_REQUEST && /* 400 */
+        (error.code == MatrixError.M_USER_IN_USE ||
+                error.code == MatrixError.M_INVALID_USERNAME ||
+                error.code == MatrixError.M_EXCLUSIVE)
 
 /**
  * Try to convert to a ScanFailure. Return null in the cases it's not possible

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
@@ -22,6 +22,7 @@ import org.matrix.android.sdk.api.session.contentscanner.ContentScannerError
 import org.matrix.android.sdk.api.session.contentscanner.ScanFailure
 import org.matrix.android.sdk.internal.di.MoshiProvider
 import java.io.IOException
+import java.net.UnknownHostException
 import javax.net.ssl.HttpsURLConnection
 
 fun Throwable.is401() =
@@ -97,6 +98,11 @@ fun Throwable.isInvalidUIAAuth(): Boolean {
     return this is Failure.ServerError &&
             error.code == MatrixError.M_FORBIDDEN &&
             error.flows != null
+}
+
+fun Throwable.isHomeserverUnavailable(): Boolean {
+    return this is Failure.NetworkConnection &&
+            this.ioException is UnknownHostException
 }
 
 /**

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -615,10 +615,10 @@ class OnboardingViewModel @AssistedInject constructor(
                         onAuthenticationStartedSuccess(homeServerConnectionConfig, it, serverTypeOverride)
                     },
                     onFailure = {
-                        setState { copy(isLoading = false) }
                         _viewEvents.post(OnboardingViewEvents.Failure(it))
                     }
             )
+            setState { copy(isLoading = false) }
         }
     }
 
@@ -632,7 +632,6 @@ class OnboardingViewModel @AssistedInject constructor(
             copy(
                     serverType = alignServerTypeAfterSubmission(config, serverTypeOverride),
                     selectedHomeserver = authResult.selectedHomeserver,
-                    isLoading = false
             )
         }
         val state = awaitState()

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -628,24 +628,33 @@ class OnboardingViewModel @AssistedInject constructor(
             _viewEvents.post(OnboardingViewEvents.OutdatedHomeserver)
         }
 
-        setState {
-            copy(
-                    serverType = alignServerTypeAfterSubmission(config, serverTypeOverride),
-                    selectedHomeserver = authResult.selectedHomeserver,
-            )
-        }
         val state = awaitState()
+
         when (lastAction) {
             is OnboardingAction.HomeServerChange.EditHomeServer   -> {
                 when (state.onboardingFlow) {
-                    OnboardingFlow.SignUp -> handleRegisterAction(RegisterAction.StartRegistration) { _ ->
+                    OnboardingFlow.SignUp -> internalRegisterAction(RegisterAction.StartRegistration) { _ ->
+                        setState {
+                            copy(
+                                    serverType = alignServerTypeAfterSubmission(config, serverTypeOverride),
+                                    selectedHomeserver = authResult.selectedHomeserver,
+                            )
+                        }
                         _viewEvents.post(OnboardingViewEvents.OnHomeserverEdited)
                     }
                     else                  -> throw IllegalArgumentException("developer error")
                 }
             }
             is OnboardingAction.HomeServerChange.SelectHomeServer -> {
-                if (state.selectedHomeserver.preferredLoginMode.supportsSignModeScreen()) {
+                setState {
+                    copy(
+                            serverType = alignServerTypeAfterSubmission(config, serverTypeOverride),
+                            selectedHomeserver = authResult.selectedHomeserver,
+                    )
+                }
+
+
+                if (authResult.selectedHomeserver.preferredLoginMode.supportsSignModeScreen()) {
                     when (state.onboardingFlow) {
                         OnboardingFlow.SignIn -> internalRegisterAction(RegisterAction.StartRegistration, ::emitFlowResultViewEvent)
                         OnboardingFlow.SignUp -> internalRegisterAction(RegisterAction.StartRegistration, ::emitFlowResultViewEvent)

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -349,18 +349,17 @@ class OnboardingViewModel @AssistedInject constructor(
     }
 
     private fun handleUpdateSignMode(action: OnboardingAction.UpdateSignMode) {
-        setState {
-            copy(
-                    signMode = action.signMode
-            )
-        }
-
+        updateSignMode(action.signMode)
         when (action.signMode) {
             SignMode.SignUp             -> handleRegisterAction(RegisterAction.StartRegistration, ::emitFlowResultViewEvent)
             SignMode.SignIn             -> startAuthenticationFlow()
             SignMode.SignInWithMatrixId -> _viewEvents.post(OnboardingViewEvents.OnSignModeSelected(SignMode.SignInWithMatrixId))
             SignMode.Unknown            -> Unit
         }
+    }
+
+    private fun updateSignMode(signMode: SignMode) {
+        setState { copy(signMode = signMode) }
     }
 
     private fun handleUpdateUseCase(action: OnboardingAction.UpdateUseCase) {
@@ -644,8 +643,14 @@ class OnboardingViewModel @AssistedInject constructor(
                 updateServerSelection(config, serverTypeOverride, authResult)
                 if (authResult.selectedHomeserver.preferredLoginMode.supportsSignModeScreen()) {
                     when (awaitState().onboardingFlow) {
-                        OnboardingFlow.SignIn -> internalRegisterAction(RegisterAction.StartRegistration, ::emitFlowResultViewEvent)
-                        OnboardingFlow.SignUp -> internalRegisterAction(RegisterAction.StartRegistration, ::emitFlowResultViewEvent)
+                        OnboardingFlow.SignIn -> {
+                            updateSignMode(SignMode.SignIn)
+                            internalRegisterAction(RegisterAction.StartRegistration, ::emitFlowResultViewEvent)
+                        }
+                        OnboardingFlow.SignUp -> {
+                            updateSignMode(SignMode.SignUp)
+                            internalRegisterAction(RegisterAction.StartRegistration, ::emitFlowResultViewEvent)
+                        }
                         OnboardingFlow.SignInSignUp,
                         null                  -> {
                             _viewEvents.post(OnboardingViewEvents.OnLoginFlowRetrieved)

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -41,6 +41,7 @@ import im.vector.app.features.login.LoginMode
 import im.vector.app.features.login.ReAuthHelper
 import im.vector.app.features.login.ServerType
 import im.vector.app.features.login.SignMode
+import im.vector.app.features.onboarding.StartAuthenticationFlowUseCase.StartAuthenticationResult
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -601,7 +602,11 @@ class OnboardingViewModel @AssistedInject constructor(
         }
     }
 
-    private fun startAuthenticationFlow(trigger: OnboardingAction?, homeServerConnectionConfig: HomeServerConnectionConfig, serverTypeOverride: ServerType? = null) {
+    private fun startAuthenticationFlow(
+            trigger: OnboardingAction?,
+            homeServerConnectionConfig: HomeServerConnectionConfig,
+            serverTypeOverride: ServerType? = null
+    ) {
         currentHomeServerConnectionConfig = homeServerConnectionConfig
 
         currentJob = viewModelScope.launch {
@@ -617,7 +622,7 @@ class OnboardingViewModel @AssistedInject constructor(
     private suspend fun onAuthenticationStartedSuccess(
             trigger: OnboardingAction?,
             config: HomeServerConnectionConfig,
-            authResult: StartAuthenticationFlowUseCase.StartAuthenticationResult,
+            authResult: StartAuthenticationResult,
             serverTypeOverride: ServerType?
     ) {
         rememberHomeServer(config.homeServerUri.toString())
@@ -657,7 +662,7 @@ class OnboardingViewModel @AssistedInject constructor(
         }
     }
 
-    private fun updateServerSelection(config: HomeServerConnectionConfig, serverTypeOverride: ServerType?, authResult: StartAuthenticationFlowUseCase.StartAuthenticationResult) {
+    private fun updateServerSelection(config: HomeServerConnectionConfig, serverTypeOverride: ServerType?, authResult: StartAuthenticationResult) {
         setState {
             copy(
                     serverType = alignServerTypeAfterSubmission(config, serverTypeOverride),

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedServerSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedServerSelectionFragment.kt
@@ -21,6 +21,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
+import androidx.lifecycle.lifecycleScope
 import im.vector.app.R
 import im.vector.app.core.extensions.content
 import im.vector.app.core.extensions.editText
@@ -33,6 +34,11 @@ import im.vector.app.databinding.FragmentFtueServerSelectionCombinedBinding
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewEvents
 import im.vector.app.features.onboarding.OnboardingViewState
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.matrix.android.sdk.api.failure.Failure
+import reactivecircus.flowbinding.android.widget.textChanges
+import java.net.UnknownHostException
 import javax.inject.Inject
 
 class FtueAuthCombinedServerSelectionFragment @Inject constructor() : AbstractFtueAuthFragment<FragmentFtueServerSelectionCombinedBinding>() {
@@ -61,6 +67,9 @@ class FtueAuthCombinedServerSelectionFragment @Inject constructor() : AbstractFt
         }
         views.chooseServerGetInTouch.debouncedClicks { openUrlInExternalBrowser(requireContext(), getString(R.string.ftue_ems_url)) }
         views.chooseServerSubmit.debouncedClicks { updateServerUrl() }
+        views.chooseServerInput.editText().textChanges()
+                .onEach { views.chooseServerInput.error = null }
+                .launchIn(lifecycleScope)
     }
 
     private fun updateServerUrl() {
@@ -75,6 +84,15 @@ class FtueAuthCombinedServerSelectionFragment @Inject constructor() : AbstractFt
         if (views.chooseServerInput.content().isEmpty()) {
             val userUrlInput = state.selectedHomeserver.userFacingUrl?.toReducedUrlKeepingSchemaIfInsecure()
             views.chooseServerInput.editText().setText(userUrlInput)
+        }
+    }
+
+    override fun onError(throwable: Throwable) {
+        views.chooseServerInput.error = if (throwable is Failure.NetworkConnection &&
+                throwable.ioException is UnknownHostException) {
+            getString(R.string.login_error_homeserver_not_found)
+        } else {
+            errorFormatter.toHumanReadable(throwable)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedServerSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedServerSelectionFragment.kt
@@ -36,9 +36,8 @@ import im.vector.app.features.onboarding.OnboardingViewEvents
 import im.vector.app.features.onboarding.OnboardingViewState
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import org.matrix.android.sdk.api.failure.Failure
+import org.matrix.android.sdk.api.failure.isHomeserverUnavailable
 import reactivecircus.flowbinding.android.widget.textChanges
-import java.net.UnknownHostException
 import javax.inject.Inject
 
 class FtueAuthCombinedServerSelectionFragment @Inject constructor() : AbstractFtueAuthFragment<FragmentFtueServerSelectionCombinedBinding>() {
@@ -88,11 +87,9 @@ class FtueAuthCombinedServerSelectionFragment @Inject constructor() : AbstractFt
     }
 
     override fun onError(throwable: Throwable) {
-        views.chooseServerInput.error = if (throwable is Failure.NetworkConnection &&
-                throwable.ioException is UnknownHostException) {
-            getString(R.string.login_error_homeserver_not_found)
-        } else {
-            errorFormatter.toHumanReadable(throwable)
+        views.chooseServerInput.error = when {
+            throwable.isHomeserverUnavailable() -> getString(R.string.login_error_homeserver_not_found)
+            else                                -> errorFormatter.toHumanReadable(throwable)
         }
     }
 

--- a/vector/src/main/res/layout/fragment_ftue_server_selection_combined.xml
+++ b/vector/src/main/res/layout/fragment_ftue_server_selection_combined.xml
@@ -106,7 +106,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:imeOptions="actionDone"
-                android:inputType="text"
+                android:inputType="textUri"
                 android:maxLines="1" />
 
         </com.google.android.material.textfield.TextInputLayout>

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -73,7 +73,6 @@ class OnboardingViewModelTest {
 
     private val fakeUri = FakeUri()
     private val fakeContext = FakeContext()
-    private val initialState = OnboardingViewState()
     private val fakeSession = FakeSession()
     private val fakeUriFilenameResolver = FakeUriFilenameResolver()
     private val fakeActiveSessionHolder = FakeActiveSessionHolder(fakeSession)
@@ -85,11 +84,12 @@ class OnboardingViewModelTest {
     private val fakeStartAuthenticationFlowUseCase = FakeStartAuthenticationFlowUseCase()
     private val fakeHomeServerHistoryService = FakeHomeServerHistoryService()
 
-    lateinit var viewModel: OnboardingViewModel
+    private var initialState = OnboardingViewState()
+    private lateinit var viewModel: OnboardingViewModel
 
     @Before
     fun setUp() {
-        viewModel = createViewModel()
+        viewModelWith(initialState)
     }
 
     @Test
@@ -105,8 +105,7 @@ class OnboardingViewModelTest {
 
     @Test
     fun `given supports changing display name, when handling PersonalizeProfile, then emits contents choose display name`() = runTest {
-        val initialState = initialState.copy(personalizationState = PersonalizationState(supportsChangingDisplayName = true, supportsChangingProfilePicture = false))
-        viewModel = createViewModel(initialState)
+        viewModelWith(initialState.copy(personalizationState = PersonalizationState(supportsChangingDisplayName = true, supportsChangingProfilePicture = false)))
         val test = viewModel.test()
 
         viewModel.handle(OnboardingAction.PersonalizeProfile)
@@ -118,8 +117,7 @@ class OnboardingViewModelTest {
 
     @Test
     fun `given only supports changing profile picture, when handling PersonalizeProfile, then emits contents choose profile picture`() = runTest {
-        val initialState = initialState.copy(personalizationState = PersonalizationState(supportsChangingDisplayName = false, supportsChangingProfilePicture = true))
-        viewModel = createViewModel(initialState)
+        viewModelWith(initialState.copy(personalizationState = PersonalizationState(supportsChangingDisplayName = false, supportsChangingProfilePicture = true)))
         val test = viewModel.test()
 
         viewModel.handle(OnboardingAction.PersonalizeProfile)
@@ -131,8 +129,7 @@ class OnboardingViewModelTest {
 
     @Test
     fun `given has sign in with matrix id sign mode, when handling login or register action, then logs in directly`() = runTest {
-        val initialState = initialState.copy(signMode = SignMode.SignInWithMatrixId)
-        viewModel = createViewModel(initialState)
+        viewModelWith(initialState.copy(signMode = SignMode.SignInWithMatrixId))
         fakeDirectLoginUseCase.givenSuccessResult(A_LOGIN_OR_REGISTER_ACTION, config = null, result = fakeSession)
         givenInitialisesSession(fakeSession)
         val test = viewModel.test()
@@ -151,8 +148,7 @@ class OnboardingViewModelTest {
 
     @Test
     fun `given has sign in with matrix id sign mode, when handling login or register action fails, then emits error`() = runTest {
-        val initialState = initialState.copy(signMode = SignMode.SignInWithMatrixId)
-        viewModel = createViewModel(initialState)
+        viewModelWith(initialState.copy(signMode = SignMode.SignInWithMatrixId))
         fakeDirectLoginUseCase.givenFailureResult(A_LOGIN_OR_REGISTER_ACTION, config = null, cause = AN_ERROR)
         givenInitialisesSession(fakeSession)
         val test = viewModel.test()
@@ -235,11 +231,13 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given when editing homeserver, then updates selected homeserver state and emits edited event`() = runTest {
-        val test = viewModel.test()
+    fun `given in the sign up flow, when editing homeserver, then updates selected homeserver state and emits edited event`() = runTest {
+        viewModelWith(initialState.copy(onboardingFlow = OnboardingFlow.SignUp))
         fakeHomeServerConnectionConfigFactory.givenConfigFor(A_HOMESERVER_URL, A_HOMESERVER_CONFIG)
-        fakeStartAuthenticationFlowUseCase.givenResult(A_HOMESERVER_CONFIG, StartAuthenticationResult(false, SELECTED_HOMESERVER_STATE))
+        fakeStartAuthenticationFlowUseCase.givenResult(A_HOMESERVER_CONFIG, StartAuthenticationResult(isHomeserverOutdated = false, SELECTED_HOMESERVER_STATE))
+        givenRegistrationResultFor(RegisterAction.StartRegistration, RegistrationResult.FlowResponse(AN_IGNORED_FLOW_RESULT))
         fakeHomeServerHistoryService.expectUrlToBeAdded(A_HOMESERVER_CONFIG.homeServerUri.toString())
+        val test = viewModel.test()
 
         viewModel.handle(OnboardingAction.HomeServerChange.EditHomeServer(A_HOMESERVER_URL))
 
@@ -247,9 +245,32 @@ class OnboardingViewModelTest {
                 .assertStatesChanges(
                         initialState,
                         { copy(isLoading = true) },
-                        { copy(isLoading = false, selectedHomeserver = SELECTED_HOMESERVER_STATE) },
+                        { copy(selectedHomeserver = SELECTED_HOMESERVER_STATE) },
+                        { copy(isLoading = false) }
+
                 )
                 .assertEvents(OnboardingViewEvents.OnHomeserverEdited)
+                .finish()
+    }
+
+    @Test
+    fun `given in the sign up flow, when editing homeserver errors, then does not update the selected homeserver state and emits error`() = runTest {
+        viewModelWith(initialState.copy(onboardingFlow = OnboardingFlow.SignUp))
+        fakeHomeServerConnectionConfigFactory.givenConfigFor(A_HOMESERVER_URL, A_HOMESERVER_CONFIG)
+        fakeStartAuthenticationFlowUseCase.givenResult(A_HOMESERVER_CONFIG, StartAuthenticationResult(isHomeserverOutdated = false, SELECTED_HOMESERVER_STATE))
+        givenRegistrationActionErrors(RegisterAction.StartRegistration, AN_ERROR)
+        fakeHomeServerHistoryService.expectUrlToBeAdded(A_HOMESERVER_CONFIG.homeServerUri.toString())
+        val test = viewModel.test()
+
+        viewModel.handle(OnboardingAction.HomeServerChange.EditHomeServer(A_HOMESERVER_URL))
+
+        test
+                .assertStatesChanges(
+                        initialState,
+                        { copy(isLoading = true) },
+                        { copy(isLoading = false) }
+                )
+                .assertEvents(OnboardingViewEvents.Failure(AN_ERROR))
                 .finish()
     }
 
@@ -292,14 +313,13 @@ class OnboardingViewModelTest {
 
     @Test
     fun `given changing profile picture is supported, when updating display name, then updates upstream user display name and moves to choose profile picture`() = runTest {
-        val personalisedInitialState = initialState.copy(personalizationState = PersonalizationState(supportsChangingProfilePicture = true))
-        viewModel = createViewModel(personalisedInitialState)
+        viewModelWith(initialState.copy(personalizationState = PersonalizationState(supportsChangingProfilePicture = true)))
         val test = viewModel.test()
 
         viewModel.handle(OnboardingAction.UpdateDisplayName(A_DISPLAY_NAME))
 
         test
-                .assertStatesChanges(personalisedInitialState, expectedSuccessfulDisplayNameUpdateStates())
+                .assertStatesChanges(initialState, expectedSuccessfulDisplayNameUpdateStates())
                 .assertEvents(OnboardingViewEvents.OnChooseProfilePicture)
                 .finish()
         fakeSession.fakeProfileService.verifyUpdatedName(fakeSession.myUserId, A_DISPLAY_NAME)
@@ -307,14 +327,13 @@ class OnboardingViewModelTest {
 
     @Test
     fun `given changing profile picture is not supported, when updating display name, then updates upstream user display name and completes personalization`() = runTest {
-        val personalisedInitialState = initialState.copy(personalizationState = PersonalizationState(supportsChangingProfilePicture = false))
-        viewModel = createViewModel(personalisedInitialState)
+        viewModelWith(initialState.copy(personalizationState = PersonalizationState(supportsChangingProfilePicture = false)))
         val test = viewModel.test()
 
         viewModel.handle(OnboardingAction.UpdateDisplayName(A_DISPLAY_NAME))
 
         test
-                .assertStatesChanges(personalisedInitialState, expectedSuccessfulDisplayNameUpdateStates())
+                .assertStatesChanges(initialState, expectedSuccessfulDisplayNameUpdateStates())
                 .assertEvents(OnboardingViewEvents.OnPersonalizationComplete)
                 .finish()
         fakeSession.fakeProfileService.verifyUpdatedName(fakeSession.myUserId, A_DISPLAY_NAME)
@@ -354,14 +373,13 @@ class OnboardingViewModelTest {
 
     @Test
     fun `given a selected picture, when handling save selected profile picture, then updates upstream avatar and completes personalization`() = runTest {
-        val initialStateWithPicture = givenPictureSelected(fakeUri.instance, A_PICTURE_FILENAME)
-        viewModel = createViewModel(initialStateWithPicture)
+        viewModelWith(givenPictureSelected(fakeUri.instance, A_PICTURE_FILENAME))
         val test = viewModel.test()
 
         viewModel.handle(OnboardingAction.SaveSelectedProfilePicture)
 
         test
-                .assertStates(expectedProfilePictureSuccessStates(initialStateWithPicture))
+                .assertStates(expectedProfilePictureSuccessStates(initialState))
                 .assertEvents(OnboardingViewEvents.OnPersonalizationComplete)
                 .finish()
         fakeSession.fakeProfileService.verifyAvatarUpdated(fakeSession.myUserId, fakeUri.instance, A_PICTURE_FILENAME)
@@ -370,14 +388,13 @@ class OnboardingViewModelTest {
     @Test
     fun `given upstream update avatar fails, when saving selected profile picture, then emits failure event`() = runTest {
         fakeSession.fakeProfileService.givenUpdateAvatarErrors(AN_ERROR)
-        val initialStateWithPicture = givenPictureSelected(fakeUri.instance, A_PICTURE_FILENAME)
-        viewModel = createViewModel(initialStateWithPicture)
+        viewModelWith(givenPictureSelected(fakeUri.instance, A_PICTURE_FILENAME))
         val test = viewModel.test()
 
         viewModel.handle(OnboardingAction.SaveSelectedProfilePicture)
 
         test
-                .assertStates(expectedProfilePictureFailureStates(initialStateWithPicture))
+                .assertStates(expectedProfilePictureFailureStates(initialState))
                 .assertEvents(OnboardingViewEvents.Failure(AN_ERROR))
                 .finish()
     }
@@ -406,8 +423,8 @@ class OnboardingViewModelTest {
                 .finish()
     }
 
-    private fun createViewModel(state: OnboardingViewState = initialState): OnboardingViewModel {
-        return OnboardingViewModel(
+    private fun viewModelWith(state: OnboardingViewState) {
+        OnboardingViewModel(
                 state,
                 fakeContext.instance,
                 fakeAuthenticationService,
@@ -423,7 +440,10 @@ class OnboardingViewModelTest {
                 fakeDirectLoginUseCase.instance,
                 fakeStartAuthenticationFlowUseCase.instance,
                 FakeVectorOverrides()
-        )
+        ).also {
+            viewModel = it
+            initialState = state
+        }
     }
 
     private fun givenPictureSelected(fileUri: Uri, filename: String): OnboardingViewState {
@@ -480,6 +500,12 @@ class OnboardingViewModelTest {
         val registrationWizard = FakeRegistrationWizard()
         fakeAuthenticationService.givenRegistrationWizard(registrationWizard)
         fakeRegisterActionHandler.givenResultsFor(registrationWizard, results)
+    }
+
+    private fun givenRegistrationActionErrors(action: RegisterAction, cause: Throwable) {
+        val registrationWizard = FakeRegistrationWizard()
+        fakeAuthenticationService.givenRegistrationWizard(registrationWizard)
+        fakeRegisterActionHandler.givenThrowsFor(registrationWizard, action, cause)
     }
 }
 

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeRegisterActionHandler.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeRegisterActionHandler.kt
@@ -33,4 +33,8 @@ class FakeRegisterActionHandler {
             result.first { it.first == actionArg }.second
         }
     }
+
+    fun givenThrowsFor(wizard: RegistrationWizard, action: RegisterAction, cause: Throwable) {
+        coEvery { instance.handleRegisterAction(wizard, action) } throws cause
+    }
 }


### PR DESCRIPTION
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Uses the TextUri type for url entry (fixes spaces being added when typing)
- Adds missing error states to the `Server Selection` screen instead of when submitting the account details
  - Starts the registration flow at the point of setting the homeserver url instead of waiting until details submission  
- Fixes flashing loading state when selecting a usage option by flattening nested scope launching and only applying loading changes to top level entry points

## Motivation and context

Fixes #5749

## Screenshots / GIFs

|Before|After|
|-|-|
|![before-disabled-reg](https://user-images.githubusercontent.com/1848238/163376485-e021f5c8-efa2-402a-90a6-a273511cdff2.gif)|![after-disabled-reg](https://user-images.githubusercontent.com/1848238/163376507-73c8de5d-f239-4a03-b3ef-e60997b5a5c6.gif)|
|![before-wrong-url](https://user-images.githubusercontent.com/1848238/163376743-5f595978-3abb-43f6-915c-ebd342bbc626.png)|![after-wrong-url](https://user-images.githubusercontent.com/1848238/163376744-094f576f-d4c7-47f4-a132-24ca43aa535d.png)

## Tests


- With the combined register feature flag enabled
- Start the account creation flow
- Edit the server and supply a server with registration disabled or an invalid url
- Notice the error message is now displayed within the entry field

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 29