### PR TITLE
Homeserver version without patch number parsing

### DIFF
--- a/changelog.d/6017.misc
+++ b/changelog.d/6017.misc
@@ -1,0 +1,1 @@
+Adds support for parsing homeserver versions without a patch number

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/extensions/Strings.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/extensions/Strings.kt
@@ -27,3 +27,8 @@ fun CharSequence.ensurePrefix(prefix: CharSequence): CharSequence {
  * Append a new line and then the provided string.
  */
 fun StringBuilder.appendNl(str: String) = append("\n").append(str)
+
+/**
+ * Returns null if the string is empty.
+ */
+fun String.ensureNotEmpty() = ifEmpty { null }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersion.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersion.kt
@@ -38,14 +38,14 @@ internal data class HomeServerVersion(
     }
 
     companion object {
-        internal val pattern = Regex("""[r|v](\d+)\.(\d+)\.(\d+)""")
+        internal val pattern = Regex("""[r|v](\d+)\.(\d+)(?:\.(\d+))?""")
 
         internal fun parse(value: String): HomeServerVersion? {
             val result = pattern.matchEntire(value) ?: return null
             return HomeServerVersion(
                     major = result.groupValues[1].toInt(),
                     minor = result.groupValues[2].toInt(),
-                    patch = result.groupValues[3].toInt()
+                    patch = result.groupValues.getOptional(index = 3, default = "0").toInt()
             )
         }
 
@@ -59,3 +59,5 @@ internal data class HomeServerVersion(
         val v1_3_0 = HomeServerVersion(major = 1, minor = 3, patch = 0)
     }
 }
+
+private fun List<String>.getOptional(index: Int, default: String) = getOrNull(index)?.ifEmpty { default } ?: default

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersion.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersion.kt
@@ -16,6 +16,8 @@
 
 package org.matrix.android.sdk.internal.auth.version
 
+import org.matrix.android.sdk.api.extensions.ensureNotEmpty
+
 /**
  * Values will take the form "rX.Y.Z".
  * Ref: https://matrix.org/docs/spec/client_server/latest#get-matrix-client-versions
@@ -45,7 +47,7 @@ internal data class HomeServerVersion(
             return HomeServerVersion(
                     major = result.groupValues[1].toInt(),
                     minor = result.groupValues[2].toInt(),
-                    patch = result.groupValues.getOptional(index = 3, default = "0").toInt()
+                    patch = result.groupValues.getOrNull(index = 3)?.ensureNotEmpty()?.toInt() ?: 0
             )
         }
 
@@ -59,5 +61,3 @@ internal data class HomeServerVersion(
         val v1_3_0 = HomeServerVersion(major = 1, minor = 3, patch = 0)
     }
 }
-
-private fun List<String>.getOptional(index: Int, default: String) = getOrNull(index)?.ifEmpty { default } ?: default

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersionTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersionTest.kt
@@ -22,27 +22,23 @@ import org.junit.Test
 class HomeServerVersionTest {
 
     @Test
-    fun `given a semantic version, when parsing then converts to home server version`() {
-        val cases = buildList {
-            addAll(
-                    listOf(
-                            case("0.5.1", expected = aVersion(0, 5, 1)),
-                            case("1.0.0", expected = aVersion(1, 0, 0)),
-                            case("1.10.3", expected = aVersion(1, 10, 3))
-                    ).withPrefixes("v", "r"),
-            )
-            addAll(
-                    listOf(
-                            case("-1.5.1", expected = null),
-                            case("1", expected = null),
-                            case("a", expected = null),
-                            case("1.0", expected = null),
-                            case("1a.2b.3c", expected = null),
-                    )
-            )
-        }
+    fun `given a semantic version, when parsing, then converts to home server version`() {
+        val supportedVersions = listOf(
+                case("1.5", expected = aVersion(1, 5, 0)),
+                case("0.5.1", expected = aVersion(0, 5, 1)),
+                case("1.0.0", expected = aVersion(1, 0, 0)),
+                case("1.10.3", expected = aVersion(1, 10, 3))
+        ).withPrefixes("v", "r")
 
-        cases.forEach { (input, expected) ->
+        val unsupportedVersions = listOf(
+                case("v-1.5.1", expected = null),
+                case("r1", expected = null),
+                case("a", expected = null),
+                case("1a.2b.3c", expected = null),
+                case("r", expected = null)
+        )
+
+        (supportedVersions + unsupportedVersions).forEach { (input, expected) ->
             val result = HomeServerVersion.parse(input)
 
             assertEquals(expected, result, "Expected $input to be $expected but got $result")

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersionTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersionTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.auth.version
+
+import org.amshove.kluent.internal.assertEquals
+import org.junit.Test
+
+class HomeServerVersionTest {
+
+    @Test
+    fun `given a semantic version, when parsing then converts to home server version`() {
+        val cases = buildList {
+            addAll(
+                    listOf(
+                            case("0.5.1", expected = aVersion(0, 5, 1)),
+                            case("1.0.0", expected = aVersion(1, 0, 0)),
+                            case("1.10.3", expected = aVersion(1, 10, 3))
+                    ).withPrefixes("v", "r"),
+            )
+            addAll(
+                    listOf(
+                            case("-1.5.1", expected = null),
+                            case("1", expected = null),
+                            case("a", expected = null),
+                            case("1.0", expected = null),
+                            case("1a.2b.3c", expected = null),
+                    )
+            )
+        }
+
+        cases.forEach { (input, expected) ->
+            val result = HomeServerVersion.parse(input)
+
+            assertEquals(expected, result, "Expected $input to be $expected but got $result")
+        }
+    }
+}
+
+private fun aVersion(major: Int, minor: Int, patch: Int) = HomeServerVersion(major, minor, patch)
+private fun case(input: String, expected: HomeServerVersion?) = Case(input, expected)
+
+private fun List<Case>.withPrefixes(vararg prefixes: String) = map { case ->
+    prefixes.map { prefix -> case.copy(input = "$prefix${case.input}") }
+}.flatten()
+
+private data class Case(val input: String, val expected: HomeServerVersion?)

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersionTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersionTest.kt
@@ -32,6 +32,8 @@ class HomeServerVersionTest {
 
         val unsupportedVersions = listOf(
                 case("v-1.5.1", expected = null),
+                case("1.4.", expected = null),
+                case("1.5.1.", expected = null),
                 case("r1", expected = null),
                 case("a", expected = null),
                 case("1a.2b.3c", expected = null),

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersionTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersionTest.kt
@@ -27,7 +27,7 @@ class HomeServerVersionTest {
                 case("1.5", expected = aVersion(1, 5, 0)),
                 case("0.5.1", expected = aVersion(0, 5, 1)),
                 case("1.0.0", expected = aVersion(1, 0, 0)),
-                case("1.10.3", expected = aVersion(1, 10, 3))
+                case("1.10.3", expected = aVersion(1, 10, 3)),
         ).withPrefixes("v", "r")
 
         val unsupportedVersions = listOf(
@@ -37,7 +37,7 @@ class HomeServerVersionTest {
                 case("r1", expected = null),
                 case("a", expected = null),
                 case("1a.2b.3c", expected = null),
-                case("r", expected = null)
+                case("r", expected = null),
         )
 
         (supportedVersions + unsupportedVersions).forEach { (input, expected) ->

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersionTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/auth/version/HomeServerVersionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright 2022 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.matrix.android.sdk.internal.auth.version
 
 import org.amshove.kluent.internal.assertEquals


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Fixes #6017 Supporting Homeserver versions without a patch number.

Versions without a patch are considered as having a patch of `0` eg 1.5 is parsed as `major: 1 minor: 5 patch: 0`

- Makes the Homeserver version regex support optional patch numbers 
- Adds unit tests around the parsing

## Motivation and context

To support version formats defined by the spec 

## Screenshots / GIFs

No UI changes

## Tests

Handled by unit tests 

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28
