### PR TITLE
Feature/bca/fix 5906

### DIFF
--- a/changelog.d/5906.bugfix
+++ b/changelog.d/5906.bugfix
@@ -1,0 +1,1 @@
+Desynchronized 4S | Megolm backup causing Unusable backup

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/KeysBackupVersionTrustSignature.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/keysbackup/KeysBackupVersionTrustSignature.kt
@@ -16,25 +16,35 @@
 
 package org.matrix.android.sdk.api.session.crypto.keysbackup
 
+import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigningKey
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
 
 /**
  * A signature in a `KeysBackupVersionTrust` object.
  */
-data class KeysBackupVersionTrustSignature(
-        /**
-         * The id of the device that signed the backup version.
-         */
-        val deviceId: String?,
 
-        /**
-         * The device that signed the backup version.
-         * Can be null if the device is not known.
-         */
-        val device: CryptoDeviceInfo?,
+sealed class KeysBackupVersionTrustSignature {
 
-        /**
-         * Flag to indicate the signature from this device is valid.
-         */
-        val valid: Boolean,
-)
+    data class DeviceSignature(
+            /**
+             * The id of the device that signed the backup version.
+             */
+            val deviceId: String?,
+
+            /**
+             * The device that signed the backup version.
+             * Can be null if the device is not known.
+             */
+            val device: CryptoDeviceInfo?,
+
+            /**
+             * Flag to indicate the signature from this device is valid.
+             */
+            val valid: Boolean) : KeysBackupVersionTrustSignature()
+
+    data class UserSignature(
+            val keyId: String?,
+            val cryptoCrossSigningKey: CryptoCrossSigningKey?,
+            val valid: Boolean
+    ) : KeysBackupVersionTrustSignature()
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/CrossSigningOlm.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/CrossSigningOlm.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.crypto.crosssigning
+
+import org.matrix.android.sdk.api.util.JsonDict
+import org.matrix.android.sdk.internal.crypto.store.IMXCryptoStore
+import org.matrix.android.sdk.internal.session.SessionScope
+import org.matrix.android.sdk.internal.util.JsonCanonicalizer
+import org.matrix.olm.OlmPkSigning
+import org.matrix.olm.OlmUtility
+import javax.inject.Inject
+
+/**
+ * Holds the OlmPkSigning for cross signing.
+ * Can be injected without having to get the full cross signing service
+ */
+@SessionScope
+internal class CrossSigningOlm @Inject constructor(
+        private val cryptoStore: IMXCryptoStore,
+) {
+
+    enum class KeyType {
+        SELF,
+        USER,
+        MASTER
+    }
+
+    var olmUtility: OlmUtility = OlmUtility()
+
+    var masterPkSigning: OlmPkSigning? = null
+    var userPkSigning: OlmPkSigning? = null
+    var selfSigningPkSigning: OlmPkSigning? = null
+
+    fun release() {
+        olmUtility.releaseUtility()
+        listOf(masterPkSigning, userPkSigning, selfSigningPkSigning).forEach { it?.releaseSigning() }
+    }
+
+    fun signObject(type: KeyType, strToSign: String): Map<String, String> {
+        val myKeys = cryptoStore.getMyCrossSigningInfo()
+        val pubKey = when (type) {
+            KeyType.SELF   -> myKeys?.selfSigningKey()
+            KeyType.USER   -> myKeys?.userKey()
+            KeyType.MASTER -> myKeys?.masterKey()
+        }?.unpaddedBase64PublicKey
+        val pkSigning = when (type) {
+            KeyType.SELF   -> selfSigningPkSigning
+            KeyType.USER   -> userPkSigning
+            KeyType.MASTER -> masterPkSigning
+        }
+        if (pubKey == null || pkSigning == null) {
+            throw Throwable("Cannot sign from this account, public and/or privateKey Unknown $type|$pkSigning")
+        }
+        val signature = pkSigning.sign(strToSign)
+        return mapOf(
+                "ed25519:$pubKey" to signature
+        )
+    }
+
+    fun verifySignature(type: KeyType, signable: JsonDict, signatures: Map<String, Map<String, String>>) {
+        val myKeys = cryptoStore.getMyCrossSigningInfo()
+                ?: throw NoSuchElementException("Cross Signing not configured")
+        val myUserID = myKeys.userId
+        val pubKey = when (type) {
+            KeyType.SELF   -> myKeys.selfSigningKey()
+            KeyType.USER   -> myKeys.userKey()
+            KeyType.MASTER -> myKeys.masterKey()
+        }?.unpaddedBase64PublicKey ?: throw NoSuchElementException("Cross Signing not configured")
+        val signaturesMadeByMyKey = signatures[myUserID] // Signatures made by me
+                ?.get("ed25519:$pubKey")
+
+        if (signaturesMadeByMyKey.isNullOrBlank()) {
+            throw IllegalArgumentException("Not signed with my key $type")
+        }
+
+        // Check that Alice USK signature of Bob MSK is valid
+        olmUtility.verifyEd25519Signature(signaturesMadeByMyKey, pubKey, JsonCanonicalizer.getCanonicalJson(Map::class.java, signable))
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/crypto/keysbackup/restore/KeysBackupRestoreActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysbackup/restore/KeysBackupRestoreActivity.kt
@@ -128,7 +128,7 @@ class KeysBackupRestoreActivity : SimpleFragmentActivity() {
     }
 
     private fun launch4SActivity() {
-        SharedSecureStorageActivity.newIntent(
+        SharedSecureStorageActivity.newReadIntent(
                 context = this,
                 keyId = null, // default key
                 requestedSecrets = listOf(KEYBACKUP_SECRET_SSSS_NAME),

--- a/vector/src/main/java/im/vector/app/features/crypto/keysbackup/settings/KeyBackupSettingsAction.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysbackup/settings/KeyBackupSettingsAction.kt
@@ -22,4 +22,8 @@ sealed class KeyBackupSettingsAction : VectorViewModelAction {
     object Init : KeyBackupSettingsAction()
     object GetKeyBackupTrust : KeyBackupSettingsAction()
     object DeleteKeyBackup : KeyBackupSettingsAction()
+    object SetUpKeyBackup : KeyBackupSettingsAction()
+    data class StoreIn4SSuccess(val recoveryKey: String, val alias: String) : KeyBackupSettingsAction()
+    object StoreIn4SReset : KeyBackupSettingsAction()
+    object StoreIn4SFailure : KeyBackupSettingsAction()
 }

--- a/vector/src/main/java/im/vector/app/features/crypto/keysbackup/settings/KeysBackupManageActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysbackup/settings/KeysBackupManageActivity.kt
@@ -15,6 +15,7 @@
  */
 package im.vector.app.features.crypto.keysbackup.settings
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import com.airbnb.mvrx.Fail
@@ -23,9 +24,13 @@ import com.airbnb.mvrx.viewModel
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
+import im.vector.app.core.extensions.registerStartForActivityResult
 import im.vector.app.core.extensions.replaceFragment
 import im.vector.app.core.platform.SimpleFragmentActivity
 import im.vector.app.core.platform.WaitingViewData
+import im.vector.app.features.crypto.keysbackup.setup.KeysBackupSetupActivity
+import im.vector.app.features.crypto.quads.SharedSecureStorageActivity
+import org.matrix.android.sdk.api.session.crypto.crosssigning.KEYBACKUP_SECRET_SSSS_NAME
 
 @AndroidEntryPoint
 class KeysBackupManageActivity : SimpleFragmentActivity() {
@@ -40,6 +45,21 @@ class KeysBackupManageActivity : SimpleFragmentActivity() {
     override fun getTitleRes() = R.string.encryption_message_recovery
 
     private val viewModel: KeysBackupSettingsViewModel by viewModel()
+
+    private val secretStartForActivityResult = registerStartForActivityResult { activityResult ->
+        if (activityResult.resultCode == Activity.RESULT_OK) {
+            val result = activityResult.data?.getStringExtra(SharedSecureStorageActivity.EXTRA_DATA_RESULT)
+            val reset = activityResult.data?.getBooleanExtra(SharedSecureStorageActivity.EXTRA_DATA_RESET, false) ?: false
+            if (result != null) {
+                viewModel.handle(KeyBackupSettingsAction.StoreIn4SSuccess(result, SharedSecureStorageActivity.DEFAULT_RESULT_KEYSTORE_ALIAS))
+            } else if (reset) {
+                // all have been reset so a new backup would have been created
+                viewModel.handle(KeyBackupSettingsAction.StoreIn4SReset)
+            }
+        } else {
+            viewModel.handle(KeyBackupSettingsAction.StoreIn4SFailure)
+        }
+    }
 
     override fun initUiAndData() {
         super.initUiAndData()
@@ -66,6 +86,23 @@ class KeysBackupManageActivity : SimpleFragmentActivity() {
                 }
                 else       -> {
                     updateWaitingView(null)
+                }
+            }
+        }
+
+        viewModel.observeViewEvents {
+            when (it) {
+                KeysBackupViewEvents.OpenLegacyCreateBackup  -> {
+                    startActivity(KeysBackupSetupActivity.intent(this, false))
+                }
+                is KeysBackupViewEvents.RequestStore4SSecret -> {
+                    secretStartForActivityResult.launch(
+                            SharedSecureStorageActivity.newWriteIntent(
+                                    this,
+                                    null, // default key
+                                    listOf(KEYBACKUP_SECRET_SSSS_NAME to it.recoveryKey)
+                            )
+                    )
                 }
             }
         }

--- a/vector/src/main/java/im/vector/app/features/crypto/keysbackup/settings/KeysBackupSettingsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysbackup/settings/KeysBackupSettingsFragment.kt
@@ -28,7 +28,6 @@ import im.vector.app.core.extensions.configureWith
 import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.databinding.FragmentKeysBackupSettingsBinding
 import im.vector.app.features.crypto.keysbackup.restore.KeysBackupRestoreActivity
-import im.vector.app.features.crypto.keysbackup.setup.KeysBackupSetupActivity
 import javax.inject.Inject
 
 class KeysBackupSettingsFragment @Inject constructor(private val keysBackupSettingsRecyclerViewController: KeysBackupSettingsRecyclerViewController) :
@@ -58,9 +57,7 @@ class KeysBackupSettingsFragment @Inject constructor(private val keysBackupSetti
     }
 
     override fun didSelectSetupMessageRecovery() {
-        context?.let {
-            startActivity(KeysBackupSetupActivity.intent(it, false))
-        }
+        viewModel.handle(KeyBackupSettingsAction.SetUpKeyBackup)
     }
 
     override fun didSelectRestoreMessageRecovery() {

--- a/vector/src/main/java/im/vector/app/features/crypto/keysbackup/settings/KeysBackupSettingsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysbackup/settings/KeysBackupSettingsViewModel.kt
@@ -25,8 +25,8 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
-import im.vector.app.core.platform.EmptyViewEvents
 import im.vector.app.core.platform.VectorViewModel
+import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.MatrixCallback
 import org.matrix.android.sdk.api.NoOpMatrixCallback
 import org.matrix.android.sdk.api.session.Session
@@ -34,10 +34,16 @@ import org.matrix.android.sdk.api.session.crypto.keysbackup.KeysBackupService
 import org.matrix.android.sdk.api.session.crypto.keysbackup.KeysBackupState
 import org.matrix.android.sdk.api.session.crypto.keysbackup.KeysBackupStateListener
 import org.matrix.android.sdk.api.session.crypto.keysbackup.KeysBackupVersionTrust
+import org.matrix.android.sdk.api.session.crypto.keysbackup.KeysVersion
+import org.matrix.android.sdk.api.session.crypto.keysbackup.MegolmBackupCreationInfo
+import org.matrix.android.sdk.api.session.crypto.keysbackup.extractCurveKeyFromRecoveryKey
+import org.matrix.android.sdk.api.util.awaitCallback
+import org.matrix.android.sdk.api.util.toBase64NoPadding
+import timber.log.Timber
 
 class KeysBackupSettingsViewModel @AssistedInject constructor(@Assisted initialState: KeysBackupSettingViewState,
-                                                              session: Session
-) : VectorViewModel<KeysBackupSettingViewState, KeyBackupSettingsAction, EmptyViewEvents>(initialState),
+                                                              private val session: Session
+) : VectorViewModel<KeysBackupSettingViewState, KeyBackupSettingsAction, KeysBackupViewEvents>(initialState),
         KeysBackupStateListener {
 
     @AssistedFactory
@@ -48,6 +54,8 @@ class KeysBackupSettingsViewModel @AssistedInject constructor(@Assisted initialS
     companion object : MavericksViewModelFactory<KeysBackupSettingsViewModel, KeysBackupSettingViewState> by hiltMavericksViewModelFactory()
 
     private val keysBackupService: KeysBackupService = session.cryptoService().keysBackupService()
+
+    var pendingBackupCreationInfo: MegolmBackupCreationInfo? = null
 
     init {
         setState {
@@ -62,9 +70,18 @@ class KeysBackupSettingsViewModel @AssistedInject constructor(@Assisted initialS
 
     override fun handle(action: KeyBackupSettingsAction) {
         when (action) {
-            KeyBackupSettingsAction.Init              -> init()
-            KeyBackupSettingsAction.GetKeyBackupTrust -> getKeysBackupTrust()
-            KeyBackupSettingsAction.DeleteKeyBackup   -> deleteCurrentBackup()
+            KeyBackupSettingsAction.Init                -> init()
+            KeyBackupSettingsAction.GetKeyBackupTrust   -> getKeysBackupTrust()
+            KeyBackupSettingsAction.DeleteKeyBackup     -> deleteCurrentBackup()
+            KeyBackupSettingsAction.SetUpKeyBackup      -> viewModelScope.launch {
+                setUpKeyBackup()
+            }
+            KeyBackupSettingsAction.StoreIn4SReset,
+            KeyBackupSettingsAction.StoreIn4SFailure    -> {
+                pendingBackupCreationInfo = null
+                // nothing to do just stay on fragment
+            }
+            is KeyBackupSettingsAction.StoreIn4SSuccess -> viewModelScope.launch { completeBackupCreation() }
         }
     }
 
@@ -118,6 +135,35 @@ class KeysBackupSettingsViewModel @AssistedInject constructor(@Assisted initialS
         }
 
         getKeysBackupTrust()
+    }
+
+    suspend fun setUpKeyBackup() {
+        // We need to check if 4S is enabled first.
+        // If it is we need to use it, generate a random key
+        // for the backup and store it in the 4S
+        if (session.sharedSecretStorageService().isRecoverySetup()) {
+            val creationInfo = awaitCallback<MegolmBackupCreationInfo> {
+                session.cryptoService().keysBackupService().prepareKeysBackupVersion(null, null, it)
+            }
+            pendingBackupCreationInfo = creationInfo
+            val recoveryKey = extractCurveKeyFromRecoveryKey(creationInfo.recoveryKey)?.toBase64NoPadding()
+            _viewEvents.post(KeysBackupViewEvents.RequestStore4SSecret(recoveryKey!!))
+        } else {
+            // No 4S so we can open legacy flow
+            _viewEvents.post(KeysBackupViewEvents.OpenLegacyCreateBackup)
+        }
+    }
+
+    suspend fun completeBackupCreation() {
+        val info = pendingBackupCreationInfo ?: return
+        val version = awaitCallback<KeysVersion> {
+            session.cryptoService().keysBackupService().createKeysBackupVersion(info, it)
+        }
+        // Save it for gossiping
+        Timber.d("## BootstrapCrossSigningTask: Creating 4S - Save megolm backup key for gossiping")
+        session.cryptoService().keysBackupService().saveBackupRecoveryKey(info.recoveryKey, version = version.version)
+
+        // TODO catch, delete 4S account data
     }
 
     private fun deleteCurrentBackup() {

--- a/vector/src/main/java/im/vector/app/features/crypto/keysbackup/settings/KeysBackupViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysbackup/settings/KeysBackupViewEvents.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.crypto.keysbackup.settings
+
+import im.vector.app.core.platform.VectorViewEvents
+
+sealed class KeysBackupViewEvents : VectorViewEvents {
+    object OpenLegacyCreateBackup : KeysBackupViewEvents()
+    data class RequestStore4SSecret(val recoveryKey: String) : KeysBackupViewEvents()
+}

--- a/vector/src/main/java/im/vector/app/features/crypto/quads/SharedSecureStorageActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/quads/SharedSecureStorageActivity.kt
@@ -48,8 +48,9 @@ class SharedSecureStorageActivity :
     @Parcelize
     data class Args(
             val keyId: String?,
-            val requestedSecrets: List<String>,
-            val resultKeyStoreAlias: String
+            val requestedSecrets: List<String> = emptyList(),
+            val resultKeyStoreAlias: String,
+            val writeSecrets: List<Pair<String, String>> = emptyList(),
     ) : Parcelable
 
     private val viewModel: SharedSecureStorageViewModel by viewModel()
@@ -148,17 +149,37 @@ class SharedSecureStorageActivity :
         const val EXTRA_DATA_RESET = "EXTRA_DATA_RESET"
         const val DEFAULT_RESULT_KEYSTORE_ALIAS = "SharedSecureStorageActivity"
 
-        fun newIntent(context: Context,
-                      keyId: String? = null,
-                      requestedSecrets: List<String>,
-                      resultKeyStoreAlias: String = DEFAULT_RESULT_KEYSTORE_ALIAS): Intent {
+        fun newReadIntent(context: Context,
+                          keyId: String? = null,
+                          requestedSecrets: List<String>,
+                          resultKeyStoreAlias: String = DEFAULT_RESULT_KEYSTORE_ALIAS): Intent {
             require(requestedSecrets.isNotEmpty())
             return Intent(context, SharedSecureStorageActivity::class.java).also {
-                it.putExtra(Mavericks.KEY_ARG, Args(
-                        keyId,
-                        requestedSecrets,
-                        resultKeyStoreAlias
-                ))
+                it.putExtra(
+                        Mavericks.KEY_ARG,
+                        Args(
+                                keyId = keyId,
+                                requestedSecrets = requestedSecrets,
+                                resultKeyStoreAlias = resultKeyStoreAlias
+                        )
+                )
+            }
+        }
+
+        fun newWriteIntent(context: Context,
+                           keyId: String? = null,
+                           writeSecrets: List<Pair<String, String>>,
+                           resultKeyStoreAlias: String = DEFAULT_RESULT_KEYSTORE_ALIAS): Intent {
+            require(writeSecrets.isNotEmpty())
+            return Intent(context, SharedSecureStorageActivity::class.java).also {
+                it.putExtra(
+                        Mavericks.KEY_ARG,
+                        Args(
+                                keyId = keyId,
+                                writeSecrets = writeSecrets,
+                                resultKeyStoreAlias = resultKeyStoreAlias
+                        )
+                )
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationBottomSheet.kt
@@ -95,7 +95,7 @@ class VerificationBottomSheet : VectorBaseBottomSheetDialogFragment<BottomSheetV
             when (it) {
                 is VerificationBottomSheetViewEvents.Dismiss           -> dismiss()
                 is VerificationBottomSheetViewEvents.AccessSecretStore -> {
-                    secretStartForActivityResult.launch(SharedSecureStorageActivity.newIntent(
+                    secretStartForActivityResult.launch(SharedSecureStorageActivity.newReadIntent(
                             requireContext(),
                             null, // use default key
                             listOf(MASTER_KEY_SSSS_NAME, USER_SIGNING_KEY_SSSS_NAME, SELF_SIGNING_KEY_SSSS_NAME, KEYBACKUP_SECRET_SSSS_NAME),

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1514,6 +1514,7 @@
     <string name="keys_backup_settings_status_not_setup">Your keys are not being backed up from this session.</string>
 
     <string name="keys_backup_settings_signature_from_unknown_device">Backup has a signature from unknown session with ID %s.</string>
+    <string name="keys_backup_settings_signature_from_this_user">Backup has a valid signature from this user.</string>
     <string name="keys_backup_settings_valid_signature_from_this_device">Backup has a valid signature from this session.</string>
     <string name="keys_backup_settings_valid_signature_from_verified_device">Backup has a valid signature from verified session %s.</string>
     <string name="keys_backup_settings_valid_signature_from_unverified_device">Backup has a valid signature from unverified session %s</string>


### PR DESCRIPTION
Fixes #5906 
Fixes #1260
Fixes #3368
 
## Type of change

- [x] Bugfix

## Content

Change to keep 4S in sync with megolm backup:

If 4S is setup and you try to delete then create a new megolm backup, you will now be prompted to enter the 4S passphrase. A new random key will be generated for the backup and will be then saved in the 4S (replacing the old one), and will also be saved locally for gossiping.
**Code Change** => The `SharedSecureStorageActivity` has been modified to support 2 modes now, read and write. So all the code to request the password/key is the same. In the write mode you can now pass a secretName/Value to be stored.

Sign & Verify backup using MSK signature.

When the backup is created we now also add the MSK signature if possible (cross signing enabled and we have private part).
The signature is also checked in order to trust the backup .
**Code Change** => `KeysBackupVersionTrustSignature` is changed to a sealed class of `DeviceSignature`or `UserSignature`
The backup settings screens have been modified to show the new signatures.


## Screenshots / GIFs

<!--
|Before|After|
|-|-|
|![before](https://user-images.githubusercontent.com/9841565/166879151-708f37d7-e868-4cc0-adc0-b7ced5e947d9.png)|![after](https://user-images.githubusercontent.com/9841565/166879176-7f9aa361-7665-40d8-8fc3-9ac9d07aa76d.png)|
 -->

## Tests

<!-- Explain how you tested your development -->

See step to reproduce from #5906 
Unit test has been updated to check signatures

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
