### PR TITLE
No animation -> no chat effect

### DIFF
--- a/changelog.d/5941.bugfix
+++ b/changelog.d/5941.bugfix
@@ -1,0 +1,1 @@
+If animations are disable on the System, chat effects and confetti will be disabled too

--- a/vector/src/fdroid/java/im/vector/app/fdroid/features/settings/troubleshoot/TestBatteryOptimization.kt
+++ b/vector/src/fdroid/java/im/vector/app/fdroid/features/settings/troubleshoot/TestBatteryOptimization.kt
@@ -31,7 +31,7 @@ class TestBatteryOptimization @Inject constructor(
 ) : TroubleshootTest(R.string.settings_troubleshoot_test_battery_title) {
 
     override fun perform(activityResultLauncher: ActivityResultLauncher<Intent>) {
-        if (isIgnoringBatteryOptimizations(context)) {
+        if (context.isIgnoringBatteryOptimizations()) {
             description = stringProvider.getString(R.string.settings_troubleshoot_test_battery_success)
             status = TestStatus.SUCCESS
             quickFix = null

--- a/vector/src/main/java/im/vector/app/core/utils/SystemUtils.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/SystemUtils.kt
@@ -43,21 +43,20 @@ import im.vector.app.features.notifications.NotificationUtils
  * This user option appears on Android M but Android O enforces its usage and kills apps not
  * authorised by the user to run in background.
  *
- * @param context the context
  * @return true if battery optimisations are ignored
  */
-fun isIgnoringBatteryOptimizations(context: Context): Boolean {
+fun Context.isIgnoringBatteryOptimizations(): Boolean {
     // no issue before Android M, battery optimisations did not exist
     return Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
-            context.getSystemService<PowerManager>()?.isIgnoringBatteryOptimizations(context.packageName) == true
+            getSystemService<PowerManager>()?.isIgnoringBatteryOptimizations(packageName) == true
 }
 
-fun isAirplaneModeOn(context: Context): Boolean {
-    return Settings.Global.getInt(context.contentResolver, Settings.Global.AIRPLANE_MODE_ON, 0) != 0
+fun Context.isAirplaneModeOn(): Boolean {
+    return Settings.Global.getInt(contentResolver, Settings.Global.AIRPLANE_MODE_ON, 0) != 0
 }
 
-fun isAnimationDisabled(context: Context): Boolean {
-    return Settings.Global.getFloat(context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f) == 0f
+fun Context.isAnimationDisabled(): Boolean {
+    return Settings.Global.getFloat(contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f) == 0f
 }
 
 /**

--- a/vector/src/main/java/im/vector/app/core/utils/SystemUtils.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/SystemUtils.kt
@@ -55,8 +55,8 @@ fun Context.isAirplaneModeOn(): Boolean {
     return Settings.Global.getInt(contentResolver, Settings.Global.AIRPLANE_MODE_ON, 0) != 0
 }
 
-fun Context.isAnimationDisabled(): Boolean {
-    return Settings.Global.getFloat(contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f) == 0f
+fun Context.isAnimationEnabled(): Boolean {
+    return Settings.Global.getFloat(contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f) != 0f
 }
 
 /**

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -105,6 +105,7 @@ import im.vector.app.core.utils.colorizeMatchingText
 import im.vector.app.core.utils.copyToClipboard
 import im.vector.app.core.utils.createJSonViewerStyleProvider
 import im.vector.app.core.utils.createUIHandler
+import im.vector.app.core.utils.isAnimationDisabled
 import im.vector.app.core.utils.isValidUrl
 import im.vector.app.core.utils.onPermissionDeniedDialog
 import im.vector.app.core.utils.onPermissionDeniedSnackbar
@@ -586,6 +587,10 @@ class TimelineFragment @Inject constructor(
     }
 
     private fun handleChatEffect(chatEffect: ChatEffect) {
+        if (requireContext().isAnimationDisabled()) {
+            Timber.d("Do not perform chat effect, animations are disabled.")
+            return
+        }
         when (chatEffect) {
             ChatEffect.CONFETTI -> {
                 views.viewKonfetti.isVisible = true

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -666,11 +666,13 @@ class TimelineFragment @Inject constructor(
             ).apply {
                 directListener = { granted ->
                     if (granted) {
-                        timelineViewModel.handle(RoomDetailAction.EnsureNativeWidgetAllowed(
-                                widget = it.widget,
-                                userJustAccepted = true,
-                                grantedEvents = it.grantedEvents
-                        ))
+                        timelineViewModel.handle(
+                                RoomDetailAction.EnsureNativeWidgetAllowed(
+                                        widget = it.widget,
+                                        userJustAccepted = true,
+                                        grantedEvents = it.grantedEvents
+                                )
+                        )
                     }
                 }
             }
@@ -791,25 +793,29 @@ class TimelineFragment @Inject constructor(
 
             override fun onSendVoiceMessage() {
                 messageComposerViewModel.handle(
-                        MessageComposerAction.EndRecordingVoiceMessage(isCancelled = false, rootThreadEventId = getRootThreadEventId()))
+                        MessageComposerAction.EndRecordingVoiceMessage(isCancelled = false, rootThreadEventId = getRootThreadEventId())
+                )
                 updateRecordingUiState(RecordingUiState.Idle)
             }
 
             override fun onDeleteVoiceMessage() {
                 messageComposerViewModel.handle(
-                        MessageComposerAction.EndRecordingVoiceMessage(isCancelled = true, rootThreadEventId = getRootThreadEventId()))
+                        MessageComposerAction.EndRecordingVoiceMessage(isCancelled = true, rootThreadEventId = getRootThreadEventId())
+                )
                 updateRecordingUiState(RecordingUiState.Idle)
             }
 
             override fun onRecordingLimitReached() {
                 messageComposerViewModel.handle(
-                        MessageComposerAction.PauseRecordingVoiceMessage)
+                        MessageComposerAction.PauseRecordingVoiceMessage
+                )
                 updateRecordingUiState(RecordingUiState.Draft)
             }
 
             override fun onRecordingWaveformClicked() {
                 messageComposerViewModel.handle(
-                        MessageComposerAction.PauseRecordingVoiceMessage)
+                        MessageComposerAction.PauseRecordingVoiceMessage
+                )
                 updateRecordingUiState(RecordingUiState.Draft)
             }
 
@@ -827,7 +833,8 @@ class TimelineFragment @Inject constructor(
 
             private fun updateRecordingUiState(state: RecordingUiState) {
                 messageComposerViewModel.handle(
-                        MessageComposerAction.OnVoiceRecordingUiStateChanged(state))
+                        MessageComposerAction.OnVoiceRecordingUiStateChanged(state)
+                )
             }
         }
     }
@@ -1527,9 +1534,11 @@ class TimelineFragment @Inject constructor(
                     attachmentTypeSelector = AttachmentTypeSelectorView(vectorBaseActivity, vectorBaseActivity.layoutInflater, this@TimelineFragment)
                     attachmentTypeSelector.setAttachmentVisibility(
                             AttachmentTypeSelectorView.Type.LOCATION,
-                            vectorPreferences.isLocationSharingEnabled())
+                            vectorPreferences.isLocationSharingEnabled()
+                    )
                     attachmentTypeSelector.setAttachmentVisibility(
-                            AttachmentTypeSelectorView.Type.POLL, !isThreadTimeLine())
+                            AttachmentTypeSelectorView.Type.POLL, !isThreadTimeLine()
+                    )
                 }
                 attachmentTypeSelector.show(views.composerLayout.views.attachmentButton)
             }
@@ -2292,12 +2301,18 @@ class TimelineFragment @Inject constructor(
                 handleCancelSend(action)
             }
             is EventSharedAction.ReportContentSpam          -> {
-                timelineViewModel.handle(RoomDetailAction.ReportContent(
-                        action.eventId, action.senderId, "This message is spam", spam = true))
+                timelineViewModel.handle(
+                        RoomDetailAction.ReportContent(
+                                action.eventId, action.senderId, "This message is spam", spam = true
+                        )
+                )
             }
             is EventSharedAction.ReportContentInappropriate -> {
-                timelineViewModel.handle(RoomDetailAction.ReportContent(
-                        action.eventId, action.senderId, "This message is inappropriate", inappropriate = true))
+                timelineViewModel.handle(
+                        RoomDetailAction.ReportContent(
+                                action.eventId, action.senderId, "This message is inappropriate", inappropriate = true
+                        )
+                )
             }
             is EventSharedAction.ReportContentCustom        -> {
                 promptReasonToReportContent(action)
@@ -2443,7 +2458,8 @@ class TimelineFragment @Inject constructor(
                     displayName = timelineViewModel.getRoomSummary()?.displayName,
                     avatarUrl = timelineViewModel.getRoomSummary()?.avatarUrl,
                     roomEncryptionTrustLevel = timelineViewModel.getRoomSummary()?.roomEncryptionTrustLevel,
-                    rootThreadEventId = rootThreadEventId)
+                    rootThreadEventId = rootThreadEventId
+            )
             navigator.openThread(it, roomThreadDetailArgs)
         }
     }
@@ -2479,7 +2495,8 @@ class TimelineFragment @Inject constructor(
                     roomId = timelineArgs.roomId,
                     displayName = timelineViewModel.getRoomSummary()?.displayName,
                     roomEncryptionTrustLevel = timelineViewModel.getRoomSummary()?.roomEncryptionTrustLevel,
-                    avatarUrl = timelineViewModel.getRoomSummary()?.avatarUrl)
+                    avatarUrl = timelineViewModel.getRoomSummary()?.avatarUrl
+            )
             navigator.openThreadList(it, roomThreadDetailArgs)
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -105,7 +105,7 @@ import im.vector.app.core.utils.colorizeMatchingText
 import im.vector.app.core.utils.copyToClipboard
 import im.vector.app.core.utils.createJSonViewerStyleProvider
 import im.vector.app.core.utils.createUIHandler
-import im.vector.app.core.utils.isAnimationDisabled
+import im.vector.app.core.utils.isAnimationEnabled
 import im.vector.app.core.utils.isValidUrl
 import im.vector.app.core.utils.onPermissionDeniedDialog
 import im.vector.app.core.utils.onPermissionDeniedSnackbar
@@ -587,7 +587,7 @@ class TimelineFragment @Inject constructor(
     }
 
     private fun handleChatEffect(chatEffect: ChatEffect) {
-        if (requireContext().isAnimationDisabled()) {
+        if (!requireContext().isAnimationEnabled()) {
             Timber.d("Do not perform chat effect, animations are disabled.")
             return
         }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthAccountCreatedFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthAccountCreatedFragment.kt
@@ -24,7 +24,7 @@ import androidx.core.view.isVisible
 import im.vector.app.R
 import im.vector.app.core.animations.play
 import im.vector.app.core.di.ActiveSessionHolder
-import im.vector.app.core.utils.isAnimationDisabled
+import im.vector.app.core.utils.isAnimationEnabled
 import im.vector.app.databinding.FragmentFtueAccountCreatedBinding
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewEvents
@@ -58,7 +58,7 @@ class FtueAuthAccountCreatedFragment @Inject constructor(
         views.personalizeButtonGroup.isVisible = canPersonalize
         views.takeMeHomeButtonGroup.isVisible = !canPersonalize
 
-        if (!hasPlayedConfetti && !canPersonalize && !requireContext().isAnimationDisabled()) {
+        if (!hasPlayedConfetti && !canPersonalize && requireContext().isAnimationEnabled()) {
             hasPlayedConfetti = true
             views.viewKonfetti.isVisible = true
             views.viewKonfetti.play()

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthAccountCreatedFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthAccountCreatedFragment.kt
@@ -24,6 +24,7 @@ import androidx.core.view.isVisible
 import im.vector.app.R
 import im.vector.app.core.animations.play
 import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.core.utils.isAnimationDisabled
 import im.vector.app.databinding.FragmentFtueAccountCreatedBinding
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewEvents
@@ -57,7 +58,7 @@ class FtueAuthAccountCreatedFragment @Inject constructor(
         views.personalizeButtonGroup.isVisible = canPersonalize
         views.takeMeHomeButtonGroup.isVisible = !canPersonalize
 
-        if (!hasPlayedConfetti && !canPersonalize) {
+        if (!hasPlayedConfetti && !canPersonalize && !requireContext().isAnimationDisabled()) {
             hasPlayedConfetti = true
             views.viewKonfetti.isVisible = true
             views.viewKonfetti.play()

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPersonalizationCompleteFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPersonalizationCompleteFragment.kt
@@ -22,7 +22,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import im.vector.app.core.animations.play
-import im.vector.app.core.utils.isAnimationDisabled
+import im.vector.app.core.utils.isAnimationEnabled
 import im.vector.app.databinding.FragmentFtuePersonalizationCompleteBinding
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewEvents
@@ -44,7 +44,7 @@ class FtueAuthPersonalizationCompleteFragment @Inject constructor() : AbstractFt
     private fun setupViews() {
         views.personalizationCompleteCta.debouncedClicks { viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnTakeMeHome)) }
 
-        if (!hasPlayedConfetti && !requireContext().isAnimationDisabled()) {
+        if (!hasPlayedConfetti && requireContext().isAnimationEnabled()) {
             hasPlayedConfetti = true
             views.viewKonfetti.isVisible = true
             views.viewKonfetti.play()

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPersonalizationCompleteFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPersonalizationCompleteFragment.kt
@@ -22,6 +22,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import im.vector.app.core.animations.play
+import im.vector.app.core.utils.isAnimationDisabled
 import im.vector.app.databinding.FragmentFtuePersonalizationCompleteBinding
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewEvents
@@ -43,7 +44,7 @@ class FtueAuthPersonalizationCompleteFragment @Inject constructor() : AbstractFt
     private fun setupViews() {
         views.personalizationCompleteCta.debouncedClicks { viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnTakeMeHome)) }
 
-        if (!hasPlayedConfetti) {
+        if (!hasPlayedConfetti && !requireContext().isAnimationDisabled()) {
             hasPlayedConfetti = true
             views.viewKonfetti.isVisible = true
             views.viewKonfetti.play()

--- a/vector/src/main/java/im/vector/app/features/popup/PopupAlertManager.kt
+++ b/vector/src/main/java/im/vector/app/features/popup/PopupAlertManager.kt
@@ -218,7 +218,7 @@ class PopupAlertManager @Inject constructor(
         if (!alert.isLight) {
             clearLightStatusBar()
         }
-        val noAnimation = !animate || isAnimationDisabled(activity)
+        val noAnimation = !animate || activity.isAnimationDisabled()
 
         alert.weakCurrentActivity = WeakReference(activity)
         val alerter = Alerter.create(activity, alert.layoutRes)

--- a/vector/src/main/java/im/vector/app/features/popup/PopupAlertManager.kt
+++ b/vector/src/main/java/im/vector/app/features/popup/PopupAlertManager.kt
@@ -25,7 +25,7 @@ import com.tapadoo.alerter.Alerter
 import im.vector.app.R
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.core.time.Clock
-import im.vector.app.core.utils.isAnimationDisabled
+import im.vector.app.core.utils.isAnimationEnabled
 import im.vector.app.features.analytics.ui.consent.AnalyticsOptInActivity
 import im.vector.app.features.pin.PinActivity
 import im.vector.app.features.signout.hard.SignedOutActivity
@@ -218,7 +218,7 @@ class PopupAlertManager @Inject constructor(
         if (!alert.isLight) {
             clearLightStatusBar()
         }
-        val noAnimation = !animate || activity.isAnimationDisabled()
+        val noAnimation = !(animate && activity.isAnimationEnabled())
 
         alert.weakCurrentActivity = WeakReference(activity)
         val alerter = Alerter.create(activity, alert.layoutRes)

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/VectorSettingsNotificationPreferenceFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/VectorSettingsNotificationPreferenceFragment.kt
@@ -204,7 +204,7 @@ class VectorSettingsNotificationPreferenceFragment @Inject constructor(
             // Important, Battery optim white listing is needed in this mode;
             // Even if using foreground service with foreground notif, it stops to work
             // in doze mode for certain devices :/
-            if (!isIgnoringBatteryOptimizations(requireContext())) {
+            if (!requireContext().isIgnoringBatteryOptimizations()) {
                 requestDisablingBatteryOptimization(requireActivity(), batteryStartForActivityResult)
             }
         }

--- a/vector/src/main/java/im/vector/app/features/sync/widget/SyncStateView.kt
+++ b/vector/src/main/java/im/vector/app/features/sync/widget/SyncStateView.kt
@@ -54,7 +54,7 @@ class SyncStateView @JvmOverloads constructor(context: Context, attrs: Attribute
         views.syncStateProgressBar.isVisible = newState is SyncState.Running && newState.afterPause
 
         if (newState == SyncState.NoNetwork) {
-            val isAirplaneModeOn = isAirplaneModeOn(context)
+            val isAirplaneModeOn = context.isAirplaneModeOn()
             views.syncStateNoNetwork.isVisible = isAirplaneModeOn.not()
             views.syncStateNoNetworkAirplane.isVisible = isAirplaneModeOn
         } else {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
If the user does not want to see animation, no chat effect will be performed. Also no account creation celebration will e displayed.


## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
It will speed up the UI test, which have animation disabled.

It can also be useful to user with health condition (see #5557)

I tried to update the speed for Konfetti regarding the animation scale, but I think it has to be handled by the third party library. Same for the snowfall.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
