### PR TITLE
FTUE - Homeserver sign in/up deeplinks

### DIFF
--- a/vector/src/main/java/im/vector/app/core/di/SingletonModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/SingletonModule.kt
@@ -186,7 +186,6 @@ object VectorStaticModule {
         return analyticsConfig
     }
 
-
     @Provides
     @Singleton
     fun providesBuildMeta() = BuildMeta()

--- a/vector/src/main/java/im/vector/app/core/di/SingletonModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/SingletonModule.kt
@@ -33,6 +33,7 @@ import im.vector.app.config.analyticsConfig
 import im.vector.app.core.dispatchers.CoroutineDispatchers
 import im.vector.app.core.error.DefaultErrorFormatter
 import im.vector.app.core.error.ErrorFormatter
+import im.vector.app.core.resources.BuildMeta
 import im.vector.app.core.time.Clock
 import im.vector.app.core.time.DefaultClock
 import im.vector.app.features.analytics.AnalyticsConfig
@@ -184,4 +185,9 @@ object VectorStaticModule {
     fun providesAnalyticsConfig(): AnalyticsConfig {
         return analyticsConfig
     }
+
+
+    @Provides
+    @Singleton
+    fun providesBuildMeta() = BuildMeta()
 }

--- a/vector/src/main/java/im/vector/app/core/extensions/Context.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/Context.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.core.extensions
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.net.ConnectivityManager
@@ -30,11 +31,13 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.FloatRange
 import androidx.core.content.ContextCompat
+import androidx.core.content.getSystemService
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import dagger.hilt.EntryPoints
 import im.vector.app.core.datastore.dataStoreProvider
 import im.vector.app.core.di.SingletonEntryPoint
+import im.vector.app.core.resources.BuildMeta
 import java.io.OutputStream
 import kotlin.math.roundToInt
 
@@ -88,9 +91,10 @@ fun Context.safeOpenOutputStream(uri: Uri): OutputStream? {
  * @return true if no active connection is found
  */
 @Suppress("deprecation")
-fun Context.inferNoConnectivity(): Boolean {
-    val connectivityManager: ConnectivityManager = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-    return if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
+@SuppressLint("NewApi") // false positive
+fun Context.inferNoConnectivity(buildMeta: BuildMeta): Boolean {
+    val connectivityManager = getSystemService<ConnectivityManager>()!!
+    return if (buildMeta.sdkInt > Build.VERSION_CODES.M) {
         val networkCapabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
         when {
             networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true -> false

--- a/vector/src/main/java/im/vector/app/core/resources/BuildMeta.kt
+++ b/vector/src/main/java/im/vector/app/core/resources/BuildMeta.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.resources
+
+import android.os.Build
+
+data class BuildMeta(
+        val sdkInt: Int = Build.VERSION.SDK_INT
+)

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
@@ -25,7 +25,6 @@ import org.matrix.android.sdk.api.auth.data.Credentials
 import org.matrix.android.sdk.api.network.ssl.Fingerprint
 
 sealed interface OnboardingAction : VectorViewModelAction {
-    object ResetDeeplinkConfig : OnboardingAction
     data class OnGetStarted(val onboardingFlow: OnboardingFlow) : OnboardingAction
     data class OnIAlreadyHaveAnAccount(val onboardingFlow: OnboardingFlow) : OnboardingAction
 
@@ -59,7 +58,7 @@ sealed interface OnboardingAction : VectorViewModelAction {
 
     // Reset actions
     sealed interface ResetAction : OnboardingAction
-
+    object ResetDeeplinkConfig : ResetAction
     object ResetHomeServerType : ResetAction
     object ResetHomeServerUrl : ResetAction
     object ResetSignMode : ResetAction

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
@@ -25,8 +25,9 @@ import org.matrix.android.sdk.api.auth.data.Credentials
 import org.matrix.android.sdk.api.network.ssl.Fingerprint
 
 sealed interface OnboardingAction : VectorViewModelAction {
-    data class OnGetStarted(val resetLoginConfig: Boolean, val onboardingFlow: OnboardingFlow) : OnboardingAction
-    data class OnIAlreadyHaveAnAccount(val resetLoginConfig: Boolean, val onboardingFlow: OnboardingFlow) : OnboardingAction
+    object ResetDeeplinkConfig : OnboardingAction
+    data class OnGetStarted(val onboardingFlow: OnboardingFlow) : OnboardingAction
+    data class OnIAlreadyHaveAnAccount(val onboardingFlow: OnboardingFlow) : OnboardingAction
 
     data class UpdateServerType(val serverType: ServerType) : OnboardingAction
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
@@ -25,8 +25,12 @@ import org.matrix.android.sdk.api.auth.data.Credentials
 import org.matrix.android.sdk.api.network.ssl.Fingerprint
 
 sealed interface OnboardingAction : VectorViewModelAction {
-    data class OnGetStarted(val onboardingFlow: OnboardingFlow) : OnboardingAction
-    data class OnIAlreadyHaveAnAccount(val onboardingFlow: OnboardingFlow) : OnboardingAction
+    sealed interface SplashAction: OnboardingAction {
+        val onboardingFlow: OnboardingFlow
+
+        data class OnGetStarted(override val onboardingFlow: OnboardingFlow) : SplashAction
+        data class OnIAlreadyHaveAnAccount(override val onboardingFlow: OnboardingFlow) : SplashAction
+    }
 
     data class UpdateServerType(val serverType: ServerType) : OnboardingAction
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewEvents.kt
@@ -28,6 +28,7 @@ import org.matrix.android.sdk.api.auth.registration.FlowResult
 sealed class OnboardingViewEvents : VectorViewEvents {
     data class Loading(val message: CharSequence? = null) : OnboardingViewEvents()
     data class Failure(val throwable: Throwable) : OnboardingViewEvents()
+    data class DeeplinkAuthenticationFailure(val retryAction: OnboardingAction) : OnboardingViewEvents()
 
     data class RegistrationFlowResult(val flowResult: FlowResult, val isRegistrationStarted: Boolean) : OnboardingViewEvents()
     object OutdatedHomeserver : OnboardingViewEvents()

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -109,8 +109,7 @@ class OnboardingViewModel @AssistedInject constructor(
     private var currentHomeServerConnectionConfig: HomeServerConnectionConfig? = null
 
     private val matrixOrgUrl = stringProvider.getString(R.string.matrix_org_server_url).ensureTrailingSlash()
-    private val defaultHomeserverUrl: String
-        get() = loginConfig?.homeServerUrl?.ensureProtocol() ?: matrixOrgUrl
+    private val defaultHomeserverUrl = matrixOrgUrl
 
     private val registrationWizard: RegistrationWizard
         get() = authenticationService.getRegistrationWizard()
@@ -161,7 +160,6 @@ class OnboardingViewModel @AssistedInject constructor(
             OnboardingAction.SaveSelectedProfilePicture    -> updateProfilePicture()
             is OnboardingAction.PostViewEvent              -> _viewEvents.post(action.viewEvent)
             OnboardingAction.StopEmailValidationCheck      -> cancelWaitForEmailValidation()
-            OnboardingAction.ResetDeeplinkConfig           -> loginConfig = null
         }
     }
 
@@ -180,21 +178,7 @@ class OnboardingViewModel @AssistedInject constructor(
 
     private fun handleSplashAction(onboardingFlow: OnboardingFlow) {
         setState { copy(onboardingFlow = onboardingFlow) }
-
-        return when (val config = loginConfig.toHomeserverConfig()) {
-            null -> continueToPageAfterSplash(onboardingFlow)
-            else -> startAuthenticationFlow(trigger = null, config, ServerType.Other)
-        }
-    }
-
-    private fun LoginConfig?.toHomeserverConfig(): HomeServerConnectionConfig? {
-        return this?.homeServerUrl?.takeIf { it.isNotEmpty() }?.let { url ->
-            homeServerConnectionConfigFactory.create(url).also {
-                if (it == null) {
-                    Timber.w("Url from config url was invalid: $url")
-                }
-            }
-        }
+        continueToPageAfterSplash(onboardingFlow)
     }
 
     private fun continueToPageAfterSplash(onboardingFlow: OnboardingFlow) {
@@ -208,10 +192,21 @@ class OnboardingViewModel @AssistedInject constructor(
                         }
                 )
             }
-            OnboardingFlow.SignIn       -> if (vectorFeatures.isOnboardingCombinedLoginEnabled()) {
-                handle(OnboardingAction.HomeServerChange.SelectHomeServer(defaultHomeserverUrl))
-            } else _viewEvents.post(OnboardingViewEvents.OpenServerSelection)
-            OnboardingFlow.SignInSignUp -> _viewEvents.post(OnboardingViewEvents.OpenServerSelection)
+            OnboardingFlow.SignIn       -> when {
+                vectorFeatures.isOnboardingCombinedLoginEnabled() -> {
+                    handle(OnboardingAction.HomeServerChange.SelectHomeServer(deeplinkOrDefaultHomeserverUrl()))
+                }
+                else                                              -> openServerSelectionOrDeeplinkToOther()
+            }
+
+            OnboardingFlow.SignInSignUp -> openServerSelectionOrDeeplinkToOther()
+        }
+    }
+
+    private fun openServerSelectionOrDeeplinkToOther() {
+        when (loginConfig) {
+            null -> _viewEvents.post(OnboardingViewEvents.OpenServerSelection)
+            else -> handleHomeserverChange(OnboardingAction.HomeServerChange.SelectHomeServer(deeplinkOrDefaultHomeserverUrl()), ServerType.Other)
         }
     }
 
@@ -222,7 +217,7 @@ class OnboardingViewModel @AssistedInject constructor(
             is OnboardingAction.HomeServerChange.SelectHomeServer -> {
                 currentHomeServerConnectionConfig
                         ?.let { it.copy(allowedFingerprints = it.allowedFingerprints + action.fingerprint) }
-                        ?.let { startAuthenticationFlow(finalLastAction, it) }
+                        ?.let { startAuthenticationFlow(finalLastAction, it, serverTypeOverride = null) }
             }
             is AuthenticateAction.LoginDirect                     ->
                 handleDirectLogin(
@@ -359,6 +354,7 @@ class OnboardingViewModel @AssistedInject constructor(
                     )
                 }
             }
+            OnboardingAction.ResetDeeplinkConfig        -> loginConfig = null
         }
     }
 
@@ -379,10 +375,12 @@ class OnboardingViewModel @AssistedInject constructor(
     private fun handleUpdateUseCase(action: OnboardingAction.UpdateUseCase) {
         setState { copy(useCase = action.useCase) }
         when (vectorFeatures.isOnboardingCombinedRegisterEnabled()) {
-            true  -> handle(OnboardingAction.HomeServerChange.SelectHomeServer(defaultHomeserverUrl))
+            true  -> handle(OnboardingAction.HomeServerChange.SelectHomeServer(deeplinkOrDefaultHomeserverUrl()))
             false -> _viewEvents.post(OnboardingViewEvents.OpenServerSelection)
         }
     }
+
+    private fun deeplinkOrDefaultHomeserverUrl() = loginConfig?.homeServerUrl?.ensureProtocol() ?: defaultHomeserverUrl
 
     private fun resetUseCase() {
         setState { copy(useCase = null) }
@@ -595,20 +593,20 @@ class OnboardingViewModel @AssistedInject constructor(
         }
     }
 
-    private fun handleHomeserverChange(action: OnboardingAction.HomeServerChange) {
+    private fun handleHomeserverChange(action: OnboardingAction.HomeServerChange, serverTypeOverride: ServerType? = null) {
         val homeServerConnectionConfig = homeServerConnectionConfigFactory.create(action.homeServerUrl)
         if (homeServerConnectionConfig == null) {
             // This is invalid
             _viewEvents.post(OnboardingViewEvents.Failure(Throwable("Unable to create a HomeServerConnectionConfig")))
         } else {
-            startAuthenticationFlow(action, homeServerConnectionConfig)
+            startAuthenticationFlow(action, homeServerConnectionConfig, serverTypeOverride)
         }
     }
 
     private fun startAuthenticationFlow(
-            trigger: OnboardingAction?,
+            trigger: OnboardingAction.HomeServerChange,
             homeServerConnectionConfig: HomeServerConnectionConfig,
-            serverTypeOverride: ServerType? = null
+            serverTypeOverride: ServerType?
     ) {
         currentHomeServerConnectionConfig = homeServerConnectionConfig
 
@@ -623,7 +621,7 @@ class OnboardingViewModel @AssistedInject constructor(
     }
 
     private suspend fun onAuthenticationStartedSuccess(
-            trigger: OnboardingAction?,
+            trigger: OnboardingAction.HomeServerChange,
             config: HomeServerConnectionConfig,
             authResult: StartAuthenticationResult,
             serverTypeOverride: ServerType?
@@ -639,10 +637,6 @@ class OnboardingViewModel @AssistedInject constructor(
             }
             is OnboardingAction.HomeServerChange.EditHomeServer   -> {
                 onHomeServerEdited(config, serverTypeOverride, authResult)
-            }
-            else                                                  -> {
-                updateServerSelection(config, serverTypeOverride, authResult)
-                _viewEvents.post(OnboardingViewEvents.OnLoginFlowRetrieved)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashCarouselFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashCarouselFragment.kt
@@ -17,6 +17,9 @@
 package im.vector.app.features.onboarding.ftueauth
 
 import android.annotation.SuppressLint
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -41,8 +44,7 @@ import im.vector.app.features.settings.VectorPreferences
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.matrix.android.sdk.api.failure.Failure
-import java.net.UnknownHostException
+import org.matrix.android.sdk.api.failure.isHomeserverUnavailable
 import javax.inject.Inject
 
 private const val CAROUSEL_ROTATION_DELAY_MS = 5000L
@@ -128,11 +130,11 @@ class FtueAuthSplashCarouselFragment @Inject constructor(
 
     private fun splashSubmit(isAlreadyHaveAccountEnabled: Boolean) {
         val getStartedFlow = if (isAlreadyHaveAccountEnabled) OnboardingFlow.SignUp else OnboardingFlow.SignInSignUp
-        viewModel.handle(OnboardingAction.OnGetStarted(resetLoginConfig = false, onboardingFlow = getStartedFlow))
+        viewModel.handle(OnboardingAction.OnGetStarted(onboardingFlow = getStartedFlow))
     }
 
     private fun alreadyHaveAnAccount() {
-        viewModel.handle(OnboardingAction.OnIAlreadyHaveAnAccount(resetLoginConfig = false, onboardingFlow = OnboardingFlow.SignIn))
+        viewModel.handle(OnboardingAction.OnIAlreadyHaveAnAccount(onboardingFlow = OnboardingFlow.SignIn))
     }
 
     override fun resetViewModel() {
@@ -140,21 +142,56 @@ class FtueAuthSplashCarouselFragment @Inject constructor(
     }
 
     override fun onError(throwable: Throwable) {
-        if (throwable is Failure.NetworkConnection &&
-                throwable.ioException is UnknownHostException) {
-            // Invalid homeserver from URL config
-            val url = viewModel.getInitialHomeServerUrl().orEmpty()
-            MaterialAlertDialogBuilder(requireActivity())
-                    .setTitle(R.string.dialog_title_error)
-                    .setMessage(getString(R.string.login_error_homeserver_from_url_not_found, url))
-                    .setPositiveButton(R.string.login_error_homeserver_from_url_not_found_enter_manual) { _, _ ->
-                        val flow = withState(viewModel) { it.onboardingFlow } ?: OnboardingFlow.SignInSignUp
-                        viewModel.handle(OnboardingAction.OnGetStarted(resetLoginConfig = true, flow))
-                    }
-                    .setNegativeButton(R.string.action_cancel, null)
-                    .show()
-        } else {
-            super.onError(throwable)
+        when {
+            requireContext().inferNoConnectivity() -> super.onError(throwable)
+            throwable.isHomeserverUnavailable()    -> {
+                val url = viewModel.getInitialHomeServerUrl().orEmpty()
+                homeserverUnavailableDialog(url) { onContinueFlowWithLoginConfigReset() }
+            }
+            else                                   -> super.onError(throwable)
         }
     }
+
+    private fun onContinueFlowWithLoginConfigReset() {
+        viewModel.handle(OnboardingAction.ResetDeeplinkConfig)
+        when (val flow = withState(viewModel) { it.onboardingFlow } ?: OnboardingFlow.SignInSignUp) {
+            OnboardingFlow.SignIn -> if (vectorFeatures.isOnboardingCombinedLoginEnabled()) {
+                viewModel.handle(OnboardingAction.OnIAlreadyHaveAnAccount(flow))
+            } else {
+                viewModel.handle(OnboardingAction.OnGetStarted(flow))
+            }
+            else                  -> viewModel.handle(OnboardingAction.OnGetStarted(flow))
+        }
+    }
+
+    private fun homeserverUnavailableDialog(url: String, action: () -> Unit) {
+        MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(R.string.dialog_title_error)
+                .setMessage(getString(R.string.login_error_homeserver_from_url_not_found, url))
+                .setPositiveButton(R.string.login_error_homeserver_from_url_not_found_enter_manual) { _, _ -> action() }
+                .setNegativeButton(R.string.action_cancel, null)
+                .show()
+    }
+}
+
+fun Context.inferNoConnectivity(): Boolean {
+    var networkAvailable = false
+
+    val connectivityManager: ConnectivityManager = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    val network = connectivityManager.activeNetwork
+    val networkCapabilities = connectivityManager.getNetworkCapabilities(network)
+
+    when {
+        networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true -> {
+            networkAvailable = true
+        }
+        networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true     -> {
+            networkAvailable = true
+        }
+        networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true      -> {
+            networkAvailable = true
+        }
+    }
+
+    return !networkAvailable
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashFragment.kt
@@ -22,8 +22,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
-import com.airbnb.mvrx.withState
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import im.vector.app.BuildConfig
 import im.vector.app.R
 import im.vector.app.databinding.FragmentFtueAuthSplashBinding
@@ -31,8 +29,6 @@ import im.vector.app.features.VectorFeatures
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingFlow
 import im.vector.app.features.settings.VectorPreferences
-import org.matrix.android.sdk.api.failure.Failure
-import java.net.UnknownHostException
 import javax.inject.Inject
 
 /**
@@ -75,34 +71,14 @@ class FtueAuthSplashFragment @Inject constructor(
 
     private fun splashSubmit(isAlreadyHaveAccountEnabled: Boolean) {
         val getStartedFlow = if (isAlreadyHaveAccountEnabled) OnboardingFlow.SignUp else OnboardingFlow.SignInSignUp
-        viewModel.handle(OnboardingAction.OnGetStarted(onboardingFlow = getStartedFlow))
+        viewModel.handle(OnboardingAction.SplashAction.OnGetStarted(onboardingFlow = getStartedFlow))
     }
 
     private fun alreadyHaveAnAccount() {
-        viewModel.handle(OnboardingAction.OnIAlreadyHaveAnAccount(onboardingFlow = OnboardingFlow.SignIn))
+        viewModel.handle(OnboardingAction.SplashAction.OnIAlreadyHaveAnAccount(onboardingFlow = OnboardingFlow.SignIn))
     }
 
     override fun resetViewModel() {
         // Nothing to do
-    }
-
-    override fun onError(throwable: Throwable) {
-        if (throwable is Failure.NetworkConnection &&
-                throwable.ioException is UnknownHostException) {
-            // Invalid homeserver from URL config
-            val url = viewModel.getInitialHomeServerUrl().orEmpty()
-            MaterialAlertDialogBuilder(requireActivity())
-                    .setTitle(R.string.dialog_title_error)
-                    .setMessage(getString(R.string.login_error_homeserver_from_url_not_found, url))
-                    .setPositiveButton(R.string.login_error_homeserver_from_url_not_found_enter_manual) { _, _ ->
-                        val flow = withState(viewModel) { it.onboardingFlow } ?: OnboardingFlow.SignInSignUp
-                        viewModel.handle(OnboardingAction.ResetDeeplinkConfig)
-                        viewModel.handle(OnboardingAction.OnGetStarted(flow))
-                    }
-                    .setNegativeButton(R.string.action_cancel, null)
-                    .show()
-        } else {
-            super.onError(throwable)
-        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashFragment.kt
@@ -75,11 +75,11 @@ class FtueAuthSplashFragment @Inject constructor(
 
     private fun splashSubmit(isAlreadyHaveAccountEnabled: Boolean) {
         val getStartedFlow = if (isAlreadyHaveAccountEnabled) OnboardingFlow.SignUp else OnboardingFlow.SignInSignUp
-        viewModel.handle(OnboardingAction.OnGetStarted(resetLoginConfig = false, onboardingFlow = getStartedFlow))
+        viewModel.handle(OnboardingAction.OnGetStarted(onboardingFlow = getStartedFlow))
     }
 
     private fun alreadyHaveAnAccount() {
-        viewModel.handle(OnboardingAction.OnIAlreadyHaveAnAccount(resetLoginConfig = false, onboardingFlow = OnboardingFlow.SignIn))
+        viewModel.handle(OnboardingAction.OnIAlreadyHaveAnAccount(onboardingFlow = OnboardingFlow.SignIn))
     }
 
     override fun resetViewModel() {
@@ -96,7 +96,8 @@ class FtueAuthSplashFragment @Inject constructor(
                     .setMessage(getString(R.string.login_error_homeserver_from_url_not_found, url))
                     .setPositiveButton(R.string.login_error_homeserver_from_url_not_found_enter_manual) { _, _ ->
                         val flow = withState(viewModel) { it.onboardingFlow } ?: OnboardingFlow.SignInSignUp
-                        viewModel.handle(OnboardingAction.OnGetStarted(resetLoginConfig = true, flow))
+                        viewModel.handle(OnboardingAction.ResetDeeplinkConfig)
+                        viewModel.handle(OnboardingAction.OnGetStarted(flow))
                     }
                     .setNegativeButton(R.string.action_cancel, null)
                     .show()

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthUseCaseFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthUseCaseFragment.kt
@@ -28,8 +28,6 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
-import com.airbnb.mvrx.withState
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import im.vector.app.R
 import im.vector.app.core.extensions.getResTintedDrawable
 import im.vector.app.core.extensions.getTintedDrawable
@@ -40,7 +38,6 @@ import im.vector.app.features.login.ServerType
 import im.vector.app.features.onboarding.FtueUseCase
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.themes.ThemeProvider
-import org.matrix.android.sdk.api.failure.isHomeserverUnavailable
 import javax.inject.Inject
 
 private const val DARK_MODE_ICON_BACKGROUND_ALPHA = 0.30f
@@ -107,38 +104,11 @@ class FtueAuthUseCaseFragment @Inject constructor(
     private fun createIcon(@ColorRes tint: Int, icon: Int, isLightMode: Boolean): Drawable {
         val context = requireContext()
         val alpha = when (isLightMode) {
-            true  -> LIGHT_MODE_ICON_BACKGROUND_ALPHA
+            true -> LIGHT_MODE_ICON_BACKGROUND_ALPHA
             false -> DARK_MODE_ICON_BACKGROUND_ALPHA
         }
         val iconBackground = context.getResTintedDrawable(R.drawable.bg_feature_icon, tint, alpha = alpha)
         val whiteLayer = context.getTintedDrawable(R.drawable.bg_feature_icon, Color.WHITE)
         return LayerDrawable(arrayOf(whiteLayer, iconBackground, ContextCompat.getDrawable(context, icon)))
-    }
-
-    override fun onError(throwable: Throwable) {
-        when {
-            requireContext().inferNoConnectivity() -> super.onError(throwable)
-            throwable.isHomeserverUnavailable()    -> {
-                val url = viewModel.getInitialHomeServerUrl().orEmpty()
-                homeserverUnavailableDialog(url) { onContinueFlowWithLoginConfigReset() }
-            }
-            else                                   -> super.onError(throwable)
-        }
-    }
-
-    private fun onContinueFlowWithLoginConfigReset() {
-        viewModel.handle(OnboardingAction.ResetDeeplinkConfig)
-        withState(viewModel) { it.useCase }?.let {
-            viewModel.handle(OnboardingAction.UpdateUseCase(it))
-        }
-    }
-
-    private fun homeserverUnavailableDialog(url: String, action: () -> Unit) {
-        MaterialAlertDialogBuilder(requireActivity())
-                .setTitle(R.string.dialog_title_error)
-                .setMessage(getString(R.string.login_error_homeserver_from_url_not_found, url))
-                .setPositiveButton(R.string.login_error_homeserver_from_url_not_found_enter_manual) { _, _ -> action() }
-                .setNegativeButton(R.string.action_cancel, null)
-                .show()
     }
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -228,9 +228,26 @@ class FtueAuthVariant(
                         option = commonOption
                 )
             }
-            OnboardingViewEvents.OnHomeserverEdited -> activity.popBackstack()
-            OnboardingViewEvents.OpenCombinedLogin  -> onStartCombinedLogin()
+            OnboardingViewEvents.OnHomeserverEdited                            -> activity.popBackstack()
+            OnboardingViewEvents.OpenCombinedLogin                             -> onStartCombinedLogin()
+            is OnboardingViewEvents.DeeplinkAuthenticationFailure              -> onDeeplinkedHomeserverUnavailable(viewEvents)
         }
+    }
+
+    private fun onDeeplinkedHomeserverUnavailable(viewEvents: OnboardingViewEvents.DeeplinkAuthenticationFailure) {
+        showHomeserverUnavailableDialog(onboardingViewModel.getInitialHomeServerUrl().orEmpty()) {
+            onboardingViewModel.handle(OnboardingAction.ResetDeeplinkConfig)
+            onboardingViewModel.handle(viewEvents.retryAction)
+        }
+    }
+
+    private fun showHomeserverUnavailableDialog(url: String, action: () -> Unit) {
+        MaterialAlertDialogBuilder(activity)
+                .setTitle(R.string.dialog_title_error)
+                .setMessage(activity.getString(R.string.login_error_homeserver_from_url_not_found, url))
+                .setPositiveButton(R.string.login_error_homeserver_from_url_not_found_enter_manual) { _, _ -> action() }
+                .setNegativeButton(R.string.action_cancel, null)
+                .show()
     }
 
     private fun onStartCombinedLogin() {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueExtensions.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueExtensions.kt
@@ -17,13 +17,17 @@
 package im.vector.app.features.onboarding.ftueauth
 
 import android.widget.Button
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputLayout
+import im.vector.app.R
 import im.vector.app.core.extensions.hasContentFlow
+import im.vector.app.core.extensions.inferNoConnectivity
 import im.vector.app.features.login.SignMode
 import im.vector.app.features.onboarding.OnboardingAction
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onEach
+import org.matrix.android.sdk.api.failure.isHomeserverUnavailable
 
 fun SignMode.toAuthenticateAction(login: String, password: String, initialDeviceName: String): OnboardingAction.AuthenticateAction {
     return when (this) {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueExtensions.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueExtensions.kt
@@ -17,17 +17,13 @@
 package im.vector.app.features.onboarding.ftueauth
 
 import android.widget.Button
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputLayout
-import im.vector.app.R
 import im.vector.app.core.extensions.hasContentFlow
-import im.vector.app.core.extensions.inferNoConnectivity
 import im.vector.app.features.login.SignMode
 import im.vector.app.features.onboarding.OnboardingAction
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onEach
-import org.matrix.android.sdk.api.failure.isHomeserverUnavailable
 
 fun SignMode.toAuthenticateAction(login: String, password: String, initialDeviceName: String): OnboardingAction.AuthenticateAction {
     return when (this) {

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -18,6 +18,8 @@ package im.vector.app.features.onboarding
 
 import android.net.Uri
 import com.airbnb.mvrx.test.MvRxTestRule
+import im.vector.app.R
+import im.vector.app.features.login.LoginConfig
 import im.vector.app.features.login.LoginMode
 import im.vector.app.features.login.ReAuthHelper
 import im.vector.app.features.login.SignMode
@@ -38,6 +40,8 @@ import im.vector.app.test.fakes.FakeUri
 import im.vector.app.test.fakes.FakeUriFilenameResolver
 import im.vector.app.test.fakes.FakeVectorFeatures
 import im.vector.app.test.fakes.FakeVectorOverrides
+import im.vector.app.test.fakes.toTestString
+import im.vector.app.test.fixtures.aBuildMeta
 import im.vector.app.test.fixtures.aHomeServerCapabilities
 import im.vector.app.test.test
 import kotlinx.coroutines.test.runTest
@@ -239,6 +243,28 @@ class OnboardingViewModelTest {
                         { copy(isLoading = false) }
                 )
                 .assertNoEvents()
+                .finish()
+    }
+
+    @Test
+    fun `given unavailable deeplink, when selecting homeserver, then emits failure with default homeserver as retry action`() = runTest {
+        fakeContext.givenHasConnection()
+        fakeHomeServerConnectionConfigFactory.givenConfigFor(A_HOMESERVER_URL, A_HOMESERVER_CONFIG)
+        fakeStartAuthenticationFlowUseCase.givenHomeserverUnavailable(A_HOMESERVER_CONFIG)
+        val test = viewModel.test()
+
+        viewModel.handle(OnboardingAction.InitWith(LoginConfig(A_HOMESERVER_URL, null)))
+        viewModel.handle(OnboardingAction.HomeServerChange.SelectHomeServer(A_HOMESERVER_URL))
+
+        val expectedRetryAction = OnboardingAction.HomeServerChange.SelectHomeServer("${R.string.matrix_org_server_url.toTestString()}/")
+        test
+                .assertStatesChanges(
+                        initialState,
+                        { copy(isLoading = true) },
+                        { copy(isLoading = false) }
+
+                )
+                .assertEvents(OnboardingViewEvents.DeeplinkAuthenticationFailure(expectedRetryAction))
                 .finish()
     }
 
@@ -451,7 +477,8 @@ class OnboardingViewModelTest {
                 fakeRegisterActionHandler.instance,
                 fakeDirectLoginUseCase.instance,
                 fakeStartAuthenticationFlowUseCase.instance,
-                FakeVectorOverrides()
+                FakeVectorOverrides(),
+                aBuildMeta()
         ).also {
             viewModel = it
             initialState = state

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeConnectivityManager.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeConnectivityManager.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import io.mockk.every
+import io.mockk.mockk
+
+class FakeConnectivityManager {
+    val instance = mockk<ConnectivityManager>()
+
+    fun givenNoActiveConnection() {
+        every { instance.activeNetwork } returns null
+    }
+
+    fun givenHasActiveConnection() {
+        val network = mockk<Network>()
+        every { instance.activeNetwork } returns network
+
+        val networkCapabilities = FakeNetworkCapabilities()
+        networkCapabilities.givenTransports(
+                NetworkCapabilities.TRANSPORT_CELLULAR,
+                NetworkCapabilities.TRANSPORT_WIFI,
+                NetworkCapabilities.TRANSPORT_VPN
+        )
+        every { instance.getNetworkCapabilities(network) } returns networkCapabilities.instance
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeContext.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeContext.kt
@@ -18,6 +18,7 @@ package im.vector.app.test.fakes
 
 import android.content.ContentResolver
 import android.content.Context
+import android.net.ConnectivityManager
 import android.net.Uri
 import android.os.ParcelFileDescriptor
 import io.mockk.every
@@ -47,5 +48,22 @@ class FakeContext(
 
     fun givenMissingSafeOutputStreamFor(uri: Uri) {
         every { contentResolver.openOutputStream(uri, "wt") } returns null
+    }
+
+    fun givenNoConnection() {
+        val connectivityManager = FakeConnectivityManager()
+        connectivityManager.givenNoActiveConnection()
+        givenService(Context.CONNECTIVITY_SERVICE, ConnectivityManager::class.java, connectivityManager.instance)
+    }
+
+    private fun <T> givenService(name: String, klass: Class<T>, service: T) {
+        every { instance.getSystemService(name) } returns service
+        every { instance.getSystemService(klass) } returns service
+    }
+
+    fun givenHasConnection() {
+        val connectivityManager = FakeConnectivityManager()
+        connectivityManager.givenHasActiveConnection()
+        givenService(Context.CONNECTIVITY_SERVICE, ConnectivityManager::class.java, connectivityManager.instance)
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeNetworkCapabilities.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeNetworkCapabilities.kt
@@ -14,15 +14,19 @@
  * limitations under the License.
  */
 
-package im.vector.app.test.fixtures
+package im.vector.app.test.fakes
 
-import org.matrix.android.sdk.api.failure.Failure
-import org.matrix.android.sdk.api.failure.MatrixError
-import java.net.UnknownHostException
-import javax.net.ssl.HttpsURLConnection
+import android.net.NetworkCapabilities
+import io.mockk.every
+import io.mockk.mockk
 
-fun a401ServerError() = Failure.ServerError(
-        MatrixError(MatrixError.M_UNAUTHORIZED, ""), HttpsURLConnection.HTTP_UNAUTHORIZED
-)
+class FakeNetworkCapabilities {
+    val instance = mockk<NetworkCapabilities>()
 
-fun aHomeserverUnavailableError() = Failure.NetworkConnection(UnknownHostException())
+    fun givenTransports(vararg type: Int) {
+        every { instance.hasTransport(any()) } answers {
+            val input = it.invocation.args.first() as Int
+            type.contains(input)
+        }
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeStartAuthenticationFlowUseCase.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeStartAuthenticationFlowUseCase.kt
@@ -18,9 +18,11 @@ package im.vector.app.test.fakes
 
 import im.vector.app.features.onboarding.StartAuthenticationFlowUseCase
 import im.vector.app.features.onboarding.StartAuthenticationFlowUseCase.StartAuthenticationResult
+import im.vector.app.test.fixtures.aHomeserverUnavailableError
 import io.mockk.coEvery
 import io.mockk.mockk
 import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
+import org.matrix.android.sdk.api.failure.Failure
 
 class FakeStartAuthenticationFlowUseCase {
 
@@ -28,5 +30,9 @@ class FakeStartAuthenticationFlowUseCase {
 
     fun givenResult(config: HomeServerConnectionConfig, result: StartAuthenticationResult) {
         coEvery { instance.execute(config) } returns result
+    }
+
+    fun givenHomeserverUnavailable(config: HomeServerConnectionConfig) {
+        coEvery { instance.execute(config) } throws  aHomeserverUnavailableError()
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fixtures/BuildMetaFixture.kt
+++ b/vector/src/test/java/im/vector/app/test/fixtures/BuildMetaFixture.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fixtures
+
+import android.os.Build
+import im.vector.app.core.resources.BuildMeta
+
+fun aBuildMeta() = BuildMeta(Build.VERSION_CODES.O)


### PR DESCRIPTION
Opened as a draft as this relies on #5995 

## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Adds missing deeplink handling to the new FTUE combined login/registration screens
- Fixes offline errors when attempting to sign in being treated as an invalid homeserver selection
  - Introduces a helper for inferring if the device has an active connection, if not we can further breakdown unknown host errors and infer that the failure is caused by being offline rather than the homeserver being unavailable 
- Lifts the invalid homeserver error dialog to the Activity(/FtueVariant) with a retry action passed from the `ViewModel`

## Motivation and context

Fixes #6023 

## Screenshots / GIFs

#### Legacy flows

| WITH FTUE DISABLED | GET STARTED WITH FTUE DISABLED | LEGACY RESETTING DEEPLINK |
| --- | --- | --- |
![after-deeplink-legacy-sign-in](https://user-images.githubusercontent.com/1848238/168087798-6490acaa-c400-459c-aa3c-0bbbc8e0383b.gif)|![after-deeplink-legacy-get-started](https://user-images.githubusercontent.com/1848238/168087803-a0d17d32-a98e-46da-b29b-b77e38dffa62.gif)|![after-deeplink-legacy-error](https://user-images.githubusercontent.com/1848238/168087807-2ef19b0f-a486-4174-9199-9ef7be076f90.gif)|

#### FTUE flows

| SIGN UP | SIGN IN |
| --- | --- |
![after-deeplink-sign-up-error](https://user-images.githubusercontent.com/1848238/168087819-0c2ab698-e033-423b-aefc-aa4512af872a.gif)|![after-deeplink-new-sign-in-error](https://user-images.githubusercontent.com/1848238/168087812-a69b6d09-1a23-4a34-b829-403b8dfef679.gif)

| SIGN UP | SIGN IN | 
| --- | --- |
|![deeplink-reg-disabled](https://user-images.githubusercontent.com/1848238/168091628-dd453a02-91a5-4336-8686-bae49bd40568.gif)|![after-sign-in-valid](https://user-images.githubusercontent.com/1848238/168091621-18c3ce78-8699-4a44-8ab4-51e51a99d873.gif)

#### Offline deeplink

|BEFORE | AFTER |
| --- | --- |
|![Screenshot_20220512_144406](https://user-images.githubusercontent.com/1848238/168089461-71b9cded-3633-4cde-bf76-2e187526eb4e.png)|![after-offline-sign-in](https://user-images.githubusercontent.com/1848238/168088324-2eaa3b84-6d4b-4c9b-b76b-0f57ffbb4ad6.png)


## Tests

- Open the app via valid and invalid deeplinks 
  - Invalid - https://mobile.element.io/?hs_url=matrix.example.com&is_url=identity.example.com 
  - Valid with registration disabled - https://mobile.element.io/?hs_url=iswell.cool&is_url=identity.example.com 
- Sign in or sign up
- Notice homeserver is preselected or an error to choose a different homeserver is shown 

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28

