### PR TITLE
FTUE - Sign up analytics

### DIFF
--- a/changelog.d/5285.wip
+++ b/changelog.d/5285.wip
@@ -1,0 +1,1 @@
+FTUE - Adds Sign Up tracking 

--- a/vector/src/main/java/im/vector/app/features/analytics/extensions/SignUpExt.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/extensions/SignUpExt.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.analytics.extensions
+
+import im.vector.app.features.analytics.plan.Signup
+import im.vector.app.features.onboarding.AuthenticationDescription
+
+fun AuthenticationDescription.AuthenticationType.toAnalyticsType() = when (this) {
+    AuthenticationDescription.AuthenticationType.Password -> Signup.AuthenticationType.Password
+    AuthenticationDescription.AuthenticationType.Apple    -> Signup.AuthenticationType.Apple
+    AuthenticationDescription.AuthenticationType.Facebook -> Signup.AuthenticationType.Facebook
+    AuthenticationDescription.AuthenticationType.Github   -> Signup.AuthenticationType.GitHub
+    AuthenticationDescription.AuthenticationType.Gitlab   -> Signup.AuthenticationType.GitLab
+    AuthenticationDescription.AuthenticationType.Google   -> Signup.AuthenticationType.Google
+    AuthenticationDescription.AuthenticationType.SSO      -> Signup.AuthenticationType.SSO
+    AuthenticationDescription.AuthenticationType.Other    -> Signup.AuthenticationType.Other
+}

--- a/vector/src/main/java/im/vector/app/features/analytics/extensions/SignUpExt.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/extensions/SignUpExt.kt
@@ -23,9 +23,9 @@ fun AuthenticationDescription.AuthenticationType.toAnalyticsType() = when (this)
     AuthenticationDescription.AuthenticationType.Password -> Signup.AuthenticationType.Password
     AuthenticationDescription.AuthenticationType.Apple    -> Signup.AuthenticationType.Apple
     AuthenticationDescription.AuthenticationType.Facebook -> Signup.AuthenticationType.Facebook
-    AuthenticationDescription.AuthenticationType.Github   -> Signup.AuthenticationType.GitHub
-    AuthenticationDescription.AuthenticationType.Gitlab   -> Signup.AuthenticationType.GitLab
-    AuthenticationDescription.AuthenticationType.Google   -> Signup.AuthenticationType.Google
+    AuthenticationDescription.AuthenticationType.GitHub -> Signup.AuthenticationType.GitHub
+    AuthenticationDescription.AuthenticationType.GitLab -> Signup.AuthenticationType.GitLab
+    AuthenticationDescription.AuthenticationType.Google -> Signup.AuthenticationType.Google
     AuthenticationDescription.AuthenticationType.SSO      -> Signup.AuthenticationType.SSO
     AuthenticationDescription.AuthenticationType.Other    -> Signup.AuthenticationType.Other
 }

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -249,7 +249,7 @@ class HomeActivity :
         if (isFirstCreation()) {
             handleIntent(intent)
         }
-        homeActivityViewModel.handle(HomeActivityViewActions.ViewStarted(args?.authenticationDescription))
+        homeActivityViewModel.handle(HomeActivityViewActions.ViewStarted)
     }
 
     private fun openGroup(shouldClearFragment: Boolean) {

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -56,6 +56,7 @@ import im.vector.app.features.matrixto.MatrixToBottomSheet
 import im.vector.app.features.matrixto.OriginOfMatrixTo
 import im.vector.app.features.navigation.Navigator
 import im.vector.app.features.notifications.NotificationDrawerManager
+import im.vector.app.features.onboarding.AuthenticationDescription
 import im.vector.app.features.permalink.NavigationInterceptor
 import im.vector.app.features.permalink.PermalinkHandler
 import im.vector.app.features.permalink.PermalinkHandler.Companion.MATRIX_TO_CUSTOM_SCHEME_URL_BASE
@@ -91,7 +92,7 @@ import javax.inject.Inject
 @Parcelize
 data class HomeActivityArgs(
         val clearNotification: Boolean,
-        val accountCreation: Boolean,
+        val authenticationDescription: AuthenticationDescription? = null,
         val hasExistingSession: Boolean = false,
         val inviteNotificationRoomId: String? = null
 ) : Parcelable
@@ -248,7 +249,7 @@ class HomeActivity :
         if (isFirstCreation()) {
             handleIntent(intent)
         }
-        homeActivityViewModel.handle(HomeActivityViewActions.ViewStarted)
+        homeActivityViewModel.handle(HomeActivityViewActions.ViewStarted(args?.authenticationDescription))
     }
 
     private fun openGroup(shouldClearFragment: Boolean) {
@@ -612,13 +613,13 @@ class HomeActivity :
         fun newIntent(
                 context: Context,
                 clearNotification: Boolean = false,
-                accountCreation: Boolean = false,
+                authenticationDescription: AuthenticationDescription? = null,
                 existingSession: Boolean = false,
                 inviteNotificationRoomId: String? = null
         ): Intent {
             val args = HomeActivityArgs(
                     clearNotification = clearNotification,
-                    accountCreation = accountCreation,
+                    authenticationDescription = authenticationDescription,
                     hasExistingSession = existingSession,
                     inviteNotificationRoomId = inviteNotificationRoomId
             )

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewActions.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewActions.kt
@@ -17,8 +17,9 @@
 package im.vector.app.features.home
 
 import im.vector.app.core.platform.VectorViewModelAction
+import im.vector.app.features.onboarding.AuthenticationDescription
 
 sealed interface HomeActivityViewActions : VectorViewModelAction {
-    object ViewStarted : HomeActivityViewActions
+    data class ViewStarted(val recentAuthentication: AuthenticationDescription?) : HomeActivityViewActions
     object PushPromptHasBeenReviewed : HomeActivityViewActions
 }

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewActions.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewActions.kt
@@ -20,6 +20,6 @@ import im.vector.app.core.platform.VectorViewModelAction
 import im.vector.app.features.onboarding.AuthenticationDescription
 
 sealed interface HomeActivityViewActions : VectorViewModelAction {
-    data class ViewStarted(val recentAuthentication: AuthenticationDescription?) : HomeActivityViewActions
+    object ViewStarted : HomeActivityViewActions
     object PushPromptHasBeenReviewed : HomeActivityViewActions
 }

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewActions.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewActions.kt
@@ -17,7 +17,6 @@
 package im.vector.app.features.home
 
 import im.vector.app.core.platform.VectorViewModelAction
-import im.vector.app.features.onboarding.AuthenticationDescription
 
 sealed interface HomeActivityViewActions : VectorViewModelAction {
     object ViewStarted : HomeActivityViewActions

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -101,18 +101,18 @@ class HomeActivityViewModel @AssistedInject constructor(
     private var hasCheckedBootstrap = false
     private var onceTrusted = false
 
-    private fun initialize(recentAuthentication: AuthenticationDescription?) {
+    private fun initialize() {
         if (isInitialized) return
         isInitialized = true
         cleanupFiles()
         observeInitialSync()
         checkSessionPushIsOn()
         observeCrossSigningReset()
-        observeAnalytics(recentAuthentication)
+        observeAnalytics()
         initThreadsMigration()
     }
 
-    private fun observeAnalytics(recentAuthentication: AuthenticationDescription?) {
+    private fun observeAnalytics() {
         if (analyticsConfig.isEnabled) {
             analyticsStore.didAskUserConsentFlow
                     .onEach { didAskUser ->
@@ -122,7 +122,7 @@ class HomeActivityViewModel @AssistedInject constructor(
                     }
                     .launchIn(viewModelScope)
 
-            recentAuthentication?.let {
+            initialState.authenticationDescription?.let { recentAuthentication ->
                 when (recentAuthentication) {
                     is AuthenticationDescription.Register -> {
                         viewModelScope.launch {
@@ -426,7 +426,7 @@ class HomeActivityViewModel @AssistedInject constructor(
                 vectorPreferences.setDidAskUserToEnableSessionPush()
             }
             is HomeActivityViewActions.ViewStarted            -> {
-                initialize(action.recentAuthentication)
+                initialize()
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -28,8 +28,12 @@ import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.VectorViewModel
+import im.vector.app.features.analytics.AnalyticsTracker
+import im.vector.app.features.analytics.extensions.toAnalyticsType
+import im.vector.app.features.analytics.plan.Signup
 import im.vector.app.features.analytics.store.AnalyticsStore
 import im.vector.app.features.login.ReAuthHelper
+import im.vector.app.features.onboarding.AuthenticationDescription
 import im.vector.app.features.raw.wellknown.ElementWellKnown
 import im.vector.app.features.raw.wellknown.getElementWellknown
 import im.vector.app.features.raw.wellknown.isSecureBackupRequired
@@ -37,8 +41,11 @@ import im.vector.app.features.session.coroutineScope
 import im.vector.app.features.settings.VectorPreferences
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.auth.UIABaseAuth
 import org.matrix.android.sdk.api.auth.UserInteractiveAuthInterceptor
@@ -72,7 +79,8 @@ class HomeActivityViewModel @AssistedInject constructor(
         private val reAuthHelper: ReAuthHelper,
         private val analyticsStore: AnalyticsStore,
         private val lightweightSettingsStorage: LightweightSettingsStorage,
-        private val vectorPreferences: VectorPreferences
+        private val vectorPreferences: VectorPreferences,
+        private val analyticsTracker: AnalyticsTracker
 ) : VectorViewModel<HomeActivityViewState, HomeActivityViewActions, HomeActivityViewEvents>(initialState) {
 
     @AssistedFactory
@@ -84,7 +92,7 @@ class HomeActivityViewModel @AssistedInject constructor(
         override fun initialState(viewModelContext: ViewModelContext): HomeActivityViewState? {
             val activity: HomeActivity = viewModelContext.activity()
             val args: HomeActivityArgs? = activity.intent.getParcelableExtra(Mavericks.KEY_ARG)
-            return args?.let { HomeActivityViewState(accountCreation = it.accountCreation) }
+            return args?.let { HomeActivityViewState(authenticationDescription = it.authenticationDescription) }
                     ?: super.initialState(viewModelContext)
         }
     }
@@ -93,18 +101,18 @@ class HomeActivityViewModel @AssistedInject constructor(
     private var hasCheckedBootstrap = false
     private var onceTrusted = false
 
-    private fun initialize() {
+    private fun initialize(recentAuthentication: AuthenticationDescription?) {
         if (isInitialized) return
         isInitialized = true
         cleanupFiles()
         observeInitialSync()
         checkSessionPushIsOn()
         observeCrossSigningReset()
-        observeAnalytics()
+        observeAnalytics(recentAuthentication)
         initThreadsMigration()
     }
 
-    private fun observeAnalytics() {
+    private fun observeAnalytics(recentAuthentication: AuthenticationDescription?) {
         if (analyticsConfig.isEnabled) {
             analyticsStore.didAskUserConsentFlow
                     .onEach { didAskUser ->
@@ -113,7 +121,29 @@ class HomeActivityViewModel @AssistedInject constructor(
                         }
                     }
                     .launchIn(viewModelScope)
+
+            recentAuthentication?.let {
+                when (recentAuthentication) {
+                    is AuthenticationDescription.Register -> {
+                        viewModelScope.launch {
+                            analyticsStore.onUserGaveConsent {
+                                analyticsTracker.capture(Signup(authenticationType = recentAuthentication.type.toAnalyticsType()))
+                            }
+                        }
+                    }
+                    AuthenticationDescription.Login       -> {
+                        // do nothing
+                    }
+                }
+            }
         }
+    }
+
+    private suspend fun AnalyticsStore.onUserGaveConsent(action: () -> Unit) {
+        userConsentFlow
+                .takeWhile { !it }
+                .onCompletion { action() }
+                .collect()
     }
 
     private fun cleanupFiles() {
@@ -285,7 +315,7 @@ class HomeActivityViewModel @AssistedInject constructor(
             val isSecureBackupRequired = elementWellKnown?.isSecureBackupRequired() ?: false
 
             // In case of account creation, it is already done before
-            if (initialState.accountCreation) {
+            if (initialState.authenticationDescription is AuthenticationDescription.Register) {
                 if (isSecureBackupRequired) {
                     _viewEvents.post(HomeActivityViewEvents.StartRecoverySetupFlow)
                 } else {
@@ -395,8 +425,8 @@ class HomeActivityViewModel @AssistedInject constructor(
             HomeActivityViewActions.PushPromptHasBeenReviewed -> {
                 vectorPreferences.setDidAskUserToEnableSessionPush()
             }
-            HomeActivityViewActions.ViewStarted               -> {
-                initialize()
+            is HomeActivityViewActions.ViewStarted            -> {
+                initialize(action.recentAuthentication)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -122,18 +122,19 @@ class HomeActivityViewModel @AssistedInject constructor(
                     }
                     .launchIn(viewModelScope)
 
-            initialState.authenticationDescription?.let { recentAuthentication ->
-                when (recentAuthentication) {
-                    is AuthenticationDescription.Register -> {
-                        viewModelScope.launch {
-                            analyticsStore.onUserGaveConsent {
-                                analyticsTracker.capture(Signup(authenticationType = recentAuthentication.type.toAnalyticsType()))
-                            }
+            when (val recentAuthentication = initialState.authenticationDescription) {
+                is AuthenticationDescription.Register -> {
+                    viewModelScope.launch {
+                        analyticsStore.onUserGaveConsent {
+                            analyticsTracker.capture(Signup(authenticationType = recentAuthentication.type.toAnalyticsType()))
                         }
                     }
-                    AuthenticationDescription.Login       -> {
-                        // do nothing
-                    }
+                }
+                AuthenticationDescription.Login       -> {
+                    // do nothing
+                }
+                null                                  -> {
+                    // do nothing
                 }
             }
         }
@@ -221,10 +222,10 @@ class HomeActivityViewModel @AssistedInject constructor(
                 .asFlow()
                 .onEach { status ->
                     when (status) {
-                        is SyncStatusService.Status.Idle                   -> {
+                        is SyncStatusService.Status.Idle -> {
                             maybeVerifyOrBootstrapCrossSigning()
                         }
-                        else                                               -> Unit
+                        else                             -> Unit
                     }
 
                     setState {

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -426,7 +426,7 @@ class HomeActivityViewModel @AssistedInject constructor(
             HomeActivityViewActions.PushPromptHasBeenReviewed -> {
                 vectorPreferences.setDidAskUserToEnableSessionPush()
             }
-            is HomeActivityViewActions.ViewStarted            -> {
+            HomeActivityViewActions.ViewStarted               -> {
                 initialize()
             }
         }

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewState.kt
@@ -17,9 +17,10 @@
 package im.vector.app.features.home
 
 import com.airbnb.mvrx.MavericksState
+import im.vector.app.features.onboarding.AuthenticationDescription
 import org.matrix.android.sdk.api.session.initsync.SyncStatusService
 
 data class HomeActivityViewState(
         val syncStatusServiceStatus: SyncStatusService.Status = SyncStatusService.Status.Idle,
-        val accountCreation: Boolean = false
+        val authenticationDescription: AuthenticationDescription? = null
 ) : MavericksState

--- a/vector/src/main/java/im/vector/app/features/login/LoginActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginActivity.kt
@@ -218,10 +218,7 @@ open class LoginActivity : VectorBaseActivity<ActivityLoginBinding>(), UnlockedA
                 // change the screen name
                 analyticsScreenName = MobileScreen.ScreenName.Register
             }
-            val intent = HomeActivity.newIntent(
-                    this,
-                    accountCreation = loginViewState.signMode == SignMode.SignUp
-            )
+            val intent = HomeActivity.newIntent(this)
             startActivity(intent)
             finish()
             return

--- a/vector/src/main/java/im/vector/app/features/login/LoginActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginActivity.kt
@@ -42,6 +42,7 @@ import im.vector.app.features.analytics.plan.MobileScreen
 import im.vector.app.features.home.HomeActivity
 import im.vector.app.features.login.terms.LoginTermsFragment
 import im.vector.app.features.login.terms.LoginTermsFragmentArgument
+import im.vector.app.features.onboarding.AuthenticationDescription
 import im.vector.app.features.pin.UnlockedActivity
 import org.matrix.android.sdk.api.auth.registration.FlowResult
 import org.matrix.android.sdk.api.auth.registration.Stage
@@ -218,7 +219,8 @@ open class LoginActivity : VectorBaseActivity<ActivityLoginBinding>(), UnlockedA
                 // change the screen name
                 analyticsScreenName = MobileScreen.ScreenName.Register
             }
-            val intent = HomeActivity.newIntent(this)
+            val authDescription = inferAuthDescription(loginViewState)
+            val intent = HomeActivity.newIntent(this, authenticationDescription = authDescription)
             startActivity(intent)
             finish()
             return
@@ -226,6 +228,13 @@ open class LoginActivity : VectorBaseActivity<ActivityLoginBinding>(), UnlockedA
 
         // Loading
         views.loginLoading.isVisible = loginViewState.isLoading()
+    }
+
+    private fun inferAuthDescription(loginViewState: LoginViewState) = when (loginViewState.signMode) {
+        SignMode.Unknown            -> null
+        SignMode.SignUp             -> AuthenticationDescription.Register(type = AuthenticationDescription.AuthenticationType.Other)
+        SignMode.SignIn             -> AuthenticationDescription.Login
+        SignMode.SignInWithMatrixId -> AuthenticationDescription.Login
     }
 
     private fun onWebLoginError(onWebLoginError: LoginViewEvents.OnWebLoginError) {

--- a/vector/src/main/java/im/vector/app/features/login/LoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginFragment.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import org.matrix.android.sdk.api.auth.data.SsoIdentityProvider
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.failure.MatrixError
 import org.matrix.android.sdk.api.failure.isInvalidPassword
@@ -202,11 +203,11 @@ class LoginFragment @Inject constructor() : AbstractSSOLoginFragment<FragmentLog
                 views.loginSocialLoginContainer.isVisible = true
                 views.loginSocialLoginButtons.ssoIdentityProviders = state.loginMode.ssoIdentityProviders?.sorted()
                 views.loginSocialLoginButtons.listener = object : SocialLoginButtonsView.InteractionListener {
-                    override fun onProviderSelected(id: String?) {
+                    override fun onProviderSelected(provider: SsoIdentityProvider?) {
                         loginViewModel.getSsoUrl(
                                 redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                                 deviceId = state.deviceId,
-                                providerId = id
+                                providerId = provider?.id
                         )
                                 ?.let { openInCustomTab(it) }
                     }

--- a/vector/src/main/java/im/vector/app/features/login/LoginSignUpSignInSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginSignUpSignInSelectionFragment.kt
@@ -25,6 +25,7 @@ import com.airbnb.mvrx.withState
 import im.vector.app.R
 import im.vector.app.core.extensions.toReducedUrl
 import im.vector.app.databinding.FragmentLoginSignupSigninSelectionBinding
+import org.matrix.android.sdk.api.auth.data.SsoIdentityProvider
 import javax.inject.Inject
 
 /**
@@ -74,11 +75,11 @@ class LoginSignUpSignInSelectionFragment @Inject constructor() : AbstractSSOLogi
                 views.loginSignupSigninSignInSocialLoginContainer.isVisible = true
                 views.loginSignupSigninSocialLoginButtons.ssoIdentityProviders = state.loginMode.ssoIdentityProviders()?.sorted()
                 views.loginSignupSigninSocialLoginButtons.listener = object : SocialLoginButtonsView.InteractionListener {
-                    override fun onProviderSelected(id: String?) {
+                    override fun onProviderSelected(provider: SsoIdentityProvider?) {
                         loginViewModel.getSsoUrl(
                                 redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                                 deviceId = state.deviceId,
-                                providerId = id
+                                providerId = provider?.id
                         )
                                 ?.let { openInCustomTab(it) }
                     }

--- a/vector/src/main/java/im/vector/app/features/login/SocialLoginButtonsView.kt
+++ b/vector/src/main/java/im/vector/app/features/login/SocialLoginButtonsView.kt
@@ -31,7 +31,7 @@ class SocialLoginButtonsView @JvmOverloads constructor(context: Context, attrs: 
         LinearLayout(context, attrs, defStyle) {
 
     fun interface InteractionListener {
-        fun onProviderSelected(id: String?)
+        fun onProviderSelected(provider: SsoIdentityProvider?)
     }
 
     enum class Mode {
@@ -113,7 +113,7 @@ class SocialLoginButtonsView @JvmOverloads constructor(context: Context, attrs: 
             button.text = getButtonTitle(identityProvider.name)
             button.setTag(R.id.loginSignupSigninSocialLoginButtons, identityProvider.id)
             button.setOnClickListener {
-                listener?.onProviderSelected(identityProvider.id)
+                listener?.onProviderSelected(identityProvider)
             }
             addView(button)
         }
@@ -160,7 +160,7 @@ class SocialLoginButtonsView @JvmOverloads constructor(context: Context, attrs: 
     }
 }
 
-fun SocialLoginButtonsView.render(ssoProviders: List<SsoIdentityProvider>?, mode: SocialLoginButtonsView.Mode, listener: (String?) -> Unit) {
+fun SocialLoginButtonsView.render(ssoProviders: List<SsoIdentityProvider>?, mode: SocialLoginButtonsView.Mode, listener: (SsoIdentityProvider?) -> Unit) {
     this.mode = mode
     this.ssoIdentityProviders = ssoProviders?.sorted()
     this.listener = SocialLoginButtonsView.InteractionListener { listener(it) }

--- a/vector/src/main/java/im/vector/app/features/login2/LoginFragmentSignupUsername2.kt
+++ b/vector/src/main/java/im/vector/app/features/login2/LoginFragmentSignupUsername2.kt
@@ -35,6 +35,7 @@ import im.vector.app.features.login.SocialLoginButtonsView
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import org.matrix.android.sdk.api.auth.data.SsoIdentityProvider
 import reactivecircus.flowbinding.android.widget.textChanges
 import javax.inject.Inject
 
@@ -96,11 +97,11 @@ class LoginFragmentSignupUsername2 @Inject constructor() : AbstractSSOLoginFragm
             views.loginSocialLoginContainer.isVisible = true
             views.loginSocialLoginButtons.ssoIdentityProviders = state.loginMode.ssoIdentityProviders?.sorted()
             views.loginSocialLoginButtons.listener = object : SocialLoginButtonsView.InteractionListener {
-                override fun onProviderSelected(id: String?) {
+                override fun onProviderSelected(provider: SsoIdentityProvider?) {
                     loginViewModel.getSsoUrl(
                             redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                             deviceId = state.deviceId,
-                            providerId = id
+                            providerId = provider?.id
                     )
                             ?.let { openInCustomTab(it) }
                 }

--- a/vector/src/main/java/im/vector/app/features/login2/LoginFragmentToAny2.kt
+++ b/vector/src/main/java/im/vector/app/features/login2/LoginFragmentToAny2.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import org.matrix.android.sdk.api.auth.data.SsoIdentityProvider
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.failure.MatrixError
 import org.matrix.android.sdk.api.failure.isInvalidPassword
@@ -123,11 +124,11 @@ class LoginFragmentToAny2 @Inject constructor() : AbstractSSOLoginFragment2<Frag
             views.loginSocialLoginContainer.isVisible = true
             views.loginSocialLoginButtons.ssoIdentityProviders = state.loginMode.ssoIdentityProviders?.sorted()
             views.loginSocialLoginButtons.listener = object : SocialLoginButtonsView.InteractionListener {
-                override fun onProviderSelected(id: String?) {
+                override fun onProviderSelected(provider: SsoIdentityProvider?) {
                     loginViewModel.getSsoUrl(
                             redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                             deviceId = state.deviceId,
-                            providerId = id
+                            providerId = provider?.id
                     )
                             ?.let { openInCustomTab(it) }
                 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/AuthenticationDescription.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/AuthenticationDescription.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.onboarding
+
+import im.vector.app.features.onboarding.AuthenticationDescription.AuthenticationType
+import org.matrix.android.sdk.api.auth.data.SsoIdentityProvider
+
+sealed interface AuthenticationDescription {
+    object Login : AuthenticationDescription
+    data class AccountCreated(val type: AuthenticationType) : AuthenticationDescription
+
+    enum class AuthenticationType {
+        Password,
+        Apple,
+        Facebook,
+        Github,
+        Gitlab,
+        Google,
+        SSO,
+        Other
+    }
+}
+
+fun SsoIdentityProvider?.toAuthenticationType() = when (this?.brand) {
+    SsoIdentityProvider.BRAND_GOOGLE   -> AuthenticationType.Google
+    SsoIdentityProvider.BRAND_GITHUB   -> AuthenticationType.Github
+    SsoIdentityProvider.BRAND_APPLE    -> AuthenticationType.Apple
+    SsoIdentityProvider.BRAND_FACEBOOK -> AuthenticationType.Facebook
+    SsoIdentityProvider.BRAND_GITLAB   -> AuthenticationType.Gitlab
+    SsoIdentityProvider.BRAND_TWITTER  -> AuthenticationType.SSO
+    null                               -> AuthenticationType.SSO
+    else                               -> AuthenticationType.SSO
+}

--- a/vector/src/main/java/im/vector/app/features/onboarding/AuthenticationDescription.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/AuthenticationDescription.kt
@@ -16,12 +16,17 @@
 
 package im.vector.app.features.onboarding
 
+import android.os.Parcelable
 import im.vector.app.features.onboarding.AuthenticationDescription.AuthenticationType
+import kotlinx.parcelize.Parcelize
 import org.matrix.android.sdk.api.auth.data.SsoIdentityProvider
 
-sealed interface AuthenticationDescription {
+sealed interface AuthenticationDescription : Parcelable {
+    @Parcelize
     object Login : AuthenticationDescription
-    data class AccountCreated(val type: AuthenticationType) : AuthenticationDescription
+
+    @Parcelize
+    data class Register(val type: AuthenticationType) : AuthenticationDescription
 
     enum class AuthenticationType {
         Password,

--- a/vector/src/main/java/im/vector/app/features/onboarding/AuthenticationDescription.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/AuthenticationDescription.kt
@@ -32,8 +32,8 @@ sealed interface AuthenticationDescription : Parcelable {
         Password,
         Apple,
         Facebook,
-        Github,
-        Gitlab,
+        GitHub,
+        GitLab,
         Google,
         SSO,
         Other
@@ -42,10 +42,10 @@ sealed interface AuthenticationDescription : Parcelable {
 
 fun SsoIdentityProvider?.toAuthenticationType() = when (this?.brand) {
     SsoIdentityProvider.BRAND_GOOGLE   -> AuthenticationType.Google
-    SsoIdentityProvider.BRAND_GITHUB   -> AuthenticationType.Github
+    SsoIdentityProvider.BRAND_GITHUB   -> AuthenticationType.GitHub
     SsoIdentityProvider.BRAND_APPLE    -> AuthenticationType.Apple
     SsoIdentityProvider.BRAND_FACEBOOK -> AuthenticationType.Facebook
-    SsoIdentityProvider.BRAND_GITLAB   -> AuthenticationType.Gitlab
+    SsoIdentityProvider.BRAND_GITLAB   -> AuthenticationType.GitLab
     SsoIdentityProvider.BRAND_TWITTER  -> AuthenticationType.SSO
     null                               -> AuthenticationType.SSO
     else                               -> AuthenticationType.SSO

--- a/vector/src/main/java/im/vector/app/features/onboarding/Login2Variant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/Login2Variant.kt
@@ -276,7 +276,7 @@ class Login2Variant(
             is LoginViewEvents2.OnLoginModeNotSupported                    ->
                 onLoginModeNotSupported(event.supportedTypes)
             is LoginViewEvents2.OnSessionCreated                           -> handleOnSessionCreated(event)
-            is LoginViewEvents2.Finish                                     -> terminate(true)
+            is LoginViewEvents2.Finish                                     -> terminate()
             is LoginViewEvents2.CancelRegistration                         -> handleCancelRegistration()
         }
     }
@@ -296,14 +296,13 @@ class Login2Variant(
                     option = commonOption
             )
         } else {
-            terminate(false)
+            terminate()
         }
     }
 
-    private fun terminate(newAccount: Boolean) {
+    private fun terminate() {
         val intent = HomeActivity.newIntent(
-                activity,
-                accountCreation = newAccount
+                activity
         )
         activity.startActivity(intent)
         activity.finish()

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -292,9 +292,8 @@ class OnboardingViewModel @AssistedInject constructor(
                                 else                   -> when (it) {
                                     is RegistrationResult.Complete         -> onSessionCreated(
                                             it.session,
-                                            authenticationDescription = AuthenticationDescription.AccountCreated(
-                                                    awaitState().selectedAuthenticationState.type ?: AuthenticationDescription.AuthenticationType.Other
-                                            )
+                                            authenticationDescription = awaitState().selectedAuthenticationState.description
+                                                    ?: AuthenticationDescription.Register(AuthenticationDescription.AuthenticationType.Other)
                                     )
                                     is RegistrationResult.NextStep         -> onFlowResponse(it.flowResult, onNextRegistrationStepAction)
                                     is RegistrationResult.SendEmailSuccess -> _viewEvents.post(OnboardingViewEvents.OnSendEmailSuccess(it.email))
@@ -325,7 +324,10 @@ class OnboardingViewModel @AssistedInject constructor(
     private fun OnboardingViewState.hasSelectedMatrixOrg() = selectedHomeserver.userFacingUrl == matrixOrgUrl
 
     private fun handleRegisterWith(action: AuthenticateAction.Register) {
-        setState { copy(selectedAuthenticationState = SelectedAuthenticationState(AuthenticationDescription.AuthenticationType.Password)) }
+        setState {
+            val authDescription = AuthenticationDescription.Register(AuthenticationDescription.AuthenticationType.Password)
+            copy(selectedAuthenticationState = SelectedAuthenticationState(authDescription))
+        }
         reAuthHelper.data = action.password
         handleRegisterAction(
                 RegisterAction.CreateAccount(
@@ -572,14 +574,14 @@ class OnboardingViewModel @AssistedInject constructor(
         session.configureAndStart(applicationContext)
 
         when (authenticationDescription) {
-            is AuthenticationDescription.AccountCreated -> {
+            is AuthenticationDescription.Register -> {
                 val personalizationState = createPersonalizationState(session, state)
                 setState {
                     copy(isLoading = false, personalizationState = personalizationState)
                 }
                 _viewEvents.post(OnboardingViewEvents.OnAccountCreated)
             }
-            AuthenticationDescription.Login             -> {
+            AuthenticationDescription.Login       -> {
                 setState { copy(isLoading = false) }
                 _viewEvents.post(OnboardingViewEvents.OnAccountSignedIn)
             }
@@ -753,7 +755,10 @@ class OnboardingViewModel @AssistedInject constructor(
     }
 
     fun getSsoUrl(redirectUrl: String, deviceId: String?, provider: SsoIdentityProvider?): String? {
-        setState { copy(selectedAuthenticationState = SelectedAuthenticationState(provider.toAuthenticationType())) }
+        setState {
+            val authDescription = AuthenticationDescription.Register(provider.toAuthenticationType())
+            copy(selectedAuthenticationState = SelectedAuthenticationState(authDescription))
+        }
         return authenticationService.getSsoUrl(redirectUrl, deviceId, provider?.id)
     }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -255,7 +255,7 @@ class OnboardingViewModel @AssistedInject constructor(
             currentJob = viewModelScope.launch {
                 try {
                     val result = safeLoginWizard.loginWithToken(action.loginToken)
-                    onSessionCreated(result, isAccountCreated = false)
+                    onSessionCreated(result, authenticationDescription = AuthenticationDescription.Login)
                 } catch (failure: Throwable) {
                     setState { copy(isLoading = false) }
                     _viewEvents.post(OnboardingViewEvents.Failure(failure))
@@ -289,7 +289,12 @@ class OnboardingViewModel @AssistedInject constructor(
                                     // do nothing
                                 }
                                 else                   -> when (it) {
-                                    is RegistrationResult.Complete         -> onSessionCreated(it.session, isAccountCreated = true)
+                                    is RegistrationResult.Complete         -> onSessionCreated(
+                                            it.session,
+                                            authenticationDescription = AuthenticationDescription.AccountCreated(
+                                                    AuthenticationDescription.AuthenticationType.Password
+                                            )
+                                    )
                                     is RegistrationResult.NextStep         -> onFlowResponse(it.flowResult, onNextRegistrationStepAction)
                                     is RegistrationResult.SendEmailSuccess -> _viewEvents.post(OnboardingViewEvents.OnSendEmailSuccess(it.email))
                                     is RegistrationResult.Error            -> _viewEvents.post(OnboardingViewEvents.Failure(it.cause))
@@ -499,7 +504,7 @@ class OnboardingViewModel @AssistedInject constructor(
         setState { copy(isLoading = true) }
         currentJob = viewModelScope.launch {
             directLoginUseCase.execute(action, homeServerConnectionConfig).fold(
-                    onSuccess = { onSessionCreated(it, isAccountCreated = false) },
+                    onSuccess = { onSessionCreated(it, authenticationDescription = AuthenticationDescription.Login) },
                     onFailure = {
                         setState { copy(isLoading = false) }
                         _viewEvents.post(OnboardingViewEvents.Failure(it))
@@ -524,7 +529,7 @@ class OnboardingViewModel @AssistedInject constructor(
                             action.initialDeviceName
                     )
                     reAuthHelper.data = action.password
-                    onSessionCreated(result, isAccountCreated = false)
+                    onSessionCreated(result, authenticationDescription = AuthenticationDescription.Login)
                 } catch (failure: Throwable) {
                     setState { copy(isLoading = false) }
                     _viewEvents.post(OnboardingViewEvents.Failure(failure))
@@ -553,7 +558,7 @@ class OnboardingViewModel @AssistedInject constructor(
         internalRegisterAction(RegisterAction.RegisterDummy, onNextRegistrationStepAction)
     }
 
-    private suspend fun onSessionCreated(session: Session, isAccountCreated: Boolean) {
+    private suspend fun onSessionCreated(session: Session, authenticationDescription: AuthenticationDescription) {
         val state = awaitState()
         state.useCase?.let { useCase ->
             session.vectorStore(applicationContext).setUseCase(useCase)
@@ -564,15 +569,15 @@ class OnboardingViewModel @AssistedInject constructor(
         authenticationService.reset()
         session.configureAndStart(applicationContext)
 
-        when (isAccountCreated) {
-            true  -> {
+        when (authenticationDescription) {
+            is AuthenticationDescription.AccountCreated -> {
                 val personalizationState = createPersonalizationState(session, state)
                 setState {
                     copy(isLoading = false, personalizationState = personalizationState)
                 }
                 _viewEvents.post(OnboardingViewEvents.OnAccountCreated)
             }
-            false -> {
+            AuthenticationDescription.Login             -> {
                 setState { copy(isLoading = false) }
                 _viewEvents.post(OnboardingViewEvents.OnAccountSignedIn)
             }
@@ -603,7 +608,7 @@ class OnboardingViewModel @AssistedInject constructor(
             currentJob = viewModelScope.launch {
                 try {
                     val result = authenticationService.createSessionFromSso(homeServerConnectionConfigFinal, action.credentials)
-                    onSessionCreated(result, isAccountCreated = false)
+                    onSessionCreated(result, authenticationDescription = AuthenticationDescription.Login)
                 } catch (failure: Throwable) {
                     setState { copy(isLoading = false) }
                 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -754,7 +754,7 @@ class OnboardingViewModel @AssistedInject constructor(
         return loginConfig?.homeServerUrl
     }
 
-    fun getSsoUrl(redirectUrl: String, deviceId: String?, provider: SsoIdentityProvider?): String? {
+    fun fetchSsoUrl(redirectUrl: String, deviceId: String?, provider: SsoIdentityProvider?): String? {
         setState {
             val authDescription = AuthenticationDescription.Register(provider.toAuthenticationType())
             copy(selectedAuthenticationState = SelectedAuthenticationState(authDescription))

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
@@ -52,6 +52,9 @@ data class OnboardingViewState(
         val selectedHomeserver: SelectedHomeserverState = SelectedHomeserverState(),
 
         @PersistState
+        val selectedAuthenticationState: SelectedAuthenticationState = SelectedAuthenticationState(),
+
+        @PersistState
         val personalizationState: PersonalizationState = PersonalizationState()
 ) : MavericksState
 
@@ -80,3 +83,8 @@ data class PersonalizationState(
 
     fun supportsPersonalization() = supportsChangingDisplayName || supportsChangingProfilePicture
 }
+
+@Parcelize
+data class SelectedAuthenticationState(
+        val type: AuthenticationDescription.AuthenticationType? = null,
+) : Parcelable

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
@@ -86,5 +86,5 @@ data class PersonalizationState(
 
 @Parcelize
 data class SelectedAuthenticationState(
-        val type: AuthenticationDescription.AuthenticationType? = null,
+        val description: AuthenticationDescription? = null,
 ) : Parcelable

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/AbstractSSOFtueAuthFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/AbstractSSOFtueAuthFragment.kt
@@ -93,7 +93,7 @@ abstract class AbstractSSOFtueAuthFragment<VB : ViewBinding> : AbstractFtueAuthF
                 viewModel.getSsoUrl(
                         redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                         deviceId = state.deviceId,
-                        providerId = null
+                        provider = null
                 )
                         ?.let { prefetchUrl(it) }
             }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/AbstractSSOFtueAuthFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/AbstractSSOFtueAuthFragment.kt
@@ -90,7 +90,7 @@ abstract class AbstractSSOFtueAuthFragment<VB : ViewBinding> : AbstractFtueAuthF
         withState(viewModel) { state ->
             if (state.selectedHomeserver.preferredLoginMode.hasSso() && state.selectedHomeserver.preferredLoginMode.ssoIdentityProviders().isNullOrEmpty()) {
                 // in this case we can prefetch (not other cases for privacy concerns)
-                viewModel.getSsoUrl(
+                viewModel.fetchSsoUrl(
                         redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                         deviceId = state.deviceId,
                         provider = null

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedLoginFragment.kt
@@ -134,7 +134,7 @@ class FtueAuthCombinedLoginFragment @Inject constructor(
             viewModel.getSsoUrl(
                     redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                     deviceId = deviceId,
-                    providerId = id
+                    provider = id
             )?.let { openInCustomTab(it) }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedLoginFragment.kt
@@ -131,7 +131,7 @@ class FtueAuthCombinedLoginFragment @Inject constructor(
         views.ssoGroup.isVisible = ssoProviders?.isNotEmpty() == true
         views.ssoButtonsHeader.isVisible = views.ssoGroup.isVisible && views.loginEntryGroup.isVisible
         views.ssoButtons.render(ssoProviders, SocialLoginButtonsView.Mode.MODE_CONTINUE) { id ->
-            viewModel.getSsoUrl(
+            viewModel.fetchSsoUrl(
                     redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                     deviceId = deviceId,
                     provider = id

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedRegisterFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedRegisterFragment.kt
@@ -168,7 +168,7 @@ class FtueAuthCombinedRegisterFragment @Inject constructor() : AbstractSSOFtueAu
             viewModel.getSsoUrl(
                     redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                     deviceId = deviceId,
-                    providerId = provider?.id
+                    provider = provider
             )?.let { openInCustomTab(it) }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedRegisterFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedRegisterFragment.kt
@@ -164,11 +164,11 @@ class FtueAuthCombinedRegisterFragment @Inject constructor() : AbstractSSOFtueAu
 
     private fun renderSsoProviders(deviceId: String?, ssoProviders: List<SsoIdentityProvider>?) {
         views.ssoGroup.isVisible = ssoProviders?.isNotEmpty() == true
-        views.ssoButtons.render(ssoProviders, SocialLoginButtonsView.Mode.MODE_CONTINUE) { id ->
+        views.ssoButtons.render(ssoProviders, SocialLoginButtonsView.Mode.MODE_CONTINUE) { provider ->
             viewModel.getSsoUrl(
                     redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                     deviceId = deviceId,
-                    providerId = id
+                    providerId = provider?.id
             )?.let { openInCustomTab(it) }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedRegisterFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedRegisterFragment.kt
@@ -165,7 +165,7 @@ class FtueAuthCombinedRegisterFragment @Inject constructor() : AbstractSSOFtueAu
     private fun renderSsoProviders(deviceId: String?, ssoProviders: List<SsoIdentityProvider>?) {
         views.ssoGroup.isVisible = ssoProviders?.isNotEmpty() == true
         views.ssoButtons.render(ssoProviders, SocialLoginButtonsView.Mode.MODE_CONTINUE) { provider ->
-            viewModel.getSsoUrl(
+            viewModel.fetchSsoUrl(
                     redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                     deviceId = deviceId,
                     provider = provider

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import org.matrix.android.sdk.api.auth.data.SsoIdentityProvider
 import org.matrix.android.sdk.api.failure.isInvalidPassword
 import org.matrix.android.sdk.api.failure.isInvalidUsername
 import org.matrix.android.sdk.api.failure.isLoginEmailUnknown
@@ -216,11 +217,11 @@ class FtueAuthLoginFragment @Inject constructor() : AbstractSSOFtueAuthFragment<
                 views.loginSocialLoginContainer.isVisible = true
                 views.loginSocialLoginButtons.ssoIdentityProviders = state.selectedHomeserver.preferredLoginMode.ssoIdentityProviders?.sorted()
                 views.loginSocialLoginButtons.listener = object : SocialLoginButtonsView.InteractionListener {
-                    override fun onProviderSelected(id: String?) {
+                    override fun onProviderSelected(provider: SsoIdentityProvider?) {
                         viewModel.getSsoUrl(
                                 redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                                 deviceId = state.deviceId,
-                                providerId = id
+                                providerId = provider?.id
                         )
                                 ?.let { openInCustomTab(it) }
                     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
@@ -221,7 +221,7 @@ class FtueAuthLoginFragment @Inject constructor() : AbstractSSOFtueAuthFragment<
                         viewModel.getSsoUrl(
                                 redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                                 deviceId = state.deviceId,
-                                providerId = provider?.id
+                                provider = provider
                         )
                                 ?.let { openInCustomTab(it) }
                     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
@@ -218,7 +218,7 @@ class FtueAuthLoginFragment @Inject constructor() : AbstractSSOFtueAuthFragment<
                 views.loginSocialLoginButtons.ssoIdentityProviders = state.selectedHomeserver.preferredLoginMode.ssoIdentityProviders?.sorted()
                 views.loginSocialLoginButtons.listener = object : SocialLoginButtonsView.InteractionListener {
                     override fun onProviderSelected(provider: SsoIdentityProvider?) {
-                        viewModel.getSsoUrl(
+                        viewModel.fetchSsoUrl(
                                 redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                                 deviceId = state.deviceId,
                                 provider = provider

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSignUpSignInSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSignUpSignInSelectionFragment.kt
@@ -34,6 +34,7 @@ import im.vector.app.features.login.SocialLoginButtonsView
 import im.vector.app.features.login.ssoIdentityProviders
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewState
+import org.matrix.android.sdk.api.auth.data.SsoIdentityProvider
 import javax.inject.Inject
 
 /**
@@ -81,11 +82,11 @@ class FtueAuthSignUpSignInSelectionFragment @Inject constructor() : AbstractSSOF
                 views.loginSignupSigninSignInSocialLoginContainer.isVisible = true
                 views.loginSignupSigninSocialLoginButtons.ssoIdentityProviders = state.selectedHomeserver.preferredLoginMode.ssoIdentityProviders()?.sorted()
                 views.loginSignupSigninSocialLoginButtons.listener = object : SocialLoginButtonsView.InteractionListener {
-                    override fun onProviderSelected(id: String?) {
+                    override fun onProviderSelected(provider: SsoIdentityProvider?) {
                         viewModel.getSsoUrl(
                                 redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                                 deviceId = state.deviceId,
-                                providerId = id
+                                providerId = provider?.id
                         )
                                 ?.let { openInCustomTab(it) }
                     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSignUpSignInSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSignUpSignInSelectionFragment.kt
@@ -86,7 +86,7 @@ class FtueAuthSignUpSignInSelectionFragment @Inject constructor() : AbstractSSOF
                         viewModel.getSsoUrl(
                                 redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                                 deviceId = state.deviceId,
-                                providerId = provider?.id
+                                provider = provider
                         )
                                 ?.let { openInCustomTab(it) }
                     }
@@ -127,7 +127,7 @@ class FtueAuthSignUpSignInSelectionFragment @Inject constructor() : AbstractSSOF
             viewModel.getSsoUrl(
                     redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                     deviceId = state.deviceId,
-                    providerId = null
+                    provider = null
             )
                     ?.let { openInCustomTab(it) }
         } else {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSignUpSignInSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSignUpSignInSelectionFragment.kt
@@ -83,7 +83,7 @@ class FtueAuthSignUpSignInSelectionFragment @Inject constructor() : AbstractSSOF
                 views.loginSignupSigninSocialLoginButtons.ssoIdentityProviders = state.selectedHomeserver.preferredLoginMode.ssoIdentityProviders()?.sorted()
                 views.loginSignupSigninSocialLoginButtons.listener = object : SocialLoginButtonsView.InteractionListener {
                     override fun onProviderSelected(provider: SsoIdentityProvider?) {
-                        viewModel.getSsoUrl(
+                        viewModel.fetchSsoUrl(
                                 redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                                 deviceId = state.deviceId,
                                 provider = provider
@@ -124,7 +124,7 @@ class FtueAuthSignUpSignInSelectionFragment @Inject constructor() : AbstractSSOF
 
     private fun submit() = withState(viewModel) { state ->
         if (state.selectedHomeserver.preferredLoginMode is LoginMode.Sso) {
-            viewModel.getSsoUrl(
+            viewModel.fetchSsoUrl(
                     redirectUrl = SSORedirectRouterActivity.VECTOR_REDIRECT_URL,
                     deviceId = state.deviceId,
                     provider = null

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -216,7 +216,7 @@ class FtueAuthVariant(
             is OnboardingViewEvents.OnAccountCreated                           -> onAccountCreated()
             OnboardingViewEvents.OnAccountSignedIn                             -> onAccountSignedIn()
             OnboardingViewEvents.OnChooseDisplayName                           -> onChooseDisplayName()
-            OnboardingViewEvents.OnTakeMeHome                                  -> navigateToHome(createdAccount = true)
+            OnboardingViewEvents.OnTakeMeHome                                  -> navigateToHome()
             OnboardingViewEvents.OnChooseProfilePicture                        -> onChooseProfilePicture()
             OnboardingViewEvents.OnPersonalizationComplete                     -> onPersonalizationComplete()
             OnboardingViewEvents.OnBack                                        -> activity.popBackstack()
@@ -467,7 +467,7 @@ class FtueAuthVariant(
     }
 
     private fun onAccountSignedIn() {
-        navigateToHome(createdAccount = false)
+        navigateToHome()
     }
 
     private fun onAccountCreated() {
@@ -479,10 +479,12 @@ class FtueAuthVariant(
         )
     }
 
-    private fun navigateToHome(createdAccount: Boolean) {
-        val intent = HomeActivity.newIntent(activity, accountCreation = createdAccount)
-        activity.startActivity(intent)
-        activity.finish()
+    private fun navigateToHome() {
+        withState(onboardingViewModel) {
+            val intent = HomeActivity.newIntent(activity, authenticationDescription = it.selectedAuthenticationState.description)
+            activity.startActivity(intent)
+            activity.finish()
+        }
     }
 
     private fun onChooseDisplayName() {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueExtensions.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueExtensions.kt
@@ -17,13 +17,17 @@
 package im.vector.app.features.onboarding.ftueauth
 
 import android.widget.Button
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputLayout
+import im.vector.app.R
 import im.vector.app.core.extensions.hasContentFlow
+import im.vector.app.core.extensions.inferNoConnectivity
 import im.vector.app.features.login.SignMode
 import im.vector.app.features.onboarding.OnboardingAction
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onEach
+import org.matrix.android.sdk.api.failure.isHomeserverUnavailable
 
 fun SignMode.toAuthenticateAction(login: String, password: String, initialDeviceName: String): OnboardingAction.AuthenticateAction {
     return when (this) {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueExtensions.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueExtensions.kt
@@ -17,17 +17,13 @@
 package im.vector.app.features.onboarding.ftueauth
 
 import android.widget.Button
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputLayout
-import im.vector.app.R
 import im.vector.app.core.extensions.hasContentFlow
-import im.vector.app.core.extensions.inferNoConnectivity
 import im.vector.app.features.login.SignMode
 import im.vector.app.features.onboarding.OnboardingAction
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onEach
-import org.matrix.android.sdk.api.failure.isHomeserverUnavailable
 
 fun SignMode.toAuthenticateAction(login: String, password: String, initialDeviceName: String): OnboardingAction.AuthenticateAction {
     return when (this) {


### PR DESCRIPTION
## Type of change

- [x] WIP Feature 
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes #5285 

Adds `SignUp` event tracking after the user creates an account **AND** consents to tracking. 

- Creates an `AuthenticationDescription` abstraction  and also sets the ground work for tracking sign in in the future.
- Chains the `AuthenticationDescription` through to the `HomeActivity` in order to be tracked

## Motivation and context

To enable the collection of sign up metrics (and sign up type)

## Screenshots / GIFs

No UI changes

```
D/Analytics: capture(Signup(authenticationType=Password))
```

![2022-05-13T09:09:08,565852105+01:00](https://user-images.githubusercontent.com/1848238/168239970-8cb7f232-b196-4787-a49a-5f817cd61fca.png)

## Tests

- With the combined login feature flag enabled
- Create an account
- Notice the SignUp tracking event in posthog

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28
