### PR TITLE
Notify other devices of acceptance of verification request

### DIFF
--- a/changelog.d/5724.sdk
+++ b/changelog.d/5724.sdk
@@ -1,0 +1,1 @@
+- Notifies other devices when a verification request sent from an Android device is accepted.`

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/verification/qrcode/VerificationTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/verification/qrcode/VerificationTest.kt
@@ -27,11 +27,13 @@ import org.matrix.android.sdk.api.auth.UIABaseAuth
 import org.matrix.android.sdk.api.auth.UserInteractiveAuthInterceptor
 import org.matrix.android.sdk.api.auth.UserPasswordAuth
 import org.matrix.android.sdk.api.auth.registration.RegistrationFlowResponse
+import org.matrix.android.sdk.api.session.crypto.verification.CancelCode
 import org.matrix.android.sdk.api.session.crypto.verification.PendingVerificationRequest
 import org.matrix.android.sdk.api.session.crypto.verification.VerificationMethod
 import org.matrix.android.sdk.api.session.crypto.verification.VerificationService
 import org.matrix.android.sdk.common.CommonTestHelper
 import org.matrix.android.sdk.common.CryptoTestHelper
+import org.matrix.android.sdk.common.SessionTestParams
 import org.matrix.android.sdk.common.TestConstants
 import java.util.concurrent.CountDownLatch
 import kotlin.coroutines.Continuation
@@ -251,5 +253,49 @@ class VerificationTest : InstrumentedTest {
         }
 
         cryptoTestData.cleanUp(testHelper)
+    }
+
+    @Test
+    fun test_selfVerificationAcceptedCancelsItForOtherSessions() {
+        val defaultSessionParams = SessionTestParams(true)
+        val testHelper = CommonTestHelper(context())
+
+        val aliceSessionToVerify = testHelper.createAccount(TestConstants.USER_ALICE, defaultSessionParams)
+        val aliceSessionThatVerifies = testHelper.logIntoAccount(aliceSessionToVerify.myUserId, TestConstants.PASSWORD, defaultSessionParams)
+        val aliceSessionThatReceivesCanceledEvent = testHelper.logIntoAccount(aliceSessionToVerify.myUserId, TestConstants.PASSWORD, defaultSessionParams)
+
+        val verificationMethods = listOf(VerificationMethod.SAS, VerificationMethod.QR_CODE_SCAN, VerificationMethod.QR_CODE_SHOW)
+
+        val serviceOfVerified = aliceSessionToVerify.cryptoService().verificationService()
+        val serviceOfVerifier = aliceSessionThatVerifies.cryptoService().verificationService()
+        val serviceOfUserWhoReceivesCancellation = aliceSessionThatReceivesCanceledEvent.cryptoService().verificationService()
+
+        serviceOfVerifier.addListener(object : VerificationService.Listener {
+            override fun verificationRequestCreated(pr: PendingVerificationRequest) {
+                // Accept verification request
+                serviceOfVerifier.readyPendingVerification(
+                        verificationMethods,
+                        pr.otherUserId,
+                        pr.transactionId!!,
+                )
+            }
+        })
+
+        serviceOfVerified.requestKeyVerification(
+                methods = verificationMethods,
+                otherUserId = aliceSessionToVerify.myUserId,
+                otherDevices = listOfNotNull(aliceSessionThatVerifies.sessionParams.deviceId, aliceSessionThatReceivesCanceledEvent.sessionParams.deviceId),
+        )
+
+        testHelper.waitWithLatch { latch ->
+            testHelper.retryPeriodicallyWithLatch(latch) {
+                val requests = serviceOfUserWhoReceivesCancellation.getExistingVerificationRequests(aliceSessionToVerify.myUserId)
+                requests.any { it.cancelConclusion == CancelCode.AcceptedByAnotherDevice }
+            }
+        }
+
+        testHelper.signOutAndClose(aliceSessionToVerify)
+        testHelper.signOutAndClose(aliceSessionThatVerifies)
+        testHelper.signOutAndClose(aliceSessionThatReceivesCanceledEvent)
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/verification/CancelCode.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/verification/CancelCode.kt
@@ -28,7 +28,8 @@ enum class CancelCode(val value: String, val humanReadable: String) {
     MismatchedKeys("m.key_mismatch", "Key mismatch"),
     UserError("m.user_error", "User error"),
     MismatchedUser("m.user_mismatch", "User mismatch"),
-    QrCodeInvalid("m.qr_code.invalid", "Invalid QR code")
+    QrCodeInvalid("m.qr_code.invalid", "Invalid QR code"),
+    AcceptedByAnotherDevice("m.accepted", "Verification request accepted by another device")
 }
 
 fun safeValueOf(code: String?): CancelCode {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/verification/VerificationTransport.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/verification/VerificationTransport.kt
@@ -49,6 +49,11 @@ internal interface VerificationTransport {
                           otherUserDeviceId: String?,
                           code: CancelCode)
 
+    fun cancelTransaction(transactionId: String,
+                          otherUserId: String,
+                          otherUserDeviceIds: List<String>,
+                          code: CancelCode)
+
     fun done(transactionId: String,
              onDone: (() -> Unit)?)
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/verification/VerificationTransportRoomMessage.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/verification/VerificationTransportRoomMessage.kt
@@ -160,6 +160,9 @@ internal class VerificationTransportRoomMessage(
         }
     }
 
+    override fun cancelTransaction(transactionId: String, otherUserId: String, otherUserDeviceIds: List<String>, code: CancelCode) =
+            cancelTransaction(transactionId, otherUserId, null, code)
+
     override fun done(transactionId: String,
                       onDone: (() -> Unit)?) {
         Timber.d("## SAS sending done for $transactionId")


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

When a verification request sent from a client is answered, this same client should notify other clients that verification is no longer necessary.

## Motivation and context

Issue: #5724 .

## Tests

Using the same account:

- Log into a client, verify session (I used the web client).
- Log into another client.
- Log into the Android client.
- A 'verify your session' banner should appear, tap on it.
- On one of the other clients, accept the verification request.
- Check that the verification popup disappears on the other client.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 10

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account.
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d.
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off]
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
