### PR TITLE
Ensure calling 'fail()' is not caught by the Exception handler

### DIFF
--- a/changelog.d/6089.misc
+++ b/changelog.d/6089.misc
@@ -1,0 +1,1 @@
+Test: Ensure calling 'fail()' is not caught by the catch block

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/Util.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/Util.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/Util.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/Util.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk
+
+import junit.framework.TestCase.fail
+
+/**
+ * Will fail the test if invoking [block] is not throwing a Throwable.
+ *
+ * @param message the failure message, if the block does not throw any Throwable
+ * @param failureBlock a Lambda to be able to do extra check on the thrown Throwable
+ * @param block the block to test
+ */
+internal suspend fun mustFail(
+        message: String = "must fail",
+        failureBlock: ((Throwable) -> Unit)? = null,
+        block: suspend () -> Unit,
+) {
+    val isSuccess = try {
+        block.invoke()
+        true
+    } catch (throwable: Throwable) {
+        failureBlock?.invoke(throwable)
+        false
+    }
+
+    if (isSuccess) {
+        fail(message)
+    }
+}

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/E2eeSanityTests.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/E2eeSanityTests.kt
@@ -62,6 +62,7 @@ import org.matrix.android.sdk.common.RetryTestRule
 import org.matrix.android.sdk.common.SessionTestParams
 import org.matrix.android.sdk.common.TestConstants
 import org.matrix.android.sdk.common.TestMatrixCallback
+import org.matrix.android.sdk.mustFail
 import java.util.concurrent.CountDownLatch
 
 @RunWith(JUnit4::class)
@@ -525,10 +526,8 @@ class E2eeSanityTests : InstrumentedTest {
 
         // Confirm we can decrypt one but not the other
         testHelper.runBlockingTest {
-            try {
+            mustFail(message = "Should not be able to decrypt event") {
                 newBobSession.cryptoService().decryptEvent(firstEventNewBobPov.root, "")
-                fail("Should not be able to decrypt event")
-            } catch (_: MXCryptoError) {
             }
         }
 

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/gossiping/KeyShareTests.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/gossiping/KeyShareTests.kt
@@ -21,7 +21,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertTrue
-import junit.framework.TestCase.fail
 import org.amshove.kluent.internal.assertEquals
 import org.junit.Assert
 import org.junit.Assert.assertNull
@@ -47,6 +46,7 @@ import org.matrix.android.sdk.common.CryptoTestHelper
 import org.matrix.android.sdk.common.RetryTestRule
 import org.matrix.android.sdk.common.SessionTestParams
 import org.matrix.android.sdk.common.TestConstants
+import org.matrix.android.sdk.mustFail
 
 @RunWith(AndroidJUnit4::class)
 @FixMethodOrder(MethodSorters.JVM)
@@ -95,12 +95,10 @@ class KeyShareTests : InstrumentedTest {
         assertNotNull(receivedEvent)
         assert(receivedEvent!!.isEncrypted())
 
-        try {
-            commonTestHelper.runBlockingTest {
+        commonTestHelper.runBlockingTest {
+            mustFail {
                 aliceSession2.cryptoService().decryptEvent(receivedEvent.root, "foo")
             }
-            fail("should fail")
-        } catch (failure: Throwable) {
         }
 
         val outgoingRequestsBefore = aliceSession2.cryptoService().getOutgoingRoomKeyRequests()
@@ -168,12 +166,10 @@ class KeyShareTests : InstrumentedTest {
             }
         }
 
-        try {
-            commonTestHelper.runBlockingTest {
+        commonTestHelper.runBlockingTest {
+            mustFail {
                 aliceSession2.cryptoService().decryptEvent(receivedEvent.root, "foo")
             }
-            fail("should fail")
-        } catch (failure: Throwable) {
         }
 
         // Mark the device as trusted


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : test which should fail may not fail

## Content

<!-- Describe shortly what has been changed -->

Ensure tests which should fail are actually failing.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Make test fail if they have to.

A quick local local test confirm that the test was not failing when `fail()` is called in a try block and `Throwable` are caught.

## Screenshots / GIFs

NA

## Tests

<!-- Explain how you tested your development -->

- Run android tests

There are 2 failing tests, not related to this PR: `testUnwedging()` and `trustKeyBackupVersionWithRecoveryKeyTest()`

<img width="571" alt="image" src="https://user-images.githubusercontent.com/3940906/169025131-2006f62c-85dd-4da7-81f8-71a1b13cf27c.png">


## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):
