### PR TITLE
[SDK] Allow passwords to be set at the point of reset confirmation

### DIFF
--- a/changelog.d/6169.sdk
+++ b/changelog.d/6169.sdk
@@ -1,0 +1,1 @@
+Allows new passwords to be passed at the point of confirmation when resetting a password

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/login/LoginWizard.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/login/LoginWizard.kt
@@ -63,14 +63,15 @@ interface LoginWizard {
      * [resetPasswordMailConfirmed] is successfully called.
      *
      * @param email an email previously associated to the account the user wants the password to be reset.
-     * @param newPassword the desired new password
+     * @param newPassword the desired new password, can be optionally set here or as part of [resetPasswordMailConfirmed]
      */
-    suspend fun resetPassword(email: String,
-                              newPassword: String)
+    suspend fun resetPassword(email: String, newPassword: String? = null)
 
     /**
      * Confirm the new password, once the user has checked their email
      * When this method succeed, tha account password will be effectively modified.
+     *
+     * @param newPassword the desired new password, required if a password was not supplied to [resetPassword]
      */
-    suspend fun resetPasswordMailConfirmed()
+    suspend fun resetPasswordMailConfirmed(newPassword: String? = null)
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/login/LoginWizard.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/auth/login/LoginWizard.kt
@@ -63,15 +63,14 @@ interface LoginWizard {
      * [resetPasswordMailConfirmed] is successfully called.
      *
      * @param email an email previously associated to the account the user wants the password to be reset.
-     * @param newPassword the desired new password, can be optionally set here or as part of [resetPasswordMailConfirmed]
      */
-    suspend fun resetPassword(email: String, newPassword: String? = null)
+    suspend fun resetPassword(email: String)
 
     /**
      * Confirm the new password, once the user has checked their email
      * When this method succeed, tha account password will be effectively modified.
      *
-     * @param newPassword the desired new password, required if a password was not supplied to [resetPassword]
+     * @param newPassword the desired new password
      */
-    suspend fun resetPasswordMailConfirmed(newPassword: String? = null)
+    suspend fun resetPasswordMailConfirmed(newPassword: String)
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/DefaultLoginWizard.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/DefaultLoginWizard.kt
@@ -30,6 +30,7 @@ import org.matrix.android.sdk.internal.auth.data.ThreePidMedium
 import org.matrix.android.sdk.internal.auth.data.TokenLoginParams
 import org.matrix.android.sdk.internal.auth.db.PendingSessionData
 import org.matrix.android.sdk.internal.auth.registration.AddThreePidRegistrationParams
+import org.matrix.android.sdk.internal.auth.registration.AddThreePidRegistrationResponse
 import org.matrix.android.sdk.internal.auth.registration.RegisterAddThreePidTask
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.session.content.DefaultContentUrlResolver
@@ -101,7 +102,7 @@ internal class DefaultLoginWizard(
         return sessionCreator.createSession(credentials, pendingSessionData.homeServerConnectionConfig)
     }
 
-    override suspend fun resetPassword(email: String, newPassword: String) {
+    override suspend fun resetPassword(email: String, newPassword: String?) {
         val param = RegisterAddThreePidTask.Params(
                 RegisterThreePid.Email(email),
                 pendingSessionData.clientSecret,
@@ -119,15 +120,14 @@ internal class DefaultLoginWizard(
                 .also { pendingSessionStore.savePendingSessionData(it) }
     }
 
-    override suspend fun resetPasswordMailConfirmed() {
-        val safeResetPasswordData = pendingSessionData.resetPasswordData
-                ?: throw IllegalStateException("developer error, no reset password in progress")
-
-        val param = ResetPasswordMailConfirmed.create(
-                pendingSessionData.clientSecret,
-                safeResetPasswordData.addThreePidRegistrationResponse.sid,
-                safeResetPasswordData.newPassword
-        )
+    override suspend fun resetPasswordMailConfirmed(newPassword: String?) {
+        val param = pendingSessionData.readResetPasswordDataOrThrow(newPassword).let { (response, password) ->
+            ResetPasswordMailConfirmed.create(
+                    pendingSessionData.clientSecret,
+                    response.sid,
+                    password
+            )
+        }
 
         executeRequest(null) {
             authAPI.resetPasswordMailConfirmed(param)
@@ -135,5 +135,15 @@ internal class DefaultLoginWizard(
 
         // Set to null?
         // resetPasswordData = null
+    }
+
+    private fun PendingSessionData.readResetPasswordDataOrThrow(newPassword: String?): Pair<AddThreePidRegistrationResponse, String> {
+        return when (resetPasswordData) {
+            null -> throw IllegalStateException("developer error, no reset password in progress")
+            else -> {
+                val password = newPassword ?: resetPasswordData.newPassword ?: throw IllegalStateException("developer error, no new password set")
+                resetPasswordData.addThreePidRegistrationResponse to password
+            }
+        }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/DefaultLoginWizard.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/DefaultLoginWizard.kt
@@ -30,7 +30,6 @@ import org.matrix.android.sdk.internal.auth.data.ThreePidMedium
 import org.matrix.android.sdk.internal.auth.data.TokenLoginParams
 import org.matrix.android.sdk.internal.auth.db.PendingSessionData
 import org.matrix.android.sdk.internal.auth.registration.AddThreePidRegistrationParams
-import org.matrix.android.sdk.internal.auth.registration.AddThreePidRegistrationResponse
 import org.matrix.android.sdk.internal.auth.registration.RegisterAddThreePidTask
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.session.content.DefaultContentUrlResolver

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/ResetPasswordData.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/ResetPasswordData.kt
@@ -24,6 +24,5 @@ import org.matrix.android.sdk.internal.auth.registration.AddThreePidRegistration
  */
 @JsonClass(generateAdapter = true)
 internal data class ResetPasswordData(
-        val newPassword: String?,
         val addThreePidRegistrationResponse: AddThreePidRegistrationResponse
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/ResetPasswordData.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/ResetPasswordData.kt
@@ -24,6 +24,6 @@ import org.matrix.android.sdk.internal.auth.registration.AddThreePidRegistration
  */
 @JsonClass(generateAdapter = true)
 internal data class ResetPasswordData(
-        val newPassword: String,
+        val newPassword: String?,
         val addThreePidRegistrationResponse: AddThreePidRegistrationResponse
 )

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
@@ -411,7 +411,8 @@ class LoginViewModel @AssistedInject constructor(
                     copy(
                             asyncResetPassword = Uninitialized,
                             asyncResetMailConfirmed = Uninitialized,
-                            resetPasswordEmail = null
+                            resetPasswordEmail = null,
+                            resetPasswordNewPassword = null
                     )
                 }
             }
@@ -486,7 +487,7 @@ class LoginViewModel @AssistedInject constructor(
 
             currentJob = viewModelScope.launch {
                 try {
-                    safeLoginWizard.resetPassword(action.email, action.newPassword)
+                    safeLoginWizard.resetPassword(action.email)
                 } catch (failure: Throwable) {
                     setState {
                         copy(
@@ -499,7 +500,8 @@ class LoginViewModel @AssistedInject constructor(
                 setState {
                     copy(
                             asyncResetPassword = Success(Unit),
-                            resetPasswordEmail = action.email
+                            resetPasswordEmail = action.email,
+                            resetPasswordNewPassword = action.newPassword
                     )
                 }
 
@@ -528,7 +530,8 @@ class LoginViewModel @AssistedInject constructor(
 
             currentJob = viewModelScope.launch {
                 try {
-                    safeLoginWizard.resetPasswordMailConfirmed()
+                    val state = awaitState()
+                    safeLoginWizard.resetPasswordMailConfirmed(state.resetPasswordNewPassword!!)
                 } catch (failure: Throwable) {
                     setState {
                         copy(
@@ -540,7 +543,8 @@ class LoginViewModel @AssistedInject constructor(
                 setState {
                     copy(
                             asyncResetMailConfirmed = Success(Unit),
-                            resetPasswordEmail = null
+                            resetPasswordEmail = null,
+                            resetPasswordNewPassword = null
                     )
                 }
 

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
@@ -531,13 +531,14 @@ class LoginViewModel @AssistedInject constructor(
             currentJob = viewModelScope.launch {
                 val state = awaitState()
 
-                if (state.resetPasswordNewPassword == null)
+                if (state.resetPasswordNewPassword == null) {
                     setState {
                         copy(
                                 asyncResetPassword = Uninitialized,
                                 asyncResetMailConfirmed = Fail(Throwable("Developer error - New password not set"))
                         )
-                    } else {
+                    }
+                } else {
                     try {
                         safeLoginWizard.resetPasswordMailConfirmed(state.resetPasswordNewPassword)
                     } catch (failure: Throwable) {

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
@@ -529,26 +529,34 @@ class LoginViewModel @AssistedInject constructor(
             }
 
             currentJob = viewModelScope.launch {
-                try {
-                    val state = awaitState()
-                    safeLoginWizard.resetPasswordMailConfirmed(state.resetPasswordNewPassword!!)
-                } catch (failure: Throwable) {
+                val state = awaitState()
+
+                if (state.resetPasswordNewPassword == null)
                     setState {
                         copy(
-                                asyncResetMailConfirmed = Fail(failure)
+                                asyncResetPassword = Uninitialized,
+                                asyncResetMailConfirmed = Fail(Throwable("Developer error - New password not set"))
+                        )
+                    } else {
+                    try {
+                        safeLoginWizard.resetPasswordMailConfirmed(state.resetPasswordNewPassword)
+                    } catch (failure: Throwable) {
+                        setState {
+                            copy(
+                                    asyncResetMailConfirmed = Fail(failure)
+                            )
+                        }
+                        return@launch
+                    }
+                    setState {
+                        copy(
+                                asyncResetMailConfirmed = Success(Unit),
+                                resetPasswordEmail = null,
+                                resetPasswordNewPassword = null
                         )
                     }
-                    return@launch
+                    _viewEvents.post(LoginViewEvents.OnResetPasswordMailConfirmationSuccess)
                 }
-                setState {
-                    copy(
-                            asyncResetMailConfirmed = Success(Unit),
-                            resetPasswordEmail = null,
-                            resetPasswordNewPassword = null
-                    )
-                }
-
-                _viewEvents.post(LoginViewEvents.OnResetPasswordMailConfirmationSuccess)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewState.kt
@@ -38,6 +38,8 @@ data class LoginViewState(
         @PersistState
         val resetPasswordEmail: String? = null,
         @PersistState
+        val resetPasswordNewPassword: String? = null,
+        @PersistState
         val homeServerUrlFromUser: String? = null,
 
         // Can be modified after a Wellknown request

--- a/vector/src/main/java/im/vector/app/features/login2/LoginViewModel2.kt
+++ b/vector/src/main/java/im/vector/app/features/login2/LoginViewModel2.kt
@@ -390,7 +390,8 @@ class LoginViewModel2 @AssistedInject constructor(
             LoginAction2.ResetResetPassword -> {
                 setState {
                     copy(
-                            resetPasswordEmail = null
+                            resetPasswordEmail = null,
+                            resetPasswordNewPassword = null
                     )
                 }
             }
@@ -441,7 +442,7 @@ class LoginViewModel2 @AssistedInject constructor(
 
             currentJob = viewModelScope.launch {
                 try {
-                    safeLoginWizard.resetPassword(action.email, action.newPassword)
+                    safeLoginWizard.resetPassword(action.email)
                 } catch (failure: Throwable) {
                     _viewEvents.post(LoginViewEvents2.Failure(failure))
                     setState { copy(isLoading = false) }
@@ -451,7 +452,8 @@ class LoginViewModel2 @AssistedInject constructor(
                 setState {
                     copy(
                             isLoading = false,
-                            resetPasswordEmail = action.email
+                            resetPasswordEmail = action.email,
+                            resetPasswordNewPassword = action.newPassword
                     )
                 }
 
@@ -470,7 +472,8 @@ class LoginViewModel2 @AssistedInject constructor(
 
             currentJob = viewModelScope.launch {
                 try {
-                    safeLoginWizard.resetPasswordMailConfirmed()
+                    val state = awaitState()
+                    safeLoginWizard.resetPasswordMailConfirmed(state.resetPasswordNewPassword!!)
                 } catch (failure: Throwable) {
                     _viewEvents.post(LoginViewEvents2.Failure(failure))
                     setState { copy(isLoading = false) }
@@ -479,7 +482,8 @@ class LoginViewModel2 @AssistedInject constructor(
                 setState {
                     copy(
                             isLoading = false,
-                            resetPasswordEmail = null
+                            resetPasswordEmail = null,
+                            resetPasswordNewPassword = null
                     )
                 }
 

--- a/vector/src/main/java/im/vector/app/features/login2/LoginViewState2.kt
+++ b/vector/src/main/java/im/vector/app/features/login2/LoginViewState2.kt
@@ -36,6 +36,8 @@ data class LoginViewState2(
         @PersistState
         val resetPasswordEmail: String? = null,
         @PersistState
+        val resetPasswordNewPassword: String? = null,
+        @PersistState
         val homeServerUrlFromUser: String? = null,
 
         // Can be modified after a Wellknown request

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -247,21 +247,15 @@ class OnboardingViewModel @AssistedInject constructor(
 
     private fun handleLoginWithToken(action: OnboardingAction.LoginWithToken) {
         val safeLoginWizard = loginWizard
+        setState { copy(isLoading = true) }
 
-        if (safeLoginWizard == null) {
-            setState { copy(isLoading = false) }
-            _viewEvents.post(OnboardingViewEvents.Failure(Throwable("Bad configuration")))
-        } else {
-            setState { copy(isLoading = true) }
-
-            currentJob = viewModelScope.launch {
-                try {
-                    val result = safeLoginWizard.loginWithToken(action.loginToken)
-                    onSessionCreated(result, isAccountCreated = false)
-                } catch (failure: Throwable) {
-                    setState { copy(isLoading = false) }
-                    _viewEvents.post(OnboardingViewEvents.Failure(failure))
-                }
+        currentJob = viewModelScope.launch {
+            try {
+                val result = safeLoginWizard.loginWithToken(action.loginToken)
+                onSessionCreated(result, isAccountCreated = false)
+            } catch (failure: Throwable) {
+                setState { copy(isLoading = false) }
+                _viewEvents.post(OnboardingViewEvents.Failure(failure))
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -447,7 +447,7 @@ class OnboardingViewModel @AssistedInject constructor(
 
             currentJob = viewModelScope.launch {
                 try {
-                    safeLoginWizard.resetPassword(action.email, action.newPassword)
+                    safeLoginWizard.resetPassword(action.email)
                 } catch (failure: Throwable) {
                     setState { copy(isLoading = false) }
                     _viewEvents.post(OnboardingViewEvents.Failure(failure))
@@ -457,7 +457,7 @@ class OnboardingViewModel @AssistedInject constructor(
                 setState {
                     copy(
                             isLoading = false,
-                            resetState = ResetState(email = action.email)
+                            resetState = ResetState(email = action.email, newPassword = action.newPassword)
                     )
                 }
 
@@ -477,7 +477,8 @@ class OnboardingViewModel @AssistedInject constructor(
 
             currentJob = viewModelScope.launch {
                 try {
-                    safeLoginWizard.resetPasswordMailConfirmed()
+                    val state = awaitState()
+                    safeLoginWizard.resetPasswordMailConfirmed(state.resetState.newPassword!!)
                 } catch (failure: Throwable) {
                     setState { copy(isLoading = false) }
                     _viewEvents.post(OnboardingViewEvents.Failure(failure))

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -370,7 +370,7 @@ class OnboardingViewModel @AssistedInject constructor(
                 setState {
                     copy(
                             isLoading = false,
-                            resetPasswordEmail = null
+                            resetState = ResetState()
                     )
                 }
             }
@@ -457,7 +457,7 @@ class OnboardingViewModel @AssistedInject constructor(
                 setState {
                     copy(
                             isLoading = false,
-                            resetPasswordEmail = action.email
+                            resetState = ResetState(email = action.email)
                     )
                 }
 
@@ -486,7 +486,7 @@ class OnboardingViewModel @AssistedInject constructor(
                 setState {
                     copy(
                             isLoading = false,
-                            resetPasswordEmail = null
+                            resetState = ResetState()
                     )
                 }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -122,7 +122,7 @@ class OnboardingViewModel @AssistedInject constructor(
     val isRegistrationStarted: Boolean
         get() = authenticationService.isRegistrationStarted
 
-    private val loginWizard: LoginWizard?
+    private val loginWizard: LoginWizard
         get() = authenticationService.getLoginWizard()
 
     private var loginConfig: LoginConfig? = null
@@ -438,60 +438,51 @@ class OnboardingViewModel @AssistedInject constructor(
 
     private fun handleResetPassword(action: OnboardingAction.ResetPassword) {
         val safeLoginWizard = loginWizard
-
-        if (safeLoginWizard == null) {
-            setState { copy(isLoading = false) }
-            _viewEvents.post(OnboardingViewEvents.Failure(Throwable("Bad configuration")))
-        } else {
-            setState { copy(isLoading = true) }
-
-            currentJob = viewModelScope.launch {
-                try {
-                    safeLoginWizard.resetPassword(action.email)
-                } catch (failure: Throwable) {
-                    setState { copy(isLoading = false) }
-                    _viewEvents.post(OnboardingViewEvents.Failure(failure))
-                    return@launch
-                }
-
-                setState {
-                    copy(
-                            isLoading = false,
-                            resetState = ResetState(email = action.email, newPassword = action.newPassword)
-                    )
-                }
-
-                _viewEvents.post(OnboardingViewEvents.OnResetPasswordSendThreePidDone)
-            }
+        setState { copy(isLoading = true) }
+        currentJob = viewModelScope.launch {
+            runCatching { safeLoginWizard.resetPassword(action.email) }.fold(
+                    onSuccess = {
+                        setState {
+                            copy(
+                                    isLoading = false,
+                                    resetState = ResetState(email = action.email, newPassword = action.newPassword)
+                            )
+                        }
+                        _viewEvents.post(OnboardingViewEvents.OnResetPasswordSendThreePidDone)
+                    },
+                    onFailure = {
+                        setState { copy(isLoading = false) }
+                        _viewEvents.post(OnboardingViewEvents.Failure(it))
+                    }
+            )
         }
     }
 
     private fun handleResetPasswordMailConfirmed() {
-        val safeLoginWizard = loginWizard
-
-        if (safeLoginWizard == null) {
-            setState { copy(isLoading = false) }
-            _viewEvents.post(OnboardingViewEvents.Failure(Throwable("Bad configuration")))
-        } else {
-            setState { copy(isLoading = false) }
-
-            currentJob = viewModelScope.launch {
-                try {
-                    val state = awaitState()
-                    safeLoginWizard.resetPasswordMailConfirmed(state.resetState.newPassword!!)
-                } catch (failure: Throwable) {
+        currentJob = viewModelScope.launch {
+            val resetState = awaitState().resetState
+            when (val newPassword = resetState.newPassword) {
+                null -> {
                     setState { copy(isLoading = false) }
-                    _viewEvents.post(OnboardingViewEvents.Failure(failure))
-                    return@launch
+                    _viewEvents.post(OnboardingViewEvents.Failure(IllegalStateException("Developer error - No new password has been set")))
                 }
-                setState {
-                    copy(
-                            isLoading = false,
-                            resetState = ResetState()
+                else -> {
+                    runCatching { loginWizard.resetPasswordMailConfirmed(newPassword) }.fold(
+                            onSuccess = {
+                                setState {
+                                    copy(
+                                            isLoading = false,
+                                            resetState = ResetState()
+                                    )
+                                }
+                                _viewEvents.post(OnboardingViewEvents.OnResetPasswordMailConfirmationSuccess)
+                            },
+                            onFailure = {
+                                setState { copy(isLoading = false) }
+                                _viewEvents.post(OnboardingViewEvents.Failure(it))
+                            }
                     )
                 }
-
-                _viewEvents.post(OnboardingViewEvents.OnResetPasswordMailConfirmationSuccess)
             }
         }
     }
@@ -511,25 +502,19 @@ class OnboardingViewModel @AssistedInject constructor(
 
     private fun handleLogin(action: AuthenticateAction.Login) {
         val safeLoginWizard = loginWizard
-
-        if (safeLoginWizard == null) {
-            setState { copy(isLoading = false) }
-            _viewEvents.post(OnboardingViewEvents.Failure(Throwable("Bad configuration")))
-        } else {
-            setState { copy(isLoading = true) }
-            currentJob = viewModelScope.launch {
-                try {
-                    val result = safeLoginWizard.login(
-                            action.username,
-                            action.password,
-                            action.initialDeviceName
-                    )
-                    reAuthHelper.data = action.password
-                    onSessionCreated(result, isAccountCreated = false)
-                } catch (failure: Throwable) {
-                    setState { copy(isLoading = false) }
-                    _viewEvents.post(OnboardingViewEvents.Failure(failure))
-                }
+        setState { copy(isLoading = true) }
+        currentJob = viewModelScope.launch {
+            try {
+                val result = safeLoginWizard.login(
+                        action.username,
+                        action.password,
+                        action.initialDeviceName
+                )
+                reAuthHelper.data = action.password
+                onSessionCreated(result, isAccountCreated = false)
+            } catch (failure: Throwable) {
+                setState { copy(isLoading = false) }
+                _viewEvents.post(OnboardingViewEvents.Failure(failure))
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -453,6 +453,7 @@ class OnboardingViewModel @AssistedInject constructor(
     }
 
     private fun handleResetPasswordMailConfirmed() {
+        setState { copy(isLoading = true) }
         currentJob = viewModelScope.launch {
             val resetState = awaitState().resetState
             when (val newPassword = resetState.newPassword) {

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
@@ -83,5 +83,6 @@ data class PersonalizationState(
 
 @Parcelize
 data class ResetState(
-        val email: String? = null
+        val email: String? = null,
+        val newPassword: String? = null,
 ) : Parcelable

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
@@ -39,7 +39,7 @@ data class OnboardingViewState(
         @PersistState
         val signMode: SignMode = SignMode.Unknown,
         @PersistState
-        val resetPasswordEmail: String? = null,
+        val resetState: ResetState = ResetState(),
 
         // For SSO session recovery
         @PersistState
@@ -80,3 +80,8 @@ data class PersonalizationState(
 
     fun supportsPersonalization() = supportsChangingDisplayName || supportsChangingProfilePicture
 }
+
+@Parcelize
+data class ResetState(
+        val email: String? = null
+) : Parcelable

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/AbstractFtueAuthFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/AbstractFtueAuthFragment.kt
@@ -153,7 +153,7 @@ abstract class AbstractFtueAuthFragment<VB : ViewBinding> : VectorBaseFragment<V
 
     final override fun invalidate() = withState(viewModel) { state ->
         // True when email is sent with success to the homeserver
-        isResetPasswordStarted = state.resetPasswordEmail.isNullOrBlank().not()
+        isResetPasswordStarted = state.resetState.email.isNullOrBlank().not()
 
         updateWithState(state)
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthResetPasswordMailConfirmationFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthResetPasswordMailConfirmationFragment.kt
@@ -44,7 +44,7 @@ class FtueAuthResetPasswordMailConfirmationFragment @Inject constructor() : Abst
     }
 
     private fun setupUi(state: OnboardingViewState) {
-        views.resetPasswordMailConfirmationNotice.text = getString(R.string.login_reset_password_mail_confirmation_notice, state.resetPasswordEmail)
+        views.resetPasswordMailConfirmationNotice.text = getString(R.string.login_reset_password_mail_confirmation_notice, state.resetState.email)
     }
 
     private fun submit() {

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -29,6 +29,7 @@ import im.vector.app.test.fakes.FakeContext
 import im.vector.app.test.fakes.FakeDirectLoginUseCase
 import im.vector.app.test.fakes.FakeHomeServerConnectionConfigFactory
 import im.vector.app.test.fakes.FakeHomeServerHistoryService
+import im.vector.app.test.fakes.FakeLoginWizard
 import im.vector.app.test.fakes.FakeRegisterActionHandler
 import im.vector.app.test.fakes.FakeRegistrationWizard
 import im.vector.app.test.fakes.FakeSession
@@ -63,6 +64,8 @@ private val A_DIRECT_LOGIN = OnboardingAction.AuthenticateAction.LoginDirect("@a
 private const val A_HOMESERVER_URL = "https://edited-homeserver.org"
 private val A_HOMESERVER_CONFIG = HomeServerConnectionConfig(FakeUri().instance)
 private val SELECTED_HOMESERVER_STATE = SelectedHomeserverState(preferredLoginMode = LoginMode.Password)
+private const val AN_EMAIL = "hello@example.com"
+private const val A_PASSWORD = "a-password"
 
 class OnboardingViewModelTest {
 
@@ -81,6 +84,7 @@ class OnboardingViewModelTest {
     private val fakeHomeServerConnectionConfigFactory = FakeHomeServerConnectionConfigFactory()
     private val fakeStartAuthenticationFlowUseCase = FakeStartAuthenticationFlowUseCase()
     private val fakeHomeServerHistoryService = FakeHomeServerHistoryService()
+    private val fakeLoginWizard = FakeLoginWizard()
 
     private var initialState = OnboardingViewState()
     private lateinit var viewModel: OnboardingViewModel
@@ -438,6 +442,43 @@ class OnboardingViewModelTest {
         test
                 .assertStates(initialState)
                 .assertEvents(OnboardingViewEvents.OnPersonalizationComplete)
+                .finish()
+    }
+
+    @Test
+    fun `given can successfully reset password, when resetting password, then emits reset done event`() = runTest {
+        val test = viewModel.test()
+        fakeLoginWizard.givenResetPasswordSuccess(AN_EMAIL)
+        fakeAuthenticationService.givenLoginWizard(fakeLoginWizard)
+
+        viewModel.handle(OnboardingAction.ResetPassword(email = AN_EMAIL, newPassword = A_PASSWORD))
+
+        test
+                .assertStatesChanges(
+                        initialState,
+                        { copy(isLoading = true) },
+                        { copy(isLoading = false, resetState = ResetState(AN_EMAIL, A_PASSWORD)) }
+                )
+                .assertEvents(OnboardingViewEvents.OnResetPasswordSendThreePidDone)
+                .finish()
+    }
+
+    @Test
+    fun `given can successfully confirm reset password, when confirm reset password, then emits reset success`() = runTest {
+        viewModelWith(initialState.copy(resetState = ResetState(AN_EMAIL, A_PASSWORD)))
+        val test = viewModel.test()
+        fakeLoginWizard.givenConfirmResetPasswordSuccess(A_PASSWORD)
+        fakeAuthenticationService.givenLoginWizard(fakeLoginWizard)
+
+        viewModel.handle(OnboardingAction.ResetPasswordMailConfirmed)
+
+        test
+                .assertStatesChanges(
+                        initialState,
+                        { copy(isLoading = true) },
+                        { copy(isLoading = false, resetState = ResetState()) }
+                )
+                .assertEvents(OnboardingViewEvents.OnResetPasswordMailConfirmationSuccess)
                 .finish()
     }
 

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
@@ -23,6 +23,7 @@ import io.mockk.mockk
 import org.matrix.android.sdk.api.auth.AuthenticationService
 import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
 import org.matrix.android.sdk.api.auth.data.LoginFlowResult
+import org.matrix.android.sdk.api.auth.login.LoginWizard
 import org.matrix.android.sdk.api.auth.registration.RegistrationWizard
 import org.matrix.android.sdk.api.auth.wellknown.WellknownResult
 
@@ -34,6 +35,10 @@ class FakeAuthenticationService : AuthenticationService by mockk() {
 
     fun givenRegistrationStarted(started: Boolean) {
         every { isRegistrationStarted } returns started
+    }
+
+    fun givenLoginWizard(loginWizard: LoginWizard) {
+        every { getLoginWizard() } returns loginWizard
     }
 
     fun givenLoginFlow(config: HomeServerConnectionConfig, result: LoginFlowResult) {

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeLoginWizard.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeLoginWizard.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import io.mockk.coJustRun
+import io.mockk.mockk
+import org.matrix.android.sdk.api.auth.login.LoginWizard
+
+class FakeLoginWizard : LoginWizard by mockk() {
+
+    fun givenResetPasswordSuccess(email: String) {
+        coJustRun { resetPassword(email) }
+    }
+
+    fun givenConfirmResetPasswordSuccess(password: String) {
+        coJustRun { resetPasswordMailConfirmed(password) }
+    }
+}


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Fixes #6169 

Updates the `LoginWizard` reset api to allow passing the new password at the point of confirmation
- Makes the `newPassword` parameter in `LoginWizard.resetPassword` optional
- A missing password at the point of `resetPasswordMailConfirmed` will throw an `IllegalStateException` 
- Also introduces a `ResetState` to the `OnboardingViewModel` in preparation for the flow changes

## Motivation and context

To enable the FTUE reset password journey which involves supplying a password after the reset email has been confirmed instead of the current flow which involves passing the email and password upfront.

## Screenshots / GIFs

No UI changes

## Tests

No production changes

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 31
