### PR TITLE
Feature/aris/threads improve rendering issue 5151

### DIFF
--- a/changelog.d/5151.misc
+++ b/changelog.d/5151.misc
@@ -1,0 +1,1 @@
+Improve threads rendering in the main timeline

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/style/TimelineMessageLayoutFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/style/TimelineMessageLayoutFactory.kt
@@ -95,6 +95,7 @@ class TimelineMessageLayoutFactory @Inject constructor(private val session: Sess
                 nextDisplayableEvent.root.getClearType() !in listOf(EventType.MESSAGE, EventType.STICKER, EventType.ENCRYPTED) ||
                 isNextMessageReceivedMoreThanOneHourAgo ||
                 isTileTypeMessage(nextDisplayableEvent) ||
+                nextDisplayableEvent.isRootThread() ||
                 event.isRootThread() ||
                 nextDisplayableEvent.isEdition()
 


### PR DESCRIPTION
Closes issue #5151 

This PR improves the threads rendering in the main timeline. 

|Before|After|
|-|-|
|![5151_before](https://user-images.githubusercontent.com/60798129/166663437-101e9b21-1149-4a4f-985b-be9a9bf14c84.png)|![5151_after](https://user-images.githubusercontent.com/60798129/166663465-c26135f8-ae6e-4759-b938-cf415515fa95.png)|