### PR TITLE
Add diag request for Synapse

### DIFF
--- a/tools/hs_diag.py
+++ b/tools/hs_diag.py
@@ -58,6 +58,9 @@ items = [
     # Need token , ["Capability", baseUrl + "_matrix/client/r0/capabilities", True]
     # Need token , ["Media config", baseUrl + "_matrix/media/r0/config", True]
     # Need token , ["Turn", baseUrl + "_matrix/client/r0/voip/turnServer", True]
+
+    # Only for Synapse
+    , ["Synapse version", baseUrl + "_synapse/admin/v1/server_version", True]
 ]
 
 for item in items:


### PR DESCRIPTION
Improve the hs_diag script to fetch info about the server version:

For instance, when running ` ./tools/hs_diag.py -s matrix.org`

We will get this extra bloc:

```
====================================================================================================
# Synapse version (https://matrix.org/_synapse/admin/v1/server_version)
====================================================================================================
{
    "server_version": "1.58.0rc2",
    "python_version": "3.7.3"
}

```