### PR TITLE
Fix animated images only autoplaying sometimes

### DIFF
--- a/changelog.d/6215.bugfix
+++ b/changelog.d/6215.bugfix
@@ -1,0 +1,1 @@
+Fix animated images not autoplaying sometimes if only a thumbnail was fetched from the server

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -453,12 +453,15 @@ class MessageItemFactory @Inject constructor(
                 maxWidth = maxWidth,
                 allowNonMxcUrls = informationData.sendState.isSending()
         )
+
+        val playable = messageContent.mimeType == MimeTypes.Gif
+
         return MessageImageVideoItem_()
                 .attributes(attributes)
                 .leftGuideline(avatarSizeProvider.leftGuideline)
                 .imageContentRenderer(imageContentRenderer)
                 .contentUploadStateTrackerBinder(contentUploadStateTrackerBinder)
-                .playable(messageContent.mimeType == MimeTypes.Gif)
+                .playable(playable)
                 .highlighted(highlight)
                 .mediaData(data)
                 .apply {
@@ -471,6 +474,10 @@ class MessageItemFactory @Inject constructor(
                         clickListener { view ->
                             callback?.onImageMessageClicked(messageContent, data, view, emptyList())
                         }
+                    }
+                }.apply {
+                    if (playable && vectorPreferences.autoplayAnimatedImages()) {
+                        mode(ImageContentRenderer.Mode.ANIMATED_THUMBNAIL)
                     }
                 }
     }

--- a/vector/src/main/java/im/vector/app/features/media/ImageContentRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/media/ImageContentRenderer.kt
@@ -38,7 +38,6 @@ import im.vector.app.core.glide.GlideRequest
 import im.vector.app.core.glide.GlideRequests
 import im.vector.app.core.ui.model.Size
 import im.vector.app.core.utils.DimensionConverter
-import im.vector.app.features.settings.VectorPreferences
 import kotlinx.parcelize.Parcelize
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.content.ContentUrlResolver
@@ -65,7 +64,6 @@ class ImageContentRenderer @Inject constructor(
         private val localFilesHelper: LocalFilesHelper,
         private val activeSessionHolder: ActiveSessionHolder,
         private val dimensionConverter: DimensionConverter,
-        private val vectorPreferences: VectorPreferences
 ) {
 
     @Parcelize
@@ -134,7 +132,7 @@ class ImageContentRenderer @Inject constructor(
 
         createGlideRequest(data, mode, imageView, size)
                 .let {
-                    if (vectorPreferences.autoplayAnimatedImages()) it
+                    if (mode == Mode.ANIMATED_THUMBNAIL) it
                     else it.dontAnimate()
                 }
                 .transform(cornerTransformation)

--- a/vector/src/main/java/im/vector/app/features/media/ImageContentRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/media/ImageContentRenderer.kt
@@ -85,6 +85,7 @@ class ImageContentRenderer @Inject constructor(
 
     enum class Mode {
         FULL_SIZE,
+        ANIMATED_THUMBNAIL,
         THUMBNAIL,
         STICKER
     }
@@ -231,6 +232,7 @@ class ImageContentRenderer @Inject constructor(
             val contentUrlResolver = activeSessionHolder.getActiveSession().contentUrlResolver()
             val resolvedUrl = when (mode) {
                 Mode.FULL_SIZE,
+                Mode.ANIMATED_THUMBNAIL,
                 Mode.STICKER -> resolveUrl(data)
                 Mode.THUMBNAIL -> contentUrlResolver.resolveThumbnail(data.url, size.width, size.height, ContentUrlResolver.ThumbnailMethod.SCALE)
             }
@@ -269,6 +271,7 @@ class ImageContentRenderer @Inject constructor(
                     finalHeight = height
                     finalWidth = width
                 }
+                Mode.ANIMATED_THUMBNAIL,
                 Mode.THUMBNAIL -> {
                     finalHeight = min(maxImageWidth * height / width, maxImageHeight)
                     finalWidth = finalHeight * width / height


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other:

## Content

This pull request fixes autoplaying animated images only actually autoplaying in some cases as only thumbnail data would be fetched in the other cases.

It introduces a new `ImageContentRenderer` mode specifically for animated images with thumbnail sizing that always resolves to the actual image url just like stickers for example

The autoplaying feature was originally introduced in #6166

<!-- Describe shortly what has been changed -->

## Motivation and context

This issue was brought up in the element-android matrix channel after release 1.4.18

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|![before](https://user-images.githubusercontent.com/42888162/171280858-bfbc721c-055b-4dad-b419-a7c6f1d30327.gif)|![after](https://user-images.githubusercontent.com/42888162/171280945-dacc24cc-bbd6-40a3-83bb-ac0fe32fc0b0.gif)|

## Tests

<!-- Explain how you tested your development -->

- Send an animated image in a public room
- Check that the image actually autoplays instead of just showing the thumbnail

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 12 x86_64, Android 5 x86_64

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
