### PR TITLE
Remove duplicated code from placeholder mesage in message bar.

### DIFF
--- a/changelog.d/6246.bugfix
+++ b/changelog.d/6246.bugfix
@@ -1,0 +1,1 @@
+Remove duplicated code when setting placeholder message.

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerView.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerView.kt
@@ -148,10 +148,6 @@ class MessageComposerView @JvmOverloads constructor(
     }
 
     fun setRoomEncrypted(isEncrypted: Boolean) {
-        if (isEncrypted) {
-            views.composerEditText.setHint(R.string.room_message_placeholder)
-        } else {
-            views.composerEditText.setHint(R.string.room_message_placeholder)
-        }
+        views.composerEditText.setHint(R.string.room_message_placeholder)
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Remove a unneeded branch and duplicated code.

Also serves to test sonarqube updates on new PRs.

## Motivation and context

https://sonarcloud.io/project/issues?issues=AYD6dWQSC49RlAsZNa4p&open=AYD6dWQSC49RlAsZNa4p&id=vector-im_element-android

## Screenshots / GIFs


## Tests

<!-- Explain how you tested your development -->

- Examined text when sending message in encrypted room
- Examined text when sending message in unencrypted room

Both were the same, i think we have success.

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
