### PR TITLE
Native lookup fixes

### DIFF
--- a/changelog.d/6101.bugfix
+++ b/changelog.d/6101.bugfix
@@ -1,0 +1,1 @@
+Refactor - better naming, return native user id and not sip user id and create a dm with the native user instead of with the sip user.

--- a/vector/src/main/java/im/vector/app/features/call/dialpad/DialPadLookup.kt
+++ b/vector/src/main/java/im/vector/app/features/call/dialpad/DialPadLookup.kt
@@ -42,18 +42,23 @@ class DialPadLookup @Inject constructor(
         val sipUserId = thirdPartyUser.userId
         val nativeLookupResults = session.sipNativeLookup(thirdPartyUser.userId)
         // If I have a native user I check for an existing native room with him...
-        val roomId = if (nativeLookupResults.isNotEmpty()) {
+        if (nativeLookupResults.isNotEmpty()) {
             val nativeUserId = nativeLookupResults.first().userId
             if (nativeUserId == session.myUserId) {
                 throw Failure.NumberIsYours
             }
-            session.roomService().getExistingDirectRoomWithUser(nativeUserId)
-            // if there is not, just create a DM with the sip user
-                    ?: directRoomHelper.ensureDMExists(sipUserId)
-        } else {
-            // do the same if there is no corresponding native user.
-            directRoomHelper.ensureDMExists(sipUserId)
+            var nativeRoomId = session.getExistingDirectRoomWithUser(nativeUserId)
+            if (nativeRoomId == null) {
+                // if there is no existing native room with the existing native user,
+                // just create a DM with the native user
+                nativeRoomId = directRoomHelper.ensureDMExists(nativeUserId)
+            }
+            Timber.d("lookupPhoneNumber with nativeUserId: $nativeUserId and nativeRoomId: $nativeRoomId")
+            return Result(userId = nativeUserId, roomId = nativeRoomId)
         }
-        return Result(userId = sipUserId, roomId = roomId)
+        // If there is no native user then we return sipUserId and sipRoomId - this is usually a PSTN call.
+        val sipRoomId = directRoomHelper.ensureDMExists(sipUserId)
+        Timber.d("lookupPhoneNumber with sipRoomId: $sipRoomId and sipUserId: $sipUserId")
+        return Result(userId = sipUserId, roomId = sipRoomId)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/call/dialpad/DialPadLookup.kt
+++ b/vector/src/main/java/im/vector/app/features/call/dialpad/DialPadLookup.kt
@@ -23,6 +23,7 @@ import im.vector.app.features.call.webrtc.WebRtcCallManager
 import im.vector.app.features.createdirect.DirectRoomHelper
 import org.matrix.android.sdk.api.session.Session
 import javax.inject.Inject
+import timber.log.Timber
 
 class DialPadLookup @Inject constructor(
         private val session: Session,
@@ -47,7 +48,7 @@ class DialPadLookup @Inject constructor(
             if (nativeUserId == session.myUserId) {
                 throw Failure.NumberIsYours
             }
-            var nativeRoomId = session.getExistingDirectRoomWithUser(nativeUserId)
+            var nativeRoomId = session.roomService().getExistingDirectRoomWithUser(nativeUserId)
             if (nativeRoomId == null) {
                 // if there is no existing native room with the existing native user,
                 // just create a DM with the native user

--- a/vector/src/main/java/im/vector/app/features/call/dialpad/DialPadLookup.kt
+++ b/vector/src/main/java/im/vector/app/features/call/dialpad/DialPadLookup.kt
@@ -22,8 +22,8 @@ import im.vector.app.features.call.vectorCallService
 import im.vector.app.features.call.webrtc.WebRtcCallManager
 import im.vector.app.features.createdirect.DirectRoomHelper
 import org.matrix.android.sdk.api.session.Session
-import javax.inject.Inject
 import timber.log.Timber
+import javax.inject.Inject
 
 class DialPadLookup @Inject constructor(
         private val session: Session,


### PR DESCRIPTION


<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content
refactor - better naming, return native user id and not sip user id and create a dm with the native user instead of with the sip user
<!-- Describe shortly what has been changed -->

## Motivation and context
When dialing an extension which has a native user behind it, a native matrix call happens instead of a matrix sip call because the user id of the sip user was used instead of the native one - so the sip virtual lookup (which comes in this case after the native lookup) failed. Otherwise also creating a native room when one does not exist seems like the right thing to do and the code looks more clear with these names.
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- private setup - you should have access in Aarenet/Element room

## Tested devices

- [X] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [X] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

Signed-off-by: Chagai Friedlander @me:chagai.website
