### PR TITLE
Unignore user must perform an initial sync

### DIFF
--- a/changelog.d/5767.bugfix
+++ b/changelog.d/5767.bugfix
@@ -1,0 +1,1 @@
+Unignoring a user will perform an initial sync

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/user/UserService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/user/UserService.kt
@@ -75,11 +75,14 @@ interface UserService {
 
     /**
      * Ignore users
+     * Note: once done, for the change to take effect, you have to request an initial sync.
+     * This may be improved in the future
      */
     suspend fun ignoreUserIds(userIds: List<String>)
 
     /**
      * Un-ignore some users
+     * Note: once done, for the change to take effect, you have to request an initial sync.
      */
     suspend fun unIgnoreUserIds(userIds: List<String>)
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -119,6 +119,8 @@ import im.vector.app.core.utils.startInstallFromSourceIntent
 import im.vector.app.core.utils.toast
 import im.vector.app.databinding.DialogReportContentBinding
 import im.vector.app.databinding.FragmentTimelineBinding
+import im.vector.app.features.MainActivity
+import im.vector.app.features.MainActivityArgs
 import im.vector.app.features.analytics.extensions.toAnalyticsInteraction
 import im.vector.app.features.analytics.plan.Interaction
 import im.vector.app.features.analytics.plan.MobileScreen
@@ -136,6 +138,7 @@ import im.vector.app.features.call.conference.ConferenceEventObserver
 import im.vector.app.features.call.conference.JitsiCallViewModel
 import im.vector.app.features.call.webrtc.WebRtcCallManager
 import im.vector.app.features.command.Command
+import im.vector.app.features.command.ParsedCommand
 import im.vector.app.features.crypto.keysbackup.restore.KeysBackupRestoreActivity
 import im.vector.app.features.crypto.verification.VerificationBottomSheet
 import im.vector.app.features.home.AvatarRenderer
@@ -437,6 +440,7 @@ class TimelineFragment @Inject constructor(
         messageComposerViewModel.observeViewEvents {
             when (it) {
                 is MessageComposerViewEvents.JoinRoomCommandSuccess          -> handleJoinedToAnotherRoom(it)
+                is MessageComposerViewEvents.SlashCommandConfirmationRequest -> handleSlashCommandConfirmationRequest(it)
                 is MessageComposerViewEvents.SendMessageResult               -> renderSendMessageResult(it)
                 is MessageComposerViewEvents.ShowMessage                     -> showSnackWithMessage(it.message)
                 is MessageComposerViewEvents.ShowRoomUpgradeDialog           -> handleShowRoomUpgradeDialog(it)
@@ -493,6 +497,25 @@ class TimelineFragment @Inject constructor(
             handleShareData()
             handleSpaceShare()
         }
+    }
+
+    private fun handleSlashCommandConfirmationRequest(action: MessageComposerViewEvents.SlashCommandConfirmationRequest) {
+        when (action.parsedCommand) {
+            is ParsedCommand.UnignoreUser -> promptUnignoreUser(action.parsedCommand)
+            else                          -> TODO("Add case for ${action.parsedCommand.javaClass.simpleName}")
+        }
+        lockSendButton = false
+    }
+
+    private fun promptUnignoreUser(command: ParsedCommand.UnignoreUser) {
+        MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(R.string.room_participants_action_unignore_title)
+                .setMessage(getString(R.string.settings_unignore_user, command.userId))
+                .setPositiveButton(R.string.unignore) { _, _ ->
+                    messageComposerViewModel.handle(MessageComposerAction.SlashCommandConfirmed(command))
+                }
+                .setNegativeButton(R.string.action_cancel, null)
+                .show()
     }
 
     private fun renderVoiceMessageMode(content: String) {
@@ -1679,9 +1702,7 @@ class TimelineFragment @Inject constructor(
                 displayCommandError(getString(R.string.unrecognized_command, sendMessageResult.command))
             }
             is MessageComposerViewEvents.SlashCommandResultOk              -> {
-                dismissLoadingDialog()
-                views.composerLayout.setTextIfDifferent("")
-                sendMessageResult.messageRes?.let { showSnackWithMessage(getString(it)) }
+                handleSlashCommandResultOk(sendMessageResult.parsedCommand)
             }
             is MessageComposerViewEvents.SlashCommandResultError           -> {
                 dismissLoadingDialog()
@@ -1696,6 +1717,21 @@ class TimelineFragment @Inject constructor(
         }
 
         lockSendButton = false
+    }
+
+    private fun handleSlashCommandResultOk(parsedCommand: ParsedCommand) {
+        dismissLoadingDialog()
+        views.composerLayout.setTextIfDifferent("")
+        when (parsedCommand) {
+            is ParsedCommand.SetMarkdown  -> {
+                showSnackWithMessage(getString(if (parsedCommand.enable) R.string.markdown_has_been_enabled else R.string.markdown_has_been_disabled))
+            }
+            is ParsedCommand.UnignoreUser -> {
+                // A user has been un-ignored, perform a initial sync
+                MainActivity.restartApp(requireActivity(), MainActivityArgs(clearCache = true))
+            }
+            else                          -> Unit
+        }
     }
 
     private fun displayCommandError(message: String) {
@@ -2411,23 +2447,23 @@ class TimelineFragment @Inject constructor(
     }
 
     private fun displayThreadsBetaOptInDialog() {
-            activity?.let {
-                MaterialAlertDialogBuilder(it)
-                        .setTitle(R.string.threads_beta_enable_notice_title)
-                        .setMessage(threadsManager.getBetaEnableThreadsMessage())
-                        .setCancelable(true)
-                        .setNegativeButton(R.string.action_not_now) { _, _ -> }
-                        .setPositiveButton(R.string.action_try_it_out) { _, _ ->
-                            threadsManager.enableThreadsAndRestart(it)
-                        }
-                        .show()
-                        ?.findViewById<TextView>(android.R.id.message)
-                        ?.apply {
-                            linksClickable = true
-                            movementMethod = LinkMovementMethod.getInstance()
-                        }
-            }
+        activity?.let {
+            MaterialAlertDialogBuilder(it)
+                    .setTitle(R.string.threads_beta_enable_notice_title)
+                    .setMessage(threadsManager.getBetaEnableThreadsMessage())
+                    .setCancelable(true)
+                    .setNegativeButton(R.string.action_not_now) { _, _ -> }
+                    .setPositiveButton(R.string.action_try_it_out) { _, _ ->
+                        threadsManager.enableThreadsAndRestart(it)
+                    }
+                    .show()
+                    ?.findViewById<TextView>(android.R.id.message)
+                    ?.apply {
+                        linksClickable = true
+                        movementMethod = LinkMovementMethod.getInstance()
+                    }
         }
+    }
 
     /**
      * Navigate to Threads list for the current room

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerAction.kt
@@ -17,6 +17,7 @@
 package im.vector.app.features.home.room.detail.composer
 
 import im.vector.app.core.platform.VectorViewModelAction
+import im.vector.app.features.command.ParsedCommand
 import im.vector.app.features.home.room.detail.composer.voice.VoiceMessageRecorderView
 import org.matrix.android.sdk.api.session.content.ContentAttachmentData
 import org.matrix.android.sdk.api.session.room.model.message.MessageAudioContent
@@ -30,6 +31,7 @@ sealed class MessageComposerAction : VectorViewModelAction {
     data class UserIsTyping(val isTyping: Boolean) : MessageComposerAction()
     data class OnTextChanged(val text: CharSequence) : MessageComposerAction()
     data class OnEntersBackground(val composerText: String) : MessageComposerAction()
+    data class SlashCommandConfirmed(val parsedCommand: ParsedCommand) : MessageComposerAction()
 
     // Voice Message
     data class InitializeVoiceRecorder(val attachmentData: ContentAttachmentData) : MessageComposerAction()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewEvents.kt
@@ -16,7 +16,6 @@
 
 package im.vector.app.features.home.room.detail.composer
 
-import androidx.annotation.StringRes
 import im.vector.app.core.platform.VectorViewEvents
 import im.vector.app.features.command.Command
 import im.vector.app.features.command.ParsedCommand
@@ -34,7 +33,6 @@ sealed class MessageComposerViewEvents : VectorViewEvents {
     data class SlashCommandError(val command: Command) : SendMessageResult()
     data class SlashCommandUnknown(val command: String) : SendMessageResult()
     data class SlashCommandNotSupportedInThreads(val command: Command) : SendMessageResult()
-    data class SlashCommandHandled(@StringRes val messageRes: Int? = null) : SendMessageResult()
     object SlashCommandLoading : SendMessageResult()
     data class SlashCommandResultOk(val parsedCommand: ParsedCommand) : SendMessageResult()
     data class SlashCommandResultError(val throwable: Throwable) : SendMessageResult()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewEvents.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.home.room.detail.composer
 import androidx.annotation.StringRes
 import im.vector.app.core.platform.VectorViewEvents
 import im.vector.app.features.command.Command
+import im.vector.app.features.command.ParsedCommand
 
 sealed class MessageComposerViewEvents : VectorViewEvents {
 
@@ -35,8 +36,10 @@ sealed class MessageComposerViewEvents : VectorViewEvents {
     data class SlashCommandNotSupportedInThreads(val command: Command) : SendMessageResult()
     data class SlashCommandHandled(@StringRes val messageRes: Int? = null) : SendMessageResult()
     object SlashCommandLoading : SendMessageResult()
-    data class SlashCommandResultOk(@StringRes val messageRes: Int? = null) : SendMessageResult()
+    data class SlashCommandResultOk(val parsedCommand: ParsedCommand) : SendMessageResult()
     data class SlashCommandResultError(val throwable: Throwable) : SendMessageResult()
+
+    data class SlashCommandConfirmationRequest(val parsedCommand: ParsedCommand) : MessageComposerViewEvents()
 
     data class OpenRoomMemberProfile(val userId: String) : MessageComposerViewEvents()
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewEvents.kt
@@ -30,13 +30,13 @@ sealed class MessageComposerViewEvents : VectorViewEvents {
 
     object MessageSent : SendMessageResult()
     data class JoinRoomCommandSuccess(val roomId: String) : SendMessageResult()
-    class SlashCommandError(val command: Command) : SendMessageResult()
-    class SlashCommandUnknown(val command: String) : SendMessageResult()
-    class SlashCommandNotSupportedInThreads(val command: Command) : SendMessageResult()
+    data class SlashCommandError(val command: Command) : SendMessageResult()
+    data class SlashCommandUnknown(val command: String) : SendMessageResult()
+    data class SlashCommandNotSupportedInThreads(val command: Command) : SendMessageResult()
     data class SlashCommandHandled(@StringRes val messageRes: Int? = null) : SendMessageResult()
     object SlashCommandLoading : SendMessageResult()
     data class SlashCommandResultOk(@StringRes val messageRes: Int? = null) : SendMessageResult()
-    class SlashCommandResultError(val throwable: Throwable) : SendMessageResult()
+    data class SlashCommandResultError(val throwable: Throwable) : SendMessageResult()
 
     data class OpenRoomMemberProfile(val userId: String) : MessageComposerViewEvents()
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
@@ -110,6 +110,7 @@ class MessageComposerViewModel @AssistedInject constructor(
             is MessageComposerAction.VoiceWaveformTouchedUp         -> handleVoiceWaveformTouchedUp(action)
             is MessageComposerAction.VoiceWaveformMovedTo           -> handleVoiceWaveformMovedTo(action)
             is MessageComposerAction.AudioSeekBarMovedTo            -> handleAudioSeekBarMovedTo(action)
+            is MessageComposerAction.SlashCommandConfirmed          -> handleSlashCommandConfirmed(action)
         }
     }
 
@@ -255,8 +256,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                         }
                         is ParsedCommand.SetMarkdown                       -> {
                             vectorPreferences.setMarkdownEnabled(parsedCommand.enable)
-                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(
-                                    if (parsedCommand.enable) R.string.markdown_has_been_enabled else R.string.markdown_has_been_disabled))
+                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                             popDraft()
                         }
                         is ParsedCommand.BanUser                           -> {
@@ -291,7 +291,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                             } else {
                                 room.sendTextMessage(parsedCommand.message, msgType = MessageType.MSGTYPE_EMOTE, autoMarkdown = action.autoMarkdown)
                             }
-                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                             popDraft()
                         }
                         is ParsedCommand.SendRainbow                       -> {
@@ -304,7 +304,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                             } else {
                                 room.sendFormattedTextMessage(message, rainbowGenerator.generate(message))
                             }
-                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                             popDraft()
                         }
                         is ParsedCommand.SendRainbowEmote                  -> {
@@ -319,7 +319,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                                 room.sendFormattedTextMessage(message, rainbowGenerator.generate(message), MessageType.MSGTYPE_EMOTE)
                             }
 
-                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                             popDraft()
                         }
                         is ParsedCommand.SendSpoiler                       -> {
@@ -335,22 +335,22 @@ class MessageComposerViewModel @AssistedInject constructor(
                                         text,
                                         formattedText)
                             }
-                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                             popDraft()
                         }
                         is ParsedCommand.SendShrug                         -> {
                             sendPrefixedMessage("¯\\_(ツ)_/¯", parsedCommand.message, state.rootThreadEventId)
-                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                             popDraft()
                         }
                         is ParsedCommand.SendLenny                         -> {
                             sendPrefixedMessage("( ͡° ͜ʖ ͡°)", parsedCommand.message, state.rootThreadEventId)
-                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                             popDraft()
                         }
                         is ParsedCommand.SendChatEffect                    -> {
                             sendChatEffect(parsedCommand)
-                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                             popDraft()
                         }
                         is ParsedCommand.ChangeTopic                       -> {
@@ -369,17 +369,17 @@ class MessageComposerViewModel @AssistedInject constructor(
                             handleChangeAvatarForRoomSlashCommand(parsedCommand)
                         }
                         is ParsedCommand.ShowUser                          -> {
-                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                             handleWhoisSlashCommand(parsedCommand)
                             popDraft()
                         }
                         is ParsedCommand.DiscardSession                    -> {
                             if (room.isEncrypted()) {
                                 session.cryptoService().discardOutboundSession(room.roomId)
-                                _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                                _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                                 popDraft()
                             } else {
-                                _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                                _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                                 _viewEvents.post(
                                         MessageComposerViewEvents
                                                 .ShowMessage(stringProvider.getString(R.string.command_description_discard_session_not_handled))
@@ -403,7 +403,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                                                     true
                                             )
                                     popDraft()
-                                    _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                                    _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                                 } catch (failure: Throwable) {
                                     _viewEvents.post(MessageComposerViewEvents.SlashCommandResultError(failure))
                                 }
@@ -422,7 +422,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                                                     false
                                             )
                                     popDraft()
-                                    _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                                    _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                                 } catch (failure: Throwable) {
                                     _viewEvents.post(MessageComposerViewEvents.SlashCommandResultError(failure))
                                 }
@@ -435,7 +435,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                                 try {
                                     session.spaceService().joinSpace(parsedCommand.spaceIdOrAlias)
                                     popDraft()
-                                    _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                                    _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                                 } catch (failure: Throwable) {
                                     _viewEvents.post(MessageComposerViewEvents.SlashCommandResultError(failure))
                                 }
@@ -447,7 +447,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                                 try {
                                     session.leaveRoom(parsedCommand.roomId)
                                     popDraft()
-                                    _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                                    _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                                 } catch (failure: Throwable) {
                                     _viewEvents.post(MessageComposerViewEvents.SlashCommandResultError(failure))
                                 }
@@ -461,7 +461,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                                             room.roomSummary()?.isPublic ?: false
                                     )
                             )
-                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk())
+                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                             popDraft()
                         }
                     }
@@ -644,19 +644,19 @@ class MessageComposerViewModel @AssistedInject constructor(
     }
 
     private fun handleChangeTopicSlashCommand(changeTopic: ParsedCommand.ChangeTopic) {
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(changeTopic) {
             room.updateTopic(changeTopic.topic)
         }
     }
 
     private fun handleInviteSlashCommand(invite: ParsedCommand.Invite) {
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(invite) {
             room.invite(invite.userId, invite.reason)
         }
     }
 
     private fun handleInvite3pidSlashCommand(invite: ParsedCommand.Invite3Pid) {
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(invite) {
             room.invite3pid(invite.threePid)
         }
     }
@@ -669,19 +669,19 @@ class MessageComposerViewModel @AssistedInject constructor(
                 ?.toContent()
                 ?: return
 
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(setUserPowerLevel) {
             room.sendStateEvent(EventType.STATE_ROOM_POWER_LEVELS, stateKey = "", newPowerLevelsContent)
         }
     }
 
     private fun handleChangeDisplayNameSlashCommand(changeDisplayName: ParsedCommand.ChangeDisplayName) {
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(changeDisplayName) {
             session.setDisplayName(session.myUserId, changeDisplayName.displayName)
         }
     }
 
     private fun handlePartSlashCommand(command: ParsedCommand.PartRoom) {
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(command) {
             if (command.roomAlias == null) {
                 // Leave the current room
                 room
@@ -697,25 +697,25 @@ class MessageComposerViewModel @AssistedInject constructor(
     }
 
     private fun handleRemoveSlashCommand(removeUser: ParsedCommand.RemoveUser) {
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(removeUser) {
             room.remove(removeUser.userId, removeUser.reason)
         }
     }
 
     private fun handleBanSlashCommand(ban: ParsedCommand.BanUser) {
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(ban) {
             room.ban(ban.userId, ban.reason)
         }
     }
 
     private fun handleUnbanSlashCommand(unban: ParsedCommand.UnbanUser) {
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(unban) {
             room.unban(unban.userId, unban.reason)
         }
     }
 
     private fun handleChangeRoomNameSlashCommand(changeRoomName: ParsedCommand.ChangeRoomName) {
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(changeRoomName) {
             room.updateName(changeRoomName.name)
         }
     }
@@ -727,7 +727,7 @@ class MessageComposerViewModel @AssistedInject constructor(
     }
 
     private fun handleChangeDisplayNameForRoomSlashCommand(changeDisplayName: ParsedCommand.ChangeDisplayNameForRoom) {
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(changeDisplayName) {
             getMyRoomMemberContent()
                     ?.copy(displayName = changeDisplayName.displayName)
                     ?.toContent()
@@ -738,13 +738,13 @@ class MessageComposerViewModel @AssistedInject constructor(
     }
 
     private fun handleChangeRoomAvatarSlashCommand(changeAvatar: ParsedCommand.ChangeRoomAvatar) {
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(changeAvatar) {
             room.sendStateEvent(EventType.STATE_ROOM_AVATAR, stateKey = "", RoomAvatarContent(changeAvatar.url).toContent())
         }
     }
 
     private fun handleChangeAvatarForRoomSlashCommand(changeAvatar: ParsedCommand.ChangeAvatarForRoom) {
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(changeAvatar) {
             getMyRoomMemberContent()
                     ?.copy(avatarUrl = changeAvatar.url)
                     ?.toContent()
@@ -755,13 +755,24 @@ class MessageComposerViewModel @AssistedInject constructor(
     }
 
     private fun handleIgnoreSlashCommand(ignore: ParsedCommand.IgnoreUser) {
-        launchSlashCommandFlowSuspendable {
+        launchSlashCommandFlowSuspendable(ignore) {
             session.ignoreUserIds(listOf(ignore.userId))
         }
     }
 
     private fun handleUnignoreSlashCommand(unignore: ParsedCommand.UnignoreUser) {
-        launchSlashCommandFlowSuspendable {
+        _viewEvents.post(MessageComposerViewEvents.SlashCommandConfirmationRequest(unignore))
+    }
+
+    private fun handleSlashCommandConfirmed(action: MessageComposerAction.SlashCommandConfirmed) {
+        when (action.parsedCommand) {
+            is ParsedCommand.UnignoreUser -> handleUnignoreSlashCommandConfirmed(action.parsedCommand)
+            else                          -> TODO("Not handled yet")
+        }
+    }
+
+    private fun handleUnignoreSlashCommandConfirmed(unignore: ParsedCommand.UnignoreUser) {
+        launchSlashCommandFlowSuspendable(unignore) {
             session.unIgnoreUserIds(listOf(unignore.userId))
         }
     }
@@ -900,13 +911,13 @@ class MessageComposerViewModel @AssistedInject constructor(
         }
     }
 
-    private fun launchSlashCommandFlowSuspendable(block: suspend () -> Unit) {
+    private fun launchSlashCommandFlowSuspendable(parsedCommand: ParsedCommand, block: suspend () -> Unit) {
         _viewEvents.post(MessageComposerViewEvents.SlashCommandLoading)
         viewModelScope.launch {
             val event = try {
                 block()
                 popDraft()
-                MessageComposerViewEvents.SlashCommandResultOk()
+                MessageComposerViewEvents.SlashCommandResultOk(parsedCommand)
             } catch (failure: Throwable) {
                 MessageComposerViewEvents.SlashCommandResultError(failure)
             }

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
@@ -47,6 +47,8 @@ import im.vector.app.databinding.DialogBaseEditTextBinding
 import im.vector.app.databinding.DialogShareQrCodeBinding
 import im.vector.app.databinding.FragmentMatrixProfileBinding
 import im.vector.app.databinding.ViewStubRoomMemberProfileHeaderBinding
+import im.vector.app.features.MainActivity
+import im.vector.app.features.MainActivityArgs
 import im.vector.app.features.analytics.plan.MobileScreen
 import im.vector.app.features.crypto.verification.VerificationBottomSheet
 import im.vector.app.features.displayname.getBestName
@@ -131,11 +133,18 @@ class RoomMemberProfileFragment @Inject constructor(
                 is RoomMemberProfileViewEvents.OnKickActionSuccess         -> Unit
                 is RoomMemberProfileViewEvents.OnSetPowerLevelSuccess      -> Unit
                 is RoomMemberProfileViewEvents.OnBanActionSuccess          -> Unit
-                is RoomMemberProfileViewEvents.OnIgnoreActionSuccess       -> Unit
+                is RoomMemberProfileViewEvents.OnIgnoreActionSuccess       -> handleOnIgnoreActionSuccess(it)
                 is RoomMemberProfileViewEvents.OnInviteActionSuccess       -> Unit
             }
         }
         setupLongClicks()
+    }
+
+    private fun handleOnIgnoreActionSuccess(action: RoomMemberProfileViewEvents.OnIgnoreActionSuccess) {
+        if (action.shouldPerformInitialSync) {
+            // A user has been un-ignored, perform a initial sync
+            MainActivity.restartApp(requireActivity(), MainActivityArgs(clearCache = true))
+        }
     }
 
     private fun setupLongClicks() {

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewEvents.kt
@@ -25,7 +25,7 @@ sealed class RoomMemberProfileViewEvents : VectorViewEvents {
     data class Loading(val message: CharSequence? = null) : RoomMemberProfileViewEvents()
     data class Failure(val throwable: Throwable) : RoomMemberProfileViewEvents()
 
-    object OnIgnoreActionSuccess : RoomMemberProfileViewEvents()
+    data class OnIgnoreActionSuccess(val shouldPerformInitialSync: Boolean) : RoomMemberProfileViewEvents()
     object OnSetPowerLevelSuccess : RoomMemberProfileViewEvents()
     object OnInviteActionSuccess : RoomMemberProfileViewEvents()
     object OnKickActionSuccess : RoomMemberProfileViewEvents()

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewModel.kt
@@ -390,7 +390,7 @@ class RoomMemberProfileViewModel @AssistedInject constructor(
                 } else {
                     session.ignoreUserIds(listOf(state.userId))
                 }
-                RoomMemberProfileViewEvents.OnIgnoreActionSuccess
+                RoomMemberProfileViewEvents.OnIgnoreActionSuccess(isIgnored)
             } catch (failure: Throwable) {
                 RoomMemberProfileViewEvents.Failure(failure)
             }

--- a/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersAction.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersAction.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.ignored
+
+import im.vector.app.core.platform.VectorViewModelAction
+
+sealed class IgnoredUsersAction : VectorViewModelAction {
+    data class UnIgnore(val userId: String) : IgnoredUsersAction()
+}

--- a/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersViewEvents.kt
@@ -25,4 +25,5 @@ import im.vector.app.core.platform.VectorViewEvents
 sealed class IgnoredUsersViewEvents : VectorViewEvents {
     data class Loading(val message: CharSequence? = null) : IgnoredUsersViewEvents()
     data class Failure(val throwable: Throwable) : IgnoredUsersViewEvents()
+    object Success : IgnoredUsersViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersViewModel.kt
@@ -16,10 +16,7 @@
 
 package im.vector.app.features.settings.ignored
 
-import com.airbnb.mvrx.Fail
-import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.MavericksViewModelFactory
-import com.airbnb.mvrx.Success
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -63,19 +60,10 @@ class IgnoredUsersViewModel @AssistedInject constructor(
     }
 
     private fun handleUnIgnore(action: IgnoredUsersAction.UnIgnore) {
-        setState {
-            copy(
-                    unIgnoreRequest = Loading()
-            )
-        }
-
+        setState { copy(isLoading = true) }
         viewModelScope.launch {
             val result = runCatching { session.unIgnoreUserIds(listOf(action.userId)) }
-            setState {
-                copy(
-                        unIgnoreRequest = result.fold(::Success, ::Fail)
-                )
-            }
+            setState { copy(isLoading = false) }
             result.onFailure { _viewEvents.post(IgnoredUsersViewEvents.Failure(it)) }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersViewModel.kt
@@ -16,37 +16,24 @@
 
 package im.vector.app.features.settings.ignored
 
-import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
-import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Success
-import com.airbnb.mvrx.Uninitialized
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.VectorViewModel
-import im.vector.app.core.platform.VectorViewModelAction
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.session.Session
-import org.matrix.android.sdk.api.session.user.model.User
 import org.matrix.android.sdk.flow.flow
 
-data class IgnoredUsersViewState(
-        val ignoredUsers: List<User> = emptyList(),
-        val unIgnoreRequest: Async<Unit> = Uninitialized
-) : MavericksState
-
-sealed class IgnoredUsersAction : VectorViewModelAction {
-    data class UnIgnore(val userId: String) : IgnoredUsersAction()
-}
-
-class IgnoredUsersViewModel @AssistedInject constructor(@Assisted initialState: IgnoredUsersViewState,
-                                                        private val session: Session) :
-    VectorViewModel<IgnoredUsersViewState, IgnoredUsersAction, IgnoredUsersViewEvents>(initialState) {
+class IgnoredUsersViewModel @AssistedInject constructor(
+        @Assisted initialState: IgnoredUsersViewState,
+        private val session: Session
+) : VectorViewModel<IgnoredUsersViewState, IgnoredUsersAction, IgnoredUsersViewEvents>(initialState) {
 
     @AssistedFactory
     interface Factory : MavericksAssistedViewModelFactory<IgnoredUsersViewModel, IgnoredUsersViewState> {

--- a/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersViewModel.kt
@@ -62,9 +62,14 @@ class IgnoredUsersViewModel @AssistedInject constructor(
     private fun handleUnIgnore(action: IgnoredUsersAction.UnIgnore) {
         setState { copy(isLoading = true) }
         viewModelScope.launch {
-            val result = runCatching { session.unIgnoreUserIds(listOf(action.userId)) }
+            val viewEvent = try {
+                session.unIgnoreUserIds(listOf(action.userId))
+                IgnoredUsersViewEvents.Success
+            } catch (throwable: Throwable) {
+                IgnoredUsersViewEvents.Failure(throwable)
+            }
             setState { copy(isLoading = false) }
-            result.onFailure { _viewEvents.post(IgnoredUsersViewEvents.Failure(it)) }
+            _viewEvents.post(viewEvent)
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersViewState.kt
@@ -16,12 +16,10 @@
 
 package im.vector.app.features.settings.ignored
 
-import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.MavericksState
-import com.airbnb.mvrx.Uninitialized
 import org.matrix.android.sdk.api.session.user.model.User
 
 data class IgnoredUsersViewState(
         val ignoredUsers: List<User> = emptyList(),
-        val unIgnoreRequest: Async<Unit> = Uninitialized
+        val isLoading: Boolean = false
 ) : MavericksState

--- a/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/ignored/IgnoredUsersViewState.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.ignored
+
+import com.airbnb.mvrx.Async
+import com.airbnb.mvrx.MavericksState
+import com.airbnb.mvrx.Uninitialized
+import org.matrix.android.sdk.api.session.user.model.User
+
+data class IgnoredUsersViewState(
+        val ignoredUsers: List<User> = emptyList(),
+        val unIgnoreRequest: Async<Unit> = Uninitialized
+) : MavericksState

--- a/vector/src/main/java/im/vector/app/features/settings/ignored/VectorSettingsIgnoredUsersFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/ignored/VectorSettingsIgnoredUsersFragment.kt
@@ -80,11 +80,12 @@ class VectorSettingsIgnoredUsersFragment @Inject constructor(
 
     override fun onUserIdClicked(userId: String) {
         MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(R.string.room_participants_action_unignore_title)
                 .setMessage(getString(R.string.settings_unignore_user, userId))
-                .setPositiveButton(R.string.yes) { _, _ ->
+                .setPositiveButton(R.string.unignore) { _, _ ->
                     viewModel.handle(IgnoredUsersAction.UnIgnore(userId))
                 }
-                .setNegativeButton(R.string.no, null)
+                .setNegativeButton(R.string.action_cancel, null)
                 .show()
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/ignored/VectorSettingsIgnoredUsersFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/ignored/VectorSettingsIgnoredUsersFragment.kt
@@ -22,8 +22,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
-import com.airbnb.mvrx.Async
-import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.withState
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -95,14 +93,6 @@ class VectorSettingsIgnoredUsersFragment @Inject constructor(
 
     override fun invalidate() = withState(viewModel) { state ->
         ignoredUsersController.update(state)
-
-        handleUnIgnoreRequestStatus(state.unIgnoreRequest)
-    }
-
-    private fun handleUnIgnoreRequestStatus(unIgnoreRequest: Async<Unit>) {
-        views.waitingView.root.isVisible = when (unIgnoreRequest) {
-            is Loading -> true
-            else       -> false
-        }
+        views.waitingView.root.isVisible = state.isLoading
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/ignored/VectorSettingsIgnoredUsersFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/ignored/VectorSettingsIgnoredUsersFragment.kt
@@ -30,6 +30,8 @@ import im.vector.app.core.extensions.cleanup
 import im.vector.app.core.extensions.configureWith
 import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.databinding.FragmentGenericRecyclerBinding
+import im.vector.app.features.MainActivity
+import im.vector.app.features.MainActivityArgs
 import im.vector.app.features.analytics.plan.MobileScreen
 import javax.inject.Inject
 
@@ -60,8 +62,14 @@ class VectorSettingsIgnoredUsersFragment @Inject constructor(
             when (it) {
                 is IgnoredUsersViewEvents.Loading -> showLoading(it.message)
                 is IgnoredUsersViewEvents.Failure -> showFailure(it.throwable)
+                IgnoredUsersViewEvents.Success    -> handleSuccess()
             }
         }
+    }
+
+    private fun handleSuccess() {
+        // A user has been un-ignored, perform a initial sync
+        MainActivity.restartApp(requireActivity(), MainActivityArgs(clearCache = true))
     }
 
     override fun onDestroyView() {

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -634,7 +634,7 @@
     <string name="room_participants_action_ignore">Ignore</string>
 
     <string name="room_participants_action_unignore_title">Unignore user</string>
-    <string name="room_participants_action_unignore_prompt_msg">Unignoring this user will show all messages from them again.</string>
+    <string name="room_participants_action_unignore_prompt_msg">Unignoring this user will show all messages from them again.\n\nNote that this action will restart the app and it may take some time.</string>
     <string name="room_participants_action_unignore">Unignore</string>
 
     <string name="room_participants_action_cancel_invite_title">Cancel invite</string>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

Displaying a confirmation dialog when a user is unignored, and perform an init sync when it's done:

- from the main setting screen
- from the room member list
- from the slash command action

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

Closes #3439

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

|From room member list|From settings|From slash command|
|-|-|-|
|![unignore](https://user-images.githubusercontent.com/3940906/163416991-12e3e8f3-8ec0-4b45-bbd3-86df3de7ca46.gif)|![unignore2](https://user-images.githubusercontent.com/3940906/163417010-33c9fb5d-55be-4dc4-b19c-9a60651ecfc2.gif)|![unignore3](https://user-images.githubusercontent.com/3940906/163417030-b8f97965-5da7-4c21-869f-e688d8eb5eec.gif)|

## Tests

<!-- Explain how you tested your development -->

- Ignore a user
- Unignore a user -> observe the initial sync

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
