### PR TITLE
Fixing sign in via Other needing registration to be enabled

### DIFF
--- a/changelog.d/5874.bugfix
+++ b/changelog.d/5874.bugfix
@@ -1,0 +1,1 @@
+Fixes sign in via other requiring homeserver registration to be enabled

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -645,7 +645,7 @@ class OnboardingViewModel @AssistedInject constructor(
                     when (awaitState().onboardingFlow) {
                         OnboardingFlow.SignIn -> {
                             updateSignMode(SignMode.SignIn)
-                            internalRegisterAction(RegisterAction.StartRegistration, ::emitFlowResultViewEvent)
+                            _viewEvents.post(OnboardingViewEvents.OnSignModeSelected(SignMode.SignIn))
                         }
                         OnboardingFlow.SignUp -> {
                             updateSignMode(SignMode.SignUp)


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes #5874 

- Caused by the sign in flow using the registration homeserver validation, fixed by posting the sign in mode event directly

_Will add a test case in a separate PR to help speed this up_

## Motivation and context

To fix a regression in the onboarding sign in 

## Screenshots / GIFs

#### Other

|Before|After|
|-|-|
|![before-other-sign-in](https://user-images.githubusercontent.com/1848238/166666042-0ff3b1f0-5f7e-4ecf-b538-6895f1ae7ca3.gif)|![after-other-sign-in](https://user-images.githubusercontent.com/1848238/166666054-d856db9b-9e7f-4be9-83d3-39f1f9f014c6.gif)|

#### Matrix.org (no changes)

| Before | After |
| --- | --- | 
|![before-matrix-sign-in](https://user-images.githubusercontent.com/1848238/166667173-1565c4ad-c5c0-4330-8acf-bfe75abe3514.gif)|![after-matrix-sign-in](https://user-images.githubusercontent.com/1848238/166666742-8c3556ce-faac-438b-a92b-224e872f8f03.gif)


 ## Tests

- Have a homeserver with registration disabled
- Attempt to sign in via Other
- Notice sign in denied due to homeserver requiring registration

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 29