### PR TITLE
Update the PR process doc with 2 reviewers and a new reviewer team

### DIFF
--- a/changelog.d/5836.doc
+++ b/changelog.d/5836.doc
@@ -1,0 +1,1 @@
+Update the PR process doc with 2 reviewers and a new reviewer team.

--- a/docs/pull_request.md
+++ b/docs/pull_request.md
@@ -32,14 +32,15 @@ Also, draft PR should not stay indefinitely in this state. It may be removed if 
 
 ##### PR Review Assignment
 
-We use automatic assignment for PR reviews. A PR is automatically routed by GitHub to a team member using the round robin algorithm. The process is the following:
+We use automatic assignment for PR reviews. A PR is automatically routed by GitHub to 2 team members using the round robin algorithm. The process is the following:
 
-- The PR creator assigns the [element-android](https://github.com/orgs/vector-im/teams/element-android) team as a reviewer. They can skip this process and assign directly a specific member if they think they should take a look at it.
-- GitHub automatically assigns one reviewer. If the chosen reviewer is not available (holiday, etc.), remove them and set again the team, GitHub will select another reviewer.
-- The reviewer gets a notification to make the review: they review the code following the good practice (see the rest of this document).
+- The PR creator can assign specific people if they have another Android developer in their team or they think a specific reviewer should take a look at the PR.
+- If there are missing reviewers, the PR creator assigns the [element-android-reviewers](https://github.com/orgs/vector-im/teams/element-android-reviewers) team as a reviewer.
+- GitHub automatically assigns other reviewers. If one of the chosen reviewers is not available (holiday, etc.), remove them and set again the team, GitHub will select another reviewer.
+- Reviewers get a notification to make the review: they review the code following the good practice (see the rest of this document).
 - After making their own review, if they feel not confident enough, they can ask another person for a full review, or they can tag someone within a PR comment to check specific lines.
 
-For PRs coming from the community, the issue wrangler can assign either the team [element-android](https://github.com/orgs/vector-im/teams/element-android) or any member directly.
+For PRs coming from the community, the issue wrangler can assign either the team [element-android-reviewers](https://github.com/orgs/vector-im/teams/element-android-reviewers) or any members directly.
 
 ##### PR review time
 


### PR DESCRIPTION
We are going to have 2 reviewers per PR to improve the review quality.