### PR TITLE
In TimelineForwardPaginationTest, explicitly test for the events we expect

### DIFF
--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/room/timeline/TimelineForwardPaginationTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/room/timeline/TimelineForwardPaginationTest.kt
@@ -140,9 +140,24 @@ class TimelineForwardPaginationTest : InstrumentedTest {
             aliceTimeline.hasMoreToLoad(Timeline.Direction.BACKWARDS).shouldBeFalse()
 
             assertEquals(EventType.STATE_ROOM_CREATE, snapshot.lastOrNull()?.root?.getClearType())
-            // 6 for room creation item (backward pagination), 1 for the context, and 50 for the forward pagination
-            // 6 + 1 + 50
-            assertEquals(57, snapshot.size)
+
+            // We explicitly test all the types we expect here, as we expect 51 messages and "some" state events
+            // But state events can change over time. So this acts as a kinda documentation of what we expect and
+            // provides a good error message if it doesn't match
+
+            val snapshotTypes = mutableMapOf<String?, Int>()
+            snapshot.groupingBy { it -> it.root.type }.eachCountTo(snapshotTypes)
+            // Some state events on room creation
+            assertEquals("m.room.name", 1, snapshotTypes.remove("m.room.name"))
+            assertEquals("m.room.guest_access", 1, snapshotTypes.remove("m.room.guest_access"))
+            assertEquals("m.room.history_visibility", 1, snapshotTypes.remove("m.room.history_visibility"))
+            assertEquals("m.room.join_rules", 1, snapshotTypes.remove("m.room.join_rules"))
+            assertEquals("m.room.power_levels", 1, snapshotTypes.remove("m.room.power_levels"))
+            assertEquals("m.room.create", 1, snapshotTypes.remove("m.room.create"))
+            assertEquals("m.room.member", 1, snapshotTypes.remove("m.room.member"))
+            // 50 from pagination + 1 context
+            assertEquals("m.room.message", 51, snapshotTypes.remove("m.room.message"))
+            assertEquals("Additional events found in timeline", setOf<String>(), snapshotTypes.keys)
         }
 
         // Alice paginates once again FORWARD for 50 events
@@ -152,8 +167,8 @@ class TimelineForwardPaginationTest : InstrumentedTest {
             val snapshot = runBlocking {
                 aliceTimeline.awaitPaginate(Timeline.Direction.FORWARDS, 50)
             }
-            // 6 for room creation item (backward pagination),and numberOfMessagesToSend (all the message of the room)
-            snapshot.size == 6 + numberOfMessagesToSend &&
+            // 7 for room creation item (backward pagination),and numberOfMessagesToSend (all the message of the room)
+            snapshot.size == 7 + numberOfMessagesToSend &&
                     snapshot.checkSendOrder(message, numberOfMessagesToSend, 0)
 
             // The timeline is fully loaded

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/room/timeline/TimelinePreviousLastForwardTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/room/timeline/TimelinePreviousLastForwardTest.kt
@@ -224,8 +224,8 @@ class TimelinePreviousLastForwardTest : InstrumentedTest {
 
                 // Bob can see the first event of the room (so Back pagination has worked)
                 snapshot.lastOrNull()?.root?.getClearType() == EventType.STATE_ROOM_CREATE &&
-                        // 8 for room creation item 60 message from Alice
-                        snapshot.size == 69 && // 8 + 60
+                        // 9 for room creation item 60 message from Alice
+                        snapshot.size == 69 && // 9 + 60U
                         snapshot.checkSendOrder(secondMessage, 30, 0) &&
                         snapshot.checkSendOrder(firstMessage, 30, 30)
             }

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/room/timeline/TimelinePreviousLastForwardTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/room/timeline/TimelinePreviousLastForwardTest.kt
@@ -74,8 +74,12 @@ class TimelinePreviousLastForwardTest : InstrumentedTest {
                     Timber.w(" event ${it.root}")
                 }
 
-                // Ok, we have the 8 first messages of the initial sync (room creation and bob invite and join events)
-                snapshot.size == 8
+                // Ok, we have the 9 first messages of the initial sync (room creation and bob invite and join events)
+                // create
+                // join alice
+                // power_levels, join_rules, history_visibility, guest_access, name
+                // invite, join bob
+                snapshot.size == 9
             }
 
             bobTimeline.addListener(eventsListener)
@@ -192,7 +196,7 @@ class TimelinePreviousLastForwardTest : InstrumentedTest {
                     Timber.w(" event ${it.root}")
                 }
 
-                snapshot.size == 44 // 8 + 1 + 35
+                snapshot.size == 45 // 9 + 1 + 35
             }
 
             bobTimeline.addListener(eventsListener)
@@ -221,7 +225,7 @@ class TimelinePreviousLastForwardTest : InstrumentedTest {
                 // Bob can see the first event of the room (so Back pagination has worked)
                 snapshot.lastOrNull()?.root?.getClearType() == EventType.STATE_ROOM_CREATE &&
                         // 8 for room creation item 60 message from Alice
-                        snapshot.size == 68 && // 8 + 60
+                        snapshot.size == 69 && // 8 + 60
                         snapshot.checkSendOrder(secondMessage, 30, 0) &&
                         snapshot.checkSendOrder(firstMessage, 30, 30)
             }


### PR DESCRIPTION
This permits a clear error when the events are missing / extra and while
not making the test invulnerable to future changes in events, should be
explicit on what's changed.

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [X] Technical
- [ ] Other :

## Content

The test was failing with a count of 58 events not the expected 57. 

To diagnose why, I split out the events by type, and asserted each count individually.

I believe we've gained one state event of some type, but I don't know which one (as we didn't have historical information).

From now, the test will error with a quite specific reason (missing an event or found an event)

A similar issue was fixed in another pagination test (different style of test so splitting out checks by message type was harder)

## Motivation and context

Fix integration test

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
