### PR TITLE
Correct public_baseurl for nightly tests.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,11 +43,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Start synapse server
-        uses: michaelkaye/setup-matrix-synapse@v1.0.2
+        uses: michaelkaye/setup-matrix-synapse@v1.0.3
         with:
           uploadLogs: true
           httpPort: 8080
           disableRateLimiting: true
+          public_baseurl: "http://10.0.2.2:8080/"
       # package: org.matrix.android.sdk.session
       - name: Run integration tests for  Matrix SDK [org.matrix.android.sdk.session] API[${{ matrix.api-level }}]
         uses: reactivecircus/android-emulator-runner@v2
@@ -230,11 +231,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Start synapse server
-        uses: michaelkaye/setup-matrix-synapse@v1.0.2
+        uses: michaelkaye/setup-matrix-synapse@v1.0.3
         with:
           uploadLogs: true
           httpPort: 8080
           disableRateLimiting: true
+          public_baseurl: "http://10.0.2.2:8080/"
       - uses: actions/setup-java@v3
         with:
           distribution: 'adopt'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -334,5 +334,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           hookshot_url: ${{ secrets.ELEMENT_ANDROID_HOOKSHOT_URL }}
-          text_template: "{{#if '${{ github.event_name }}' == 'schedule' }}Nightly test run{{else}}Test run (on ${{ github.ref }}){{/if }}: {{#each job_statuses }}{{#with this }}{{#if completed }}  {{name}} {{conclusion}} at {{completed_at}}, {{/if}}{{/with}}{{/each}}"
-          html_template: "{{#if '${{ github.event_name }}' == 'schedule' }}Nightly test run{{else}}Test run (on ${{ github.ref }}){{/if }}: {{#each job_statuses }}{{#with this }}{{#if completed }}<br />{{icon conclusion}} {{name}} <font color='{{color conclusion}}'>{{conclusion}} at {{completed_at}} <a href=\"{{html_url}}\">[details]</a></font>{{/if}}{{/with}}{{/each}}"
+          text_template: "{{#if '${{ github.event_name == 'schedule' }}' }}Nightly test run{{else}}Test run (on ${{ github.ref }}){{/if }}: {{#each job_statuses }}{{#with this }}{{#if completed }}  {{name}} {{conclusion}} at {{completed_at}}, {{/if}}{{/with}}{{/each}}"
+          html_template: "{{#if '${{ github.event_name == 'schedule' }}' }}Nightly test run{{else}}Test run (on ${{ github.ref }}){{/if }}: {{#each job_statuses }}{{#with this }}{{#if completed }}<br />{{icon conclusion}} {{name}} <font color='{{color conclusion}}'>{{conclusion}} at {{completed_at}} <a href=\"{{html_url}}\">[details]</a></font>{{/if}}{{/with}}{{/each}}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Start synapse server
-        uses: michaelkaye/setup-matrix-synapse@v1.0.1
+        uses: michaelkaye/setup-matrix-synapse@v1.0.2
         with:
           uploadLogs: true
           httpPort: 8080
@@ -230,7 +230,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Start synapse server
-        uses: michaelkaye/setup-matrix-synapse@v1.0.1
+        uses: michaelkaye/setup-matrix-synapse@v1.0.2
         with:
           uploadLogs: true
           httpPort: 8080


### PR DESCRIPTION
The tests seem to function against a synapse with an incorrect public_baseurl - some parts of the client use the public_baseurl for information and timeout, others use the configured http endpoint (which is hardcoded in the tests to be correct).

Making this change reduces timeouts waiting for requests to these incorrect endpoints.