### PR TITLE
Fix copyright attributions of map views [PSF-1058] - [PSF-1072]

### DIFF
--- a/changelog.d/6247.bugfix
+++ b/changelog.d/6247.bugfix
@@ -1,0 +1,1 @@
+Fix copyright attributions of map views

--- a/library/ui-styles/src/main/res/values/dimens_font.xml
+++ b/library/ui-styles/src/main/res/values/dimens_font.xml
@@ -7,6 +7,7 @@
     <dimen name="text_size_body">14sp</dimen>
     <dimen name="text_size_caption">12sp</dimen>
     <dimen name="text_size_micro">10sp</dimen>
+    <dimen name="text_size_nano">8sp</dimen>
 
     <dimen name="text_size_button">14sp</dimen>
 

--- a/library/ui-styles/src/main/res/values/styles_location.xml
+++ b/library/ui-styles/src/main/res/values/styles_location.xml
@@ -40,4 +40,9 @@
         <item name="android:gravity">center</item>
     </style>
 
+    <style name="Widget.Vector.TextView.Nano.Copyright">
+        <!-- Static map view is always light in both light and dark theme. So we need to use a static dark color -->
+        <item name="android:textColor">@color/element_content_primary_light</item>
+    </style>
+
 </resources>

--- a/library/ui-styles/src/main/res/values/styles_text_view.xml
+++ b/library/ui-styles/src/main/res/values/styles_text_view.xml
@@ -48,4 +48,9 @@
         <item name="lineHeight">16sp</item>
     </style>
 
+    <style name="Widget.Vector.TextView.Nano">
+        <item name="android:textAppearance">@style/TextAppearance.Vector.Nano</item>
+        <item name="lineHeight">16sp</item>
+    </style>
+
 </resources>

--- a/library/ui-styles/src/main/res/values/text_appearances.xml
+++ b/library/ui-styles/src/main/res/values/text_appearances.xml
@@ -85,4 +85,11 @@
         <item name="android:letterSpacing">0.02</item>
     </style>
 
+    <style name="TextAppearance.Vector.Nano" parent="TextAppearance.MaterialComponents.Caption">
+        <item name="fontFamily">sans-serif</item>
+        <item name="android:fontFamily">sans-serif</item>
+        <item name="android:textSize">@dimen/text_size_nano</item>
+        <item name="android:letterSpacing">0</item>
+    </style>
+
 </resources>

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
@@ -85,7 +85,7 @@ abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder> : AbsMe
                     ): Boolean {
                         holder.staticMapPinImageView.setImageResource(R.drawable.ic_location_pin_failed)
                         holder.staticMapErrorTextView.isVisible = true
-                        holder.mapCopyrightTextView.isVisible = false
+                        holder.staticMapCopyrightTextView.isVisible = false
                         return false
                     }
 
@@ -101,7 +101,7 @@ abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder> : AbsMe
                             holder.staticMapPinImageView.setImageDrawable(pinDrawable)
                         }
                         holder.staticMapErrorTextView.isVisible = false
-                        holder.mapCopyrightTextView.isVisible = true
+                        holder.staticMapCopyrightTextView.isVisible = true
                         return false
                     }
                 })
@@ -113,6 +113,6 @@ abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder> : AbsMe
         val staticMapImageView by bind<ImageView>(R.id.staticMapImageView)
         val staticMapPinImageView by bind<ImageView>(R.id.staticMapPinImageView)
         val staticMapErrorTextView by bind<TextView>(R.id.staticMapErrorTextView)
-        val mapCopyrightTextView by bind<TextView>(R.id.mapCopyrightTextView)
+        val staticMapCopyrightTextView by bind<TextView>(R.id.staticMapCopyrightTextView)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
@@ -85,6 +85,7 @@ abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder> : AbsMe
                     ): Boolean {
                         holder.staticMapPinImageView.setImageResource(R.drawable.ic_location_pin_failed)
                         holder.staticMapErrorTextView.isVisible = true
+                        holder.mapCopyrightTextView.isVisible = false
                         return false
                     }
 
@@ -100,6 +101,7 @@ abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder> : AbsMe
                             holder.staticMapPinImageView.setImageDrawable(pinDrawable)
                         }
                         holder.staticMapErrorTextView.isVisible = false
+                        holder.mapCopyrightTextView.isVisible = true
                         return false
                     }
                 })
@@ -111,5 +113,6 @@ abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder> : AbsMe
         val staticMapImageView by bind<ImageView>(R.id.staticMapImageView)
         val staticMapPinImageView by bind<ImageView>(R.id.staticMapPinImageView)
         val staticMapErrorTextView by bind<TextView>(R.id.staticMapErrorTextView)
+        val mapCopyrightTextView by bind<TextView>(R.id.mapCopyrightTextView)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/location/MapTilerMapView.kt
+++ b/vector/src/main/java/im/vector/app/features/location/MapTilerMapView.kt
@@ -33,6 +33,7 @@ import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions
 import com.mapbox.mapboxsdk.style.layers.Property
 import im.vector.app.R
+import im.vector.app.core.utils.DimensionConverter
 import timber.log.Timber
 
 class MapTilerMapView @JvmOverloads constructor(
@@ -56,6 +57,7 @@ class MapTilerMapView @JvmOverloads constructor(
     private var mapRefs: MapRefs? = null
     private var initZoomDone = false
     private var showLocationButton = false
+    private var dimensionConverter: DimensionConverter? = null
 
     init {
         context.theme.obtainStyledAttributes(
@@ -70,6 +72,7 @@ class MapTilerMapView @JvmOverloads constructor(
                 recycle()
             }
         }
+        dimensionConverter = DimensionConverter(resources)
     }
 
     private fun setLocateButtonVisibility(typedArray: TypedArray) {
@@ -151,7 +154,12 @@ class MapTilerMapView @JvmOverloads constructor(
             pendingState = state
         }
 
-        safeMapRefs.map.uiSettings.setLogoMargins(0, 0, 0, state.logoMarginBottom)
+        safeMapRefs.map.uiSettings.apply {
+            setLogoMargins(0, 0, 0, state.logoMarginBottom)
+            dimensionConverter?.let {
+                setAttributionMargins(it.dpToPx(88), 0, 0, state.logoMarginBottom)
+            }
+        }
 
         val pinDrawable = state.pinDrawable ?: userLocationDrawable
         pinDrawable?.let { drawable ->

--- a/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
+++ b/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
@@ -17,7 +17,6 @@
 package im.vector.app.features.location
 
 import im.vector.app.BuildConfig
-import im.vector.app.core.resources.LocaleProvider
 import im.vector.app.features.raw.wellknown.getElementWellknown
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.raw.RawService

--- a/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
+++ b/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
@@ -18,7 +18,6 @@ package im.vector.app.features.location
 
 import im.vector.app.BuildConfig
 import im.vector.app.core.resources.LocaleProvider
-import im.vector.app.core.resources.isRTL
 import im.vector.app.features.raw.wellknown.getElementWellknown
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.raw.RawService

--- a/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
+++ b/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
@@ -63,10 +63,8 @@ class UrlMapProvider @Inject constructor(
             append(height)
             append(".png")
             append(keyParam)
-            if (!localeProvider.isRTL()) {
-                // On LTR languages we want the legal mentions to be displayed on the bottom left of the image
-                append("&attribution=bottomleft")
-            }
+            // Since the default copyright font is too small we put a custom one on map
+            append("&attribution=0")
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
+++ b/vector/src/main/java/im/vector/app/features/location/UrlMapProvider.kt
@@ -25,7 +25,6 @@ import org.matrix.android.sdk.api.session.Session
 import javax.inject.Inject
 
 class UrlMapProvider @Inject constructor(
-        private val localeProvider: LocaleProvider,
         private val session: Session,
         private val rawService: RawService
 ) {
@@ -63,7 +62,7 @@ class UrlMapProvider @Inject constructor(
             append(".png")
             append(keyParam)
             // Since the default copyright font is too small we put a custom one on map
-            append("&attribution=0")
+            append("&attribution=false")
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapViewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapViewFragment.kt
@@ -25,6 +25,7 @@ import androidx.core.graphics.drawable.toBitmap
 import androidx.lifecycle.lifecycleScope
 import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.withState
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.geometry.LatLngBounds
 import com.mapbox.mapboxsdk.maps.MapView
@@ -96,10 +97,11 @@ class LocationLiveMapViewFragment @Inject constructor() : VectorBaseFragment<Fra
     private fun setupMap() {
         val mapFragment = getOrCreateSupportMapFragment()
         mapFragment.getMapAsync { mapboxMap ->
+            val bottomSheetHeight = BottomSheetBehavior.from(views.bottomSheet).peekHeight
             mapboxMap.uiSettings.apply {
                 // Place copyright above the user list bottom sheet
-                setLogoMargins(dimensionConverter.dpToPx(8), 0, 0, dimensionConverter.dpToPx(208))
-                setAttributionMargins(dimensionConverter.dpToPx(96), 0, 0, dimensionConverter.dpToPx(208))
+                setLogoMargins(dimensionConverter.dpToPx(8), 0, 0, bottomSheetHeight + dimensionConverter.dpToPx(8))
+                setAttributionMargins(dimensionConverter.dpToPx(96), 0, 0, bottomSheetHeight + dimensionConverter.dpToPx(8))
             }
 
             lifecycleScope.launch {

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapViewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapViewFragment.kt
@@ -40,6 +40,7 @@ import im.vector.app.R
 import im.vector.app.core.extensions.addChildFragment
 import im.vector.app.core.extensions.configureWith
 import im.vector.app.core.platform.VectorBaseFragment
+import im.vector.app.core.utils.DimensionConverter
 import im.vector.app.databinding.FragmentLocationLiveMapViewBinding
 import im.vector.app.features.location.UrlMapProvider
 import im.vector.app.features.location.zoomToBounds
@@ -58,6 +59,7 @@ class LocationLiveMapViewFragment @Inject constructor() : VectorBaseFragment<Fra
 
     @Inject lateinit var urlMapProvider: UrlMapProvider
     @Inject lateinit var bottomSheetController: LiveLocationBottomSheetController
+    @Inject lateinit var dimensionConverter: DimensionConverter
 
     private val viewModel: LocationLiveMapViewModel by fragmentViewModel()
 
@@ -94,6 +96,12 @@ class LocationLiveMapViewFragment @Inject constructor() : VectorBaseFragment<Fra
     private fun setupMap() {
         val mapFragment = getOrCreateSupportMapFragment()
         mapFragment.getMapAsync { mapboxMap ->
+            mapboxMap.uiSettings.apply {
+                // Place copyright above the user list bottom sheet
+                setLogoMargins(dimensionConverter.dpToPx(8), 0, 0, dimensionConverter.dpToPx(208))
+                setAttributionMargins(dimensionConverter.dpToPx(96), 0, 0, dimensionConverter.dpToPx(208))
+            }
+
             lifecycleScope.launch {
                 mapboxMap.setStyle(urlMapProvider.getMapUrl()) { style ->
                     mapStyle = style

--- a/vector/src/main/res/layout/fragment_location_live_map_view.xml
+++ b/vector/src/main/res/layout/fragment_location_live_map_view.xml
@@ -16,8 +16,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@drawable/bg_live_location_users_bottom_sheet"
-        app:behavior_peekHeight="200dp"
         app:behavior_hideable="false"
+        app:behavior_peekHeight="200dp"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
         <View

--- a/vector/src/main/res/layout/item_timeline_event_location_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_location_stub.xml
@@ -66,7 +66,7 @@
         android:id="@+id/mapCopyrightTextView"
         style="@style/Widget.Vector.TextView.Nano.Copyright"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_margin="4dp"
         android:text="@string/location_map_view_copyright"
         app:layout_constraintStart_toStartOf="parent"

--- a/vector/src/main/res/layout/item_timeline_event_location_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_location_stub.xml
@@ -63,7 +63,7 @@
         app:layout_constraintGuide_percent="0.5" />
 
     <TextView
-        android:id="@+id/mapCopyrightTextView"
+        android:id="@+id/staticMapCopyrightTextView"
         style="@style/Widget.Vector.TextView.Nano.Copyright"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/vector/src/main/res/layout/item_timeline_event_location_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_location_stub.xml
@@ -62,4 +62,14 @@
         android:orientation="horizontal"
         app:layout_constraintGuide_percent="0.5" />
 
+    <TextView
+        android:id="@+id/mapCopyrightTextView"
+        style="@style/Widget.Vector.TextView.Nano.Copyright"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_margin="4dp"
+        android:text="@string/location_map_view_copyright"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/main/res/values/donottranslate.xml
+++ b/vector/src/main/res/values/donottranslate.xml
@@ -42,4 +42,6 @@
     <string name="ftue_auth_email_verification_subtitle">To confirm your email address, tap the button in the email we just sent to %s</string>
     <string name="ftue_auth_email_verification_footer">Did not receive an email?</string>
     <string name="ftue_auth_email_resend_email">Resend email</string>
+
+    <string name="location_map_view_copyright">© MapTiler © OpenStreetMap contributors</string>
 </resources>

--- a/vector/src/main/res/values/donottranslate.xml
+++ b/vector/src/main/res/values/donottranslate.xml
@@ -43,5 +43,5 @@
     <string name="ftue_auth_email_verification_footer">Did not receive an email?</string>
     <string name="ftue_auth_email_resend_email">Resend email</string>
 
-    <string name="location_map_view_copyright">© MapTiler © OpenStreetMap contributors</string>
+    <string name="location_map_view_copyright" translatable="false">© MapTiler © OpenStreetMap contributors</string>
 </resources>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3036,6 +3036,7 @@
     <string name="labs_enable_live_location_summary">Temporary implementation: locations persist in room history</string>
     <string name="live_location_bottom_sheet_stop_sharing">Stop sharing</string>
     <string name="live_location_bottom_sheet_last_updated_at">Updated %1$s ago</string>
+    <string name="location_map_view_copyright">© MapTiler © OpenStreetMap contributors</string>
 
     <string name="message_bubbles">Show Message bubbles</string>
 

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3036,7 +3036,6 @@
     <string name="labs_enable_live_location_summary">Temporary implementation: locations persist in room history</string>
     <string name="live_location_bottom_sheet_stop_sharing">Stop sharing</string>
     <string name="live_location_bottom_sheet_last_updated_at">Updated %1$s ago</string>
-    <string name="location_map_view_copyright">© MapTiler © OpenStreetMap contributors</string>
 
     <string name="message_bubbles">Show Message bubbles</string>
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
- Static map copyright text on the timeline item was not readable because of the font size
- Static map copyright text on the timeline item of live location sharing was behind the informative tile
- Mapbox copyright attribution items on the maximized map were behind the user list bottom sheet
- This PR suggests to use custom copyright text on the timeline item and to fix the position of attribution items

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
- Required copyright attributes should always be visible and readible

## Screenshots / GIFs
| Before    | After     | Maximized |
|-|-|-|
|![copyright_before](https://user-images.githubusercontent.com/1254401/172388483-d4efbb68-f66f-44d4-9e79-328e33cf171e.png)|![copyright_after](https://user-images.githubusercontent.com/1254401/172388535-a6a95156-292b-4be2-a4fe-5b3867949b4c.png)|![copyright_maximized](https://user-images.githubusercontent.com/1254401/172388589-0f369903-9e4e-40bd-b1dc-293a827dc71e.png)|

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->
- Share static location and you should see copyright text on timeline location item
- Share live location (after enabling from labs flag) and you should see the copyright icon in maximized screen

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
