### PR TITLE
Replaces monarchy.doWithRealm with monarchy.awaitTransaction

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/SyncResponsePostTreatmentAggregatorHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/SyncResponsePostTreatmentAggregatorHandler.kt
@@ -93,7 +93,7 @@ internal class SyncResponsePostTreatmentAggregatorHandler @Inject constructor(
 
     private fun List<User>.saveLocally() {
         val userEntities = map { user -> UserEntityFactory.create(user) }
-        monarchy.doWithRealm {
+        monarchy.writeAsync {
             it.insertOrUpdate(userEntities)
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/SyncResponsePostTreatmentAggregatorHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/SyncResponsePostTreatmentAggregatorHandler.kt
@@ -28,6 +28,7 @@ import org.matrix.android.sdk.internal.session.sync.model.accountdata.toMutable
 import org.matrix.android.sdk.internal.session.user.UserEntityFactory
 import org.matrix.android.sdk.internal.session.user.accountdata.DirectChatsHelper
 import org.matrix.android.sdk.internal.session.user.accountdata.UpdateUserAccountDataTask
+import org.matrix.android.sdk.internal.util.awaitTransaction
 import javax.inject.Inject
 
 internal class SyncResponsePostTreatmentAggregatorHandler @Inject constructor(
@@ -91,9 +92,9 @@ internal class SyncResponsePostTreatmentAggregatorHandler @Inject constructor(
         }
     }
 
-    private fun List<User>.saveLocally() {
+    private suspend fun List<User>.saveLocally() {
         val userEntities = map { user -> UserEntityFactory.create(user) }
-        monarchy.writeAsync {
+        monarchy.awaitTransaction {
             it.insertOrUpdate(userEntities)
         }
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Replaces monarchy.doWithRealm with monarchy.awaitTransaction

## Motivation and context

This fixes a bug that was crashing the whole sync

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

Test that https://github.com/vector-im/element-android/pull/5618 still works and no errors are thrown as a result of the sync

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 10

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
