### PR TITLE
Fixes Missing Call Icons when threads are enabled

### DIFF
--- a/changelog.d/5847.bugfix
+++ b/changelog.d/5847.bugfix
@@ -1,0 +1,1 @@
+Fixes missing call icons when threads are enabled

--- a/vector/src/main/res/menu/menu_timeline.xml
+++ b/vector/src/main/res/menu/menu_timeline.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="AlwaysShowAction">
 
     <item
         android:id="@+id/timeline_setting"
@@ -47,8 +48,7 @@
         app:actionLayout="@layout/view_thread_notification_badge"
         app:iconTint="?colorPrimary"
         app:showAsAction="always"
-        tools:visible="true"
-        tools:ignore="AlwaysShowAction" />
+        tools:visible="true" />
 
     <item
         android:id="@+id/join_conference"

--- a/vector/src/main/res/menu/menu_timeline.xml
+++ b/vector/src/main/res/menu/menu_timeline.xml
@@ -19,24 +19,27 @@
         android:title="@string/action_invite"
         app:showAsAction="never" />
 
+    <!-- We always want to show this item as an icon -->
     <item
         android:id="@+id/video_call"
         android:icon="@drawable/ic_video"
         android:title="@string/action_video_call"
         android:visible="false"
         app:iconTint="?colorPrimary"
-        app:showAsAction="ifRoom"
+        app:showAsAction="always"
         tools:visible="true" />
 
+    <!-- We always want to show this item as an icon -->
     <item
         android:id="@+id/voice_call"
         android:icon="@drawable/ic_phone"
         android:title="@string/call"
         android:visible="false"
         app:iconTint="?colorPrimary"
-        app:showAsAction="ifRoom"
+        app:showAsAction="always"
         tools:visible="true" />
 
+    <!-- We always want to show this item as an icon -->
     <item
         android:id="@+id/menu_timeline_thread_list"
         android:title="@string/action_view_threads"
@@ -44,7 +47,8 @@
         app:actionLayout="@layout/view_thread_notification_badge"
         app:iconTint="?colorPrimary"
         app:showAsAction="always"
-        tools:visible="true" />
+        tools:visible="true"
+        tools:ignore="AlwaysShowAction" />
 
     <item
         android:id="@+id/join_conference"

--- a/vector/src/main/res/menu/menu_timeline.xml
+++ b/vector/src/main/res/menu/menu_timeline.xml
@@ -33,7 +33,7 @@
     <item
         android:id="@+id/voice_call"
         android:icon="@drawable/ic_phone"
-        android:title="@string/call"
+        android:title="@string/action_voice_call"
         android:visible="false"
         app:iconTint="?colorPrimary"
         app:showAsAction="always"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes missing call menu items due to `ifRoom` being used instead of `always`

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/5840

I also added lint suprression and comments explaining why we keep these icons as `app:showAsAction="always"` as it can be very easy to overlook with the IDE warnings

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|![Screenshot_20220426_221120_im vector app debug](https://user-images.githubusercontent.com/20701752/165384323-ce7a323f-9832-413c-9dc0-8f32eaca49c4.jpg)|![Screenshot_20220426_220258_im vector app debug](https://user-images.githubusercontent.com/20701752/165384319-8ab2fd31-e968-4f98-8844-68f08a901464.jpg)|
 
## Tests

<!-- Explain how you tested your development -->

- Enable threads
- Go to any room
- See video call, voice call, and threads icons in the action bar

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 10

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
