### PR TITLE
Using the same User Avatar for all messages in the timeline 

### DIFF
--- a/changelog.d/pse-329.feature
+++ b/changelog.d/pse-329.feature
@@ -1,0 +1,1 @@
+Using the same User Avatar for all messages in the timeline

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/sender/SenderInfo.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/sender/SenderInfo.kt
@@ -23,15 +23,15 @@ data class SenderInfo(
         /**
          * Consider using [disambiguatedDisplayName]
          */
-        val displayName: String?,
+        var displayName: String?,
         val isUniqueDisplayName: Boolean,
-        val avatarUrl: String?
+        var avatarUrl: String?
 ) {
     val disambiguatedDisplayName: String
         get() = when {
-            displayName == null                       -> userId
-            displayName.replaceSpaceChars().isBlank() -> "$displayName ($userId)"
-            isUniqueDisplayName                       -> displayName
+            displayName == null                         -> userId
+            displayName!!.replaceSpaceChars().isBlank() -> "$displayName ($userId)"
+            isUniqueDisplayName                         -> displayName!!
             else                                      -> "$displayName ($userId)"
         }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/timeline/TimelineSettings.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/timeline/TimelineSettings.kt
@@ -31,7 +31,12 @@ data class TimelineSettings(
         /**
          * The root thread eventId if this is a thread timeline, or null if this is NOT a thread timeline
          */
-        val rootThreadEventId: String? = null) {
+        val rootThreadEventId: String? = null,
+
+        /**
+         * If true Sender Info shown in room will get the latest data information (avatar + displayName)
+         */
+        val isLiveSenderInfo : Boolean = false) {
 
     /**
      * Returns true if this is a thread timeline or false otherwise

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/timeline/TimelineSettings.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/timeline/TimelineSettings.kt
@@ -36,7 +36,7 @@ data class TimelineSettings(
         /**
          * If true Sender Info shown in room will get the latest data information (avatar + displayName)
          */
-        val isLiveSenderInfo : Boolean = false) {
+        val isLiveSenderInfo: Boolean = false) {
 
     /**
      * Returns true if this is a thread timeline or false otherwise

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ChunkEntityHelper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ChunkEntityHelper.kt
@@ -17,7 +17,6 @@
 package org.matrix.android.sdk.internal.database.helper
 
 import io.realm.Realm
-import io.realm.RealmResults
 import io.realm.Sort
 import io.realm.kotlin.createObject
 import org.matrix.android.sdk.api.session.room.model.RoomMemberContent
@@ -236,8 +235,4 @@ internal fun ChunkEntity.isMoreRecentThan(chunkToCheck: ChunkEntity): Boolean {
     }
     // We don't know, so we assume it's false
     return false
-}
-
-internal fun ChunkEntity.getLiveRoomMember(roomId: String, userId : String): RealmResults<RoomMemberSummaryEntity>? {
-    return RoomMemberSummaryEntity.where(realm, roomId, userId = userId ).findAllAsync()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ChunkEntityHelper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ChunkEntityHelper.kt
@@ -17,6 +17,7 @@
 package org.matrix.android.sdk.internal.database.helper
 
 import io.realm.Realm
+import io.realm.RealmResults
 import io.realm.Sort
 import io.realm.kotlin.createObject
 import org.matrix.android.sdk.api.session.room.model.RoomMemberContent
@@ -235,4 +236,8 @@ internal fun ChunkEntity.isMoreRecentThan(chunkToCheck: ChunkEntity): Boolean {
     }
     // We don't know, so we assume it's false
     return false
+}
+
+internal fun ChunkEntity.getLiveRoomMember(roomId: String, userId : String): RealmResults<RoomMemberSummaryEntity>? {
+    return RoomMemberSummaryEntity.where(realm, roomId, userId = userId ).findAllAsync()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
@@ -30,7 +30,6 @@ import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.room.timeline.Timeline
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
 import org.matrix.android.sdk.api.session.room.timeline.TimelineSettings
-import org.matrix.android.sdk.internal.database.helper.getLiveRoomMember
 import org.matrix.android.sdk.internal.database.lightweight.LightweightSettingsStorage
 import org.matrix.android.sdk.internal.database.mapper.EventMapper
 import org.matrix.android.sdk.internal.database.mapper.TimelineEventMapper
@@ -135,8 +134,9 @@ internal class TimelineChunk(private val chunkEntity: ChunkEntity,
             deepBuiltItems.addAll(prevEvents)
         }
 
-        if (timelineSettings.isLiveSenderInfo)
+        if (timelineSettings.isLiveSenderInfo) {
             updateToLiveSenderData(deepBuiltItems)
+        }
 
         return deepBuiltItems
     }

--- a/vector/src/main/java/im/vector/app/core/resources/UserPreferencesProvider.kt
+++ b/vector/src/main/java/im/vector/app/core/resources/UserPreferencesProvider.kt
@@ -52,4 +52,9 @@ class UserPreferencesProvider @Inject constructor(private val vectorPreferences:
     fun areThreadMessagesEnabled(): Boolean {
         return vectorPreferences.areThreadMessagesEnabled()
     }
+
+    fun isLiveSenderInfo(): Boolean {
+        return vectorPreferences.isLiveSenderInfo()
+    }
+
 }

--- a/vector/src/main/java/im/vector/app/core/resources/UserPreferencesProvider.kt
+++ b/vector/src/main/java/im/vector/app/core/resources/UserPreferencesProvider.kt
@@ -56,5 +56,4 @@ class UserPreferencesProvider @Inject constructor(private val vectorPreferences:
     fun isLiveSenderInfo(): Boolean {
         return vectorPreferences.isLiveSenderInfo()
     }
-
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineSettingsFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineSettingsFactory.kt
@@ -26,7 +26,8 @@ class TimelineSettingsFactory @Inject constructor(private val userPreferencesPro
         return TimelineSettings(
                 initialSize = 30,
                 buildReadReceipts = userPreferencesProvider.shouldShowReadReceipts(),
-                rootThreadEventId = rootThreadEventId
+                rootThreadEventId = rootThreadEventId,
+                isLiveSenderInfo = userPreferencesProvider.isLiveSenderInfo()
         )
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -206,6 +206,8 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         const val SETTINGS_LABS_ENABLE_THREAD_MESSAGES = "SETTINGS_LABS_ENABLE_THREAD_MESSAGES_FINAL"
         const val SETTINGS_THREAD_MESSAGES_SYNCED = "SETTINGS_THREAD_MESSAGES_SYNCED"
 
+        private const val SETTINGS_LABS_SHOW_LASTEST_PROFILE = "SETTINGS_LABS_SHOW_LASTEST_PROFILE"
+
         // Possible values for TAKE_PHOTO_VIDEO_MODE
         const val TAKE_PHOTO_VIDEO_MODE_ALWAYS_ASK = 0
         const val TAKE_PHOTO_VIDEO_MODE_PHOTO = 1
@@ -1023,6 +1025,10 @@ class VectorPreferences @Inject constructor(private val context: Context) {
     /**
      * Indicates whether or not thread messages are enabled
      */
+    fun labsRenderIsLatestProfile() : Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_LABS_SHOW_LASTEST_PROFILE, false)
+    }
+
     fun areThreadMessagesEnabled(): Boolean {
         return defaultPrefs.getBoolean(SETTINGS_LABS_ENABLE_THREAD_MESSAGES, getDefault(R.bool.settings_labs_thread_messages_default))
     }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -206,7 +206,7 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         const val SETTINGS_LABS_ENABLE_THREAD_MESSAGES = "SETTINGS_LABS_ENABLE_THREAD_MESSAGES_FINAL"
         const val SETTINGS_THREAD_MESSAGES_SYNCED = "SETTINGS_THREAD_MESSAGES_SYNCED"
 
-        private const val SETTINGS_LABS_SHOW_LASTEST_PROFILE = "SETTINGS_LABS_SHOW_LASTEST_PROFILE"
+        private const val SETTINGS_LABS_IS_LIVE_SENDER_INFO = "SETTINGS_LABS_IS_LIVE_SENDER_INFO"
 
         // Possible values for TAKE_PHOTO_VIDEO_MODE
         const val TAKE_PHOTO_VIDEO_MODE_ALWAYS_ASK = 0
@@ -1022,13 +1022,6 @@ class VectorPreferences @Inject constructor(private val context: Context) {
         return defaultPrefs.getBoolean(SETTINGS_LABS_RENDER_LOCATIONS_IN_TIMELINE, true)
     }
 
-    /**
-     * Indicates whether or not thread messages are enabled
-     */
-    fun labsRenderIsLatestProfile() : Boolean {
-        return defaultPrefs.getBoolean(SETTINGS_LABS_SHOW_LASTEST_PROFILE, false)
-    }
-
     fun areThreadMessagesEnabled(): Boolean {
         return defaultPrefs.getBoolean(SETTINGS_LABS_ENABLE_THREAD_MESSAGES, getDefault(R.bool.settings_labs_thread_messages_default))
     }
@@ -1077,5 +1070,9 @@ class VectorPreferences @Inject constructor(private val context: Context) {
                 .edit()
                 .putBoolean(SETTINGS_THREAD_MESSAGES_SYNCED, shouldMigrate)
                 .apply()
+    }
+
+    fun isLiveSenderInfo(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_LABS_IS_LIVE_SENDER_INFO, false)
     }
 }

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2836,6 +2836,8 @@
     <string name="labs_auto_report_uisi_desc">Your system will automatically send logs when an unable to decrypt error occurs</string>
     <string name="labs_enable_thread_messages">Enable Thread Messages</string>
     <string name="labs_enable_thread_messages_desc">Note: app will be restarted</string>
+    <string name="labs_show_latest_profile">Show latest user avatar</string>
+    <string name="labs_show_latest_profile_description">Enable showing the latest profile data (avatar and name) or keep the history.</string>
 
     <string name="user_invites_you">%s invites you</string>
 

--- a/vector/src/main/res/xml/vector_settings_labs.xml
+++ b/vector/src/main/res/xml/vector_settings_labs.xml
@@ -70,7 +70,7 @@
 
     <im.vector.app.core.preference.VectorSwitchPreference
         android:defaultValue="false"
-        android:key="SETTINGS_LABS_SHOW_LASTEST_PROFILE"
+        android:key="SETTINGS_LABS_IS_LIVE_SENDER_INFO"
         android:summary="@string/labs_show_latest_profile_description"
         android:title="@string/labs_show_latest_profile" />
 

--- a/vector/src/main/res/xml/vector_settings_labs.xml
+++ b/vector/src/main/res/xml/vector_settings_labs.xml
@@ -68,4 +68,10 @@
         android:key="SETTINGS_LABS_RENDER_LOCATIONS_IN_TIMELINE"
         android:title="@string/labs_render_locations_in_timeline" />
 
+    <im.vector.app.core.preference.VectorSwitchPreference
+        android:defaultValue="false"
+        android:key="SETTINGS_LABS_SHOW_LASTEST_PROFILE"
+        android:summary="@string/labs_show_latest_profile_description"
+        android:title="@string/labs_show_latest_profile" />
+
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content
As a user who has updated their avatar

I want all instances of my avatar, on all previous messages to show my new avatar

So that my old messages are easy to identify, and so that I am not still tied to an image that might be inappropriate or out of date
<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
Screen 1 | Screen 2 
--- | ---
![Screenshot_20220422_021902](https://user-images.githubusercontent.com/73594434/164571531-3e98ca9a-1516-4d15-8a79-69a04db1ac52.png) | ![Screenshot_20220422_021848](https://user-images.githubusercontent.com/73594434/164571566-0b170eac-b880-4ce8-af90-8ebc95e24da6.png)


<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Change your username and/or avatar
- access to room to check that old user info still shown
- Go to settings -> Labs and enable "Show latest user avatar" 
- Back to room and verify if changes has been made that user has only one username and/or avatar for the historic discussions.

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): Android 12, 11, 8

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [x] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
