### PR TITLE
Fix timeline getting stuck on lots of new messages

### DIFF
--- a/changelog.d/5879.bugfix
+++ b/changelog.d/5879.bugfix
@@ -1,0 +1,1 @@
+Fix timeline getting stuck when receiving lots of new messages

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/LoadTimelineStrategy.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/LoadTimelineStrategy.kt
@@ -97,12 +97,15 @@ internal class LoadTimelineStrategy(
             val onEventsUpdated: (Boolean) -> Unit,
             val onEventsDeleted: () -> Unit,
             val onLimitedTimeline: () -> Unit,
+            val onLastForwardDeleted: () -> Unit,
             val onNewTimelineEvents: (List<String>) -> Unit
     )
 
     private var getContextLatch: CompletableDeferred<Unit>? = null
     private var chunkEntity: RealmResults<ChunkEntity>? = null
     private var timelineChunk: TimelineChunk? = null
+    private var lastForwardChunkEntity: RealmResults<ChunkEntity>? = null
+
     private val chunkEntityListener = OrderedRealmCollectionChangeListener { _: RealmResults<ChunkEntity>, changeSet: OrderedCollectionChangeSet ->
         // Can be call either when you open a permalink on an unknown event
         // or when there is a gap in the timeline.
@@ -116,6 +119,14 @@ internal class LoadTimelineStrategy(
             if (timelineChunk?.hasReachedLastForward().orFalse()) {
                 dependencies.onLimitedTimeline()
             }
+        }
+    }
+
+    private val lastForwardChunkEntityListener = OrderedRealmCollectionChangeListener { _: RealmResults<ChunkEntity>, changeSet: OrderedCollectionChangeSet ->
+        // When the last forward chunk changes and we had previously reached that, load forward again to avoid a stuck timeline
+        val shouldRebuildChunk = changeSet.deletions.isNotEmpty()
+        if (shouldRebuildChunk) {
+            dependencies.onLastForwardDeleted()
         }
     }
 
@@ -171,12 +182,16 @@ internal class LoadTimelineStrategy(
             it.addChangeListener(chunkEntityListener)
             timelineChunk = it.createTimelineChunk()
         }
+        lastForwardChunkEntity = getLastForwardChunkEntity(realm).also {
+            it.addChangeListener(lastForwardChunkEntityListener)
+        }
     }
 
     fun onStop() {
         dependencies.eventDecryptor.destroy()
         dependencies.timelineInput.listeners.remove(timelineInputListener)
         chunkEntity?.removeChangeListener(chunkEntityListener)
+        lastForwardChunkEntity?.removeChangeListener(lastForwardChunkEntityListener)
         sendingEventsDataSource.stop()
         timelineChunk?.close(closeNext = true, closePrev = true)
         getContextLatch?.cancel()
@@ -185,6 +200,7 @@ internal class LoadTimelineStrategy(
         if (mode is Mode.Thread) {
             clearThreadChunkEntity(dependencies.realm.get(), mode.rootThreadEventId)
         }
+        lastForwardChunkEntity = null
     }
 
     suspend fun loadMore(count: Int, direction: Timeline.Direction, fetchOnServerIfNeeded: Boolean = true): LoadMoreResult {
@@ -280,6 +296,12 @@ internal class LoadTimelineStrategy(
                 Timber.i("###THREADS LoadTimelineStrategy [onStop] thread chunk cleared..")
             }
         }
+    }
+
+    private fun getLastForwardChunkEntity(realm: Realm): RealmResults<ChunkEntity> {
+        return ChunkEntity.where(realm, roomId)
+                .equalTo(ChunkEntityFields.IS_LAST_FORWARD, true)
+                .findAll()
     }
 
     private fun hasReachedLastForward(): Boolean {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEventPersistor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEventPersistor.kt
@@ -65,6 +65,15 @@ internal class TokenChunkEventPersistor @Inject constructor(
     suspend fun insertInDb(receivedChunk: TokenChunkEvent,
                            roomId: String,
                            direction: PaginationDirection): Result {
+        if (receivedChunk.events.isEmpty() && receivedChunk.start == receivedChunk.end) {
+            Timber.w("Discard empty chunk with identical start/end token ${receivedChunk.start}")
+
+            return if (receivedChunk.hasMore()) {
+                Result.SHOULD_FETCH_MORE
+            } else {
+                Result.REACHED_END
+            }
+        }
         monarchy
                 .awaitTransaction { realm ->
                     Timber.v("Start persisting ${receivedChunk.events.size} events in $roomId towards $direction")


### PR DESCRIPTION
NOTE: this PR depends on https://github.com/vector-im/element-android/pull/5878 to work properly. Thus, it partly includes the same commits. Please review https://github.com/vector-im/element-android/pull/5878 first.

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Motivation and context

When the timeline loaded to the end, and we delete the last forward chunk to replace it, the timeline still thinks it reached the end and will not load any new messages.

This should fix https://github.com/vector-im/element-android/issues/5205 .

## Content

Observe deletions of the last forward chunk, and invoke another `loadMore()` if necessary.

## Tests

See https://github.com/vector-im/element-android/issues/5205#issuecomment-1062021046

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>