### PR TITLE
Using unix end of line character instead of windows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 [*]
 charset = utf-8
-end_of_line = crlf
+end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Reverts the change in the `.editorconfig` which uses the windows style end of line characters (crlf) as the project was originally using the unix style (lf).

This will avoid introducing entire file diffs as and when the files are automatically converted, such as the one in this PR.

## Motivation and context

To use a consistent end of line character style with the least amount of noise! 

## Screenshots / GIFs
N/A

## Tests
N/A

## Tested devices
N/A
