### PR TITLE
FTUE - Temporarily hide EMS section

### DIFF
--- a/vector/src/main/res/layout/fragment_ftue_server_selection_combined.xml
+++ b/vector/src/main/res/layout/fragment_ftue_server_selection_combined.xml
@@ -151,6 +151,13 @@
             app:layout_constraintHeight_percent="0.02"
             app:layout_constraintTop_toBottomOf="@id/chooseServerSubmit" />
 
+        <!-- EMS section is temporarily hidden whilst we sync with marketing -->
+        <androidx.constraintlayout.widget.Group
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:constraint_referenced_ids="chooseServerEmsContainer,emsTopSpacing,chooseServerEmsIcon,chooseServerEmsTitle,chooseServerEmsSubtitle,chooseServerGetInTouch,emsCtaSpacing" />
+
         <View
             android:id="@+id/chooseServerEmsContainer"
             android:layout_width="0dp"


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : 

## Content

- Temporarily hides the EMS section in the server selection screen

## Motivation and context

Fixes #5975 

- We're still determining the content of this block with marketing

## Screenshots / GIFs

|Before|After|
|-|-|
|![Screenshot_20220510_110116](https://user-images.githubusercontent.com/1848238/167603571-631d77a2-3c91-4e95-99e9-126763ae8291.png)|![Screenshot_20220509_175314](https://user-images.githubusercontent.com/1848238/167602513-6428ae15-7826-4e8e-97a3-5547299df712.png)|
 
## Tests

- With the combined login or register feature flag enabled
- Start the account create/login process and edit the homeserver
- Notice the EMS section is no longer shown

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28

