### PR TITLE
Add feature flag for live location sharing

### DIFF
--- a/vector/src/debug/java/im/vector/app/features/debug/features/DebugFeaturesStateFactory.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/DebugFeaturesStateFactory.kt
@@ -60,6 +60,11 @@ class DebugFeaturesStateFactory @Inject constructor(
                                 key = DebugFeatureKeys.onboardingCombinedRegister,
                                 factory = VectorFeatures::isOnboardingCombinedRegisterEnabled
                         ),
+                        createBooleanFeature(
+                                label = "Live location sharing",
+                                key = DebugFeatureKeys.liveLocationSharing,
+                                factory = VectorFeatures::isLiveLocationEnabled
+                        ),
                 )
         )
     }

--- a/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
@@ -57,6 +57,9 @@ class DebugVectorFeatures(
     override fun isOnboardingCombinedRegisterEnabled(): Boolean = read(DebugFeatureKeys.onboardingCombinedRegister)
             ?: vectorFeatures.isOnboardingCombinedRegisterEnabled()
 
+    override fun isLiveLocationEnabled(): Boolean = read(DebugFeatureKeys.liveLocationSharing)
+            ?: vectorFeatures.isLiveLocationEnabled()
+
     override fun isScreenSharingEnabled(): Boolean = read(DebugFeatureKeys.screenSharing)
             ?: vectorFeatures.isScreenSharingEnabled()
 

--- a/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
+++ b/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
@@ -26,6 +26,7 @@ interface VectorFeatures {
     fun isOnboardingUseCaseEnabled(): Boolean
     fun isOnboardingPersonalizeEnabled(): Boolean
     fun isOnboardingCombinedRegisterEnabled(): Boolean
+    fun isLiveLocationEnabled(): Boolean
     fun isScreenSharingEnabled(): Boolean
 
     enum class OnboardingVariant {
@@ -42,5 +43,6 @@ class DefaultVectorFeatures : VectorFeatures {
     override fun isOnboardingUseCaseEnabled() = true
     override fun isOnboardingPersonalizeEnabled() = false
     override fun isOnboardingCombinedRegisterEnabled() = false
+    override fun isLiveLocationEnabled(): Boolean = false
     override fun isScreenSharingEnabled(): Boolean = true
 }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -27,6 +27,7 @@ import im.vector.app.BuildConfig
 import im.vector.app.R
 import im.vector.app.core.di.DefaultSharedPreferences
 import im.vector.app.core.time.Clock
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.disclaimer.SHARED_PREF_KEY
 import im.vector.app.features.homeserver.ServerUrlsRepository
 import im.vector.app.features.themes.ThemeUtils
@@ -37,6 +38,7 @@ import javax.inject.Inject
 class VectorPreferences @Inject constructor(
         private val context: Context,
         private val clock: Clock,
+        private val vectorFeatures: VectorFeatures,
 ) {
 
     companion object {
@@ -203,7 +205,7 @@ class VectorPreferences @Inject constructor(
         private const val TAKE_PHOTO_VIDEO_MODE = "TAKE_PHOTO_VIDEO_MODE"
 
         private const val SETTINGS_LABS_RENDER_LOCATIONS_IN_TIMELINE = "SETTINGS_LABS_RENDER_LOCATIONS_IN_TIMELINE"
-        private const val SETTINGS_LABS_ENABLE_LIVE_LOCATION = "SETTINGS_LABS_ENABLE_LIVE_LOCATION"
+        const val SETTINGS_LABS_ENABLE_LIVE_LOCATION = "SETTINGS_LABS_ENABLE_LIVE_LOCATION"
 
         // This key will be used to identify clients with the old thread support enabled io.element.thread
         const val SETTINGS_LABS_ENABLE_THREAD_MESSAGES_OLD_CLIENTS = "SETTINGS_LABS_ENABLE_THREAD_MESSAGES"
@@ -1043,7 +1045,7 @@ class VectorPreferences @Inject constructor(
     }
 
     fun labsEnableLiveLocation(): Boolean {
-        return defaultPrefs.getBoolean(SETTINGS_LABS_ENABLE_LIVE_LOCATION, false)
+        return vectorFeatures.isLiveLocationEnabled() && defaultPrefs.getBoolean(SETTINGS_LABS_ENABLE_LIVE_LOCATION, false)
     }
 
     /**

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsLabsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsLabsFragment.kt
@@ -25,6 +25,7 @@ import im.vector.app.R
 import im.vector.app.core.preference.VectorSwitchPreference
 import im.vector.app.features.MainActivity
 import im.vector.app.features.MainActivityArgs
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.analytics.plan.MobileScreen
 import im.vector.app.features.home.room.threads.ThreadsManager
 import org.matrix.android.sdk.api.settings.LightweightSettingsStorage
@@ -33,7 +34,8 @@ import javax.inject.Inject
 class VectorSettingsLabsFragment @Inject constructor(
         private val vectorPreferences: VectorPreferences,
         private val lightweightSettingsStorage: LightweightSettingsStorage,
-        private val threadsManager: ThreadsManager
+        private val threadsManager: ThreadsManager,
+        private val vectorFeatures: VectorFeatures,
 ) : VectorSettingsBaseFragment() {
 
     override var titleRes = R.string.room_settings_labs_pref_title
@@ -57,6 +59,8 @@ class VectorSettingsLabsFragment @Inject constructor(
                 false
             }
         }
+
+        findPreference<VectorSwitchPreference>(VectorPreferences.SETTINGS_LABS_ENABLE_LIVE_LOCATION)?.isVisible = vectorFeatures.isLiveLocationEnabled()
     }
 
     /**


### PR DESCRIPTION
We were in rush to remove the feature flag for live location sharing. We need to keep it until updating the privacy.