### PR TITLE
Glide - Use current drawable while loading new static map image

### DIFF
--- a/changelog.d/6103.bugfix
+++ b/changelog.d/6103.bugfix
@@ -1,0 +1,1 @@
+Glide - Use current drawable while loading new static map image

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
@@ -75,6 +75,7 @@ abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder> : AbsMe
         GlideApp.with(holder.staticMapImageView)
                 .load(location)
                 .apply(RequestOptions.centerCropTransform())
+                .placeholder(holder.staticMapImageView.drawable)
                 .listener(object : RequestListener<Drawable> {
                     override fun onLoadFailed(e: GlideException?,
                                               model: Any?,


### PR DESCRIPTION
Interestingly, Glide is clearing current image before the new image is loaded which causes a flicker on timeline item. This PR suggests to use current drawable as placeolder while loading the new static map image.