### PR TITLE
FTYUE - Only override sign up steps for `matrix.org`

### DIFF
--- a/changelog.d/5783.wip
+++ b/changelog.d/5783.wip
@@ -1,0 +1,1 @@
+FTUE - Overrides sign up flow ordering for matrix.org only

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -54,7 +54,6 @@ import im.vector.app.features.onboarding.OnboardingViewState
 import im.vector.app.features.onboarding.ftueauth.terms.FtueAuthLegacyStyleTermsFragment
 import im.vector.app.features.onboarding.ftueauth.terms.FtueAuthTermsFragment
 import im.vector.app.features.onboarding.ftueauth.terms.FtueAuthTermsLegacyStyleFragmentArgument
-import org.matrix.android.sdk.api.auth.registration.FlowResult
 import org.matrix.android.sdk.api.auth.registration.Stage
 import org.matrix.android.sdk.api.auth.toLocalizedLoginTerms
 import org.matrix.android.sdk.api.extensions.tryOrNull
@@ -240,15 +239,10 @@ class FtueAuthVariant(
     private fun onRegistrationFlow(viewEvents: OnboardingViewEvents.RegistrationFlowResult) {
         when {
             registrationShouldFallback(viewEvents)               -> displayFallbackWebDialog()
-            viewEvents.isRegistrationStarted                     -> handleRegistrationNavigation(viewEvents.flowResult.orderedStages())
+            viewEvents.isRegistrationStarted                     -> handleRegistrationNavigation(viewEvents.flowResult.missingStages)
             vectorFeatures.isOnboardingCombinedRegisterEnabled() -> openStartCombinedRegister()
             else                                                 -> openAuthLoginFragmentWithTag(FRAGMENT_REGISTRATION_STAGE_TAG)
         }
-    }
-
-    private fun FlowResult.orderedStages() = when {
-        vectorFeatures.isOnboardingCombinedRegisterEnabled() -> missingStages.sortedWith(FtueMissingRegistrationStagesComparator())
-        else                                                 -> missingStages
     }
 
     private fun openStartCombinedRegister() {


### PR DESCRIPTION
## Type of change

- [x] WIP Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes #5783  (First iteration #5785)

Only overrides the order of the sign up flow if the selected server is `matrix.org`

## Motivation and context

Ultimately we want the homeserver to control the sign up flow however until this capability easily exists, we'll override only matrix.org's order from the client side and gather feedback. 

## Screenshots / GIFs

|Before|After|
|-|-|
|![after-sign-up-override](https://user-images.githubusercontent.com/1848238/168583449-f9bfe991-66e1-4d17-85d2-185105c0e3c3.gif)|![after-sign-up-order-3rd-p](https://user-images.githubusercontent.com/1848238/168583465-e87a8a2b-b7b5-4223-9951-dad3ed184387.gif)|

## Tests

- Create a new account of matrix.org
- Notice email is asked first
- Create an account on another server which has mandatory email (eg 0wnz.at)
- Notice recpatcha is asked first

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28