### PR TITLE
[SDK] Add missing return type in RoomApi.sendStateEvent()

### DIFF
--- a/changelog.d/5855.sdk
+++ b/changelog.d/5855.sdk
@@ -1,0 +1,1 @@
+- Add return type to RoomApi.sendStateEvent() to retrieve the created event id

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/state/StateService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/state/StateService.kt
@@ -84,8 +84,9 @@ interface StateService {
      * @param eventType The type of event to send.
      * @param stateKey The state_key for the state to send. Can be an empty string.
      * @param body The content object of the event; the fields in this object will vary depending on the type of event
+     *
      */
-    suspend fun sendStateEvent(eventType: String, stateKey: String, body: JsonDict)
+    suspend fun sendStateEvent(eventType: String, stateKey: String, body: JsonDict): String
 
     /**
      * Get a state event of the room

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/state/StateService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/state/StateService.kt
@@ -84,7 +84,7 @@ interface StateService {
      * @param eventType The type of event to send.
      * @param stateKey The state_key for the state to send. Can be an empty string.
      * @param body The content object of the event; the fields in this object will vary depending on the type of event
-     *
+     * @return the id of the created state event
      */
     suspend fun sendStateEvent(eventType: String, stateKey: String, body: JsonDict): String
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
@@ -194,7 +194,8 @@ internal interface RoomAPI {
     @PUT(NetworkConstants.URI_API_PREFIX_PATH_R0 + "rooms/{roomId}/state/{state_event_type}")
     suspend fun sendStateEvent(@Path("roomId") roomId: String,
                                @Path("state_event_type") stateEventType: String,
-                               @Body params: JsonDict)
+                               @Body params: JsonDict
+    ): SendResponse
 
     /**
      * Send a generic state event
@@ -208,7 +209,8 @@ internal interface RoomAPI {
     suspend fun sendStateEvent(@Path("roomId") roomId: String,
                                @Path("state_event_type") stateEventType: String,
                                @Path("state_key") stateKey: String,
-                               @Body params: JsonDict)
+                               @Body params: JsonDict
+    ): SendResponse
 
     /**
      * Get state events of a room

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/state/DefaultStateService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/state/DefaultStateService.kt
@@ -73,14 +73,14 @@ internal class DefaultStateService @AssistedInject constructor(@Assisted private
             eventType: String,
             stateKey: String,
             body: JsonDict
-    ) {
+    ): String {
         val params = SendStateTask.Params(
                 roomId = roomId,
                 stateKey = stateKey,
                 eventType = eventType,
                 body = body.toSafeJson(eventType)
         )
-        sendStateTask.executeRetry(params, 3)
+        return sendStateTask.executeRetry(params, 3)
     }
 
     private fun JsonDict.toSafeJson(eventType: String): JsonDict {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/state/SendStateTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/state/SendStateTask.kt
@@ -21,9 +21,10 @@ import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.session.room.RoomAPI
 import org.matrix.android.sdk.internal.task.Task
+import timber.log.Timber
 import javax.inject.Inject
 
-internal interface SendStateTask : Task<SendStateTask.Params, Unit> {
+internal interface SendStateTask : Task<SendStateTask.Params, String> {
     data class Params(
             val roomId: String,
             val stateKey: String,
@@ -37,9 +38,9 @@ internal class DefaultSendStateTask @Inject constructor(
         private val globalErrorReceiver: GlobalErrorReceiver
 ) : SendStateTask {
 
-    override suspend fun execute(params: SendStateTask.Params) {
+    override suspend fun execute(params: SendStateTask.Params): String {
         return executeRequest(globalErrorReceiver) {
-            if (params.stateKey.isEmpty()) {
+            val response = if (params.stateKey.isEmpty()) {
                 roomAPI.sendStateEvent(
                         roomId = params.roomId,
                         stateEventType = params.eventType,
@@ -52,6 +53,9 @@ internal class DefaultSendStateTask @Inject constructor(
                         stateKey = params.stateKey,
                         params = params.body
                 )
+            }
+            response.eventId.also {
+                Timber.d("State event: $it just sent in room ${params.roomId}")
             }
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/widgets/CreateWidgetTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/widgets/CreateWidgetTask.kt
@@ -29,9 +29,10 @@ import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.session.room.RoomAPI
 import org.matrix.android.sdk.internal.task.Task
+import timber.log.Timber
 import javax.inject.Inject
 
-internal interface CreateWidgetTask : Task<CreateWidgetTask.Params, Unit> {
+internal interface CreateWidgetTask : Task<CreateWidgetTask.Params, String> {
 
     data class Params(
             val roomId: String,
@@ -45,8 +46,8 @@ internal class DefaultCreateWidgetTask @Inject constructor(@SessionDatabase priv
                                                            @UserId private val userId: String,
                                                            private val globalErrorReceiver: GlobalErrorReceiver) : CreateWidgetTask {
 
-    override suspend fun execute(params: CreateWidgetTask.Params) {
-        executeRequest(globalErrorReceiver) {
+    override suspend fun execute(params: CreateWidgetTask.Params): String {
+        val response = executeRequest(globalErrorReceiver) {
             roomAPI.sendStateEvent(
                     roomId = params.roomId,
                     stateEventType = EventType.STATE_ROOM_WIDGET_LEGACY,
@@ -59,6 +60,9 @@ internal class DefaultCreateWidgetTask @Inject constructor(@SessionDatabase priv
                     .whereStateKey(it, params.roomId, type = EventType.STATE_ROOM_WIDGET_LEGACY, stateKey = params.widgetId)
                     .and()
                     .equalTo(CurrentStateEventEntityFields.ROOT.SENDER, userId)
+        }
+        return response.eventId.also {
+            Timber.d("Widget state event: $it just sent in room ${params.roomId}")
         }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Enhancement

## Content

<!-- Describe shortly what has been changed -->
Returning the id of the newly created state event in methods to send state events.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #5855
For instance, In some situation it may be useful to know the id of the newly created event to attach other related events to it.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Change the name of a room
- Check you see log of the creation of the state event.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
