### PR TITLE
Changes destination when joining space to explore space rooms

### DIFF
--- a/changelog.d/5766.bugfix
+++ b/changelog.d/5766.bugfix
@@ -1,0 +1,1 @@
+Changes destination after joining a space to Explore Space Rooms screen

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -613,6 +613,6 @@ class HomeActivity :
     }
 
     override fun mxToBottomSheetSwitchToSpace(spaceId: String) {
-        navigator.switchToSpace(this, spaceId, Navigator.PostSwitchSpaceAction.None)
+        navigator.switchToSpace(this, spaceId, Navigator.PostSwitchSpaceAction.OpenRoomList)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -580,7 +580,7 @@ class HomeActivity :
     }
 
     override fun spaceInviteBottomSheetOnAccept(spaceId: String) {
-        navigator.switchToSpace(this, spaceId, Navigator.PostSwitchSpaceAction.None)
+        navigator.switchToSpace(this, spaceId, Navigator.PostSwitchSpaceAction.OpenRoomList)
     }
 
     override fun spaceInviteBottomSheetOnDecline(spaceId: String) {

--- a/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
@@ -177,11 +177,7 @@ class DefaultNavigator @Inject constructor(
                 startActivity(context, SpaceManageActivity.newIntent(context, spaceId, ManageType.AddRooms), false)
             }
             Navigator.PostSwitchSpaceAction.OpenRoomList -> {
-                startActivity(
-                        context = context,
-                        intent = SpaceExploreActivity.newIntent(context, spaceId),
-                        buildTask = false
-                )
+                startActivity(context, SpaceExploreActivity.newIntent(context, spaceId), buildTask = false)
             }
             is Navigator.PostSwitchSpaceAction.OpenDefaultRoom   -> {
                 val args = TimelineArgs(

--- a/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
@@ -177,7 +177,11 @@ class DefaultNavigator @Inject constructor(
                 startActivity(context, SpaceManageActivity.newIntent(context, spaceId, ManageType.AddRooms), false)
             }
             Navigator.PostSwitchSpaceAction.OpenRoomList -> {
-                startActivity(context, SpaceExploreActivity.newIntent(context, spaceId), false)
+                startActivity(
+                        context = context,
+                        intent = SpaceExploreActivity.newIntent(context, spaceId),
+                        buildTask = false
+                )
             }
             is Navigator.PostSwitchSpaceAction.OpenDefaultRoom   -> {
                 val args = TimelineArgs(

--- a/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
@@ -176,6 +176,9 @@ class DefaultNavigator @Inject constructor(
             Navigator.PostSwitchSpaceAction.OpenAddExistingRooms -> {
                 startActivity(context, SpaceManageActivity.newIntent(context, spaceId, ManageType.AddRooms), false)
             }
+            Navigator.PostSwitchSpaceAction.OpenRoomList -> {
+                startActivity(context, SpaceExploreActivity.newIntent(context, spaceId), false)
+            }
             is Navigator.PostSwitchSpaceAction.OpenDefaultRoom   -> {
                 val args = TimelineArgs(
                         postSwitchSpaceAction.roomId,

--- a/vector/src/main/java/im/vector/app/features/navigation/Navigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/Navigator.kt
@@ -54,8 +54,9 @@ interface Navigator {
 
     sealed class PostSwitchSpaceAction {
         object None : PostSwitchSpaceAction()
-        data class OpenDefaultRoom(val roomId: String, val showShareSheet: Boolean) : PostSwitchSpaceAction()
         object OpenAddExistingRooms : PostSwitchSpaceAction()
+        object OpenRoomList : PostSwitchSpaceAction()
+        data class OpenDefaultRoom(val roomId: String, val showShareSheet: Boolean) : PostSwitchSpaceAction()
     }
 
     fun switchToSpace(context: Context, spaceId: String, postSwitchSpaceAction: PostSwitchSpaceAction)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Changes destination when joining space to explore space rooms (instead of not navigating anywhere)

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/5334

I only applied this change when joining a room from the HomeActivity (from both the hamburger menu and opening a notification). Looking at the code, there are other places where you can join the space e.g. RoomDetailActivity, but I would have to guess it's more intentional that we don't navigate away from those destinations

## Screenshots / GIFs

TBA

|Before|After|
|-|-|
| ![SVID_20220414_154632_1](https://user-images.githubusercontent.com/20701752/163407427-09e8dc47-7e3f-479d-a1c7-78bdd0ec5b74.gif)  | ![SVID_20220414_153806_1](https://user-images.githubusercontent.com/20701752/163407592-ff706f27-19f7-46c9-afb0-d10945d82b7e.gif) |



## Tests

- Invite a test account to a new space
- On the test account, accept the invitation via the hamburger menu. See that you're in the explore space screen
- Now leave the room, background the app, and repeat step 1
- You should get a notification saying you've been invited to the room. Open that notification and accept the invitation. See again that you're in the explore space screen

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 10

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
