### PR TITLE
Prevent widget web view from reloading on screen / orientation change (PSF-1034)

### DIFF
--- a/changelog.d/6140.bugfix
+++ b/changelog.d/6140.bugfix
@@ -1,0 +1,1 @@
+Prevent widget web view from reloading on screen / orientation change

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -306,7 +306,9 @@
             android:supportsPictureInPicture="true" />
 
         <activity android:name=".features.terms.ReviewTermsActivity" />
-        <activity android:name=".features.widgets.WidgetActivity" />
+        <activity android:name=".features.widgets.WidgetActivity"
+            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation" />
+
         <activity android:name=".features.pin.PinActivity" />
         <activity android:name=".features.analytics.ui.consent.AnalyticsOptInActivity" />
         <activity android:name=".features.home.room.detail.search.SearchActivity" />


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

This applies the same `configChange` settings we use on `VectorCallActivity` and `VectorJitsiActivity` to `WidgetActivity` to prevent the widget web view from reloading on device screen or orientation changes.

## Motivation and context

We'll be using the widget system to integrate Element Call into the app. Currently rotating the device causes the widget web view to reload which disconnects the call.

## Tests

- Join #ecwidgettest:matrix.org
- Navigate through into the widget web view running Element Call
- Rotate the device
- The web page shouldn't reload

## Tested devices

- [x] Emulator
- OS version(s): 12

## Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
