### PR TITLE
Enhance crypto posthog errors with more details

### DIFF
--- a/vector/src/main/java/im/vector/app/features/analytics/DecryptionFailureTracker.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/DecryptionFailureTracker.kt
@@ -38,7 +38,8 @@ private data class DecryptionFailure(
         val failedEventId: String,
         val error: MXCryptoError.ErrorType
 )
-private typealias DetailedErrorName  = Pair<String, Error.Name>
+private typealias DetailedErrorName = Pair<String, Error.Name>
+
 private const val GRACE_PERIOD_MILLIS = 4_000
 private const val CHECK_INTERVAL = 2_000L
 
@@ -145,10 +146,11 @@ class DecryptionFailureTracker @Inject constructor(
     private fun MXCryptoError.ErrorType.toAnalyticsErrorName(): DetailedErrorName {
         val detailed = "$name | mxc_crypto_error_type"
         return when (this) {
-            MXCryptoError.ErrorType.UNKNOWN_INBOUND_SESSION_ID -> Pair(detailed, Error.Name.OlmKeysNotSentError)
-            MXCryptoError.ErrorType.OLM                        -> Pair(detailed, Error.Name.OlmUnspecifiedError)
-            MXCryptoError.ErrorType.UNKNOWN_MESSAGE_INDEX      -> Pair(detailed, Error.Name.OlmIndexError)
-            else                                               -> Pair(detailed, Error.Name.UnknownError)
+            MXCryptoError.ErrorType.UNKNOWN_INBOUND_SESSION_ID,
+            MXCryptoError.ErrorType.KEYS_WITHHELD         -> Pair(detailed, Error.Name.OlmKeysNotSentError)
+            MXCryptoError.ErrorType.OLM                   -> Pair(detailed, Error.Name.OlmUnspecifiedError)
+            MXCryptoError.ErrorType.UNKNOWN_MESSAGE_INDEX -> Pair(detailed, Error.Name.OlmIndexError)
+            else                                          -> Pair(detailed, Error.Name.UnknownError)
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/analytics/DecryptionFailureTracker.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/DecryptionFailureTracker.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.session.crypto.MXCryptoError
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
-import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/vector/src/main/java/im/vector/app/features/analytics/DecryptionFailureTracker.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/DecryptionFailureTracker.kt
@@ -145,12 +145,13 @@ class DecryptionFailureTracker @Inject constructor(
 
     private fun MXCryptoError.ErrorType.toAnalyticsErrorName(): DetailedErrorName {
         val detailed = "$name | mxc_crypto_error_type"
-        return when (this) {
+        val errorName = when (this) {
             MXCryptoError.ErrorType.UNKNOWN_INBOUND_SESSION_ID,
-            MXCryptoError.ErrorType.KEYS_WITHHELD         -> Pair(detailed, Error.Name.OlmKeysNotSentError)
-            MXCryptoError.ErrorType.OLM                   -> Pair(detailed, Error.Name.OlmUnspecifiedError)
-            MXCryptoError.ErrorType.UNKNOWN_MESSAGE_INDEX -> Pair(detailed, Error.Name.OlmIndexError)
-            else                                          -> Pair(detailed, Error.Name.UnknownError)
+            MXCryptoError.ErrorType.KEYS_WITHHELD         -> Error.Name.OlmKeysNotSentError
+            MXCryptoError.ErrorType.OLM                   -> Error.Name.OlmUnspecifiedError
+            MXCryptoError.ErrorType.UNKNOWN_MESSAGE_INDEX -> Error.Name.OlmIndexError
+            else                                          -> Error.Name.UnknownError
         }
+        return DetailedErrorName(detailed, errorName)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/TimelineItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/TimelineItemFactory.kt
@@ -138,6 +138,7 @@ class TimelineItemFactory @Inject constructor(
                     }
                 }.also {
                     if (it != null && event.isEncrypted()) {
+//                        Timber.i("----> ${event.eventId} encryption error found")
                         decryptionFailureTracker.e2eEventDisplayedInTimeline(event)
                     }
                 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/TimelineItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/TimelineItemFactory.kt
@@ -138,7 +138,6 @@ class TimelineItemFactory @Inject constructor(
                     }
                 }.also {
                     if (it != null && event.isEncrypted()) {
-//                        Timber.i("----> ${event.eventId} encryption error found")
                         decryptionFailureTracker.e2eEventDisplayedInTimeline(event)
                     }
                 }


### PR DESCRIPTION
This PR aims to break down E2EE analytics errors into more detailed codes. 

Analytics `Error.context` schema will be used to temporary store a more detailed exception. The plan is to create a crypto specific schema/type to appropriately store crypto errors. 

`mxc_crypto_error_type` will be added in the context to differentiate crypto errors