### PR TITLE
Use fixed text size in read receipt counter

### DIFF
--- a/changelog.d/5856.bugfix
+++ b/changelog.d/5856.bugfix
@@ -1,0 +1,1 @@
+Use fixed text size in read receipt counter

--- a/library/ui-styles/src/main/res/values/styles_timeline.xml
+++ b/library/ui-styles/src/main/res/values/styles_timeline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="TimelineContentStubBaseParams">
         <item name="android:layout_width">match_parent</item>
@@ -33,5 +33,8 @@
         <item name="android:gravity">center</item>
     </style>
 
+    <style name="TimelineFixedSizeCaptionStyle" parent="@style/Widget.Vector.TextView.Caption">
+        <item name="android:textSize" tools:ignore="SpUsage">12dp</item>
+    </style>
 
 </resources>

--- a/vector/src/main/res/layout/view_read_receipts.xml
+++ b/vector/src/main/res/layout/view_read_receipts.xml
@@ -7,7 +7,7 @@
 
     <TextView
         android:id="@+id/receiptMore"
-        style="@style/Widget.Vector.TextView.Caption"
+        style="@style/TimelineFixedSizeCaptionStyle"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/item_event_message_state_size"
         android:background="@drawable/pill_receipt"
@@ -16,8 +16,6 @@
         android:paddingStart="4dp"
         android:paddingEnd="4dp"
         android:textColor="?vctr_content_primary"
-        android:textSize="12dp"
-        tools:ignore="SpUsage"
         tools:text="999+" />
 
     <ImageView

--- a/vector/src/main/res/layout/view_read_receipts.xml
+++ b/vector/src/main/res/layout/view_read_receipts.xml
@@ -16,6 +16,8 @@
         android:paddingStart="4dp"
         android:paddingEnd="4dp"
         android:textColor="?vctr_content_primary"
+        android:textSize="12dp"
+        tools:ignore="SpUsage"
         tools:text="999+" />
 
     <ImageView


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix: Fixes #5367 
- [ ] Technical
- [ ] Other :

## Content

Use a fixed `12dp` text size for the read recept counter number instead of `12sp` that would scale with the font scale setting. It's important that text should fit inside the circle and the circle has a fixed size regardless of the font scale.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->


|Before|After|
|-|-|
|![Screenshot_20220427-201459](https://user-images.githubusercontent.com/1694986/165594717-d4ba276e-96ed-49b2-a07c-18f6069f6a6a.jpg)|![Screenshot_20220427-201526](https://user-images.githubusercontent.com/1694986/165594784-9ecf95d0-0066-44b5-b8e0-3d99df4a1717.jpg)|



Screenshots taken on "Largest" font setting.

## Tests

<!-- Explain how you tested your development -->

- Use the font scale setting to set something above "Normal"
- Visit a room timeline with more than 5 read receipts

## Tested devices

- [X] Physical
- [X] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [X] UI change has been tested on both light and dark themes
- [X] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [X] Pull request includes screenshots or videos if containing UI changes
- [X] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

Signed-off-by: Olivér Falvai <ofalvai@gmail.com>
