### PR TITLE
Fix StackOverflowError while recording voice message [PSF-1065]

### DIFF
--- a/changelog.d/6222.bugfix
+++ b/changelog.d/6222.bugfix
@@ -1,0 +1,1 @@
+Fix StackOverflowError while recording voice message

--- a/vector/src/main/java/im/vector/app/features/voice/AudioWaveformView.kt
+++ b/vector/src/main/java/im/vector/app/features/voice/AudioWaveformView.kt
@@ -151,14 +151,14 @@ class AudioWaveformView @JvmOverloads constructor(
 
     private fun handleNewFftList(fftList: List<FFT>) {
         val maxVisibleBarCount = getMaxVisibleBarCount()
+
         fftList.forEach { fft ->
             rawFftList.add(fft)
             val barHeight = max(fft.value / MAX_FFT * (height - verticalPadding * 2), barMinHeight)
             visibleBarHeights.add(FFT(barHeight, fft.color))
+
             if (visibleBarHeights.size > maxVisibleBarCount) {
-                visibleBarHeights = mutableListOf<FFT>().apply {
-                    addAll(visibleBarHeights.subList(visibleBarHeights.size - maxVisibleBarCount, visibleBarHeights.size))
-                }
+                visibleBarHeights = visibleBarHeights.takeLast(maxVisibleBarCount).toMutableList()
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/voice/AudioWaveformView.kt
+++ b/vector/src/main/java/im/vector/app/features/voice/AudioWaveformView.kt
@@ -156,7 +156,9 @@ class AudioWaveformView @JvmOverloads constructor(
             val barHeight = max(fft.value / MAX_FFT * (height - verticalPadding * 2), barMinHeight)
             visibleBarHeights.add(FFT(barHeight, fft.color))
             if (visibleBarHeights.size > maxVisibleBarCount) {
-                visibleBarHeights = visibleBarHeights.subList(visibleBarHeights.size - maxVisibleBarCount, visibleBarHeights.size)
+                visibleBarHeights = mutableListOf<FFT>().apply {
+                    addAll(visibleBarHeights.subList(visibleBarHeights.size - maxVisibleBarCount, visibleBarHeights.size))
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

- Start recording a voice message and lock the mic.
- Wait for 2 minutes (max length of a voice message)
- The app crashes

## Motivation and context

Fixes #6137 

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Start recording a voice message and wait for 2 minutes
- Send the record, delete the record and everything should work as expected

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
