### PR TITLE
Fix decrypting redacted event

### DIFF
--- a/changelog.d/6148.bugfix
+++ b/changelog.d/6148.bugfix
@@ -1,0 +1,1 @@
+Fix decrypting redacted event from sending errors

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/DecryptRedactedEventTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/DecryptRedactedEventTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright 2022 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/DecryptRedactedEventTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/DecryptRedactedEventTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.crypto
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.amshove.kluent.fail
+import org.junit.FixMethodOrder
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.MethodSorters
+import org.matrix.android.sdk.InstrumentedTest
+import org.matrix.android.sdk.api.session.getRoom
+import org.matrix.android.sdk.api.session.room.getTimelineEvent
+import org.matrix.android.sdk.common.CommonTestHelper
+import org.matrix.android.sdk.common.CryptoTestHelper
+
+@RunWith(AndroidJUnit4::class)
+@FixMethodOrder(MethodSorters.JVM)
+class DecryptRedactedEventTest : InstrumentedTest {
+
+    @Test
+    fun doNotFailToDecryptRedactedEvent() {
+        val testHelper = CommonTestHelper(context())
+        val cryptoTestHelper = CryptoTestHelper(testHelper)
+
+        val testData = cryptoTestHelper.doE2ETestWithAliceAndBobInARoom(true)
+        val e2eRoomID = testData.roomId
+        val aliceSession = testData.firstSession
+        val bobSession = testData.secondSession!!
+
+        val roomALicePOV = aliceSession.getRoom(e2eRoomID)!!
+        val timelineEvent = testHelper.sendTextMessage(roomALicePOV, "Hello", 1).first()
+        roomALicePOV.sendService().redactEvent(timelineEvent.root, "Wrong Room")
+
+        // get the event from bob
+        testHelper.waitWithLatch {
+            testHelper.retryPeriodicallyWithLatch(it) {
+                bobSession.getRoom(e2eRoomID)?.getTimelineEvent(timelineEvent.eventId)?.root?.isRedacted() == true
+            }
+        }
+
+        val eventBobPov = bobSession.getRoom(e2eRoomID)?.getTimelineEvent(timelineEvent.eventId)!!
+
+        testHelper.runBlockingTest {
+            try {
+                bobSession.cryptoService().decryptEvent(eventBobPov.root, "")
+            } catch (failure: Throwable) {
+                fail("Should not throw when decrypting a redacted event")
+            }
+        }
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/EventDecryptor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/EventDecryptor.kt
@@ -29,6 +29,7 @@ import org.matrix.android.sdk.api.session.crypto.model.MXUsersDevicesMap
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.content.OlmEventContent
+import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.internal.crypto.actions.EnsureOlmSessionsForDevicesAction
 import org.matrix.android.sdk.internal.crypto.actions.MessageEncrypter
@@ -42,7 +43,7 @@ import javax.inject.Inject
 
 private const val SEND_TO_DEVICE_RETRY_COUNT = 3
 
-private val loggerTag = LoggerTag("CryptoSyncHandler", LoggerTag.CRYPTO)
+private val loggerTag = LoggerTag("EventDecryptor", LoggerTag.CRYPTO)
 
 @SessionScope
 internal class EventDecryptor @Inject constructor(
@@ -110,6 +111,16 @@ internal class EventDecryptor @Inject constructor(
         if (eventContent == null) {
             Timber.tag(loggerTag.value).e("decryptEvent : empty event content")
             throw MXCryptoError.Base(MXCryptoError.ErrorType.BAD_ENCRYPTED_MESSAGE, MXCryptoError.BAD_ENCRYPTED_MESSAGE_REASON)
+        } else if (event.isRedacted()) {
+            // we shouldn't attempt to decrypt a redacted event because the content is cleared and decryption will fail because of null algorithm
+            return MXEventDecryptionResult(
+                    clearEvent = mapOf(
+                            "room_id"  to event.roomId.orEmpty(),
+                            "type" to EventType.MESSAGE,
+                            "content" to emptyMap<String, Any>(),
+                            "unsigned" to event.unsignedData.toContent()
+                    )
+            )
         } else {
             val algorithm = eventContent["algorithm"]?.toString()
             val alg = roomDecryptorProvider.getOrCreateRoomDecryptor(event.roomId, algorithm)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/EventDecryptor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/EventDecryptor.kt
@@ -115,7 +115,7 @@ internal class EventDecryptor @Inject constructor(
             // we shouldn't attempt to decrypt a redacted event because the content is cleared and decryption will fail because of null algorithm
             return MXEventDecryptionResult(
                     clearEvent = mapOf(
-                            "room_id"  to event.roomId.orEmpty(),
+                            "room_id" to event.roomId.orEmpty(),
                             "type" to EventType.MESSAGE,
                             "content" to emptyMap<String, Any>(),
                             "unsigned" to event.unsignedData.toContent()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Bugfix
## Content

The SDK was throwing decryption errors (null algorithm) when trying to decrypt a redacted event.
This was not really visible to the user but it could trigger auto rageshakes (if on in settings), and report decryption failure to posthig

Change is as per js-sdk https://github.com/matrix-org/matrix-js-sdk/blob/ad030bfc1f919fecd80e249fc69769ce58bf9201/src/crypto/index.ts#L2873

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|<img width="428" alt="image" src="https://user-images.githubusercontent.com/9841565/170245337-e42fc68b-72bd-4a5d-8931-c265cc7945ed.png">|<img width="434" alt="image" src="https://user-images.githubusercontent.com/9841565/170245232-4c771a36-4b93-4c2e-9b9b-0a5799c28b86.png">|



## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
