### PR TITLE
Crash - Konfetti API 21/22 crash

### DIFF
--- a/changelog.d/5925.bugfix
+++ b/changelog.d/5925.bugfix
@@ -1,0 +1,1 @@
+Fixes crash on android api 21/22 devices when opening messages due to Konfetti library

--- a/vector/src/main/java/im/vector/app/core/ui/views/CompatKonfetti.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/views/CompatKonfetti.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.ui.views
+
+import android.content.Context
+import android.os.Build
+import android.util.AttributeSet
+import android.view.View
+import nl.dionsegijn.konfetti.xml.KonfettiView
+
+/**
+ * Konfetti workaround to avoid crashes on API 21/22
+ * https://github.com/DanielMartinus/Konfetti/issues/297
+ */
+class CompatKonfetti @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null
+) : KonfettiView(context, attrs) {
+
+    override fun onVisibilityChanged(changedView: View, visibility: Int) {
+        when (Build.VERSION.SDK_INT) {
+            Build.VERSION_CODES.LOLLIPOP, Build.VERSION_CODES.LOLLIPOP_MR1 -> safeOnVisibilityChanged(changedView, visibility)
+            else                                                           -> super.onVisibilityChanged(changedView, visibility)
+        }
+    }
+
+    private fun safeOnVisibilityChanged(changedView: View, visibility: Int) {
+        runCatching { super.onVisibilityChanged(changedView, visibility) }
+    }
+}

--- a/vector/src/main/res/layout/fragment_ftue_account_created.xml
+++ b/vector/src/main/res/layout/fragment_ftue_account_created.xml
@@ -162,7 +162,7 @@
         app:layout_constraintHeight_percent="0.05"
         app:layout_constraintTop_toBottomOf="@id/ctaBottomBarrier" />
 
-    <nl.dionsegijn.konfetti.xml.KonfettiView
+    <im.vector.app.core.ui.views.CompatKonfetti
         android:id="@+id/viewKonfetti"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/vector/src/main/res/layout/fragment_ftue_personalization_complete.xml
+++ b/vector/src/main/res/layout/fragment_ftue_personalization_complete.xml
@@ -106,7 +106,7 @@
         app:layout_constraintHeight_percent="0.05"
         app:layout_constraintTop_toBottomOf="@id/personalizationCompleteCta" />
 
-    <nl.dionsegijn.konfetti.xml.KonfettiView
+    <im.vector.app.core.ui.views.CompatKonfetti
         android:id="@+id/viewKonfetti"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/vector/src/main/res/layout/fragment_timeline.xml
+++ b/vector/src/main/res/layout/fragment_timeline.xml
@@ -188,7 +188,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:tint="@android:color/black" />
 
-    <nl.dionsegijn.konfetti.xml.KonfettiView
+    <im.vector.app.core.ui.views.CompatKonfetti
         android:id="@+id/viewKonfetti"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes #5925 

The Konfetti v2 upgrade introduce a regression which meant android api 21/22 were no longer able to view the timeline
- The fix is to catch the exception caused by the unexpected non initialised fields in our own `CompatKonfettiView`

## Motivation and context

To fix a crash!

## Screenshots / GIFs

|Before|After|
|-|-|
|![before-konfetti-crash](https://user-images.githubusercontent.com/1848238/166655097-163c965c-8eb1-4345-ad11-e103dc79ac03.gif)|![after-konfetti-crash](https://user-images.githubusercontent.com/1848238/166655111-c20ca6aa-7505-40c4-bdc5-f0889295b007.gif)|
 

## Tests

- Using a device running android 21
- open the timeline
- notice the crash

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 21