### PR TITLE
Text cropped: "Secure backup"

### DIFF
--- a/changelog.d/6232.bugfix
+++ b/changelog.d/6232.bugfix
@@ -1,0 +1,1 @@
+Text cropped: "Secure backup"

--- a/vector/src/main/res/layout/bottom_sheet_bootstrap.xml
+++ b/vector/src/main/res/layout/bottom_sheet_bootstrap.xml
@@ -37,6 +37,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginEnd="16dp"
+            android:layout_marginTop="16dp"
             android:ellipsize="end"
             android:textColor="?vctr_content_primary"
             android:textStyle="bold"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content
Closes #6232 
<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
![Screenshot_1654260059](https://user-images.githubusercontent.com/15031750/171856095-b3164cbc-1a32-43d3-8f18-9f413ac18678.png)

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [X] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [X] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
