### PR TITLE
Fix some notifications never getting dismissed

### DIFF
--- a/changelog.d/4862.bugfix
+++ b/changelog.d/4862.bugfix
@@ -1,0 +1,1 @@
+Fix some notifications not clearing when read

--- a/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
@@ -151,7 +151,7 @@ class NotifiableEventResolver @Inject constructor(
                     senderName = senderDisplayName,
                     senderId = event.root.senderId,
                     body = body.toString(),
-                    imageUri = event.fetchImageIfPresent(session),
+                    imageUriString = event.fetchImageIfPresent(session)?.toString(),
                     roomId = event.root.roomId!!,
                     roomName = roomName,
                     matrixID = session.myUserId
@@ -176,7 +176,7 @@ class NotifiableEventResolver @Inject constructor(
                             senderName = senderDisplayName,
                             senderId = event.root.senderId,
                             body = body,
-                            imageUri = event.fetchImageIfPresent(session),
+                            imageUriString = event.fetchImageIfPresent(session)?.toString(),
                             roomId = event.root.roomId!!,
                             roomName = roomName,
                             roomIsDirect = room.roomSummary()?.isDirect ?: false,

--- a/vector/src/main/java/im/vector/app/features/notifications/NotifiableMessageEvent.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotifiableMessageEvent.kt
@@ -27,7 +27,9 @@ data class NotifiableMessageEvent(
         val senderName: String?,
         val senderId: String?,
         val body: String?,
-        val imageUri: Uri?,
+        // We cannot use Uri? type here, as that could trigger a
+        // NotSerializableException when persisting this to storage
+        val imageUriString: String?,
         val roomId: String,
         val roomName: String?,
         val roomIsDirect: Boolean = false,
@@ -45,4 +47,7 @@ data class NotifiableMessageEvent(
     val type: String = EventType.MESSAGE
     val description: String = body ?: ""
     val title: String = senderName ?: ""
+
+    val imageUri: Uri?
+        get() = imageUriString?.let { Uri.parse(it) }
 }

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationBroadcastReceiver.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationBroadcastReceiver.kt
@@ -145,7 +145,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
                         ?: context?.getString(R.string.notification_sender_me),
                 senderId = session.myUserId,
                 body = message,
-                imageUri = null,
+                imageUriString = null,
                 roomId = room.roomId,
                 roomName = room.roomSummary()?.displayName ?: room.roomId,
                 roomIsDirect = room.roomSummary()?.isDirect == true,

--- a/vector/src/test/java/im/vector/app/test/fixtures/NotifiableEventFixture.kt
+++ b/vector/src/test/java/im/vector/app/test/fixtures/NotifiableEventFixture.kt
@@ -77,5 +77,5 @@ fun aNotifiableMessageEvent(
         roomIsDirect = false,
         canBeReplaced = false,
         isRedacted = isRedacted,
-        imageUri = null
+        imageUriString = null
 )


### PR DESCRIPTION
Persisting notification info fails for non-null Uris:

```
E NotificationEventPersistence: ## Failed to save cached notification info
E NotificationEventPersistence: java.io.NotSerializableException: android.net.Uri$HierarchicalUri
E NotificationEventPersistence: 	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1240)
E NotificationEventPersistence: 	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1604)
E NotificationEventPersistence: 	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1565)
E NotificationEventPersistence: 	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1488)
E NotificationEventPersistence: 	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1234)
E NotificationEventPersistence: 	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:354)
E NotificationEventPersistence: 	at java.util.ArrayList.writeObject(ArrayList.java:762)
E NotificationEventPersistence: 	at java.lang.reflect.Method.invoke(Native Method)
E NotificationEventPersistence: 	at java.io.ObjectStreamClass.invokeWriteObject(ObjectStreamClass.java:1036)
E NotificationEventPersistence: 	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1552)
E NotificationEventPersistence: 	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1488)
E NotificationEventPersistence: 	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1234)
E NotificationEventPersistence: 	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:354)
E NotificationEventPersistence: 	at org.matrix.android.sdk.internal.session.securestorage.SecretStoringUtils.saveSecureObjectM(SecretStoringUtils.kt:283)
E NotificationEventPersistence: 	at org.matrix.android.sdk.internal.session.securestorage.SecretStoringUtils.securelyStoreObject(SecretStoringUtils.kt:150)
E NotificationEventPersistence: 	at org.matrix.android.sdk.internal.session.securestorage.DefaultSecureStorageService.securelyStoreObject(DefaultSecureStorageService.kt:27)
E NotificationEventPersistence: 	at im.vector.app.features.notifications.NotificationEventPersistence.persistEvents(NotificationEventPersistence.kt:58)
E NotificationEventPersistence: 	at im.vector.app.features.notifications.NotificationDrawerManager$persistEvents$1.invoke(NotificationDrawerManager.kt:183)
E NotificationEventPersistence: 	at im.vector.app.features.notifications.NotificationDrawerManager$persistEvents$1.invoke(NotificationDrawerManager.kt:182)
E NotificationEventPersistence: 	at im.vector.app.features.notifications.NotificationState.queuedEvents(NotificationState.kt:55)
E NotificationEventPersistence: 	at im.vector.app.features.notifications.NotificationDrawerManager.persistEvents(NotificationDrawerManager.kt:182)
E NotificationEventPersistence: 	at im.vector.app.features.notifications.NotificationDrawerManager.refreshNotificationDrawerBg(NotificationDrawerManager.kt:177)
```

Accordingly, if a notification for an image is shown, and the
notification state is loaded from storage later, none of the previously
shown notifications will get dismissed once read.

Likely addresses https://github.com/vector-im/element-android/issues/4862.

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Store Uri as string, which can be serialized and persisted.

## Motivation and context

Fix dismissing notifications when a chat is read after restoring the persisted notification state.

## Tests

<!-- Explain how you tested your development -->

### Easy test

- Get a notification for a received image
- Check log if persisting notification info failed

### Advanced test

- Get notifications, at least one with image
- In `NotificationDrawerManager.kt`, execute `notificationState = createInitialNotificationState()` (I added some UI for me to test that)
- Read all chats
-> see if notifications dismiss

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
 
Signed-off-by: Tobias Büttner <dev@spiritcroc.de>