### PR TITLE
Space list crash fix

### DIFF
--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryController.kt
@@ -42,7 +42,8 @@ import javax.inject.Inject
 class SpaceSummaryController @Inject constructor(
         private val avatarRenderer: AvatarRenderer,
         private val colorProvider: ColorProvider,
-        private val stringProvider: StringProvider) : EpoxyController() {
+        private val stringProvider: StringProvider,
+) : EpoxyController() {
 
     var callback: Callback? = null
     private var viewState: SpaceListViewState? = null
@@ -62,7 +63,8 @@ class SpaceSummaryController @Inject constructor(
                 nonNullViewState.selectedGroupingMethod,
                 nonNullViewState.rootSpacesOrdered,
                 nonNullViewState.expandedStates,
-                nonNullViewState.homeAggregateCount)
+                nonNullViewState.homeAggregateCount
+        )
 
         if (!nonNullViewState.legacyGroups.isNullOrEmpty()) {
             genericFooterItem {
@@ -82,8 +84,10 @@ class SpaceSummaryController @Inject constructor(
                     avatarRenderer(host.avatarRenderer)
                     id("all_communities")
                     matrixItem(mxItem.copy(displayName = host.stringProvider.getString(R.string.group_all_communities)))
-                    selected(nonNullViewState.selectedGroupingMethod is RoomGroupingMethod.ByLegacyGroup &&
-                            nonNullViewState.selectedGroupingMethod.group() == null)
+                    selected(
+                            nonNullViewState.selectedGroupingMethod is RoomGroupingMethod.ByLegacyGroup &&
+                                    nonNullViewState.selectedGroupingMethod.group() == null
+                    )
                     listener { host.callback?.onGroupSelected(null) }
                 }
             }
@@ -93,8 +97,10 @@ class SpaceSummaryController @Inject constructor(
                     avatarRenderer(host.avatarRenderer)
                     id(groupSummary.groupId)
                     matrixItem(groupSummary.toMatrixItem())
-                    selected(nonNullViewState.selectedGroupingMethod is RoomGroupingMethod.ByLegacyGroup &&
-                            nonNullViewState.selectedGroupingMethod.group()?.groupId == groupSummary.groupId)
+                    selected(
+                            nonNullViewState.selectedGroupingMethod is RoomGroupingMethod.ByLegacyGroup &&
+                                    nonNullViewState.selectedGroupingMethod.group()?.groupId == groupSummary.groupId
+                    )
                     listener { host.callback?.onGroupSelected(groupSummary) }
                 }
             }
@@ -112,8 +118,8 @@ class SpaceSummaryController @Inject constructor(
         }
 
         // show invites on top
-
-        summaries?.filter { it.membership == Membership.INVITE }
+        summaries
+                ?.filter { it.membership == Membership.INVITE }
                 ?.forEach { roomSummary ->
                     spaceSummaryItem {
                         avatarRenderer(host.avatarRenderer)

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryController.kt
@@ -141,33 +141,33 @@ class SpaceSummaryController @Inject constructor(
         }
 
         rootSpaces
-                ?.forEach { groupSummary ->
-                    val isSelected = selected is RoomGroupingMethod.BySpace && groupSummary.roomId == selected.space()?.roomId
+                ?.forEach { roomSummary ->
+                    val isSelected = selected is RoomGroupingMethod.BySpace && roomSummary.roomId == selected.space()?.roomId
                     // does it have children?
-                    val subSpaces = groupSummary.spaceChildren?.filter { childInfo ->
+                    val subSpaces = roomSummary.spaceChildren?.filter { childInfo ->
                         summaries?.any { it.roomId == childInfo.childRoomId }.orFalse()
                     }?.sortedWith(subSpaceComparator)
                     val hasChildren = (subSpaces?.size ?: 0) > 0
-                    val expanded = expandedStates[groupSummary.roomId] == true
+                    val expanded = expandedStates[roomSummary.roomId] == true
 
                     spaceSummaryItem {
                         avatarRenderer(host.avatarRenderer)
-                        id(groupSummary.roomId)
+                        id(roomSummary.roomId)
                         hasChildren(hasChildren)
                         expanded(expanded)
                         // to debug order
                         // matrixItem(groupSummary.copy(displayName = "${groupSummary.displayName} / ${spaceOrderInfo?.get(groupSummary.roomId)}")
                         // .toMatrixItem())
-                        matrixItem(groupSummary.toMatrixItem())
+                        matrixItem(roomSummary.toMatrixItem())
                         selected(isSelected)
                         canDrag(true)
-                        onMore { host.callback?.onSpaceSettings(groupSummary) }
-                        listener { host.callback?.onSpaceSelected(groupSummary) }
-                        toggleExpand { host.callback?.onToggleExpand(groupSummary) }
+                        onMore { host.callback?.onSpaceSettings(roomSummary) }
+                        listener { host.callback?.onSpaceSelected(roomSummary) }
+                        toggleExpand { host.callback?.onToggleExpand(roomSummary) }
                         countState(
                                 UnreadCounterBadgeView.State(
-                                        groupSummary.notificationCount,
-                                        groupSummary.highlightCount > 0
+                                        roomSummary.notificationCount,
+                                        roomSummary.highlightCount > 0
                                 )
                         )
                     }
@@ -175,7 +175,7 @@ class SpaceSummaryController @Inject constructor(
                     if (hasChildren && expanded) {
                         // it's expanded
                         subSpaces?.forEach { child ->
-                            buildSubSpace(groupSummary.roomId, summaries, expandedStates, selected, child, 1, 3)
+                            buildSubSpace(roomSummary.roomId, summaries, expandedStates, selected, child, 1, 3)
                         }
                     }
                 }

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryController.kt
@@ -123,7 +123,7 @@ class SpaceSummaryController @Inject constructor(
                 ?.forEach { roomSummary ->
                     spaceSummaryItem {
                         avatarRenderer(host.avatarRenderer)
-                        id(roomSummary.roomId)
+                        id("invite_${roomSummary.roomId}")
                         matrixItem(roomSummary.toMatrixItem())
                         countState(UnreadCounterBadgeView.State(1, true))
                         selected(false)

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryController.kt
@@ -141,6 +141,7 @@ class SpaceSummaryController @Inject constructor(
         }
 
         rootSpaces
+                ?.filter { it.membership != Membership.INVITE }
                 ?.forEach { roomSummary ->
                     val isSelected = selected is RoomGroupingMethod.BySpace && roomSummary.roomId == selected.space()?.roomId
                     // does it have children?


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

Try to fix https://github.com/matrix-org/element-android-rageshakes/issues/37765 :

> Thread: main, Exception: java.lang.IllegalStateException: Two different ViewHolders have the same stable ID. Stable IDs in your adapter MUST BE unique and SHOULD NOT change.

According to the log, this is a space invite. We may have a race condition, where an invite is displayed for a space which is already joined? So displayed twice and the Epoxy item has the same ID. This PR adds a prefix for the space invitation items.

Also space invite will be filtered out from the space root list. This is probably the only required fix, but keeping the previous fix on the `id` does not hurt.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|<img width="353" alt="image" src="https://user-images.githubusercontent.com/3940906/166645965-277e996f-946e-4c77-ae92-55bcd0630fec.png">|<img width="348" alt="image" src="https://user-images.githubusercontent.com/3940906/166646316-375dc3e5-45ef-47d1-9b1b-347c90b125bc.png">|

## Tests

<!-- Explain how you tested your development -->

- No test performed.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
