### PR TITLE
Use fatalError instead of NPE

### DIFF
--- a/vector/src/main/java/im/vector/app/features/widgets/webview/WebviewPermissionUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/webview/WebviewPermissionUtils.kt
@@ -24,11 +24,15 @@ import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.FragmentActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import im.vector.app.R
+import im.vector.app.core.error.fatalError
 import im.vector.app.core.utils.checkPermissions
+import im.vector.app.features.settings.VectorPreferences
 import java.lang.NullPointerException
 import javax.inject.Inject
 
-class WebviewPermissionUtils @Inject constructor() {
+class WebviewPermissionUtils @Inject constructor(
+        private val vectorPreferences: VectorPreferences,
+) {
 
     private var permissionRequest: PermissionRequest? = null
     private var selectedPermissions = listOf<String>()
@@ -75,7 +79,11 @@ class WebviewPermissionUtils @Inject constructor() {
 
     fun onPermissionResult(result: Map<String, Boolean>) {
         if (permissionRequest == null) {
-            throw NullPointerException("permissionRequest was null! Make sure to call promptForPermissions first.")
+            fatalError(
+                message = "permissionRequest was null! Make sure to call promptForPermissions first.",
+                failFast = vectorPreferences.failFast()
+            )
+            return
         }
         val grantedPermissions = filterPermissionsToBeGranted(selectedPermissions, result)
         if (grantedPermissions.isNotEmpty()) {

--- a/vector/src/main/java/im/vector/app/features/widgets/webview/WebviewPermissionUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/webview/WebviewPermissionUtils.kt
@@ -27,7 +27,6 @@ import im.vector.app.R
 import im.vector.app.core.error.fatalError
 import im.vector.app.core.utils.checkPermissions
 import im.vector.app.features.settings.VectorPreferences
-import java.lang.NullPointerException
 import javax.inject.Inject
 
 class WebviewPermissionUtils @Inject constructor(

--- a/vector/src/test/java/im/vector/app/features/widgets/WebviewPermissionUtilsTest.kt
+++ b/vector/src/test/java/im/vector/app/features/widgets/WebviewPermissionUtilsTest.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.widgets
 import android.Manifest
 import android.webkit.PermissionRequest
 import im.vector.app.features.widgets.webview.WebviewPermissionUtils
+import im.vector.app.test.fakes.FakeVectorPreferences
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.FixMethodOrder
 import org.junit.Test
@@ -30,7 +31,8 @@ import org.junit.runners.MethodSorters
 @FixMethodOrder(MethodSorters.JVM)
 class WebviewPermissionUtilsTest {
 
-    private val utils = WebviewPermissionUtils()
+    private val prefs = FakeVectorPreferences()
+    private val utils = WebviewPermissionUtils(prefs.instance)
 
     @Test
     fun filterPermissionsToBeGranted_selectedAndGrantedNothing() {


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

As advised by @bmarty [here](https://github.com/vector-im/element-android/pull/6149#discussion_r885413833) this is switching from an NPE to `fatalError` to avoid crashing in production builds.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 12

## Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)