### PR TITLE
Enhance user experience when home servers do not support threads.

### DIFF
--- a/changelog.d/5761.feature
+++ b/changelog.d/5761.feature
@@ -1,0 +1,1 @@
+Improve user experience when home servers do not yet support threads

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/homeserver/HomeServerCapabilities.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/homeserver/HomeServerCapabilities.kt
@@ -54,7 +54,7 @@ data class HomeServerCapabilities(
         /**
          * True if the home server support threading
          */
-        var canUseThreading: Boolean = false
+        val canUseThreading: Boolean = false
 ) {
 
     enum class RoomCapabilitySupport {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
@@ -452,6 +452,10 @@ class MessageActionsViewModel @AssistedInject constructor(
                                  actionPermissions: ActionPermissions): Boolean {
         // We let reply in thread visible even if threads are not enabled, with an enhanced flow to attract users
 //        if (!vectorPreferences.areThreadMessagesEnabled()) return false
+        // Disable beta prompt if the homeserver do not support threads
+        if (!vectorPreferences.areThreadMessagesEnabled() &&
+                !session.getHomeServerCapabilities().canUseThreading) return false
+
         if (initialState.isFromThreadTimeline) return false
         if (event.root.isThread()) return false
         if (event.root.getClearType() != EventType.MESSAGE &&

--- a/vector/src/main/java/im/vector/app/features/home/room/threads/ThreadsManager.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/threads/ThreadsManager.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.home.room.threads
 
 import android.app.Activity
 import android.text.Spanned
+import androidx.annotation.StringRes
 import androidx.core.text.HtmlCompat
 import im.vector.app.R
 import im.vector.app.core.resources.StringProvider
@@ -49,11 +50,17 @@ class ThreadsManager @Inject constructor(
     /**
      * Generates and return an Html spanned string to be rendered especially in dialogs
      */
-    fun getBetaEnableThreadsMessage(): Spanned {
+    private fun generateLearnMoreHtmlString(@StringRes messageId: Int): Spanned {
         val learnMore = stringProvider.getString(R.string.action_learn_more)
         val learnMoreUrl = stringProvider.getString(R.string.threads_learn_more_url)
         val href = "<a href='$learnMoreUrl'>$learnMore</a>.<br><br>"
-        val message = stringProvider.getString(R.string.threads_beta_enable_notice_message, href)
+        val message = stringProvider.getString(messageId, href)
         return HtmlCompat.fromHtml(message, HtmlCompat.FROM_HTML_MODE_LEGACY)
     }
+
+    fun getBetaEnableThreadsMessage(): Spanned =
+            generateLearnMoreHtmlString(R.string.threads_beta_enable_notice_message)
+
+    fun getLabsEnableThreadsMessage(): Spanned =
+            generateLearnMoreHtmlString(R.string.threads_labs_enable_notice_message)
 }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsLabsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsLabsFragment.kt
@@ -17,18 +17,23 @@
 package im.vector.app.features.settings
 
 import android.os.Bundle
+import android.text.method.LinkMovementMethod
+import android.widget.TextView
 import androidx.preference.Preference
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import im.vector.app.R
 import im.vector.app.core.preference.VectorSwitchPreference
 import im.vector.app.features.MainActivity
 import im.vector.app.features.MainActivityArgs
 import im.vector.app.features.analytics.plan.MobileScreen
+import im.vector.app.features.home.room.threads.ThreadsManager
 import org.matrix.android.sdk.api.settings.LightweightSettingsStorage
 import javax.inject.Inject
 
 class VectorSettingsLabsFragment @Inject constructor(
         private val vectorPreferences: VectorPreferences,
-        private val lightweightSettingsStorage: LightweightSettingsStorage
+        private val lightweightSettingsStorage: LightweightSettingsStorage,
+        private val threadsManager: ThreadsManager
 ) : VectorSettingsBaseFragment() {
 
     override var titleRes = R.string.room_settings_labs_pref_title
@@ -46,15 +51,51 @@ class VectorSettingsLabsFragment @Inject constructor(
         }
 
         // clear cache
-        findPreference<VectorSwitchPreference>(VectorPreferences.SETTINGS_LABS_ENABLE_THREAD_MESSAGES)?.let {
-            it.onPreferenceClickListener = Preference.OnPreferenceClickListener {
-                // We should migrate threads only if threads are disabled
-                vectorPreferences.setShouldMigrateThreads(!vectorPreferences.areThreadMessagesEnabled())
-                lightweightSettingsStorage.setThreadMessagesEnabled(vectorPreferences.areThreadMessagesEnabled())
-                displayLoadingView()
-                MainActivity.restartApp(requireActivity(), MainActivityArgs(clearCache = true))
+        findPreference<VectorSwitchPreference>(VectorPreferences.SETTINGS_LABS_ENABLE_THREAD_MESSAGES)?.let { vectorPref ->
+            vectorPref.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+                onThreadsPreferenceClickedInterceptor(vectorPref)
                 false
             }
         }
+    }
+
+    /**
+     * Intercept the click to display a user friendly dialog when their homeserver do not support threads
+     */
+    private fun onThreadsPreferenceClickedInterceptor(vectorSwitchPreference: VectorSwitchPreference) {
+        val userEnabledThreads = vectorPreferences.areThreadMessagesEnabled()
+        if (!session.getHomeServerCapabilities().canUseThreading && userEnabledThreads) {
+            activity?.let {
+                MaterialAlertDialogBuilder(it)
+                        .setTitle(R.string.threads_labs_enable_notice_title)
+                        .setMessage(threadsManager.getLabsEnableThreadsMessage())
+                        .setCancelable(true)
+                        .setNegativeButton(R.string.action_not_now) { _, _ ->
+                            vectorSwitchPreference.isChecked = false
+                        }
+                        .setPositiveButton(R.string.action_try_it_out) { _, _ ->
+                            onThreadsPreferenceClicked()
+                        }
+                        .show()
+                        ?.findViewById<TextView>(android.R.id.message)
+                        ?.apply {
+                            linksClickable = true
+                            movementMethod = LinkMovementMethod.getInstance()
+                        }
+            }
+        } else {
+            onThreadsPreferenceClicked()
+        }
+    }
+
+    /**
+     * Action when threads preference switch is actually clicked
+     */
+    private fun onThreadsPreferenceClicked() {
+        // We should migrate threads only if threads are disabled
+        vectorPreferences.setShouldMigrateThreads(!vectorPreferences.areThreadMessagesEnabled())
+        lightweightSettingsStorage.setThreadMessagesEnabled(vectorPreferences.areThreadMessagesEnabled())
+        displayLoadingView()
+        MainActivity.restartApp(requireActivity(), MainActivityArgs(clearCache = true))
     }
 }

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -739,6 +739,9 @@
     <string name="threads_beta_enable_notice_title">Threads Beta</string>
     <!-- %s will be replaced with action_learn_more string resource that will be clickable(url redirection)  -->
     <string name="threads_beta_enable_notice_message">Threads help keep your conversations on-topic and easy to track. %sEnabling threads will refresh the app. This may take longer for some accounts.</string>
+    <string name="threads_labs_enable_notice_title">Threads Beta</string>
+    <string name="threads_labs_enable_notice_message">Your homeserver does not currently support threads, so this feature may be unreliable. Some threaded messages may not be reliably available. %sDo you want to enable threads anyway?</string>
+
 
     <!-- Search -->
     <string name="search_hint">Search</string>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Users that their home servers do not support MSC3340, they will:

- Have a popup when enabling threads informing them about the inconsistencies may occur
- Will not see the bottom sheet beta `reply in thread `

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
![Screenshot_20220415-140015_Element dbg](https://user-images.githubusercontent.com/60798129/163571758-227a9d18-a71d-4563-9a53-557670464f07.jpg)

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
