### PR TITLE
Handling SSL/TLS errors during WellKnown lookup

### DIFF
--- a/changelog.d/5965.sdk
+++ b/changelog.d/5965.sdk
@@ -1,0 +1,1 @@
+Including SSL/TLS error handing when doing WellKnown lookups without a custom HomeServerConnectionConfig

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/DefaultAuthenticationService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/DefaultAuthenticationService.kt
@@ -382,10 +382,15 @@ internal class DefaultAuthenticationService @Inject constructor(
         return getWellknownTask.execute(
                 GetWellknownTask.Params(
                         domain = matrixId.getDomain(),
-                        homeServerConnectionConfig = homeServerConnectionConfig
+                        homeServerConnectionConfig = homeServerConnectionConfig.orWellKnownDefaults()
                 )
         )
     }
+
+    private fun HomeServerConnectionConfig?.orWellKnownDefaults() = this ?: HomeServerConnectionConfig.Builder()
+            // server uri is ignored when doing a wellknown lookup as we use the matrix id domain instead
+            .withHomeServerUri("https://dummy.org")
+            .build()
 
     override suspend fun directAuthentication(homeServerConnectionConfig: HomeServerConnectionConfig,
                                               matrixId: String,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/wellknown/GetWellknownTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/wellknown/GetWellknownTask.kt
@@ -43,7 +43,7 @@ internal interface GetWellknownTask : Task<GetWellknownTask.Params, WellknownRes
              * the URL will be https://{domain}/.well-known/matrix/client
              */
             val domain: String,
-            val homeServerConnectionConfig: HomeServerConnectionConfig?
+            val homeServerConnectionConfig: HomeServerConnectionConfig
     )
 }
 
@@ -61,15 +61,11 @@ internal class DefaultGetWellknownTask @Inject constructor(
         return findClientConfig(params.domain, client)
     }
 
-    private fun buildClient(homeServerConnectionConfig: HomeServerConnectionConfig?): OkHttpClient {
-        return if (homeServerConnectionConfig != null) {
-            okHttpClient.get()
-                    .newBuilder()
-                    .addSocketFactory(homeServerConnectionConfig)
-                    .build()
-        } else {
-            okHttpClient.get()
-        }
+    private fun buildClient(homeServerConnectionConfig: HomeServerConnectionConfig): OkHttpClient {
+        return okHttpClient.get()
+                .newBuilder()
+                .addSocketFactory(homeServerConnectionConfig)
+                .build()
     }
 
     /**


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical - SDK
- [ ] Other :

## Content

Applies the SSL/TLS certificate handling logic to the `sign in with matrix id` flow

- Due to the flow inferring the homeserver url from the matrix id domain it meant we were passing a null `HomeserverConnectionConfig` which in turn meant the SSL/TLS socket factory was never applied 


## Motivation and context

To make the `sign in with matrix id` and `other` sign in flows consistent

## Screenshots / GIFs

|Before|After|
|-|-|
|![Screenshot_20220506_154304](https://user-images.githubusercontent.com/1848238/167163396-e25cf73f-0169-4749-b5c4-fecb4b40b4dd.png)|![after-certs](https://user-images.githubusercontent.com/1848238/167163406-4a9e5e13-be2e-4614-955a-41e527b86089.png)|
 
## Tests

- change the device time/date to a month in the past
- attempt to sign in via `sign in with matrix id`
- Notice invalid home server error, however when signing in via `other` a certificate error is shown

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 31
