### PR TITLE
Fixes crash when accepting VOIP calls

### DIFF
--- a/changelog.d/5421.bugfix
+++ b/changelog.d/5421.bugfix
@@ -1,0 +1,1 @@
+Fixes crash when accepting or receiving VOIP calls

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/EventInsertLiveObserver.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/EventInsertLiveObserver.kt
@@ -19,6 +19,9 @@ package org.matrix.android.sdk.internal.database
 import com.zhuinden.monarchy.Monarchy
 import io.realm.RealmConfiguration
 import io.realm.RealmResults
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.internal.database.mapper.asDomain
 import org.matrix.android.sdk.internal.database.model.EventEntity
@@ -38,10 +41,22 @@ internal class EventInsertLiveObserver @Inject constructor(@SessionDatabase real
         it.where(EventInsertEntity::class.java).equalTo(EventInsertEntityFields.CAN_BE_PROCESSED, true)
     }
 
+    private val onResultsChangedFlow = MutableSharedFlow<RealmResults<EventInsertEntity>>()
+
+    init {
+        onResultsChangedFlow
+                .onEach { handleChange(it) }
+                .launchIn(observerScope)
+    }
+
     override fun onChange(results: RealmResults<EventInsertEntity>) {
         if (!results.isLoaded || results.isEmpty()) {
             return
         }
+        observerScope.launch { onResultsChangedFlow.emit(results) }
+    }
+
+    private suspend fun handleChange(results: RealmResults<EventInsertEntity>) {
         val idsToDeleteAfterProcess = ArrayList<String>()
         val filteredEvents = ArrayList<EventInsertEntity>(results.size)
         Timber.v("EventInsertEntity updated with ${results.size} results in db")
@@ -58,30 +73,29 @@ internal class EventInsertLiveObserver @Inject constructor(@SessionDatabase real
             }
             idsToDeleteAfterProcess.add(it.eventId)
         }
-        observerScope.launch {
-            awaitTransaction(realmConfiguration) { realm ->
-                Timber.v("##Transaction: There are ${filteredEvents.size} events to process ")
-                filteredEvents.forEach { eventInsert ->
-                    val eventId = eventInsert.eventId
-                    val event = EventEntity.where(realm, eventId).findFirst()
-                    if (event == null) {
-                        Timber.v("Event $eventId not found")
-                        return@forEach
-                    }
-                    val domainEvent = event.asDomain()
-                    processors.filter {
-                        it.shouldProcess(eventId, domainEvent.getClearType(), eventInsert.insertType)
-                    }.forEach {
-                        it.process(realm, domainEvent)
-                    }
+
+        awaitTransaction(realmConfiguration) { realm ->
+            Timber.v("##Transaction: There are ${filteredEvents.size} events to process ")
+            filteredEvents.forEach { eventInsert ->
+                val eventId = eventInsert.eventId
+                val event = EventEntity.where(realm, eventId).findFirst()
+                if (event == null) {
+                    Timber.v("Event $eventId not found")
+                    return@forEach
                 }
-                realm.where(EventInsertEntity::class.java)
-                        .`in`(EventInsertEntityFields.EVENT_ID, idsToDeleteAfterProcess.toTypedArray())
-                        .findAll()
-                        .deleteAllFromRealm()
+                val domainEvent = event.asDomain()
+                processors.filter {
+                    it.shouldProcess(eventId, domainEvent.getClearType(), eventInsert.insertType)
+                }.forEach {
+                    it.process(realm, domainEvent)
+                }
             }
-            processors.forEach { it.onPostProcess() }
+            realm.where(EventInsertEntity::class.java)
+                    .`in`(EventInsertEntityFields.EVENT_ID, idsToDeleteAfterProcess.toTypedArray())
+                    .findAll()
+                    .deleteAllFromRealm()
         }
+        processors.forEach { it.onPostProcess() }
     }
 
     private fun shouldProcess(eventInsertEntity: EventInsertEntity): Boolean {


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes a crash when receiving and consuming call events #5421 (tentatively fixes #5591 and possibly other VOIP quirks)

- The event insertion logic is designed to be single threaded however due to coroutine continuation, there's unintended multiple thread access when the _processing_ and _post processing_ overlap
- Fixed by converting the launching to a flow which will sequentially process the launch logic on the single threaded scope

## Motivation and context

To fix a VOIP crash

## Screenshots / GIFs

- Adds a small delay to the postProcessing step
- Send 5 messages 

#### Before 

- Notice multiple concurrent launches    

```
Launch: LIVE_ENTITY_BACKGROUND
Process start: pool-7-thread-1
Process end: LIVE_ENTITY_BACKGROUND
Post start: LIVE_ENTITY_BACKGROUND

Launch: LIVE_ENTITY_BACKGROUND
Process start: pool-7-thread-1
Process end: LIVE_ENTITY_BACKGROUND
Post start: LIVE_ENTITY_BACKGROUND

Launch: LIVE_ENTITY_BACKGROUND
Process start: pool-7-thread-1
Process end: LIVE_ENTITY_BACKGROUND
Post start: LIVE_ENTITY_BACKGROUND

Launch: LIVE_ENTITY_BACKGROUND
Process start: pool-7-thread-1
Process end: LIVE_ENTITY_BACKGROUND
Post start: LIVE_ENTITY_BACKGROUND

Launch: LIVE_ENTITY_BACKGROUND
Process start: pool-7-thread-1
Process end: LIVE_ENTITY_BACKGROUND
Post start: LIVE_ENTITY_BACKGROUND
Post end: LIVE_ENTITY_BACKGROUND
Post end: LIVE_ENTITY_BACKGROUND
Post end: LIVE_ENTITY_BACKGROUND
Post end: LIVE_ENTITY_BACKGROUND
Post end: LIVE_ENTITY_BACKGROUND
```

#### After

- Notice sequential launches, each waiting for the post processing to complete    

```
Launch: LIVE_ENTITY_BACKGROUND
Process start: pool-7-thread-1
Process end: LIVE_ENTITY_BACKGROUND
Post start: LIVE_ENTITY_BACKGROUND
Post end: LIVE_ENTITY_BACKGROUND

Launch: LIVE_ENTITY_BACKGROUND
Process start: pool-7-thread-1
Process end: LIVE_ENTITY_BACKGROUND
Post start: LIVE_ENTITY_BACKGROUND
Post end: LIVE_ENTITY_BACKGROUND

Launch: LIVE_ENTITY_BACKGROUND
Process start: pool-7-thread-1
Process end: LIVE_ENTITY_BACKGROUND
Post start: LIVE_ENTITY_BACKGROUND
Post end: LIVE_ENTITY_BACKGROUND

Launch: LIVE_ENTITY_BACKGROUND
Process start: pool-7-thread-1
Process end: LIVE_ENTITY_BACKGROUND
Post start: LIVE_ENTITY_BACKGROUND
Post end: LIVE_ENTITY_BACKGROUND

Launch: LIVE_ENTITY_BACKGROUND
Process start: pool-7-thread-1
Process end: LIVE_ENTITY_BACKGROUND
Post start: LIVE_ENTITY_BACKGROUND
Post end: LIVE_ENTITY_BACKGROUND
```


## Tests

- Add a manual delay in the code to the call post processing
- Spam call invites 
- Notice a crash

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28
