### PR TITLE
Downgrade gradle from 7.2.0 to 7.1.3

### DIFF
--- a/changelog.d/6141.misc
+++ b/changelog.d/6141.misc
@@ -1,0 +1,1 @@
+Downgrade gradle from 7.2.0 to 7.1.3

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ ext.versions = [
         'targetCompat'      : JavaVersion.VERSION_11,
 ]
 
-def gradle = "7.2.0"
+def gradle = "7.1.3"
 // Ref: https://kotlinlang.org/releases.html
 def kotlin = "1.6.21"
 def kotlinCoroutines = "1.6.1"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,6 +7,9 @@ ext.versions = [
         'targetCompat'      : JavaVersion.VERSION_11,
 ]
 
+
+// Pinned to 7.1.3 because of https://github.com/vector-im/element-android/issues/6142
+// Please test carefully before upgrading again.
 def gradle = "7.1.3"
 // Ref: https://kotlinlang.org/releases.html
 def kotlin = "1.6.21"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

We downgrade the gradle version to address issues with running jacoco unit test coverage and the realm plugin together.

## Motivation and context

Based on tests; if the realm plugin is enabled then jacoco will not instrument classes, leading to no coverage information for those tests. This affects things in the android instrumented tests.

If we disable realm then the coverage succeeds.

If we downgrade the gradle version then coverage succeeds regardless of the realm status.

This is a big enough actual change that downgrading separately to work on the coverage tests is valid.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
