### PR TITLE
[FTUE] MSISDN / Phone number confirmation

### DIFF
--- a/vector/src/main/java/im/vector/app/core/di/FragmentModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/FragmentModule.kt
@@ -110,6 +110,7 @@ import im.vector.app.features.onboarding.ftueauth.FtueAuthLegacyStyleCaptchaFrag
 import im.vector.app.features.onboarding.ftueauth.FtueAuthLegacyWaitForEmailFragment
 import im.vector.app.features.onboarding.ftueauth.FtueAuthLoginFragment
 import im.vector.app.features.onboarding.ftueauth.FtueAuthPersonalizationCompleteFragment
+import im.vector.app.features.onboarding.ftueauth.FtueAuthPhoneConfirmationFragment
 import im.vector.app.features.onboarding.ftueauth.FtueAuthPhoneEntryFragment
 import im.vector.app.features.onboarding.ftueauth.FtueAuthResetPasswordFragment
 import im.vector.app.features.onboarding.ftueauth.FtueAuthResetPasswordMailConfirmationFragment
@@ -514,6 +515,11 @@ interface FragmentModule {
     @IntoMap
     @FragmentKey(FtueAuthPhoneEntryFragment::class)
     fun bindFtueAuthPhoneEntryFragment(fragment: FtueAuthPhoneEntryFragment): Fragment
+
+    @Binds
+    @IntoMap
+    @FragmentKey(FtueAuthPhoneConfirmationFragment::class)
+    fun bindFtueAuthPhoneConfirmationFragment(fragment: FtueAuthPhoneConfirmationFragment): Fragment
 
     @Binds
     @IntoMap

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPhoneConfirmationFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPhoneConfirmationFragment.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.onboarding.ftueauth
+
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
+import im.vector.app.R
+import im.vector.app.core.extensions.associateContentStateWith
+import im.vector.app.core.extensions.autofillPhoneNumber
+import im.vector.app.core.extensions.content
+import im.vector.app.core.extensions.editText
+import im.vector.app.core.extensions.setOnImeDoneListener
+import im.vector.app.databinding.FragmentFtuePhoneConfirmationBinding
+import im.vector.app.features.onboarding.OnboardingAction
+import im.vector.app.features.onboarding.RegisterAction
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.parcelize.Parcelize
+import org.matrix.android.sdk.api.auth.registration.RegisterThreePid
+import reactivecircus.flowbinding.android.widget.textChanges
+import javax.inject.Inject
+
+@Parcelize
+data class FtueAuthPhoneConfirmationFragmentArgument(
+        val msisdn: String
+) : Parcelable
+
+class FtueAuthPhoneConfirmationFragment @Inject constructor(
+        private val phoneNumberParser: PhoneNumberParser
+) : AbstractFtueAuthFragment<FragmentFtuePhoneConfirmationBinding>() {
+
+    override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentFtuePhoneConfirmationBinding {
+        return FragmentFtuePhoneConfirmationBinding.inflate(inflater, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupViews()
+    }
+
+    private fun setupViews() {
+        views.phoneEntryInput.associateContentStateWith(button = views.phoneEntrySubmit)
+        views.phoneEntryInput.setOnImeDoneListener { updatePhoneNumber() }
+        views.phoneEntrySubmit.debouncedClicks { updatePhoneNumber() }
+
+        views.phoneEntryInput.editText().textChanges()
+                .onEach {
+                    views.phoneEntryInput.error = null
+                    views.phoneEntrySubmit.isEnabled = it.isNotBlank()
+                }
+                .launchIn(viewLifecycleOwner.lifecycleScope)
+
+        views.phoneEntryInput.autofillPhoneNumber()
+    }
+
+    private fun updatePhoneNumber() {
+        val number = views.phoneEntryInput.content()
+
+        when (val result = phoneNumberParser.parseInternationalNumber(number)) {
+            PhoneNumberParser.Result.ErrorInvalidNumber            -> views.phoneEntryInput.error = getString(R.string.login_msisdn_error_other)
+            PhoneNumberParser.Result.ErrorMissingInternationalCode -> views.phoneEntryInput.error = getString(R.string.login_msisdn_error_not_international)
+            is PhoneNumberParser.Result.Success                    -> {
+                val (countryCode, phoneNumber) = result
+                viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.AddThreePid(RegisterThreePid.Msisdn(phoneNumber, countryCode))))
+            }
+        }
+    }
+
+    override fun onError(throwable: Throwable) {
+        views.phoneEntryInput.error = errorFormatter.toHumanReadable(throwable)
+    }
+
+    override fun resetViewModel() {
+        viewModel.handle(OnboardingAction.ResetAuthenticationAttempt)
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPhoneConfirmationFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPhoneConfirmationFragment.kt
@@ -67,10 +67,10 @@ class FtueAuthPhoneConfirmationFragment @Inject constructor() : AbstractFtueAuth
     }
 
     override fun onError(throwable: Throwable) {
-        when (throwable) {
+        views.phoneConfirmationInput.error = when (throwable) {
             // The entered code is not correct
-            is Failure.SuccessError -> views.phoneConfirmationInput.error = getString(R.string.login_validation_code_is_not_correct)
-            else -> views.phoneConfirmationInput.error = errorFormatter.toHumanReadable(throwable)
+            is Failure.SuccessError -> getString(R.string.login_validation_code_is_not_correct)
+            else -> errorFormatter.toHumanReadable(throwable)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPhoneConfirmationFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPhoneConfirmationFragment.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.lifecycleScope
 import com.airbnb.mvrx.args
 import im.vector.app.R
 import im.vector.app.core.extensions.associateContentStateWith
+import im.vector.app.core.extensions.clearErrorOnChange
 import im.vector.app.core.extensions.content
 import im.vector.app.core.extensions.editText
 import im.vector.app.core.extensions.setOnImeDoneListener
@@ -60,15 +61,8 @@ class FtueAuthPhoneConfirmationFragment @Inject constructor() : AbstractFtueAuth
         views.phoneConfirmationHeaderSubtitle.text = getString(R.string.ftue_auth_phone_confirmation_subtitle, params.msisdn)
         views.phoneConfirmationInput.associateContentStateWith(button = views.phoneConfirmationSubmit)
         views.phoneConfirmationInput.setOnImeDoneListener { submitConfirmationCode() }
+        views.phoneConfirmationInput.clearErrorOnChange(viewLifecycleOwner)
         views.phoneConfirmationSubmit.debouncedClicks { submitConfirmationCode() }
-
-        views.phoneConfirmationInput.editText().textChanges()
-                .onEach {
-                    views.phoneConfirmationInput.error = null
-                    views.phoneConfirmationSubmit.isEnabled = it.isNotBlank()
-                }
-                .launchIn(viewLifecycleOwner.lifecycleScope)
-
         views.phoneConfirmationResend.debouncedClicks { viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.SendAgainThreePid)) }
     }
 
@@ -81,7 +75,7 @@ class FtueAuthPhoneConfirmationFragment @Inject constructor() : AbstractFtueAuth
         when (throwable) {
             // The entered code is not correct
             is Failure.SuccessError -> views.phoneConfirmationInput.error = getString(R.string.login_validation_code_is_not_correct)
-            else                    -> views.phoneConfirmationInput.error = errorFormatter.toHumanReadable(throwable)
+            else -> views.phoneConfirmationInput.error = errorFormatter.toHumanReadable(throwable)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPhoneConfirmationFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPhoneConfirmationFragment.kt
@@ -21,22 +21,17 @@ import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.lifecycle.lifecycleScope
 import com.airbnb.mvrx.args
 import im.vector.app.R
 import im.vector.app.core.extensions.associateContentStateWith
 import im.vector.app.core.extensions.clearErrorOnChange
 import im.vector.app.core.extensions.content
-import im.vector.app.core.extensions.editText
 import im.vector.app.core.extensions.setOnImeDoneListener
 import im.vector.app.databinding.FragmentFtuePhoneConfirmationBinding
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.RegisterAction
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.parcelize.Parcelize
 import org.matrix.android.sdk.api.failure.Failure
-import reactivecircus.flowbinding.android.widget.textChanges
 import javax.inject.Inject
 
 @Parcelize

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -199,12 +199,7 @@ class FtueAuthVariant(
                 openWaitForEmailVerification(viewEvents.email)
             }
             is OnboardingViewEvents.OnSendMsisdnSuccess -> {
-                // Pop the enter Msisdn Fragment
-                supportFragmentManager.popBackStack(FRAGMENT_REGISTRATION_STAGE_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE)
-                addRegistrationStageFragmentToBackstack(
-                        FtueAuthGenericTextInputFormFragment::class.java,
-                        FtueAuthGenericTextInputFormFragmentArgument(TextInputFormFragmentMode.ConfirmMsisdn, true, viewEvents.msisdn),
-                )
+                openMsisdnConfirmation(viewEvents.msisdn)
             }
             is OnboardingViewEvents.Failure,
             is OnboardingViewEvents.Loading ->
@@ -428,6 +423,20 @@ class FtueAuthVariant(
             else -> addRegistrationStageFragmentToBackstack(
                     FtueAuthLegacyWaitForEmailFragment::class.java,
                     FtueAuthWaitForEmailFragmentArgument(email),
+            )
+        }
+    }
+
+    private fun openMsisdnConfirmation(msisdn: String) {
+        supportFragmentManager.popBackStack(FRAGMENT_REGISTRATION_STAGE_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        when {
+            vectorFeatures.isOnboardingCombinedRegisterEnabled() -> addRegistrationStageFragmentToBackstack(
+                    FtueAuthPhoneConfirmationFragment::class.java,
+                    FtueAuthPhoneConfirmationFragmentArgument(msisdn),
+            )
+            else -> addRegistrationStageFragmentToBackstack(
+                    FtueAuthGenericTextInputFormFragment::class.java,
+                    FtueAuthGenericTextInputFormFragmentArgument(TextInputFormFragmentMode.ConfirmMsisdn, true, msisdn),
             )
         }
     }

--- a/vector/src/main/res/layout/fragment_ftue_phone_confirmation.xml
+++ b/vector/src/main/res/layout/fragment_ftue_phone_confirmation.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     style="@style/LoginFormScrollView"
     android:layout_height="match_parent"
     android:background="?android:colorBackground"
@@ -13,14 +14,14 @@
         android:layout_height="wrap_content">
 
         <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/phoneEntryGutterStart"
+            android:id="@+id/phoneConfirmationGutterStart"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:orientation="vertical"
             app:layout_constraintGuide_percent="@dimen/ftue_auth_gutter_start_percent" />
 
         <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/phoneEntryGutterEnd"
+            android:id="@+id/phoneConfirmationGutterEnd"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:orientation="vertical"
@@ -30,11 +31,13 @@
             android:id="@+id/headerSpacing"
             android:layout_width="match_parent"
             android:layout_height="52dp"
-            app:layout_constraintBottom_toTopOf="@id/phoneEntryHeaderIcon"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintBottom_toTopOf="@id/phoneConfirmationHeaderIcon"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0"
+            app:layout_constraintVertical_chainStyle="packed" />
 
         <ImageView
-            android:id="@+id/phoneEntryHeaderIcon"
+            android:id="@+id/phoneConfirmationHeaderIcon"
             android:layout_width="wrap_content"
             android:layout_height="0dp"
             android:adjustViewBounds="true"
@@ -42,57 +45,58 @@
             android:backgroundTint="?colorSecondary"
             android:contentDescription="@null"
             android:src="@drawable/ic_ftue_phone"
-            app:layout_constraintBottom_toTopOf="@id/phoneEntryHeaderTitle"
-            app:layout_constraintEnd_toEndOf="@id/phoneEntryGutterEnd"
+            app:layout_constraintBottom_toTopOf="@id/phoneConfirmationHeaderTitle"
+            app:layout_constraintEnd_toEndOf="@id/phoneConfirmationGutterEnd"
             app:layout_constraintHeight_percent="0.12"
-            app:layout_constraintStart_toStartOf="@id/phoneEntryGutterStart"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="@id/phoneConfirmationGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/headerSpacing"
             app:tint="@color/palette_white" />
 
         <TextView
-            android:id="@+id/phoneEntryHeaderTitle"
+            android:id="@+id/phoneConfirmationHeaderTitle"
             style="@style/Widget.Vector.TextView.Title.Medium"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:gravity="center"
-            android:text="@string/ftue_auth_phone_title"
+            android:text="@string/ftue_auth_phone_confirmation_title"
             android:textColor="?vctr_content_primary"
-            app:layout_constraintBottom_toTopOf="@id/phoneEntryHeaderSubtitle"
-            app:layout_constraintEnd_toEndOf="@id/phoneEntryGutterEnd"
-            app:layout_constraintStart_toStartOf="@id/phoneEntryGutterStart"
-            app:layout_constraintTop_toBottomOf="@id/phoneEntryHeaderIcon" />
+            app:layout_constraintBottom_toTopOf="@id/phoneConfirmationHeaderSubtitle"
+            app:layout_constraintEnd_toEndOf="@id/phoneConfirmationGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/phoneConfirmationGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/phoneConfirmationHeaderIcon" />
 
         <TextView
-            android:id="@+id/phoneEntryHeaderSubtitle"
+            android:id="@+id/phoneConfirmationHeaderSubtitle"
             style="@style/Widget.Vector.TextView.Subtitle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:gravity="center"
-            android:text="@string/ftue_auth_phone_subtitle"
             android:textColor="?vctr_content_secondary"
             app:layout_constraintBottom_toTopOf="@id/titleContentSpacing"
-            app:layout_constraintEnd_toEndOf="@id/phoneEntryGutterEnd"
-            app:layout_constraintStart_toStartOf="@id/phoneEntryGutterStart"
-            app:layout_constraintTop_toBottomOf="@id/phoneEntryHeaderTitle" />
+            app:layout_constraintEnd_toEndOf="@id/phoneConfirmationGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/phoneConfirmationGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/phoneConfirmationHeaderTitle"
+            tools:text="@string/ftue_auth_phone_confirmation_subtitle" />
 
         <Space
             android:id="@+id/titleContentSpacing"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toTopOf="@id/phoneEntryInput"
+            app:layout_constraintBottom_toTopOf="@id/phoneConfirmationInput"
             app:layout_constraintHeight_percent="0.03"
-            app:layout_constraintTop_toBottomOf="@id/phoneEntryHeaderSubtitle" />
+            app:layout_constraintTop_toBottomOf="@id/phoneConfirmationHeaderSubtitle" />
 
         <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/phoneEntryInput"
+            android:id="@+id/phoneConfirmationInput"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:hint="@string/ftue_auth_phone_entry_title"
             app:endIconMode="clear_text"
-            app:layout_constraintEnd_toEndOf="@id/phoneEntryGutterEnd"
-            app:layout_constraintStart_toStartOf="@id/phoneEntryGutterStart"
+            app:layout_constraintBottom_toTopOf="@id/phoneConfirmationResend"
+            app:layout_constraintEnd_toEndOf="@id/phoneConfirmationGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/phoneConfirmationGutterStart"
             app:layout_constraintTop_toBottomOf="@id/titleContentSpacing">
 
             <com.google.android.material.textfield.TextInputEditText
@@ -104,26 +108,41 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
+        <Button
+            android:id="@+id/phoneConfirmationResend"
+            style="@style/Widget.Vector.Button.Text.Login"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/element_background_light"
+            android:text="@string/ftue_auth_phone_confirmation_resend_code"
+            android:textAllCaps="true"
+            android:textColor="?colorSecondary"
+            app:layout_constraintBottom_toTopOf="@id/entrySpacing"
+            app:layout_constraintEnd_toEndOf="@id/phoneConfirmationGutterEnd"
+            app:layout_constraintHorizontal_bias="1"
+            app:layout_constraintStart_toStartOf="@id/phoneConfirmationGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/phoneConfirmationInput" />
+
         <Space
             android:id="@+id/entrySpacing"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toTopOf="@id/phoneEntrySubmit"
+            app:layout_constraintBottom_toTopOf="@id/phoneConfirmationSubmit"
             app:layout_constraintHeight_percent="0.03"
-            app:layout_constraintTop_toBottomOf="@id/phoneEntryInput"
+            app:layout_constraintTop_toBottomOf="@id/phoneConfirmationResend"
             app:layout_constraintVertical_bias="0"
             app:layout_constraintVertical_chainStyle="packed" />
 
         <Button
-            android:id="@+id/phoneEntrySubmit"
+            android:id="@+id/phoneConfirmationSubmit"
             style="@style/Widget.Vector.Button.Login"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/login_set_email_submit"
             android:textAllCaps="true"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@id/phoneEntryGutterEnd"
-            app:layout_constraintStart_toStartOf="@id/phoneEntryGutterStart"
+            app:layout_constraintEnd_toEndOf="@id/phoneConfirmationGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/phoneConfirmationGutterStart"
             app:layout_constraintTop_toBottomOf="@id/entrySpacing" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/main/res/layout/fragment_ftue_phone_confirmation.xml
+++ b/vector/src/main/res/layout/fragment_ftue_phone_confirmation.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/LoginFormScrollView"
+    android:layout_height="match_parent"
+    android:background="?android:colorBackground"
+    android:fillViewport="true"
+    android:paddingTop="0dp"
+    android:paddingBottom="0dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/phoneEntryGutterStart"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="@dimen/ftue_auth_gutter_start_percent" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/phoneEntryGutterEnd"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="@dimen/ftue_auth_gutter_end_percent" />
+
+        <Space
+            android:id="@+id/headerSpacing"
+            android:layout_width="match_parent"
+            android:layout_height="52dp"
+            app:layout_constraintBottom_toTopOf="@id/phoneEntryHeaderIcon"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/phoneEntryHeaderIcon"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:adjustViewBounds="true"
+            android:background="@drawable/circle"
+            android:backgroundTint="?colorSecondary"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_ftue_phone"
+            app:layout_constraintBottom_toTopOf="@id/phoneEntryHeaderTitle"
+            app:layout_constraintEnd_toEndOf="@id/phoneEntryGutterEnd"
+            app:layout_constraintHeight_percent="0.12"
+            app:layout_constraintStart_toStartOf="@id/phoneEntryGutterStart"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="@color/palette_white" />
+
+        <TextView
+            android:id="@+id/phoneEntryHeaderTitle"
+            style="@style/Widget.Vector.TextView.Title.Medium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:gravity="center"
+            android:text="@string/ftue_auth_phone_title"
+            android:textColor="?vctr_content_primary"
+            app:layout_constraintBottom_toTopOf="@id/phoneEntryHeaderSubtitle"
+            app:layout_constraintEnd_toEndOf="@id/phoneEntryGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/phoneEntryGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/phoneEntryHeaderIcon" />
+
+        <TextView
+            android:id="@+id/phoneEntryHeaderSubtitle"
+            style="@style/Widget.Vector.TextView.Subtitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:text="@string/ftue_auth_phone_subtitle"
+            android:textColor="?vctr_content_secondary"
+            app:layout_constraintBottom_toTopOf="@id/titleContentSpacing"
+            app:layout_constraintEnd_toEndOf="@id/phoneEntryGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/phoneEntryGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/phoneEntryHeaderTitle" />
+
+        <Space
+            android:id="@+id/titleContentSpacing"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/phoneEntryInput"
+            app:layout_constraintHeight_percent="0.03"
+            app:layout_constraintTop_toBottomOf="@id/phoneEntryHeaderSubtitle" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/phoneEntryInput"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:hint="@string/ftue_auth_phone_entry_title"
+            app:endIconMode="clear_text"
+            app:layout_constraintEnd_toEndOf="@id/phoneEntryGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/phoneEntryGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/titleContentSpacing">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:imeOptions="actionDone"
+                android:inputType="phone"
+                android:maxLines="1" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Space
+            android:id="@+id/entrySpacing"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/phoneEntrySubmit"
+            app:layout_constraintHeight_percent="0.03"
+            app:layout_constraintTop_toBottomOf="@id/phoneEntryInput"
+            app:layout_constraintVertical_bias="0"
+            app:layout_constraintVertical_chainStyle="packed" />
+
+        <Button
+            android:id="@+id/phoneEntrySubmit"
+            style="@style/Widget.Vector.Button.Login"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/login_set_email_submit"
+            android:textAllCaps="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/phoneEntryGutterEnd"
+            app:layout_constraintStart_toStartOf="@id/phoneEntryGutterStart"
+            app:layout_constraintTop_toBottomOf="@id/entrySpacing" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/vector/src/main/res/layout/fragment_ftue_phone_confirmation.xml
+++ b/vector/src/main/res/layout/fragment_ftue_phone_confirmation.xml
@@ -92,7 +92,7 @@
             android:id="@+id/phoneConfirmationInput"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:hint="@string/ftue_auth_phone_entry_title"
+            android:hint="@string/ftue_auth_phone_confirmation_entry_title"
             app:endIconMode="clear_text"
             app:layout_constraintBottom_toTopOf="@id/phoneConfirmationResend"
             app:layout_constraintEnd_toEndOf="@id/phoneConfirmationGutterEnd"

--- a/vector/src/main/res/values/donottranslate.xml
+++ b/vector/src/main/res/values/donottranslate.xml
@@ -48,6 +48,11 @@
     <string name="ftue_auth_reset_password">Reset password</string>
     <string name="ftue_auth_sign_out_all_devices">Sign out all devices</string>
 
+    <string name="ftue_auth_phone_confirmation_title">Confirm your phone number</string>
+    <!-- Note for translators, %s is the users international phone number -->
+    <string name="ftue_auth_phone_confirmation_subtitle">We just sent a code to %s. Enter it below to verify it\'s you.</string>
+    <string name="ftue_auth_phone_confirmation_resend_code">Resend code</string>
+
     <string name="ftue_auth_email_verification_title">Check your email to verify.</string>
     <!-- Note for translators, %s is the users email address -->
     <string name="ftue_auth_email_verification_subtitle">To confirm your email address, tap the button in the email we just sent to %s</string>

--- a/vector/src/main/res/values/donottranslate.xml
+++ b/vector/src/main/res/values/donottranslate.xml
@@ -39,6 +39,7 @@
     <string name="ftue_auth_phone_title">Enter your phone number</string>
     <string name="ftue_auth_phone_subtitle">This will help verify your account and enables password recovery.</string>
     <string name="ftue_auth_phone_entry_title">Phone Number</string>
+    <string name="ftue_auth_phone_confirmation_entry_title">Confirmation code</string>
 
     <string name="ftue_auth_reset_password_email_subtitle">We will send you a verification link.</string>
     <string name="ftue_auth_reset_password_breaker_title">Check your email.</string>


### PR DESCRIPTION
## Type of change

- [x] WIP Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

The second part to #6108 -  MSISDN registration step #6043
To update the phone number entry confirmation screen to match the FTUE designs.

## Screenshots / GIFs

*using a temporary number

| CONFIRMATION | GIF |
| --- | --- |
![Screenshot_20220525_155302](https://user-images.githubusercontent.com/1848238/170292274-c164a2dd-6686-4a07-8326-5a90245d9832.png)|![confirmation-e2e](https://user-images.githubusercontent.com/1848238/170291958-30a9aaca-3233-4164-8f6d-68dfa86da01d.gif)


## Tests

- Setup a local synase with ThreePid msisdn's enabled 
- Create an account
- Supply a phone number to receive the confirmation sms on
- Enter the confirmation code and notice the sign up move to the next step

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 31v2

