### PR TITLE
Fixing crash on launch - Missing migration

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/RealmSessionStoreMigration.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/RealmSessionStoreMigration.kt
@@ -45,6 +45,7 @@ import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo024
 import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo025
 import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo026
 import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo027
+import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo028
 import org.matrix.android.sdk.internal.util.Normalizer
 import timber.log.Timber
 import javax.inject.Inject
@@ -59,7 +60,7 @@ internal class RealmSessionStoreMigration @Inject constructor(
     override fun equals(other: Any?) = other is RealmSessionStoreMigration
     override fun hashCode() = 1000
 
-    val schemaVersion = 27L
+    val schemaVersion = 28L
 
     override fun migrate(realm: DynamicRealm, oldVersion: Long, newVersion: Long) {
         Timber.d("Migrating Realm Session from $oldVersion to $newVersion")
@@ -91,5 +92,6 @@ internal class RealmSessionStoreMigration @Inject constructor(
         if (oldVersion < 25) MigrateSessionTo025(realm).perform()
         if (oldVersion < 26) MigrateSessionTo026(realm).perform()
         if (oldVersion < 27) MigrateSessionTo027(realm).perform()
+        if (oldVersion < 28) MigrateSessionTo028(realm).perform()
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/migration/MigrateSessionTo028.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/migration/MigrateSessionTo028.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.database.migration
+
+import io.realm.DynamicRealm
+import org.matrix.android.sdk.internal.database.model.livelocation.LiveLocationShareAggregatedSummaryEntityFields
+import org.matrix.android.sdk.internal.util.database.RealmMigrator
+
+/**
+ * Migrating to:
+ * Live location sharing aggregated summary
+ */
+internal class MigrateSessionTo028(realm: DynamicRealm) : RealmMigrator(realm, 28) {
+
+    override fun doMigrate(realm: DynamicRealm) {
+        realm.schema.get("LiveLocationShareAggregatedSummaryEntity")
+                ?.takeIf { !it.hasPrimaryKey() }
+                ?.addPrimaryKey(LiveLocationShareAggregatedSummaryEntityFields.EVENT_ID)
+    }
+}


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes the crash on launch in 1.4.14 when upgrading from a previous version. The crash is caused by a missing migration for the primary key in `LiveLocationShareAggregatedSummaryEntity.eventId`

## Motivation and context

To fix an upgrade crash

## Screenshots / GIFs

|Before|After|
|-|-|
|![before-missing-migration](https://user-images.githubusercontent.com/1848238/166959041-ea425a57-0123-4b12-93dc-234f85c6161a.gif)|![after-missing-migration](https://user-images.githubusercontent.com/1848238/166959225-788be860-0343-4156-9d5a-2236d53f5ff1.gif)|

## Tests

<!-- Explain how you tested your development -->

- Install 1.4.13
- Upgrade to 1.4.14
- Notice the crash on launch

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28