### PR TITLE
Fix setting transfer title

### DIFF
--- a/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/transfer/CallTransferActivity.kt
@@ -70,7 +70,6 @@ class CallTransferActivity : VectorBaseActivity<ActivityCallTransferBinding>() {
         }.attach()
         setupToolbar(views.callTransferToolbar)
                 .allowBack()
-        views.callTransferToolbar.title = getString(R.string.call_transfer_title)
         setupConnectAction()
     }
 

--- a/vector/src/main/res/layout/activity_call_transfer.xml
+++ b/vector/src/main/res/layout/activity_call_transfer.xml
@@ -17,6 +17,7 @@
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/callTransferToolbar"
+                app:title="@string/call_transfer_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content
Fixing setting transfer title in call transfer.
<!-- Describe shortly what has been changed -->

## Motivation and context
It was showing the app title (e.g. Element) instead of the `app:title` (the title of `MaterialToolbar`)
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->


|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/31655082/163396542-25e2e66e-ea7a-4bed-aeef-885fbfe60401.png)|![image](https://user-images.githubusercontent.com/31655082/163396261-f895e1a5-f647-48f8-a77a-715a69fb2eac.png)|


## Tests

<!-- Explain how you tested your development -->

- called someone
- transferred call
- looked at title

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

Signed-off-by: Chagai Friedlander <me@chagai.website>

