### PR TITLE
Ask the user to confirm urls which contain unicode direction overrides

### DIFF
--- a/changelog.d/6163.feature
+++ b/changelog.d/6163.feature
@@ -1,0 +1,1 @@
+Security - Asking for user confirmation when tapping URLs which contain unicode directional overrides

--- a/vector/src/main/java/im/vector/app/core/extensions/String.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/String.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.extensions
+
+private const val RTL_OVERRIDE_CHAR = '\u202E'
+private const val LTR_OVERRIDE_CHAR = '\u202D'
+
+fun String.ensureEndsLeftToRight() = if (containsRtLOverride()) "$this$LTR_OVERRIDE_CHAR" else this
+
+fun String.containsRtLOverride() = contains(RTL_OVERRIDE_CHAR)
+
+fun String.filterDirectionOverrides() = filterNot { it == RTL_OVERRIDE_CHAR || it == LTR_OVERRIDE_CHAR }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1927,10 +1927,14 @@ class TimelineFragment @Inject constructor(
             if (!isManaged) {
                 when {
                     url.containsRtLOverride()                                                  -> {
-                        displayUrlConfirmationDialog(title.ensureEndsLeftToRight(), url.filterDirectionOverrides())
+                        displayUrlConfirmationDialog(
+                                seenUrl = title.ensureEndsLeftToRight(),
+                                actualUrl = url.filterDirectionOverrides(),
+                                continueTo = url
+                        )
                     }
                     title.isValidUrl() && url.isValidUrl() && URL(title).host != URL(url).host -> {
-                        displayUrlConfirmationDialog(title.ensureEndsLeftToRight(), url)
+                        displayUrlConfirmationDialog(title, url)
                     }
                     else                                                                       -> {
                         openUrlInExternalBrowser(requireContext(), url)
@@ -1942,17 +1946,17 @@ class TimelineFragment @Inject constructor(
         return true
     }
 
-    private fun displayUrlConfirmationDialog(title: String, url: String) {
+    private fun displayUrlConfirmationDialog(seenUrl: String, actualUrl: String, continueTo: String = actualUrl) {
         MaterialAlertDialogBuilder(requireActivity(), R.style.ThemeOverlay_Vector_MaterialAlertDialog_NegativeDestructive)
                 .setTitle(R.string.external_link_confirmation_title)
                 .setMessage(
-                        getString(R.string.external_link_confirmation_message, title, url)
+                        getString(R.string.external_link_confirmation_message, seenUrl, actualUrl)
                                 .toSpannable()
-                                .colorizeMatchingText(url, colorProvider.getColorFromAttribute(R.attr.vctr_content_tertiary))
-                                .colorizeMatchingText(title, colorProvider.getColorFromAttribute(R.attr.vctr_content_tertiary))
+                                .colorizeMatchingText(actualUrl, colorProvider.getColorFromAttribute(R.attr.vctr_content_tertiary))
+                                .colorizeMatchingText(seenUrl, colorProvider.getColorFromAttribute(R.attr.vctr_content_tertiary))
                 )
                 .setPositiveButton(R.string._continue) { _, _ ->
-                    openUrlInExternalBrowser(requireContext(), url)
+                    openUrlInExternalBrowser(requireContext(), continueTo)
                 }
                 .setNegativeButton(R.string.action_cancel, null)
                 .show()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1926,10 +1926,13 @@ class TimelineFragment @Inject constructor(
                     })
             if (!isManaged) {
                 when {
-                    url.containsRtLOverride() || (title.isValidUrl() && url.isValidUrl() && URL(title).host != URL(url).host) -> {
+                    url.containsRtLOverride()                                                  -> {
                         displayUrlConfirmationDialog(title.ensureEndsLeftToRight(), url.filterDirectionOverrides())
                     }
-                    else                                                                                                      -> {
+                    title.isValidUrl() && url.isValidUrl() && URL(title).host != URL(url).host -> {
+                        displayUrlConfirmationDialog(title.ensureEndsLeftToRight(), url)
+                    }
+                    else                                                                       -> {
                         openUrlInExternalBrowser(requireContext(), url)
                     }
                 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -74,6 +74,9 @@ import im.vector.app.core.dialogs.ConfirmationDialogBuilder
 import im.vector.app.core.dialogs.GalleryOrCameraDialogHelper
 import im.vector.app.core.epoxy.LayoutManagerStateRestorer
 import im.vector.app.core.extensions.cleanup
+import im.vector.app.core.extensions.containsRtLOverride
+import im.vector.app.core.extensions.ensureEndsLeftToRight
+import im.vector.app.core.extensions.filterDirectionOverrides
 import im.vector.app.core.extensions.hideKeyboard
 import im.vector.app.core.extensions.registerStartForActivityResult
 import im.vector.app.core.extensions.setTextOrHide
@@ -1922,28 +1925,34 @@ class TimelineFragment @Inject constructor(
                         }
                     })
             if (!isManaged) {
-                if (title.isValidUrl() && url.isValidUrl() && URL(title).host != URL(url).host) {
-                    MaterialAlertDialogBuilder(requireActivity(), R.style.ThemeOverlay_Vector_MaterialAlertDialog_NegativeDestructive)
-                            .setTitle(R.string.external_link_confirmation_title)
-                            .setMessage(
-                                    getString(R.string.external_link_confirmation_message, title, url)
-                                            .toSpannable()
-                                            .colorizeMatchingText(url, colorProvider.getColorFromAttribute(R.attr.vctr_content_tertiary))
-                                            .colorizeMatchingText(title, colorProvider.getColorFromAttribute(R.attr.vctr_content_tertiary))
-                            )
-                            .setPositiveButton(R.string._continue) { _, _ ->
-                                openUrlInExternalBrowser(requireContext(), url)
-                            }
-                            .setNegativeButton(R.string.action_cancel, null)
-                            .show()
-                } else {
-                    // Open in external browser, in a new Tab
-                    openUrlInExternalBrowser(requireContext(), url)
+                when {
+                    url.containsRtLOverride() || (title.isValidUrl() && url.isValidUrl() && URL(title).host != URL(url).host) -> {
+                        displayUrlConfirmationDialog(title.ensureEndsLeftToRight(), url.filterDirectionOverrides())
+                    }
+                    else                                                                                                      -> {
+                        openUrlInExternalBrowser(requireContext(), url)
+                    }
                 }
             }
         }
         // In fact it is always managed
         return true
+    }
+
+    private fun displayUrlConfirmationDialog(title: String, url: String) {
+        MaterialAlertDialogBuilder(requireActivity(), R.style.ThemeOverlay_Vector_MaterialAlertDialog_NegativeDestructive)
+                .setTitle(R.string.external_link_confirmation_title)
+                .setMessage(
+                        getString(R.string.external_link_confirmation_message, title, url)
+                                .toSpannable()
+                                .colorizeMatchingText(url, colorProvider.getColorFromAttribute(R.attr.vctr_content_tertiary))
+                                .colorizeMatchingText(title, colorProvider.getColorFromAttribute(R.attr.vctr_content_tertiary))
+                )
+                .setPositiveButton(R.string._continue) { _, _ ->
+                    openUrlInExternalBrowser(requireContext(), url)
+                }
+                .setNegativeButton(R.string.action_cancel, null)
+                .show()
     }
 
     override fun onUrlLongClicked(url: String): Boolean {

--- a/vector/src/test/java/im/vector/app/core/extensions/StringExtensionsTest.kt
+++ b/vector/src/test/java/im/vector/app/core/extensions/StringExtensionsTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.extensions
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class StringExtensionsTest {
+
+    @Test
+    fun `given text with RtL unicode override, when checking contains RtL Override, then returns true`() {
+        val textWithRtlOverride = "hello\u202Eworld"
+
+        val result = textWithRtlOverride.containsRtLOverride()
+
+        result shouldBeEqualTo true
+    }
+
+    @Test
+    fun `given text without RtL unicode override, when checking contains RtL Override, then returns false`() {
+        val textWithRtlOverride = "hello world"
+
+        val result = textWithRtlOverride.containsRtLOverride()
+
+        result shouldBeEqualTo false
+    }
+
+    @Test
+    fun `given text with RtL unicode override, when ensuring ends LtR, then appends a LtR unicode override`() {
+        val textWithRtlOverride = "123\u202E456"
+
+        val result = textWithRtlOverride.ensureEndsLeftToRight()
+
+        result shouldBeEqualTo "$textWithRtlOverride\u202D"
+    }
+
+    @Test
+    fun `given text with unicode direction overrides, when filtering direction overrides, then removes all overrides`() {
+        val textWithDirectionOverrides = "123\u202E456\u202d789"
+
+        val result = textWithDirectionOverrides.filterDirectionOverrides()
+
+        result shouldBeEqualTo "123456789"
+    }
+}


### PR DESCRIPTION
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Checks for the presence of Right to Left unicode directional overrides when tapping on a URL, if one is found we'll show the user the URL with the overrides disabled and ask them to confirm they want to continue.

## Motivation and context

Fixes #6163 

Newer versions of Android (31+) seemingly handle the oddness out of the box by avoiding marking the URLs as clickable links, however previous versions will still attempt to link out to them, although the formatting is often broken.


## Screenshots / GIFs

| BEFORE | AFTER | 
| --- | --- |
![2022-05-26T10:26:35,157524612+01:00](https://user-images.githubusercontent.com/1848238/170480428-5d27e7cc-497b-4564-839b-e766fc844db9.png)|![Screenshot_20220526_113846](https://user-images.githubusercontent.com/1848238/170478636-da10c039-9f9d-4518-9362-1ce750181b44.png)

## Tests

- Using Element web /devtools construct and post a link containing a RtL override `\u202E` 
- Using an Android 25 device view and tap the link
- Notice a popup informing the user that the URL may not be what they expect

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 21, 25, 28, 31

