### PR TITLE
Direction and track need to be set for hold/unhold

### DIFF
--- a/changelog.d/5865.bugfix
+++ b/changelog.d/5865.bugfix
@@ -1,0 +1,1 @@
+Fix for audio only being received in one direction after an un-hold during a sip call.

--- a/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCall.kt
+++ b/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCall.kt
@@ -683,6 +683,8 @@ class WebRtcCall(
                 direction = RtpTransceiver.RtpTransceiverDirection.SEND_RECV
             }
             for (transceiver in peerConnection?.transceivers ?: emptyList()) {
+                transceiver.sender.track()?.setEnabled(!onHold)
+                transceiver.receiver.track()?.setEnabled(!onHold)
                 transceiver.direction = direction
             }
             updateMuteStatus()


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-android/issues/5865

As per https://www.w3.org/TR/webrtc/#hold-functionality track and direction need to be set for hold/unhold music. 
iOS client was setting tracks.