### PR TITLE
Fixing Android 12 url deeplinks

### DIFF
--- a/changelog.d/5748.bugfix
+++ b/changelog.d/5748.bugfix
@@ -1,0 +1,1 @@
+Fixes Element on Android 12+ being ineligible for URL deeplinks

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -204,6 +204,14 @@
 
                 <data android:scheme="https" />
                 <data android:host="riot.im" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
                 <data android:host="app.element.io" />
                 <data android:host="mobile.element.io" />
                 <data android:host="develop.element.io" />
@@ -304,7 +312,8 @@
             android:supportsPictureInPicture="true" />
 
         <activity android:name=".features.terms.ReviewTermsActivity" />
-        <activity android:name=".features.widgets.WidgetActivity"
+        <activity
+            android:name=".features.widgets.WidgetActivity"
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation" />
 
         <activity android:name=".features.pin.PinActivity" />


### PR DESCRIPTION
Draft as this relies on a `element.io` change


## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes #5748 Android 12 being ineligible for URL deeplinks

Creates a separate `intent-filter` to enable the required `autoVerify` on the `*.element.io` urls  

## Motivation and context

To fix missing Android 12 URL deeplink

## Screenshots / GIFs

// TODO relies on element.io's assetlinks.json to be updated 

## Tests

Follow steps in #5748 

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):
