### PR TITLE
Remove background location permission

### DIFF
--- a/changelog.d/6198.misc
+++ b/changelog.d/6198.misc
@@ -1,0 +1,1 @@
+Remove the background location permission request

--- a/vector/src/debug/AndroidManifest.xml
+++ b/vector/src/debug/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="im.vector.app">
 
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
-
     <application>
         <activity android:name=".features.debug.TestLinkifyActivity" />
         <activity android:name=".features.debug.DebugPermissionActivity" />

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -45,8 +45,6 @@
     <!-- Location Sharing -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <!--  Debug only whilst live location sharing is WIP -->
-    <!--<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />-->
 
     <!-- Jitsi SDK is now API23+ -->
     <uses-sdk tools:overrideLibrary="org.jitsi.meet.sdk,com.oney.WebRTCModule,com.learnium.RNDeviceInfo,com.reactnativecommunity.asyncstorage,com.ocetnik.timer,com.calendarevents,com.reactnativecommunity.netinfo,com.kevinresol.react_native_default_preference,com.rnimmersive,com.corbt.keepawake,com.BV.LinearGradient,com.horcrux.svg,com.oblador.performance,com.reactnativecommunity.slider,com.brentvatne.react,com.reactnativecommunity.clipboard,com.swmansion.gesturehandler.react,org.linusu,org.reactnative.maskedview,com.reactnativepagerview,com.swmansion.reanimated,com.th3rdwave.safeareacontext,com.swmansion.rnscreens,org.devio.rn.splashscreen,com.reactnativecommunity.webview" />

--- a/vector/src/main/java/im/vector/app/core/utils/PermissionsTools.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/PermissionsTools.kt
@@ -19,7 +19,6 @@ package im.vector.app.core.utils
 import android.Manifest
 import android.app.Activity
 import android.content.pm.PackageManager
-import android.os.Build
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
@@ -43,11 +42,6 @@ val PERMISSIONS_FOR_ROOM_AVATAR = listOf(Manifest.permission.CAMERA)
 val PERMISSIONS_FOR_WRITING_FILES = listOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
 val PERMISSIONS_FOR_PICKING_CONTACT = listOf(Manifest.permission.READ_CONTACTS)
 val PERMISSIONS_FOR_FOREGROUND_LOCATION_SHARING = listOf(Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION)
-val PERMISSIONS_FOR_BACKGROUND_LOCATION_SHARING = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-    listOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-} else {
-    PERMISSIONS_EMPTY
-}
 
 // This is not ideal to store the value like that, but it works
 private var permissionDialogDisplayed = false

--- a/vector/src/main/java/im/vector/app/features/location/DefaultLocationSharingNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/location/DefaultLocationSharingNavigator.kt
@@ -17,20 +17,10 @@
 package im.vector.app.features.location
 
 import android.app.Activity
-import im.vector.app.core.utils.openAppSettingsPage
 
 class DefaultLocationSharingNavigator constructor(val activity: Activity?) : LocationSharingNavigator {
 
-    override var goingToAppSettings: Boolean = false
-
     override fun quit() {
         activity?.finish()
-    }
-
-    override fun goToAppSettings() {
-        activity?.let {
-            goingToAppSettings = true
-            openAppSettingsPage(it)
-        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
@@ -32,9 +32,9 @@ import com.mapbox.mapboxsdk.maps.MapView
 import im.vector.app.R
 import im.vector.app.core.platform.VectorBaseBottomSheetDialogFragment
 import im.vector.app.core.platform.VectorBaseFragment
-import im.vector.app.core.utils.PERMISSIONS_FOR_BACKGROUND_LOCATION_SHARING
 import im.vector.app.core.utils.PERMISSIONS_FOR_FOREGROUND_LOCATION_SHARING
 import im.vector.app.core.utils.checkPermissions
+import im.vector.app.core.utils.onPermissionDeniedDialog
 import im.vector.app.core.utils.registerForPermissionsResult
 import im.vector.app.databinding.FragmentLocationSharingBinding
 import im.vector.app.features.home.AvatarRenderer
@@ -100,11 +100,6 @@ class LocationSharingFragment @Inject constructor(
     override fun onResume() {
         super.onResume()
         views.mapView.onResume()
-        if (locationSharingNavigator.goingToAppSettings) {
-            locationSharingNavigator.goingToAppSettings = false
-            // retry to start live location
-            tryStartLiveLocationSharing()
-        }
     }
 
     override fun onPause() {
@@ -162,18 +157,6 @@ class LocationSharingFragment @Inject constructor(
                 .show()
     }
 
-    private fun handleMissingBackgroundLocationPermission() {
-        MaterialAlertDialogBuilder(requireActivity())
-                .setTitle(R.string.location_in_background_missing_permission_dialog_title)
-                .setMessage(R.string.location_in_background_missing_permission_dialog_content)
-                .setPositiveButton(R.string.settings) { _, _ ->
-                    locationSharingNavigator.goToAppSettings()
-                }
-                .setNegativeButton(R.string.action_not_now, null)
-                .setCancelable(false)
-                .show()
-    }
-
     private fun initLocateButton() {
         views.mapView.locateButton.setOnClickListener {
             viewModel.handle(LocationSharingAction.ZoomToUserLocation)
@@ -212,30 +195,16 @@ class LocationSharingFragment @Inject constructor(
     }
 
     private val foregroundLocationResultLauncher = registerForPermissionsResult { allGranted, deniedPermanently ->
-        if (allGranted && checkPermissions(PERMISSIONS_FOR_BACKGROUND_LOCATION_SHARING, requireActivity(), backgroundLocationResultLauncher)) {
-            startLiveLocationSharing()
-        } else if (deniedPermanently) {
-            handleMissingBackgroundLocationPermission()
-        }
-    }
-
-    private val backgroundLocationResultLauncher = registerForPermissionsResult { allGranted, deniedPermanently ->
         if (allGranted) {
             startLiveLocationSharing()
         } else if (deniedPermanently) {
-            handleMissingBackgroundLocationPermission()
+            activity?.onPermissionDeniedDialog(R.string.denied_permission_generic)
         }
     }
 
     private fun tryStartLiveLocationSharing() {
         // we need to re-check foreground location to be sure it has not changed after landing on this screen
-        if (checkPermissions(PERMISSIONS_FOR_FOREGROUND_LOCATION_SHARING, requireActivity(), foregroundLocationResultLauncher) &&
-                checkPermissions(
-                        PERMISSIONS_FOR_BACKGROUND_LOCATION_SHARING,
-                        requireActivity(),
-                        backgroundLocationResultLauncher,
-                        R.string.location_in_background_missing_permission_dialog_content
-                )) {
+        if (checkPermissions(PERMISSIONS_FOR_FOREGROUND_LOCATION_SHARING, requireActivity(), foregroundLocationResultLauncher)) {
             startLiveLocationSharing()
         }
     }

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingNavigator.kt
@@ -17,7 +17,5 @@
 package im.vector.app.features.location
 
 interface LocationSharingNavigator {
-    var goingToAppSettings: Boolean
     fun quit()
-    fun goToAppSettings()
 }

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3017,7 +3017,9 @@
     <string name="location_share_live_select_duration_option_1">15 minutes</string>
     <string name="location_share_live_select_duration_option_2">1 hour</string>
     <string name="location_share_live_select_duration_option_3">8 hours</string>
+   <!--TODO delete-->
     <string name="location_in_background_missing_permission_dialog_title">Allow access</string>
+    <!--TODO delete-->
     <string name="location_in_background_missing_permission_dialog_content">If you’d like to share your Live location, ${app_name} needs location access all the time when the app is in the background.\nWe will only access your location for the duration that you choose.</string>
     <string name="location_not_available_dialog_title">${app_name} could not access your location</string>
     <string name="location_not_available_dialog_content">${app_name} could not access your location. Please try again later.</string>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Enhancement

## Content

<!-- Describe shortly what has been changed -->
It removes the request for background location permission when starting a live location share. We only request foreground location access.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6198 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

The test should be done on a device with Android version 11+

- Enable location sharing in Settings -> Preferences
- Enable live location sharing in Settings -> Labs
- Go to a room
- Selection location sharing option in the composer view
- Select the live location share option
- Check you current location is correctly shared
- Put the app in background and move
- Check you location is still shared and updated

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
