### PR TITLE
Add a GH workflow to push ElementX issues to the global board

### DIFF
--- a/.github/workflows/triage-labelled.yml
+++ b/.github/workflows/triage-labelled.yml
@@ -252,3 +252,30 @@ jobs:
         env:
           PROJECT_ID: "PN_kwDOAM0swc4AArk0"
           GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+
+  move_element_x_issues:
+    name: ElementX issues to ElementX project board
+    runs-on: ubuntu-latest
+    # Skip in forks
+    if: >
+      github.repository == 'vector-im/element-android' &&
+      (contains(github.event.issue.labels.*.name, 'Z-ElementX-Alpha') ||
+        contains(github.event.issue.labels.*.name, 'Z-ElementX-Beta') ||
+        contains(github.event.issue.labels.*.name, 'Z-ElementX'))
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            mutation add_to_project($projectid:ID!,$contentid:ID!) {
+              addProjectNextItem(input:{projectId:$projectid contentId:$contentid}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }
+          projectid: ${{ env.PROJECT_ID }}
+          contentid: ${{ github.event.issue.node_id }}
+        env:
+          PROJECT_ID: "PN_kwDOAM0swc4ABTXY"
+          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}

--- a/changelog.d/5832.misc
+++ b/changelog.d/5832.misc
@@ -1,0 +1,1 @@
+Add a GH workflow to push ElementX issues to the global board.


### PR DESCRIPTION
Issues with `Z-ElementX-*` labels will appear in https://github.com/orgs/vector-im/projects/43
