### PR TITLE
Avoid manual line breaks in exit onboarding dialog copy

### DIFF
--- a/changelog.d/6087.misc
+++ b/changelog.d/6087.misc
@@ -1,0 +1,1 @@
+Updating exit onboarding dialog copy formatting to match iOS

--- a/vector/src/main/res/values-bg/strings.xml
+++ b/vector/src/main/res/values-bg/strings.xml
@@ -1130,9 +1130,7 @@
     <string name="login_signup_submit">Напред</string>
     <string name="login_signup_error_user_in_use">Това потребителско име е заето</string>
     <string name="login_signup_cancel_confirmation_title">Внимание</string>
-    <string name="login_signup_cancel_confirmation_content">Профила ви все още не е създаден.
-\n
-\nПрекратяване на процеса на регистрация\?</string>
+    <string name="login_signup_cancel_confirmation_content">Профила ви все още не е създаден. Прекратяване на процеса на регистрация\?</string>
     <string name="login_a11y_choose_matrix_org">Избери matrix.org</string>
     <string name="login_a11y_choose_modular">Избери Element Matrix Services</string>
     <string name="login_a11y_choose_other">Избери собствен сървър</string>

--- a/vector/src/main/res/values-ca/strings.xml
+++ b/vector/src/main/res/values-ca/strings.xml
@@ -1602,9 +1602,7 @@
     <string name="login_a11y_choose_other">Selecciona un servidor local personalitzat</string>
     <string name="login_a11y_choose_modular">Selecciona Serveis Matrix d\'Element</string>
     <string name="login_a11y_choose_matrix_org">Selecciona matrix.org</string>
-    <string name="login_signup_cancel_confirmation_content">El teu compte encara s\'ha creat.
-\n
-\nVols aturar el procés de registre\?</string>
+    <string name="login_signup_cancel_confirmation_content">El teu compte encara s\'ha creat. Vols aturar el procés de registre\?</string>
     <string name="login_signup_cancel_confirmation_title">Atenció</string>
     <string name="login_signup_error_user_in_use">Aquest nom d\'usuari ja està agafat</string>
     <string name="login_set_msisdn_notice">Estableix un número de telèfon per, opcionalment, permetre que la gent que coneixes et pugui trobar.</string>

--- a/vector/src/main/res/values-cs/strings.xml
+++ b/vector/src/main/res/values-cs/strings.xml
@@ -1164,9 +1164,7 @@
     <string name="login_signup_username_hint">Uživatelské jméno</string>
     <string name="login_signup_error_user_in_use">Toto uživatelské jméno je již obsazeno</string>
     <string name="login_signup_cancel_confirmation_title">Varování</string>
-    <string name="login_signup_cancel_confirmation_content">Váš účet nebyl ještě založen.
-\n
-\nZastavit registrační proces\?</string>
+    <string name="login_signup_cancel_confirmation_content">Váš účet nebyl ještě založen. Zastavit registrační proces\?</string>
     <string name="login_a11y_choose_matrix_org">Vybrat matrix.org</string>
     <string name="login_a11y_choose_modular">Vybrat Element Matrix Services</string>
     <string name="login_a11y_choose_other">Vybrat vlastní domovský server</string>

--- a/vector/src/main/res/values-de/strings.xml
+++ b/vector/src/main/res/values-de/strings.xml
@@ -1118,9 +1118,7 @@
     <string name="login_signin_username_hint">Benutzername oder E-Mail-Adresse</string>
     <string name="login_signup_password_hint">Passwort</string>
     <string name="login_signup_error_user_in_use">Dieser Benutzername ist bereits belegt</string>
-    <string name="login_signup_cancel_confirmation_content">Dein Benutzerkonto ist noch nicht erstellt.
-\n
-\nMöchtest du die Registrierung stoppen\?</string>
+    <string name="login_signup_cancel_confirmation_content">Dein Benutzerkonto ist noch nicht erstellt. Möchtest du die Registrierung stoppen\?</string>
     <string name="login_a11y_choose_matrix_org">matrix.org auswählen</string>
     <string name="login_a11y_choose_modular">modular auswählen</string>
     <string name="login_a11y_choose_other">Benutzerdefinierten Server auswählen</string>

--- a/vector/src/main/res/values-eo/strings.xml
+++ b/vector/src/main/res/values-eo/strings.xml
@@ -573,9 +573,7 @@
     <string name="login_a11y_choose_other">Elekti propran hejmservilon</string>
     <string name="login_a11y_choose_modular">Elekti Element Matrix Services</string>
     <string name="login_a11y_choose_matrix_org">Elekti matrix.org</string>
-    <string name="login_signup_cancel_confirmation_content">Via konto ankoraŭ ne estas kreita.
-\n
-\nĈu haltigi la registriĝon\?</string>
+    <string name="login_signup_cancel_confirmation_content">Via konto ankoraŭ ne estas kreita. Ĉu haltigi la registriĝon\?</string>
     <string name="login_signup_cancel_confirmation_title">Averto</string>
     <string name="login_signup_error_user_in_use">Tiu uzantonomo jam estas prenita</string>
     <string name="login_signup_submit">Pluen</string>

--- a/vector/src/main/res/values-es/strings.xml
+++ b/vector/src/main/res/values-es/strings.xml
@@ -1411,9 +1411,7 @@
     <string name="login_signup_submit">Siguiente</string>
     <string name="login_signup_error_user_in_use">Ese nombre de usuario está siendo usado</string>
     <string name="login_signup_cancel_confirmation_title">Advertencia</string>
-    <string name="login_signup_cancel_confirmation_content">Tu cuenta aún no está creada.
-\n
-\n ¿Detener el proceso de registro\?</string>
+    <string name="login_signup_cancel_confirmation_content">Tu cuenta aún no está creada. ¿Detener el proceso de registro\?</string>
     <string name="login_a11y_choose_matrix_org">Seleccione matrix.org</string>
     <string name="login_a11y_choose_modular">Seleccionar servicios de matriz de elementos</string>
     <string name="login_a11y_choose_other">Seleccione un servidor doméstico personalizado</string>

--- a/vector/src/main/res/values-et/strings.xml
+++ b/vector/src/main/res/values-et/strings.xml
@@ -1242,9 +1242,7 @@
     <string name="login_signup_submit">Järgmine</string>
     <string name="login_signup_error_user_in_use">Selline kasutajanimi on juba olemas</string>
     <string name="login_signup_cancel_confirmation_title">Hoiatus</string>
-    <string name="login_signup_cancel_confirmation_content">Sinu kasutajakonto pole veel loodud.
-\n
-\nKas katkestame konto registreerimise\?</string>
+    <string name="login_signup_cancel_confirmation_content">Sinu kasutajakonto pole veel loodud. Kas katkestame konto registreerimise\?</string>
     <string name="login_a11y_choose_matrix_org">Vali matrix.org</string>
     <string name="login_a11y_choose_modular">Vali teenusepakkujaks Element Matrix Services</string>
     <string name="login_a11y_choose_other">Vali mõni muu koduserver</string>

--- a/vector/src/main/res/values-eu/strings.xml
+++ b/vector/src/main/res/values-eu/strings.xml
@@ -1396,9 +1396,7 @@ Errore hau ${app_name}-en kontroletik kanpo dago. Ez dago Google konturik gailua
     <string name="login_signup_submit">Hurrengoa</string>
     <string name="login_signup_error_user_in_use">Erabiltzaile-izen hori hartuta dago</string>
     <string name="login_signup_cancel_confirmation_title">Abisua</string>
-    <string name="login_signup_cancel_confirmation_content">Zure kontua ez da oraindik sortu.
-\n
-\nUtzi erregistratze prozesua\?</string>
+    <string name="login_signup_cancel_confirmation_content">Zure kontua ez da oraindik sortu. Utzi erregistratze prozesua\?</string>
 
     <string name="login_a11y_choose_matrix_org">Hautatu matrix.org</string>
     <string name="login_a11y_choose_modular">Hautatu Element Matrix Services</string>

--- a/vector/src/main/res/values-fi/strings.xml
+++ b/vector/src/main/res/values-fi/strings.xml
@@ -1091,9 +1091,7 @@
     <string name="login_signup_submit">Seuraava</string>
     <string name="login_signup_error_user_in_use">Käyttäjätunnus on varattu</string>
     <string name="login_signup_cancel_confirmation_title">Varoitus</string>
-    <string name="login_signup_cancel_confirmation_content">Tunnustasi ei ole vielä luotu.
-\n
-\nPeru rekisteröintiprosessi\?</string>
+    <string name="login_signup_cancel_confirmation_content">Tunnustasi ei ole vielä luotu. Peru rekisteröintiprosessi\?</string>
     <string name="login_a11y_choose_matrix_org">Valitse matrix.org</string>
     <string name="login_a11y_choose_modular">Valitse Element Matrix Services</string>
     <string name="login_a11y_choose_other">Valitse muu kotipalvelin</string>

--- a/vector/src/main/res/values-fr-rCA/strings.xml
+++ b/vector/src/main/res/values-fr-rCA/strings.xml
@@ -892,9 +892,7 @@
     <string name="login_a11y_choose_other">Sélectionner un serveur d’accueil personnalisé</string>
     <string name="login_a11y_choose_modular">Sélectionner Element Matrix Services</string>
     <string name="login_a11y_choose_matrix_org">Sélectionner matrix.org</string>
-    <string name="login_signup_cancel_confirmation_content">Votre compte n’est pas encore crée.
-\n
-\nArrêter le processus de création \?</string>
+    <string name="login_signup_cancel_confirmation_content">Votre compte n’est pas encore crée. Arrêter le processus de création \?</string>
     <string name="login_signup_cancel_confirmation_title">Attention</string>
     <string name="login_signup_error_user_in_use">Ce nom d’utilisateur est déjà pris</string>
     <string name="login_signup_submit">Suivant</string>

--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -1118,9 +1118,7 @@
     <string name="login_signup_submit">Suivant</string>
     <string name="login_signup_error_user_in_use">Ce nom d’utilisateur est déjà pris</string>
     <string name="login_signup_cancel_confirmation_title">Attention</string>
-    <string name="login_signup_cancel_confirmation_content">Votre compte n’est pas encore crée.
-\n
-\nArrêter le processus de création \?</string>
+    <string name="login_signup_cancel_confirmation_content">Votre compte n’est pas encore crée. Arrêter le processus de création \?</string>
     <string name="login_a11y_choose_matrix_org">Sélectionner matrix.org</string>
     <string name="login_a11y_choose_modular">Sélectionner Element Matrix Services</string>
     <string name="login_a11y_choose_other">Sélectionner un serveur d’accueil personnalisé</string>

--- a/vector/src/main/res/values-hu/strings.xml
+++ b/vector/src/main/res/values-hu/strings.xml
@@ -1078,9 +1078,7 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="login_signup_submit">Következő</string>
     <string name="login_signup_error_user_in_use">A felhasználónév már használatban van</string>
     <string name="login_signup_cancel_confirmation_title">Figyelmeztetés</string>
-    <string name="login_signup_cancel_confirmation_content">A felhasználói fiókod még nincs kész.
-\n
-\nMegállítód a regisztrációt\?</string>
+    <string name="login_signup_cancel_confirmation_content">A felhasználói fiókod még nincs kész. Megállítód a regisztrációt\?</string>
     <string name="login_a11y_choose_matrix_org">matrix.org kiválasztása</string>
     <string name="login_a11y_choose_modular">Element Matrix Services kiválasztása</string>
     <string name="login_a11y_choose_other">Egyedi matrix szerver kiválasztása</string>

--- a/vector/src/main/res/values-in/strings.xml
+++ b/vector/src/main/res/values-in/strings.xml
@@ -1615,9 +1615,7 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="login_a11y_choose_other">Pilih homeserver kustom</string>
     <string name="login_a11y_choose_modular">Pilih Element Matrix Services</string>
     <string name="login_a11y_choose_matrix_org">Pilih matrix.org</string>
-    <string name="login_signup_cancel_confirmation_content">Akun Anda belum dibuat.
-\n
-\nBatalkan proses pendaftaran\?</string>
+    <string name="login_signup_cancel_confirmation_content">Akun Anda belum dibuat. Batalkan proses pendaftaran\?</string>
     <string name="login_signup_cancel_confirmation_title">Peringatan</string>
     <string name="login_signup_error_user_in_use">Nama pengguna itu telah diambil</string>
     <string name="login_signup_submit">Lanjut</string>

--- a/vector/src/main/res/values-it/strings.xml
+++ b/vector/src/main/res/values-it/strings.xml
@@ -1139,9 +1139,7 @@
     <string name="login_signup_submit">Avanti</string>
     <string name="login_signup_error_user_in_use">Questo nome utente è già in uso</string>
     <string name="login_signup_cancel_confirmation_title">Attenzione</string>
-    <string name="login_signup_cancel_confirmation_content">Il tuo account non è ancora stato creato.
-\n
-\nFermare il processo di registrazione\?</string>
+    <string name="login_signup_cancel_confirmation_content">Il tuo account non è ancora stato creato. Fermare il processo di registrazione\?</string>
     <string name="login_a11y_choose_matrix_org">Seleziona matrix.org</string>
     <string name="login_a11y_choose_modular">Seleziona Element Matrix Services</string>
     <string name="login_a11y_choose_other">Seleziona un server personalizzato</string>

--- a/vector/src/main/res/values-kab/strings.xml
+++ b/vector/src/main/res/values-kab/strings.xml
@@ -1395,9 +1395,7 @@
     <string name="login_msisdn_notice">Ma ulac aɣilif seqdec amasal agreɣlan (uṭṭun n tiliɣri ilaq ad yebdu s \'+\')</string>
     <string name="login_msisdn_error_not_international">Uṭṭun n tiliɣri agreɣlan ilaq ad yebdu s \'+\'</string>
     <string name="login_msisdn_error_other">Uṭṭun n tiliɣri yettban-d d arameɣtu. Ma ulac aɣilif senqed-it</string>
-    <string name="login_signup_cancel_confirmation_content">Amiḍan-ik·im mazal ur yettwarna ara ar tura.
-\n
-\nSeḥbes akala n usekles\?</string>
+    <string name="login_signup_cancel_confirmation_content">Amiḍan-ik·im mazal ur yettwarna ara ar tura. Seḥbes akala n usekles\?</string>
     <string name="login_wait_for_email_notice">Aql-aɣ akken nuzen imayl ɣer %1$s.
 \nMa ulac aɣilif sit ɣef useɣwen i yellan deg-s i wakken ad tkemmleḍ timerna.</string>
     <string name="login_validation_code_is_not_correct">Tangalt yettwaskecmen d tarameɣtut. Ma ulac aɣilif senqed.</string>

--- a/vector/src/main/res/values-lv/strings.xml
+++ b/vector/src/main/res/values-lv/strings.xml
@@ -1083,9 +1083,7 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="login_a11y_choose_other">Izvēlēties pielāgotu bāzes serveri</string>
     <string name="login_a11y_choose_modular">Izvēlēties Element Matrix Services</string>
     <string name="login_a11y_choose_matrix_org">Izvēlēties matrix.org</string>
-    <string name="login_signup_cancel_confirmation_content">Jūsu konts vēl nav izveidots..
-\n
-\nVai pārtraukt reģistrēšanos\?</string>
+    <string name="login_signup_cancel_confirmation_content">Jūsu konts vēl nav izveidots.. Vai pārtraukt reģistrēšanos\?</string>
     <string name="login_set_msisdn_notice2">Lūdzu, izmantojiet starptautisko formātu.</string>
     <string name="login_set_msisdn_notice">Iestatiet tālruņa numuru,lai pēc izvēles ļaut jums zināmiem cilvēkiem atrast.</string>
     <string name="login_set_msisdn_title">Iestatiet tālruņa numuru</string>

--- a/vector/src/main/res/values-nb-rNO/strings.xml
+++ b/vector/src/main/res/values-nb-rNO/strings.xml
@@ -875,9 +875,7 @@
     <string name="login_reset_password_cancel_confirmation_content">Passordet ditt er ikke endret ennå.
 \n
 \nStoppe passordendringsprosessen\?</string>
-    <string name="login_signup_cancel_confirmation_content">Kontoen din er ikke opprettet ennå.
-\n
-\nStoppe registreringsprosessen\?</string>
+    <string name="login_signup_cancel_confirmation_content">Kontoen din er ikke opprettet ennå. Stoppe registreringsprosessen\?</string>
     <string name="login_a11y_choose_other">Velg en tilpasset hjemmeserver</string>
     <string name="login_a11y_captcha_container">Vennligst utfør captcha-utfordringen</string>
     <string name="login_wait_for_email_notice">Vi har nettopp sendt en e-post til %1$s.

--- a/vector/src/main/res/values-nl/strings.xml
+++ b/vector/src/main/res/values-nl/strings.xml
@@ -2138,9 +2138,7 @@
     <string name="login_a11y_captcha_container">Voer de captcha uitdaging uit</string>
     <string name="login_a11y_choose_other">Selecteer een aangepaste server</string>
     <string name="login_a11y_choose_modular">Selecteer Element Matrix Services</string>
-    <string name="login_signup_cancel_confirmation_content">Uw account is nog niet aangemaakt.
-\n
-\nHet registratieproces stoppen\?</string>
+    <string name="login_signup_cancel_confirmation_content">Uw account is nog niet aangemaakt. Het registratieproces stoppen\?</string>
     <string name="login_signup_error_user_in_use">Deze inlognaam is in gebruik</string>
     <string name="login_signin_username_hint">Inlognaam of e-mailadres</string>
     <string name="login_signup_to">Meld u aan bij %1$s</string>

--- a/vector/src/main/res/values-pl/strings.xml
+++ b/vector/src/main/res/values-pl/strings.xml
@@ -984,9 +984,7 @@
     <string name="login_signup_submit">Dalej</string>
     <string name="login_signup_error_user_in_use">Nazwa użytkownika zajęta</string>
     <string name="login_signup_cancel_confirmation_title">Ostrzeżenie</string>
-    <string name="login_signup_cancel_confirmation_content">Twoje konto wciąż nie zostalo utworzone.
-\n
-\nZatrzymać proces rejestracji\?</string>
+    <string name="login_signup_cancel_confirmation_content">Twoje konto wciąż nie zostalo utworzone. Zatrzymać proces rejestracji\?</string>
     <string name="login_a11y_choose_matrix_org">Wybierz matrix.org</string>
     <string name="login_a11y_choose_modular">Wybierz Element Matrix Services</string>
     <string name="login_a11y_choose_other">Wybierz niestandardowy serwer domowy</string>

--- a/vector/src/main/res/values-pt-rBR/strings.xml
+++ b/vector/src/main/res/values-pt-rBR/strings.xml
@@ -1224,9 +1224,7 @@
     <string name="login_signup_submit">Próximo</string>
     <string name="login_signup_error_user_in_use">Esse nome de usuária(o) está tomado</string>
     <string name="login_signup_cancel_confirmation_title">Aviso</string>
-    <string name="login_signup_cancel_confirmation_content">Sua conta não foi criada ainda.
-\n
-\nParar o processo de registro\?</string>
+    <string name="login_signup_cancel_confirmation_content">Sua conta não foi criada ainda. Parar o processo de registro\?</string>
     <string name="login_a11y_choose_matrix_org">Selecionar matrix.org</string>
     <string name="login_a11y_choose_modular">Selecionar Element Matrix Services</string>
     <string name="login_a11y_choose_other">Selecionar um servidorcasa personalizado</string>

--- a/vector/src/main/res/values-ru/strings.xml
+++ b/vector/src/main/res/values-ru/strings.xml
@@ -1143,9 +1143,7 @@
     <string name="login_signup_submit">Далее</string>
     <string name="login_signup_error_user_in_use">Это имя пользователя занято</string>
     <string name="login_signup_cancel_confirmation_title">Предупреждение</string>
-    <string name="login_signup_cancel_confirmation_content">Ваш аккаунт еще не создан.
-\n
-\nОстановить процесс регистрации\?</string>
+    <string name="login_signup_cancel_confirmation_content">Ваш аккаунт еще не создан. Остановить процесс регистрации\?</string>
     <string name="login_a11y_choose_matrix_org">Выбрать matrix.org</string>
     <string name="login_a11y_choose_modular">Выбрать Element Matrix Services</string>
     <string name="login_a11y_choose_other">Выбрать пользовательский домашний сервер</string>

--- a/vector/src/main/res/values-sk/strings.xml
+++ b/vector/src/main/res/values-sk/strings.xml
@@ -1913,9 +1913,7 @@
     <string name="verify_cancel_other">Ak to teraz zrušíte, neoveríte %1$s (%2$s). Začnite znova v ich používateľskom profile.</string>
     <string name="verify_cancel_self_verification_from_trusted">Ak to zrušíte, nebudete môcť čítať zašifrované správy v novom zariadení a ostatní používatelia mu nebudú dôverovať</string>
     <string name="verify_cancel_self_verification_from_untrusted">Ak to zrušíte, nebudete môcť čítať zašifrované správy v tomto zariadení a ostatní používatelia mu nebudú dôverovať</string>
-    <string name="login_signup_cancel_confirmation_content">Váš účet ešte nie je vytvorený.
-\n
-\nZastaviť proces registrácie\?</string>
+    <string name="login_signup_cancel_confirmation_content">Váš účet ešte nie je vytvorený. Zastaviť proces registrácie\?</string>
     <string name="login_reset_password_cancel_confirmation_content">Vaše heslo ešte nebolo zmenené.
 \n
 \nZastaviť proces zmeny hesla\?</string>

--- a/vector/src/main/res/values-sq/strings.xml
+++ b/vector/src/main/res/values-sq/strings.xml
@@ -1132,9 +1132,7 @@
     <string name="login_signup_submit">Pasuesi</string>
     <string name="login_signup_error_user_in_use">Ai emër përdoruesi është i zënë</string>
     <string name="login_signup_cancel_confirmation_title">Kujdes</string>
-    <string name="login_signup_cancel_confirmation_content">Llogaria juaj s’është krijuar ende.
-\n
-\nTë ndalet procesi i regjistrimit\?</string>
+    <string name="login_signup_cancel_confirmation_content">Llogaria juaj s’është krijuar ende. Të ndalet procesi i regjistrimit\?</string>
     <string name="login_a11y_choose_matrix_org">Përzgjidhni matrix.org</string>
     <string name="login_a11y_choose_modular">Përzgjidhni Element Matrix Services</string>
     <string name="login_a11y_choose_other">Përzgjidhni një shërbyes Home vetjak</string>

--- a/vector/src/main/res/values-sv/strings.xml
+++ b/vector/src/main/res/values-sv/strings.xml
@@ -1430,9 +1430,7 @@
     <string name="login_signup_submit">Nästa</string>
     <string name="login_signup_error_user_in_use">Det användarnamnet är upptaget</string>
     <string name="login_signup_cancel_confirmation_title">Varning</string>
-    <string name="login_signup_cancel_confirmation_content">Ditt konto är inte skapat än.
-\n
-\nVill du avbryta registreringsprocessen\?</string>
+    <string name="login_signup_cancel_confirmation_content">Ditt konto är inte skapat än. Vill du avbryta registreringsprocessen\?</string>
     <string name="login_a11y_choose_matrix_org">Välj matrix.org</string>
     <string name="login_a11y_choose_modular">Välj Element Matrix Services</string>
     <string name="login_a11y_choose_other">Välj en annan hemserver</string>

--- a/vector/src/main/res/values-tr/strings.xml
+++ b/vector/src/main/res/values-tr/strings.xml
@@ -1088,9 +1088,7 @@
     <string name="login_a11y_choose_other">Özel bir ana sunucu seçin</string>
     <string name="login_a11y_choose_modular">Element Matric Hizmetleri\'ni seç</string>
     <string name="login_a11y_choose_matrix_org">Matrix.org sunucusunu seç</string>
-    <string name="login_signup_cancel_confirmation_content">Hesabınız henüz oluşturulmadı.
-\n
-\nKayıt işlemini durdurmak istiyor musunuz\?</string>
+    <string name="login_signup_cancel_confirmation_content">Hesabınız henüz oluşturulmadı. Kayıt işlemini durdurmak istiyor musunuz\?</string>
     <string name="login_signup_cancel_confirmation_title">Uyarı</string>
     <string name="login_signup_error_user_in_use">Bu kullanıcı adı alınmış</string>
     <string name="login_signup_submit">İleri</string>

--- a/vector/src/main/res/values-uk/strings.xml
+++ b/vector/src/main/res/values-uk/strings.xml
@@ -2007,9 +2007,7 @@
     <string name="login_error_outdated_homeserver_warning_content">Цей домашній сервер працює давній версії. Попросіть адміністратора домашнього сервера оновити його. Ви можете продовжити, але деякі функції не працюватимуть.</string>
     <string name="login_wait_for_email_notice">Ми щойно надіслали листа на %1$s
 \nНатисніть на посилання, яке він містить, щоб продовжити створення облікового запису.</string>
-    <string name="login_signup_cancel_confirmation_content">Ваш обліковий запис ще не створено.
-\n
-\nЗупинити процес реєстрації\?</string>
+    <string name="login_signup_cancel_confirmation_content">Ваш обліковий запис ще не створено. Зупинити процес реєстрації\?</string>
     <string name="delete_event_dialog_title">Підтвердити вилучення</string>
     <string name="settings_key_requests">Запити ключів</string>
     <string name="login_default_session_public_name">${app_name} Android</string>

--- a/vector/src/main/res/values-vi/strings.xml
+++ b/vector/src/main/res/values-vi/strings.xml
@@ -891,9 +891,7 @@
     <string name="login_a11y_choose_other">Chọn một máy chủ khác</string>
     <string name="login_a11y_choose_modular">Chọn Dịch vụ Element Matrix</string>
     <string name="login_a11y_choose_matrix_org">Chọn matrix.org</string>
-    <string name="login_signup_cancel_confirmation_content">Tài khoản của bạn chưa được tạo.
-\n
-\nBạn muốn ngừng tiến trình đăng ký\?</string>
+    <string name="login_signup_cancel_confirmation_content">Tài khoản của bạn chưa được tạo. Bạn muốn ngừng tiến trình đăng ký\?</string>
     <string name="login_signup_cancel_confirmation_title">Cảnh báo</string>
     <string name="login_signup_error_user_in_use">Tên đăng nhập này đã được đăng ký</string>
     <string name="login_signup_submit">Tiếp</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2025,7 +2025,7 @@
     <string name="login_signup_submit">Next</string>
     <string name="login_signup_error_user_in_use">That username is taken</string>
     <string name="login_signup_cancel_confirmation_title">Warning</string>
-    <string name="login_signup_cancel_confirmation_content">Your account is not created yet.\n\nStop the registration process?</string>
+    <string name="login_signup_cancel_confirmation_content">Your account is not created yet. Stop the registration process?</string>
 
     <string name="login_a11y_choose_matrix_org">Select matrix.org</string>
     <string name="login_a11y_choose_modular">Select Element Matrix Services</string>


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Copy

## Content

Fixes #6087 Updates the copy formatting to match iOS (android/material avoids centered text in dialogs) 

- Doesn't update script based languages as I'm not sure how the sentence should be structured.

## Motivation and context

To match iOS

## Screenshots / GIFs

|Before|After|
|-|-|
|![Screenshot_20220601_150551](https://user-images.githubusercontent.com/1848238/171423971-c3416137-82c9-46be-b4f3-69f41bdbe8fd.png)|![Screenshot_20220601_145612](https://user-images.githubusercontent.com/1848238/171424006-7dab6761-1601-41aa-8b19-4ac4649cfda7.png)|

## Tests

- Start creating an account (after submitting username/password)
- Press back

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28
