### PR TITLE
Run the PR test after merge and report to channel if it fails

### DIFF
--- a/.github/workflows/post-pr.yml
+++ b/.github/workflows/post-pr.yml
@@ -1,28 +1,36 @@
-name: Nightly Tests
+name: Integration Tests
+
+# This runs for all closed pull requests against main, including those closed without merge.
+# Further filtering occurs in 'should-i-run'
 
 on:
-  push:
-    branches: [ release/* ]
-  schedule:
-    # At 20:00 every day UTC
-    - cron: '0 20 * * *'
-  workflow_dispatch:
+  pull-request:
+    types: [closed]
+    branches: [develop]
 
 # Enrich gradle.properties for CI/CD
 env:
   CI_GRADLE_ARG_PROPERTIES: >
     -Porg.gradle.jvmargs=-Xmx4g
     -Porg.gradle.parallel=false
+
 jobs:
+  should-i-run:
+    name: Check if PR is suitable for analysis
+    runs-on: ubuntu-latest
+    if: github.event.merged # Additionally require PR to have been completely merged.
+    steps:
+      - run: echo "Run those tests!" # no-op success
+        
   # Run Android Tests
   integration-tests:
     name: Matrix SDK - Running Integration Tests
+    needs: should-i-run
     runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
         api-level: [ 28 ]
-    # No concurrency required, runs every time on a schedule.
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
@@ -210,6 +218,7 @@ jobs:
 
   ui-tests:
     name: UI Tests (Synapse)
+    needs: should-i-run
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -268,6 +277,7 @@ jobs:
 
   codecov-units:
     name: Unit tests with code coverage
+    needs: should-i-run
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -292,49 +302,21 @@ jobs:
           path: |
             build/reports/jacoco/allCodeCoverageReport/allCodeCoverageReport.xml
 
-  sonarqube:
-    name: Sonarqube upload
-    runs-on: macos-latest
-    if: always() && github.event_name == 'schedule'
-    needs:
-      - codecov-units
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: '11'
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      - uses: actions/download-artifact@v3
-        with:
-          name: codecov-xml # will restore to allCodeCoverageReport.xml by default; we restore to the same location in following tasks
-      - run: mkdir -p build/reports/jacoco/allCodeCoverageReport/
-      - run: mv allCodeCoverageReport.xml build/reports/jacoco/allCodeCoverageReport/
-      - run: ./gradlew sonarqube $CI_GRADLE_ARG_PROPERTIES
-        env:
-          ORG_GRADLE_PROJECT_SONAR_LOGIN: ${{ secrets.SONAR_TOKEN }}
-
-# Notify the channel about scheduled runs, or pushes to the release branches, do not notify for manually triggered runs
+# Notify the channel about delayed failures
   notify:
     name: Notify matrix
     runs-on: ubuntu-latest
     needs:
+      - should-i-run
       - integration-tests
       - ui-tests
-      - sonarqube
-    if: always() && github.event_name != 'workflow_dispatch'
+      - codecov-units
+    if: always() && needs.should-i-run.status == "success" && (needs.codecov-units.status != "success" || needs.ui-tests.status != "success" || needs.integration-tests.status != "success")
     # No concurrency required, runs every time on a schedule.
     steps:
       - uses: michaelkaye/matrix-hookshot-action@v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           hookshot_url: ${{ secrets.ELEMENT_ANDROID_HOOKSHOT_URL }}
-          text_template: "{{#if '${{ github.event_name == 'schedule' }}' }}Nightly test run{{else}}Test run (on ${{ github.ref }}){{/if }}: {{#each job_statuses }}{{#with this }}{{#if completed }}  {{name}} {{conclusion}} at {{completed_at}}, {{/if}}{{/with}}{{/each}}"
-          html_template: "{{#if '${{ github.event_name == 'schedule' }}' }}Nightly test run{{else}}Test run (on ${{ github.ref }}){{/if }}: {{#each job_statuses }}{{#with this }}{{#if completed }}<br />{{icon conclusion}} {{name}} <font color='{{color conclusion}}'>{{conclusion}} at {{completed_at}} <a href=\"{{html_url}}\">[details]</a></font>{{/if}}{{/with}}{{/each}}"
+          text_template: "Post-merge validation of ${{ github.head_ref }} into ${{ github.base_ref }} by ${{ github.event.merged_by }} failed: {{#each job_statuses }}{{#with this }}{{#if completed }}  {{name}} {{conclusion}} at {{completed_at}}, {{/if}}{{/with}}{{/each}}"
+          html_template: "Post-merge validation of ${{ github.head_ref }} into ${{ github.base_ref }} by ${{ github.event..merged_by }} failed: {{#each job_statuses }}{{#with this }}{{#if completed }}<br />{{icon conclusion}} {{name}} <font color='{{color conclusion}}'>{{conclusion}} at {{completed_at}} <a href=\"{{html_url}}\">[details]</a></font>{{/if}}{{/with}}{{/each}}"

--- a/.github/workflows/post-pr.yml
+++ b/.github/workflows/post-pr.yml
@@ -15,6 +15,13 @@ env:
     -Porg.gradle.parallel=false
 
 jobs:
+
+  # More info on should-i-run:
+  # If this fails to run (the IF doesn't complete) then the needs will not be satisfied for any of the 
+  # other jobs below, so none will run.
+  # except for the notification job at the bottom which will run all the time, unless should-i-run isn't
+  # successful, or all the other jobs have succeeded
+
   should-i-run:
     name: Check if PR is suitable for analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -71,7 +71,7 @@ jobs:
     needs:
       - sonarqube
       - codecov-units
-    if: always() && needs.sonarqube.result != "success" and needs.codecov-units.result != "success"
+    if: always() && (needs.sonarqube.result != "success" || needs.codecov-units.result != "success") 
     steps:
       - uses: michaelkaye/matrix-hookshot-action@v1.0.0
         with:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,81 @@
+name: Sonarqube nightly
+
+on:
+  schedule:
+    - cron: '0 20 * * *'
+
+# Enrich gradle.properties for CI/CD
+env:
+  CI_GRADLE_ARG_PROPERTIES: >
+    -Porg.gradle.jvmargs=-Xmx4g
+    -Porg.gradle.parallel=false
+jobs:
+  codecov-units:
+    name: Unit tests with code coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with: 
+          distribution: 'adopt'
+          java-version: '11'
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - run: ./gradlew allCodeCoverageReport $CI_GRADLE_ARG_PROPERTIES
+      - name: Upload Codecov data
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: codecov-xml
+          path: |
+            build/reports/jacoco/allCodeCoverageReport/allCodeCoverageReport.xml
+
+  sonarqube:
+    name: Sonarqube upload
+    runs-on: ubuntu-latest
+    needs:
+      - codecov-units
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - uses: actions/download-artifact@v3
+        with:
+          name: codecov-xml # will restore to allCodeCoverageReport.xml by default; we restore to the same location in following tasks
+      - run: mkdir -p build/reports/jacoco/allCodeCoverageReport/
+      - run: mv allCodeCoverageReport.xml build/reports/jacoco/allCodeCoverageReport/
+      - run: ./gradlew sonarqube $CI_GRADLE_ARG_PROPERTIES
+        env:
+          ORG_GRADLE_PROJECT_SONAR_LOGIN: ${{ secrets.SONAR_TOKEN }}
+
+# Notify the channel about sonarqube failures
+  notify:
+    name: Notify matrix
+    runs-on: ubuntu-latest
+    needs:
+      - sonarqube
+      - codecov-units
+    if: always() && needs.sonarqube.result != "success" and needs.codecov-units.result != "success"
+    steps:
+      - uses: michaelkaye/matrix-hookshot-action@v1.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          hookshot_url: ${{ secrets.ELEMENT_ANDROID_HOOKSHOT_URL }}
+          text_template: "Sonarqube run (on ${{ github.ref }}): {{#each job_statuses }}{{#with this }}{{#if completed }}  {{name}} {{conclusion}} at {{completed_at}}, {{/if}}{{/with}}{{/each}}"
+          html_template: "Sonarqube run (on ${{ github.ref }}): {{#each job_statuses }}{{#with this }}{{#if completed }}<br />{{icon conclusion}} {{name}} <font color='{{color conclusion}}'>{{conclusion}} at {{completed_at}} <a href=\"{{html_url}}\">[details]</a></font>{{/if}}{{/with}}{{/each}}"


### PR DESCRIPTION
Additionally move sonarqube as the only nightly run; and again report to the channel only if it fails.

This should reduce noise in the channel and also provide feedback on who merged a PR with a failing test in it.