### PR TITLE
Adds Suggested Tag in Explore Space

### DIFF
--- a/changelog.d/5826.bugfix
+++ b/changelog.d/5826.bugfix
@@ -1,0 +1,1 @@
+Adds missing suggested tag for rooms in Explore Space

--- a/vector/src/main/java/im/vector/app/features/home/room/list/SpaceChildInfoItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/SpaceChildInfoItem.kt
@@ -40,7 +40,7 @@ import me.gujun.android.span.image
 import me.gujun.android.span.span
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_suggested_room)
+@EpoxyModelClass(layout = R.layout.item_explore_space_child)
 abstract class SpaceChildInfoItem : VectorEpoxyModel<SpaceChildInfoItem.Holder>() {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
@@ -51,6 +51,7 @@ abstract class SpaceChildInfoItem : VectorEpoxyModel<SpaceChildInfoItem.Holder>(
 
     @EpoxyAttribute var memberCount: Int = 0
     @EpoxyAttribute var loading: Boolean = false
+    @EpoxyAttribute var suggested: Boolean = false
 
     @EpoxyAttribute var buttonLabel: String? = null
     @EpoxyAttribute var errorLabel: String? = null
@@ -89,6 +90,7 @@ abstract class SpaceChildInfoItem : VectorEpoxyModel<SpaceChildInfoItem.Holder>(
             }
         }
 
+        holder.suggestedTag.visibility = if (suggested) View.VISIBLE else View.GONE
         holder.joinButton.text = buttonLabel
 
         if (loading) {
@@ -121,7 +123,8 @@ abstract class SpaceChildInfoItem : VectorEpoxyModel<SpaceChildInfoItem.Holder>(
         val titleView by bind<TextView>(R.id.roomNameView)
         val joinButton by bind<Button>(R.id.joinSuggestedRoomButton)
         val joinButtonLoading by bind<ProgressBar>(R.id.joinSuggestedLoading)
-        val descriptionText by bind<TextView>(R.id.suggestedRoomDescription)
+        val descriptionText by bind<TextView>(R.id.roomDescription)
+        val suggestedTag by bind<TextView>(R.id.suggestedTag)
         val avatarImageView by bind<ImageView>(R.id.roomAvatarImageView)
         val rootView by bind<ViewGroup>(R.id.itemRoomLayout)
         val errorTextView by bind<TextView>(R.id.inlineErrorText)

--- a/vector/src/main/java/im/vector/app/features/spaces/explore/SpaceDirectoryController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/explore/SpaceDirectoryController.kt
@@ -140,11 +140,13 @@ class SpaceDirectoryController @Inject constructor(
                     val matrixItem = data?.knownRoomSummaries?.find { it.roomId == info.childRoomId }?.toMatrixItem()
                             ?: info.toMatrixItem()
 
+
                     spaceChildInfoItem {
                         id(info.childRoomId)
                         matrixItem(matrixItem)
                         avatarRenderer(host.avatarRenderer)
                         topic(info.topic)
+                        suggested(info.suggested ?: false)
                         errorLabel(
                                 error?.let {
                                     host.stringProvider.getString(R.string.error_failed_to_join_room, host.errorFormatter.toHumanReadable(it))

--- a/vector/src/main/java/im/vector/app/features/spaces/explore/SpaceDirectoryController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/explore/SpaceDirectoryController.kt
@@ -140,7 +140,6 @@ class SpaceDirectoryController @Inject constructor(
                     val matrixItem = data?.knownRoomSummaries?.find { it.roomId == info.childRoomId }?.toMatrixItem()
                             ?: info.toMatrixItem()
 
-
                     spaceChildInfoItem {
                         id(info.childRoomId)
                         matrixItem(matrixItem)

--- a/vector/src/main/java/im/vector/app/features/spaces/explore/SpaceDirectoryController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/explore/SpaceDirectoryController.kt
@@ -36,6 +36,7 @@ import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.list.spaceChildInfoItem
 import im.vector.lib.core.utils.epoxy.charsequence.toEpoxyCharSequence
 import me.gujun.android.span.span
+import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.failure.MatrixError.Companion.M_UNRECOGNIZED
 import org.matrix.android.sdk.api.session.room.members.ChangeMembershipState
@@ -145,7 +146,7 @@ class SpaceDirectoryController @Inject constructor(
                         matrixItem(matrixItem)
                         avatarRenderer(host.avatarRenderer)
                         topic(info.topic)
-                        suggested(info.suggested ?: false)
+                        suggested(info.suggested.orFalse())
                         errorLabel(
                                 error?.let {
                                     host.stringProvider.getString(R.string.error_failed_to_join_room, host.errorFormatter.toHumanReadable(it))

--- a/vector/src/main/res/layout/item_explore_space_child.xml
+++ b/vector/src/main/res/layout/item_explore_space_child.xml
@@ -58,7 +58,21 @@
         tools:text="@sample/users.json/data/displayName" />
 
     <TextView
-        android:id="@+id/suggestedRoomDescription"
+        android:id="@+id/suggestedTag"
+        style="@style/Widget.Vector.TextView.Caption"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="3dp"
+        android:layout_marginEnd="8dp"
+        android:text="@string/space_suggested"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="?vctr_content_secondary"
+        app:layout_constraintStart_toStartOf="@id/roomNameView"
+        app:layout_constraintTop_toBottomOf="@id/roomNameView" />
+
+    <TextView
+        android:id="@+id/roomDescription"
         style="@style/Widget.Vector.TextView.Body"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -69,7 +83,7 @@
         android:textColor="?vctr_content_secondary"
         app:layout_constraintEnd_toStartOf="@id/joinSuggestedRoomButton"
         app:layout_constraintStart_toStartOf="@id/roomNameView"
-        app:layout_constraintTop_toBottomOf="@id/roomNameView"
+        app:layout_constraintTop_toBottomOf="@id/suggestedTag"
         tools:text="@sample/rooms.json/data/topic" />
 
     <Button
@@ -99,6 +113,7 @@
         android:id="@+id/roomBottomBarrier"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        app:barrierMargin="8dp"
         app:barrierDirection="bottom"
         app:constraint_referenced_ids="roomAvatarBottomSpace" />
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

(Could be feature because it's purely an addition, or could be bugfix because it's techinically a fix for a regression from several versions ago. Considering it a bugfix for that reason)

## Content

Adds Suggested Tag in Explore Space (for suggested rooms)

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/5715

Many versions ago (though I am unsure which), we had a suggested tag on each suggested room in the Explore Space screen. This was before the Open and Join buttons were added in the same screen, which is when I assume we lost this suggested tag.

This PR is adding this back in, with a slight design change from what it used to be to accomodate for the new Open and Join buttons.

## Screenshots / GIFs

||Before|After|
|-|-|-|
| Light | ![lightbefore](https://user-images.githubusercontent.com/20701752/164784373-5313fb57-7233-418d-ba99-61a8876991d0.jpg)| ![lightafter](https://user-images.githubusercontent.com/20701752/164784382-9ef39d17-d97f-4a63-a49f-387f849a5341.jpg)|
| Dark | ![darkbefore](https://user-images.githubusercontent.com/20701752/164784578-ef186a76-e8a0-4a16-8355-78a1d4183d39.jpg)| ![darkafter](https://user-images.githubusercontent.com/20701752/164784444-85756a84-c921-4616-9c51-bedaca1e70b6.jpg) |


## Tests

- Join (or be in) a space with suggested rooms (or make one yourself)
- Go to Explore Space of that space
- See suggested tag under suggested rooms

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
