### PR TITLE
do not switch away from home space on notification

### DIFF
--- a/changelog.d/5827.bugfix
+++ b/changelog.d/5827.bugfix
@@ -1,0 +1,1 @@
+Do not switch away from home space on notification when "Show all Rooms in Home" is selected.

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -207,7 +207,8 @@ class TimelineViewModel @AssistedInject constructor(
             appStateHandler.getCurrentRoomGroupingMethod()?.space().let { currentSpace ->
                 val currentRoomSummary = room.roomSummary() ?: return@let
                 // nothing we are good
-                if (currentSpace == null || !currentRoomSummary.flattenParentIds.contains(currentSpace.roomId)) {
+                if ((currentSpace == null && !vectorPreferences.prefSpacesShowAllRoomInHome())
+                        || (currentSpace != null && !currentRoomSummary.flattenParentIds.contains(currentSpace.roomId))) {
                     // take first one or switch to home
                     appStateHandler.setCurrentSpace(
                             currentRoomSummary


### PR DESCRIPTION
Signed-off-by: Michael Loipführer <milo@sft.lol>
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

When somebody selected the "Show all Rooms in Home" preference all rooms are shown in the home space. A user would therefore not expect to switch away to another space upon clicking a notification for a room.

Currently upon clicking a notification for a room which is part of a space, that space is automatically selected as the current space even if it is part of the home space due to "Show all Rooms in Home" being active.

This PR changes the behavior to properly respect the "Show all Rooms in Home" preference:
Now Element does not switch away from the home space when clicking on a notification.

## Motivation and context

The current behavior is quite annoying and unintuitive. For example I am part of multiple small spaces. After clicking on a notification I have to manually select the home space to view all of my rooms nearly every time I use Element. Apparently quite a few users have this issue as highlighted in #5180. 

fixes #5180

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
