### PR TITLE
Gh pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: Documentation
+
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  docs:
+    name: Generate and publish Android Matrix SDK documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build docs
+        run: ./gradlew dokkaHtml
+
+      - name: Deploy docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./matrix-sdk-android/build/dokka/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 name: Documentation
 
 on:
+  pull_request: { }
   push:
     branches: [ develop ]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,6 @@
 name: Documentation
 
 on:
-  pull_request: { }
   push:
     branches: [ develop ]
 

--- a/matrix-sdk-android/docs/modules.md
+++ b/matrix-sdk-android/docs/modules.md
@@ -1,5 +1,8 @@
 # Module matrix-sdk-android
 
+<!-- Note: the line below will appear only when the documentation is generated from Element-Android project, and not when it's generated from the SDK project -->
+**Note**: You are viewing the nightly documentation of the Android Matrix SDK library. The documentation of the released library can be found here: [https://matrix-org.github.io/matrix-android-sdk2/](https://matrix-org.github.io/matrix-android-sdk2/)
+
 ## Welcome to the matrix-sdk-android documentation!
 
 This pages list the complete API that this SDK is exposing to a client application.


### PR DESCRIPTION
Publish current SDK documentation to GH pages, with an extra note, see below:

<img width="1558" alt="image" src="https://user-images.githubusercontent.com/3940906/167816097-466c060d-8d27-40a8-9547-1579a6714da6.png">

A change will have to be done on the SDK to remove the note before generated the documentation there. 