### PR TITLE
Try to workaround Dependabot issue #5961

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,10 @@ buildscript {
     apply from: 'dependencies_groups.gradle'
 
     repositories {
-        google()
+        // Do not use `google()`, it prevents Dependabot from working properly
+        maven {
+            url 'https://maven.google.com'
+        }
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -47,6 +50,7 @@ allprojects {
     apply plugin: "org.jlleitschuh.gradle.ktlint"
 
     repositories {
+        // Do not use `mavenCentral()`, it prevents Dependabot from working properly
         maven {
             url 'https://repo1.maven.org/maven2'
             content {
@@ -71,14 +75,18 @@ allprojects {
                 groups.jitsi.group.each { includeGroup it }
             }
         }
-        google {
+        // Do not use `google()`, it prevents Dependabot from working properly
+        maven {
+            url 'https://maven.google.com'
             content {
                 groups.google.regex.each { includeGroupByRegex it }
                 groups.google.group.each { includeGroup it }
             }
         }
         //noinspection JcenterRepositoryObsolete
-        jcenter {
+        // Do not use `jcenter`, it prevents Dependabot from working properly
+        maven {
+            url 'https://jcenter.bintray.com'
             content {
                 groups.jcenter.regex.each { includeGroupByRegex it }
                 groups.jcenter.group.each { includeGroup it }

--- a/library/jsonviewer/build.gradle
+++ b/library/jsonviewer/build.gradle
@@ -6,8 +6,14 @@ apply plugin: 'com.jakewharton.butterknife'
 
 buildscript {
     repositories {
-        google()
-        maven { url 'https://repo1.maven.org/maven2' }
+        // Do not use `google()`, it prevents Dependabot from working properly
+        maven {
+            url 'https://maven.google.com'
+        }
+        // Do not use `mavenCentral()`, it prevents Dependabot from working properly
+        maven {
+            url 'https://repo1.maven.org/maven2'
+        }
     }
     dependencies {
         classpath 'com.jakewharton:butterknife-gradle-plugin:10.2.3'

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -7,7 +7,10 @@ apply plugin: "org.jetbrains.dokka"
 
 buildscript {
     repositories {
-        maven { url 'https://repo1.maven.org/maven2' }
+        // Do not use `mavenCentral()`, it prevents Dependabot from working properly
+        maven {
+            url 'https://repo1.maven.org/maven2'
+        }
     }
     dependencies {
         classpath "io.realm:realm-gradle-plugin:10.9.0"


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : closes #5961 

## Content

See #5961  for more context.

Changed gradle dependency declaration from:
```groovy
mavenCentral()
```
to
```groovy
maven { url 'https://repo1.maven.org/maven2' }
```

and same thing for other gradle repository providers.

Will replace #5966, as it's more complete. But it does not compile locally, let's see what's happening on the CI.