### PR TITLE
Build health false positives

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -269,7 +269,13 @@ dependencyAnalysis {
         }
         project(":vector") {
             onUnusedDependencies {
-                exclude("org.maplibre.gl:android-sdk", "org.maplibre.gl:android-plugin-annotation-v9") // False positives
+                // False positives
+                exclude(
+                        "org.maplibre.gl:android-sdk",
+                        "org.maplibre.gl:android-plugin-annotation-v9",
+                        "com.vanniktech:emoji-google",
+                        "com.vanniktech:emoji-material"
+                )
             }
         }
     }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Fixes failing build health task due to false positives in with the emoji dependencies (their resources are pulled in)

## Motivation and context

To fix the red (17/18 tasks passed) builds on github!

## Screenshots / GIFs

No UI changes

## Tests

- Run the `./gradlew buildHealth` task


## Tested devices
N/A