### PR TITLE
Make widget web view request system permissions for camera and microphone

### DIFF
--- a/vector/src/main/java/im/vector/app/features/webview/WebChromeEventListener.kt
+++ b/vector/src/main/java/im/vector/app/features/webview/WebChromeEventListener.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.webview
+
+import android.webkit.PermissionRequest
+
+interface WebChromeEventListener {
+
+    /**
+     * Triggered when the web view requests permissions.
+     *
+     * @param request The permission request.
+     */
+    fun onPermissionRequest(request: PermissionRequest) {
+        // NO-OP
+    }
+
+}

--- a/vector/src/main/java/im/vector/app/features/widgets/webview/WidgetWebView.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/webview/WidgetWebView.kt
@@ -25,10 +25,11 @@ import android.webkit.WebView
 import im.vector.app.R
 import im.vector.app.features.themes.ThemeUtils
 import im.vector.app.features.webview.VectorWebViewClient
+import im.vector.app.features.webview.WebChromeEventListener
 import im.vector.app.features.webview.WebViewEventListener
 
 @SuppressLint("NewApi")
-fun WebView.setupForWidget(webViewEventListener: WebViewEventListener) {
+fun WebView.setupForWidget(webViewEventListener: WebViewEventListener, webChromeEventListener: WebChromeEventListener) {
     // xml value seems ignored
     setBackgroundColor(ThemeUtils.getColor(context, R.attr.colorSurface))
 
@@ -59,7 +60,7 @@ fun WebView.setupForWidget(webViewEventListener: WebViewEventListener) {
     // Permission requests
     webChromeClient = object : WebChromeClient() {
         override fun onPermissionRequest(request: PermissionRequest) {
-            WebviewPermissionUtils.promptForPermissions(R.string.room_widget_resource_permission_title, request, context)
+            webChromeEventListener.onPermissionRequest(request)
         }
     }
     webViewClient = VectorWebViewClient(webViewEventListener)


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Previously the widget web view prompted to grant the widget permissions but it didn't actually request those permissions from the system. So if the web view requested, e.g. the camera permission but the app hadn't previously been granted that permission, the web view wouldn't get camera access even when the widget permission request had been confirmed.

With this change, the app will also request camera and microphone permissions from the system when needed.

## Motivation and context

The concrete use case that led to this change is running Element Call in a widget web view after a fresh app install (where no system permissions have been granted before and so the widget would never actually get camera or microphone access).

## Screenshots / GIFs

Before this change, only the widget permission dialog was displayed:

![Screenshot_20220525_123021](https://user-images.githubusercontent.com/1137962/170245252-677fe946-3f91-48ab-addd-80d692e77245.png)

After this change, once the widget permission dialog is confirmed, the actual system permission dialogs appear (unless permission has already been granted before):

![Screenshot_20220525_123041](https://user-images.githubusercontent.com/1137962/170245259-5a0e49ad-2f7f-436a-b208-7d6844535f1d.png)
![Screenshot_20220525_123051](https://user-images.githubusercontent.com/1137962/170245283-b2e2945e-2e23-4e18-8d4a-ca8976f4a0c2.png)

## Tests

- Perform a clean app install or reset the app's camera & microphone permissions
- Join #ecwidgettest:matrix.org
- Tap through into Element Call in the widget web view
- Confirm the widget permission dialog
- Notice the new system permission dialogs

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 12

## Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
