### PR TITLE
Crash: open private room by link

### DIFF
--- a/changelog.d/5786.bugfix
+++ b/changelog.d/5786.bugfix
@@ -1,0 +1,1 @@
+Open a room by link: use matrixId instead of alias

--- a/changelog.d/5786.bugfix
+++ b/changelog.d/5786.bugfix
@@ -1,1 +1,2 @@
-Open a room by link: use matrixId instead of alias
+Open a room by link: use the actual roomId instead of the alias
+

--- a/vector/src/main/java/im/vector/app/features/matrixto/MatrixToAction.kt
+++ b/vector/src/main/java/im/vector/app/features/matrixto/MatrixToAction.kt
@@ -24,7 +24,7 @@ sealed class MatrixToAction : VectorViewModelAction {
     object FailedToResolveUser : MatrixToAction()
     object FailedToStartChatting : MatrixToAction()
     data class JoinSpace(val spaceID: String, val viaServers: List<String>?) : MatrixToAction()
-    data class JoinRoom(val roomId: String, val viaServers: List<String>?) : MatrixToAction()
+    data class JoinRoom(val roomIdOrAlias: String, val viaServers: List<String>?) : MatrixToAction()
     data class OpenSpace(val spaceID: String) : MatrixToAction()
     data class OpenRoom(val roomId: String) : MatrixToAction()
 }

--- a/vector/src/main/java/im/vector/app/features/matrixto/MatrixToBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/matrixto/MatrixToBottomSheetViewModel.kt
@@ -297,13 +297,12 @@ class MatrixToBottomSheetViewModel @AssistedInject constructor(
         }
         viewModelScope.launch {
             try {
-                session.joinRoom(action.roomIdOrAlias, null, action.viaServers?.take(3) ?: emptyList())
-                val roomId: String = if (MatrixPatterns.isRoomAlias(action.roomIdOrAlias)) {
-                    session.getRoomIdByAlias(action.roomIdOrAlias, true).get().roomId
-                } else {
-                    action.roomIdOrAlias
-                }
-                _viewEvents.post(MatrixToViewEvents.NavigateToRoom(roomId))
+                session.joinRoom(
+                        roomIdOrAlias = action.roomIdOrAlias,
+                        reason = null,
+                        viaServers = action.viaServers?.take(3) ?: emptyList()
+                )
+                _viewEvents.post(MatrixToViewEvents.NavigateToRoom(getRoomIdFromRoomIdOrAlias(action.roomIdOrAlias)))
             } catch (failure: Throwable) {
                 _viewEvents.post(MatrixToViewEvents.ShowModalError(errorFormatter.toHumanReadable(failure)))
             } finally {
@@ -313,6 +312,12 @@ class MatrixToBottomSheetViewModel @AssistedInject constructor(
                 }
             }
         }
+    }
+
+    private suspend fun getRoomIdFromRoomIdOrAlias(roomIdOrAlias: String): String {
+        return if (MatrixPatterns.isRoomAlias(roomIdOrAlias)) {
+            session.getRoomIdByAlias(roomIdOrAlias, true).get().roomId
+        } else roomIdOrAlias
     }
 
     private fun handleStartChatting(action: MatrixToAction.StartChattingWithUser) {

--- a/vector/src/main/java/im/vector/app/features/matrixto/MatrixToBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/matrixto/MatrixToBottomSheetViewModel.kt
@@ -33,6 +33,7 @@ import im.vector.app.core.resources.StringProvider
 import im.vector.app.features.createdirect.DirectRoomHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.MatrixPatterns
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.permalinks.PermalinkData
@@ -296,8 +297,13 @@ class MatrixToBottomSheetViewModel @AssistedInject constructor(
         }
         viewModelScope.launch {
             try {
-                session.joinRoom(action.roomId, null, action.viaServers?.take(3) ?: emptyList())
-                _viewEvents.post(MatrixToViewEvents.NavigateToRoom(action.roomId))
+                session.joinRoom(action.roomIdOrAlias, null, action.viaServers?.take(3) ?: emptyList())
+                val roomId: String = if (MatrixPatterns.isRoomAlias(action.roomIdOrAlias)) {
+                    session.getRoomIdByAlias(action.roomIdOrAlias, true).get().roomId
+                } else {
+                    action.roomIdOrAlias
+                }
+                _viewEvents.post(MatrixToViewEvents.NavigateToRoom(roomId))
             } catch (failure: Throwable) {
                 _viewEvents.post(MatrixToViewEvents.ShowModalError(errorFormatter.toHumanReadable(failure)))
             } finally {

--- a/vector/src/main/java/im/vector/app/features/matrixto/MatrixToBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/matrixto/MatrixToBottomSheetViewModel.kt
@@ -297,12 +297,13 @@ class MatrixToBottomSheetViewModel @AssistedInject constructor(
         }
         viewModelScope.launch {
             try {
-                session.joinRoom(
-                        roomIdOrAlias = action.roomIdOrAlias,
-                        reason = null,
-                        viaServers = action.viaServers?.take(3) ?: emptyList()
-                )
-                _viewEvents.post(MatrixToViewEvents.NavigateToRoom(getRoomIdFormRoomIdOrAlias(action.roomIdOrAlias)))
+                session.joinRoom(action.roomIdOrAlias, null, action.viaServers?.take(3) ?: emptyList())
+                val roomId: String = if (MatrixPatterns.isRoomAlias(action.roomIdOrAlias)) {
+                    session.getRoomIdByAlias(action.roomIdOrAlias, true).get().roomId
+                } else {
+                    action.roomIdOrAlias
+                }
+                _viewEvents.post(MatrixToViewEvents.NavigateToRoom(roomId))
             } catch (failure: Throwable) {
                 _viewEvents.post(MatrixToViewEvents.ShowModalError(errorFormatter.toHumanReadable(failure)))
             } finally {
@@ -312,12 +313,6 @@ class MatrixToBottomSheetViewModel @AssistedInject constructor(
                 }
             }
         }
-    }
-
-    private suspend fun getRoomIdFormRoomIdOrAlias(roomIdOrAlias: String): String {
-        return if (MatrixPatterns.isRoomAlias(roomIdOrAlias)) {
-            session.getRoomIdByAlias(roomIdOrAlias, true).get().roomId
-        } else roomIdOrAlias
     }
 
     private fun handleStartChatting(action: MatrixToAction.StartChattingWithUser) {

--- a/vector/src/main/java/im/vector/app/features/matrixto/MatrixToBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/matrixto/MatrixToBottomSheetViewModel.kt
@@ -297,13 +297,12 @@ class MatrixToBottomSheetViewModel @AssistedInject constructor(
         }
         viewModelScope.launch {
             try {
-                session.joinRoom(action.roomIdOrAlias, null, action.viaServers?.take(3) ?: emptyList())
-                val roomId: String = if (MatrixPatterns.isRoomAlias(action.roomIdOrAlias)) {
-                    session.getRoomIdByAlias(action.roomIdOrAlias, true).get().roomId
-                } else {
-                    action.roomIdOrAlias
-                }
-                _viewEvents.post(MatrixToViewEvents.NavigateToRoom(roomId))
+                session.joinRoom(
+                        roomIdOrAlias = action.roomIdOrAlias,
+                        reason = null,
+                        viaServers = action.viaServers?.take(3) ?: emptyList()
+                )
+                _viewEvents.post(MatrixToViewEvents.NavigateToRoom(getRoomIdFormRoomIdOrAlias(action.roomIdOrAlias)))
             } catch (failure: Throwable) {
                 _viewEvents.post(MatrixToViewEvents.ShowModalError(errorFormatter.toHumanReadable(failure)))
             } finally {
@@ -313,6 +312,12 @@ class MatrixToBottomSheetViewModel @AssistedInject constructor(
                 }
             }
         }
+    }
+
+    private suspend fun getRoomIdFormRoomIdOrAlias(roomIdOrAlias: String): String {
+        return if (MatrixPatterns.isRoomAlias(roomIdOrAlias)) {
+            session.getRoomIdByAlias(roomIdOrAlias, true).get().roomId
+        } else roomIdOrAlias
     }
 
     private fun handleStartChatting(action: MatrixToAction.StartChattingWithUser) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content
Use matrixId instead of alias for NavigateToRoom
In some cases, the alias was used instead of the room id. The alias was blocking the room creation in the DB.
<!-- Describe shortly what has been changed -->

## Motivation and context
https://github.com/tchapgouv/tchap-android/issues/554
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
