### PR TITLE
Fix slow paged room list regression

### DIFF
--- a/changelog.d/6233.bugfix
+++ b/changelog.d/6233.bugfix
@@ -1,0 +1,1 @@
+Fix | performance regression on roomlist + proper display of space parents in explore rooms.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomService.kt
@@ -226,8 +226,12 @@ interface RoomService {
     ): LiveData<PagedList<RoomSummary>>
 
     /**
-     * TODO Doc.
-     * @param getFlattenParents When true, the list of known parent and grand parent summaries will be resolved.
+     * Get's a live paged list from a filter that can be dynamically updated.
+     *
+     * @param queryParams The filter to use
+     * @param pagedListConfig The paged list configuration (page size, initial load, prefetch distance...)
+     * @param sortOrder defines how to sort the results
+     * @param getFlattenParents When true, the list of known parents and grand parents summaries will be resolved.
      * This can have significant impact on performance, better be used only on manageable list (filtered by displayName, ..).
      */
     fun getFilteredPagedRoomSummariesLive(

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomService.kt
@@ -227,11 +227,14 @@ interface RoomService {
 
     /**
      * TODO Doc.
+     * @param getFlattenParents When true, the list of known parent and grand parent summaries will be resolved.
+     * This can have significant impact on performance, better be used only on manageable list (filtered by displayName, ..).
      */
     fun getFilteredPagedRoomSummariesLive(
             queryParams: RoomSummaryQueryParams,
             pagedListConfig: PagedList.Config = defaultPagedListConfig,
-            sortOrder: RoomSortOrder = RoomSortOrder.ACTIVITY
+            sortOrder: RoomSortOrder = RoomSortOrder.ACTIVITY,
+            getFlattenParents: Boolean = false,
     ): UpdatableLivePageResult
 
     /**

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoomService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoomService.kt
@@ -140,9 +140,9 @@ internal class DefaultRoomService @Inject constructor(
             queryParams: RoomSummaryQueryParams,
             pagedListConfig: PagedList.Config,
             sortOrder: RoomSortOrder,
-            getFlattenedParents: Boolean
+            getFlattenParents: Boolean
     ): UpdatableLivePageResult {
-        return roomSummaryDataSource.getUpdatablePagedRoomSummariesLive(queryParams, pagedListConfig, sortOrder, getFlattenedParents)
+        return roomSummaryDataSource.getUpdatablePagedRoomSummariesLive(queryParams, pagedListConfig, sortOrder, getFlattenParents)
     }
 
     override fun getRoomCountLive(queryParams: RoomSummaryQueryParams): LiveData<Int> {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoomService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoomService.kt
@@ -139,9 +139,10 @@ internal class DefaultRoomService @Inject constructor(
     override fun getFilteredPagedRoomSummariesLive(
             queryParams: RoomSummaryQueryParams,
             pagedListConfig: PagedList.Config,
-            sortOrder: RoomSortOrder
+            sortOrder: RoomSortOrder,
+            getFlattenedParents: Boolean
     ): UpdatableLivePageResult {
-        return roomSummaryDataSource.getUpdatablePagedRoomSummariesLive(queryParams, pagedListConfig, sortOrder, getFlattenedParents = true)
+        return roomSummaryDataSource.getUpdatablePagedRoomSummariesLive(queryParams, pagedListConfig, sortOrder, getFlattenedParents)
     }
 
     override fun getRoomCountLive(queryParams: RoomSummaryQueryParams): LiveData<Int> {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListSectionBuilderGroup.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListSectionBuilderGroup.kt
@@ -71,7 +71,7 @@ class RoomListSectionBuilderGroup(
                         },
                         { qpm ->
                             val name = stringProvider.getString(R.string.bottom_action_rooms)
-                            val updatableFilterLivePageResult = session.roomService().getFilteredPagedRoomSummariesLive(qpm)
+                            val updatableFilterLivePageResult = session.roomService().getFilteredPagedRoomSummariesLive(qpm, getFlattenParents = true)
                             onUpdatable(updatableFilterLivePageResult)
 
                             val itemCountFlow = updatableFilterLivePageResult.livePagedList.asFlow()

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListSectionBuilderSpace.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListSectionBuilderSpace.kt
@@ -332,7 +332,7 @@ class RoomListSectionBuilderSpace(
                 },
                 { queryParams ->
                     val name = stringProvider.getString(R.string.bottom_action_rooms)
-                    val updatableFilterLivePageResult = session.roomService().getFilteredPagedRoomSummariesLive(queryParams)
+                    val updatableFilterLivePageResult = session.roomService().getFilteredPagedRoomSummariesLive(queryParams, getFlattenParents = true)
                     onUpdatable(updatableFilterLivePageResult)
 
                     val itemCountFlow = updatableFilterLivePageResult.livePagedList.asFlow()

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemFactory.kt
@@ -207,7 +207,9 @@ class RoomSummaryItemFactory @Inject constructor(
 
     private fun getSearchResultSubtitle(roomSummary: RoomSummary): String {
         val userId = roomSummary.directUserId
-        val spaceName = roomSummary.spaceParents?.firstOrNull()?.roomSummary?.name
+        val spaceName = roomSummary.flattenParents
+                .takeIf { it.isNotEmpty() }
+                ?.joinToString(", ") { it.name }
         val canonicalAlias = roomSummary.canonicalAlias
 
         return (userId ?: spaceName ?: canonicalAlias).orEmpty()

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemFactory.kt
@@ -207,9 +207,7 @@ class RoomSummaryItemFactory @Inject constructor(
 
     private fun getSearchResultSubtitle(roomSummary: RoomSummary): String {
         val userId = roomSummary.directUserId
-        val spaceName = roomSummary.flattenParents
-                .takeIf { it.isNotEmpty() }
-                ?.joinToString(", ") { it.name }
+        val spaceName = roomSummary.flattenParents.lastOrNull()?.name
         val canonicalAlias = roomSummary.canonicalAlias
 
         return (userId ?: spaceName ?: canonicalAlias).orEmpty()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Bugfix

## Content

<!-- Describe shortly what has been changed -->
A new parameter was added to resolve the list of parent summaries when loading the rooms paged list.
This param is affecting performances a lot when you have some decent space hierarchy. And it was called unproperly when displaying the regular room list (should only be needed for search/filter rooms).

Also the new added `flattenParents` field (that was slowing the queries) was never used. Instead the space parent was used. I think improperly because it only reflect the presence of a `m.space.parent`relation, that is not used to decide hierarchy (`m.space.child`) are used for that.

@ericdecanini  can you confirm?

See https://github.com/vector-im/element-android/issues/3830 regarding recent degradation of performances.

<!--
|Before|After|
|-|-|
|||
 -->

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
