### PR TITLE
Fix sending multiple invites to a room reaching only one or two people

### DIFF
--- a/changelog.d/6109.bugfix
+++ b/changelog.d/6109.bugfix
@@ -1,0 +1,1 @@
+Fix sending multiple invites to a room reaching only one or two people

--- a/vector/src/main/java/im/vector/app/features/invite/InviteUsersToRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/invite/InviteUsersToRoomViewModel.kt
@@ -28,8 +28,9 @@ import im.vector.app.core.resources.StringProvider
 import im.vector.app.features.userdirectory.PendingSelection
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.onCompletion
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.getRoom
 
@@ -55,39 +56,38 @@ class InviteUsersToRoomViewModel @AssistedInject constructor(
     }
 
     private fun inviteUsersToRoom(selections: Set<PendingSelection>) {
-        viewModelScope.launch {
-            _viewEvents.post(InviteUsersToRoomViewEvents.Loading)
-            selections.asFlow()
-                    .map { user ->
-                        when (user) {
-                            is PendingSelection.UserPendingSelection     -> room.membershipService().invite(user.user.userId, null)
-                            is PendingSelection.ThreePidPendingSelection -> room.membershipService().invite3pid(user.threePid)
-                        }
+        _viewEvents.post(InviteUsersToRoomViewEvents.Loading)
+        selections.asFlow()
+                .map { user ->
+                    when (user) {
+                        is PendingSelection.UserPendingSelection     -> room.membershipService().invite(user.user.userId, null)
+                        is PendingSelection.ThreePidPendingSelection -> room.membershipService().invite3pid(user.threePid)
                     }
-                    .catch { cause ->
-                        _viewEvents.post(InviteUsersToRoomViewEvents.Failure(cause))
+                }.onCompletion { error ->
+                    if (error != null) return@onCompletion
+
+                    val successMessage = when (selections.size) {
+                        1    -> stringProvider.getString(
+                                R.string.invitation_sent_to_one_user,
+                                selections.first().getBestName()
+                        )
+                        2    -> stringProvider.getString(
+                                R.string.invitations_sent_to_two_users,
+                                selections.first().getBestName(),
+                                selections.last().getBestName()
+                        )
+                        else -> stringProvider.getQuantityString(
+                                R.plurals.invitations_sent_to_one_and_more_users,
+                                selections.size - 1,
+                                selections.first().getBestName(),
+                                selections.size - 1
+                        )
                     }
-                    .collect {
-                        val successMessage = when (selections.size) {
-                            1    -> stringProvider.getString(
-                                    R.string.invitation_sent_to_one_user,
-                                    selections.first().getBestName()
-                            )
-                            2    -> stringProvider.getString(
-                                    R.string.invitations_sent_to_two_users,
-                                    selections.first().getBestName(),
-                                    selections.last().getBestName()
-                            )
-                            else -> stringProvider.getQuantityString(
-                                    R.plurals.invitations_sent_to_one_and_more_users,
-                                    selections.size - 1,
-                                    selections.first().getBestName(),
-                                    selections.size - 1
-                            )
-                        }
-                        _viewEvents.post(InviteUsersToRoomViewEvents.Success(successMessage))
-                    }
-        }
+                    _viewEvents.post(InviteUsersToRoomViewEvents.Success(successMessage))
+                }
+                .catch { cause ->
+                    _viewEvents.post(InviteUsersToRoomViewEvents.Failure(cause))
+                }.launchIn(viewModelScope)
     }
 
     fun getUserIdsOfRoomMembers(): Set<String> {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes #6109. Based on the work of @bmarty on #6107.

Prevents early cancelation of the coroutine scope used to send the invites.

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

When inviting several people to a room, only the first couple of users were actually invited. The `InviteUsersToRoomActivity` was being finished ahead of time, cancelling the `viewModelScope` used to send the invite requests, and this prevented the rest of the users from being invited. This was caused by an `onEach` statement being used as `onCompletion`.

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Create a room or open a room where you can invite other users.
- Invite several users, at least 3 or 4.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 12.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
