### PR TITLE
Fix wrong status of live location sharing in timeline (PSF-1073)

### DIFF
--- a/changelog.d/6209.bugfix
+++ b/changelog.d/6209.bugfix
@@ -1,0 +1,1 @@
+Fix wrong status of live location sharing in timeline

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/aggregation/livelocation/DeactivateLiveLocationShareWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/aggregation/livelocation/DeactivateLiveLocationShareWorker.kt
@@ -75,6 +75,7 @@ internal class DeactivateLiveLocationShareWorker(context: Context, params: Worke
 
     private suspend fun deactivateLiveLocationShare(params: Params) {
         awaitTransaction(realmConfiguration) { realm ->
+            Timber.d("deactivating live with id=${params.eventId}")
             val aggregatedSummary = LiveLocationShareAggregatedSummaryEntity.get(
                     realm = realm,
                     roomId = params.roomId,


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Fix in the aggregation process to avoid scheduling deactivation worker too many times and when not necessary.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6209 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|<video src="https://user-images.githubusercontent.com/46314705/171189694-7176c173-c7b6-45b5-9159-6d0591944cee.mp4"/>|<video src="https://user-images.githubusercontent.com/46314705/171194021-2b0d43e2-2ee3-4aa2-8d75-a64c74bdb0b3.mp4"/>|  


## Tests

<!-- Explain how you tested your development -->

- Enable location sharing in Settings -> Preferences
- Enable live location sharing in Settings -> Labs
- Go to a room
- Start a live location share
- Remove the app from the stack of opened app
- Go back to the app
- Go to the room timeline where the live is running
- Check the live is still considered as running 

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
