### PR TITLE
Adding unit tests for live location sharing aggregation code (PSF-1063)

### DIFF
--- a/changelog.d/6155.misc
+++ b/changelog.d/6155.misc
@@ -1,0 +1,1 @@
+Add unit tests for LiveLocationAggregationProcessor code

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/query/LiveLocationShareAggregatedSummaryEntityQuery.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/query/LiveLocationShareAggregatedSummaryEntityQuery.kt
@@ -84,6 +84,7 @@ internal fun LiveLocationShareAggregatedSummaryEntity.Companion.findActiveLiveIn
             .equalTo(LiveLocationShareAggregatedSummaryEntityFields.IS_ACTIVE, true)
             .notEqualTo(LiveLocationShareAggregatedSummaryEntityFields.EVENT_ID, ignoredEventId)
             .findAll()
+            .toList()
 }
 
 /**

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/aggregation/livelocation/LiveLocationAggregationProcessor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/aggregation/livelocation/LiveLocationAggregationProcessor.kt
@@ -151,12 +151,13 @@ internal class LiveLocationAggregationProcessor @Inject constructor(
                 ?.getBestTimestampMillis()
                 ?: 0
 
-        if (updatedLocationTimestamp.isMoreRecentThan(currentLocationTimestamp)) {
+        return if (updatedLocationTimestamp.isMoreRecentThan(currentLocationTimestamp)) {
             Timber.d("updating last location of the summary of id=$relatedEventId")
             aggregatedSummary.lastLocationContent = ContentMapper.map(content.toContent())
+            true
+        } else {
+            false
         }
-
-        return true
     }
 
     private fun deactivateAllPreviousBeacons(realm: Realm, roomId: String, userId: String, currentEventId: String) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/aggregation/livelocation/LiveLocationAggregationProcessor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/aggregation/livelocation/LiveLocationAggregationProcessor.kt
@@ -36,16 +36,22 @@ import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
-// TODO add unit tests
+/**
+ * Aggregates all live location sharing related events in local database.
+ */
 internal class LiveLocationAggregationProcessor @Inject constructor(
         @SessionId private val sessionId: String,
         private val workManagerProvider: WorkManagerProvider,
         private val clock: Clock,
 ) {
 
-    fun handleBeaconInfo(realm: Realm, event: Event, content: MessageBeaconInfoContent, roomId: String, isLocalEcho: Boolean) {
+    /**
+     * Handle the content of a beacon info.
+     * @return true if it has been processed, false if ignored.
+     */
+    fun handleBeaconInfo(realm: Realm, event: Event, content: MessageBeaconInfoContent, roomId: String, isLocalEcho: Boolean): Boolean {
         if (event.senderId.isNullOrEmpty() || isLocalEcho) {
-            return
+            return false
         }
 
         val isLive = content.isLive.orTrue()
@@ -58,7 +64,7 @@ internal class LiveLocationAggregationProcessor @Inject constructor(
 
         if (targetEventId.isNullOrEmpty()) {
             Timber.w("no target event id found for the beacon content")
-            return
+            return false
         }
 
         val aggregatedSummary = LiveLocationShareAggregatedSummaryEntity.getOrCreate(
@@ -83,6 +89,8 @@ internal class LiveLocationAggregationProcessor @Inject constructor(
         } else {
             cancelDeactivationAfterTimeout(targetEventId, roomId)
         }
+
+        return true
     }
 
     private fun scheduleDeactivationAfterTimeout(eventId: String, roomId: String, endOfLiveTimestampMillis: Long?) {
@@ -110,6 +118,10 @@ internal class LiveLocationAggregationProcessor @Inject constructor(
         workManagerProvider.workManager.cancelUniqueWork(workName)
     }
 
+    /**
+     * Handle the content of a beacon location data.
+     * @return true if it has been processed, false if ignored.
+     */
     fun handleBeaconLocationData(
             realm: Realm,
             event: Event,
@@ -117,14 +129,14 @@ internal class LiveLocationAggregationProcessor @Inject constructor(
             roomId: String,
             relatedEventId: String?,
             isLocalEcho: Boolean
-    ) {
+    ): Boolean {
         if (event.senderId.isNullOrEmpty() || isLocalEcho) {
-            return
+            return false
         }
 
         if (relatedEventId.isNullOrEmpty()) {
             Timber.w("no related event id found for the live location content")
-            return
+            return false
         }
 
         val aggregatedSummary = LiveLocationShareAggregatedSummaryEntity.getOrCreate(
@@ -143,6 +155,8 @@ internal class LiveLocationAggregationProcessor @Inject constructor(
             Timber.d("updating last location of the summary of id=$relatedEventId")
             aggregatedSummary.lastLocationContent = ContentMapper.map(content.toContent())
         }
+
+        return true
     }
 
     private fun deactivateAllPreviousBeacons(realm: Realm, roomId: String, userId: String, currentEventId: String) {

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/aggregation/livelocation/LiveLocationAggregationProcessorTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/aggregation/livelocation/LiveLocationAggregationProcessorTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.room.aggregation.livelocation
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.api.session.room.model.message.MessageBeaconInfoContent
+import org.matrix.android.sdk.api.session.room.model.message.MessageBeaconLocationDataContent
+import org.matrix.android.sdk.test.fakes.FakeClock
+import org.matrix.android.sdk.test.fakes.FakeRealm
+import org.matrix.android.sdk.test.fakes.FakeWorkManagerProvider
+
+private const val A_SESSION_ID = "session_id"
+private const val A_SENDER_ID = "sender_id"
+private const val AN_EVENT_ID = "event_id"
+
+internal class LiveLocationAggregationProcessorTest {
+
+    private val fakeWorkManagerProvider = FakeWorkManagerProvider()
+    private val fakeClock = FakeClock()
+    private val fakeRealm = FakeRealm()
+
+    private val liveLocationAggregationProcessor = LiveLocationAggregationProcessor(
+            sessionId = A_SESSION_ID,
+            workManagerProvider = fakeWorkManagerProvider.instance,
+            clock = fakeClock
+    )
+
+    @Test
+    fun `given beacon info when it is local echo then it is ignored`() {
+        val event = Event(senderId = A_SENDER_ID)
+        val beaconInfo = MessageBeaconInfoContent()
+
+        val result = liveLocationAggregationProcessor.handleBeaconInfo(
+                realm = fakeRealm.instance,
+                event = event,
+                content = beaconInfo,
+                roomId = "",
+                isLocalEcho = true
+        )
+
+        result shouldBeEqualTo false
+    }
+
+    @Test
+    fun `given beacon info and event when senderId is null or empty then it is ignored`() {
+        val eventNoSenderId = Event(eventId = AN_EVENT_ID)
+        val eventEmptySenderId = Event(eventId = AN_EVENT_ID, senderId = "")
+        val beaconInfo = MessageBeaconInfoContent()
+
+        val resultNoSenderId = liveLocationAggregationProcessor.handleBeaconInfo(
+                realm = fakeRealm.instance,
+                event = eventNoSenderId,
+                content = beaconInfo,
+                roomId = "",
+                isLocalEcho = false
+        )
+        val resultEmptySenderId = liveLocationAggregationProcessor.handleBeaconInfo(
+                realm = fakeRealm.instance,
+                event = eventEmptySenderId,
+                content = beaconInfo,
+                roomId = "",
+                isLocalEcho = false
+        )
+
+        resultNoSenderId shouldBeEqualTo false
+        resultEmptySenderId shouldBeEqualTo false
+    }
+
+    @Test
+    fun `given beacon location data when it is local echo then it is ignored`() {
+        val event = Event(senderId = A_SENDER_ID)
+        val beaconLocationData = MessageBeaconLocationDataContent()
+
+        val result = liveLocationAggregationProcessor.handleBeaconLocationData(
+                realm = fakeRealm.instance,
+                event = event,
+                content = beaconLocationData,
+                roomId = "",
+                relatedEventId = "",
+                isLocalEcho = true
+        )
+
+        result shouldBeEqualTo false
+    }
+
+    @Test
+    fun `given beacon location data and event when senderId is null or empty then it is ignored`() {
+        val eventNoSenderId = Event(eventId = AN_EVENT_ID)
+        val eventEmptySenderId = Event(eventId = AN_EVENT_ID, senderId = "")
+        val beaconLocationData = MessageBeaconLocationDataContent()
+
+        val resultNoSenderId = liveLocationAggregationProcessor.handleBeaconLocationData(
+                realm = fakeRealm.instance,
+                event = eventNoSenderId,
+                content = beaconLocationData,
+                roomId = "",
+                relatedEventId = "",
+                isLocalEcho = false
+        )
+        val resultEmptySenderId = liveLocationAggregationProcessor.handleBeaconLocationData(
+                realm = fakeRealm.instance,
+                event = eventEmptySenderId,
+                content = beaconLocationData,
+                roomId = "",
+                relatedEventId = "",
+                isLocalEcho = false
+        )
+
+        resultNoSenderId shouldBeEqualTo false
+        resultEmptySenderId shouldBeEqualTo false
+    }
+}

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/aggregation/poll/PollAggregationProcessorTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/aggregation/poll/PollAggregationProcessorTest.kt
@@ -19,8 +19,6 @@ package org.matrix.android.sdk.internal.session.room.aggregation.poll
 import io.mockk.every
 import io.mockk.mockk
 import io.realm.RealmList
-import io.realm.RealmModel
-import io.realm.RealmQuery
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
 import org.junit.Before
@@ -46,6 +44,8 @@ import org.matrix.android.sdk.internal.session.room.aggregation.poll.PollEventsT
 import org.matrix.android.sdk.internal.session.room.aggregation.poll.PollEventsTestData.A_TIMELINE_EVENT
 import org.matrix.android.sdk.internal.session.room.aggregation.poll.PollEventsTestData.A_USER_ID_1
 import org.matrix.android.sdk.test.fakes.FakeRealm
+import org.matrix.android.sdk.test.fakes.givenEqualTo
+import org.matrix.android.sdk.test.fakes.givenFindFirst
 
 class PollAggregationProcessorTest {
 
@@ -135,14 +135,11 @@ class PollAggregationProcessorTest {
         pollAggregationProcessor.handlePollEndEvent(session, powerLevelsHelper, realm.instance, event).shouldBeFalse()
     }
 
-    private inline fun <reified T : RealmModel> RealmQuery<T>.givenEqualTo(fieldName: String, value: String, result: RealmQuery<T>) {
-        every { equalTo(fieldName, value) } returns result
-    }
-
     private fun mockEventAnnotationsSummaryEntity() {
-        val queryResult = realm.givenWhereReturns(result = EventAnnotationsSummaryEntity())
-        queryResult.givenEqualTo(EventAnnotationsSummaryEntityFields.ROOM_ID, A_POLL_REPLACE_EVENT.roomId!!, queryResult)
-        queryResult.givenEqualTo(EventAnnotationsSummaryEntityFields.EVENT_ID, A_POLL_REPLACE_EVENT.eventId!!, queryResult)
+        realm.givenWhere<EventAnnotationsSummaryEntity>()
+                .givenFindFirst(EventAnnotationsSummaryEntity())
+                .givenEqualTo(EventAnnotationsSummaryEntityFields.ROOM_ID, A_POLL_REPLACE_EVENT.roomId!!)
+                .givenEqualTo(EventAnnotationsSummaryEntityFields.EVENT_ID, A_POLL_REPLACE_EVENT.eventId!!)
     }
 
     private fun mockRoom(

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeClock.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeClock.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.test.fakes
+
+import io.mockk.every
+import io.mockk.mockk
+import org.matrix.android.sdk.internal.util.time.Clock
+
+internal class FakeClock : Clock by mockk() {
+    fun givenEpoch(epoch: Long) {
+        every { epochMillis() } returns epoch
+    }
+}

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeRealm.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeRealm.kt
@@ -21,16 +21,59 @@ import io.mockk.mockk
 import io.realm.Realm
 import io.realm.RealmModel
 import io.realm.RealmQuery
+import io.realm.RealmResults
 import io.realm.kotlin.where
 
 internal class FakeRealm {
 
     val instance = mockk<Realm>(relaxed = true)
 
-    inline fun <reified T : RealmModel> givenWhereReturns(result: T?): RealmQuery<T> {
-        val queryResult = mockk<RealmQuery<T>>()
-        every { queryResult.findFirst() } returns result
-        every { instance.where<T>() } returns queryResult
-        return queryResult
+    inline fun <reified T : RealmModel> givenWhere(): RealmQuery<T> {
+        val query = mockk<RealmQuery<T>>()
+        every { instance.where<T>() } returns query
+        return query
     }
+}
+
+inline fun <reified T : RealmModel> RealmQuery<T>.givenFindFirst(
+        result: T?
+): RealmQuery<T> {
+    every { findFirst() } returns result
+    return this
+}
+
+inline fun <reified T : RealmModel> RealmQuery<T>.givenFindAll(
+        result: List<T>
+): RealmQuery<T> {
+    val realmResults = mockk<RealmResults<T>>()
+    result.forEachIndexed { index, t ->
+        every { realmResults[index] } returns t
+    }
+    every { realmResults.size } returns result.size
+    every { findAll() } returns realmResults
+    return this
+}
+
+inline fun <reified T : RealmModel> RealmQuery<T>.givenEqualTo(
+        fieldName: String,
+        value: String
+): RealmQuery<T> {
+    every { equalTo(fieldName, value) } returns this
+    return this
+}
+
+inline fun <reified T : RealmModel> RealmQuery<T>.givenEqualTo(
+        fieldName: String,
+        value: Boolean
+): RealmQuery<T> {
+    every { equalTo(fieldName, value) } returns this
+    return this
+}
+
+inline fun <reified T : RealmModel> RealmQuery<T>.givenNotEqualTo(
+        fieldName: String,
+        value: String
+): RealmQuery<T> {
+    every { notEqualTo(fieldName, value) } returns this
+    return this
 }

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeWorkManager.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeWorkManager.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.test.fakes
+
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class FakeWorkManager {
+
+    val instance = mockk<WorkManager>()
+
+    fun expectEnqueueUniqueWork() {
+        every { instance.enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>()) } returns mockk()
+    }
+
+    fun verifyEnqueueUniqueWork(workName: String, policy: ExistingWorkPolicy) {
+        verify { instance.enqueueUniqueWork(workName, policy, any<OneTimeWorkRequest>()) }
+    }
+
+    fun expectCancelUniqueWork() {
+        every { instance.cancelUniqueWork(any()) } returns mockk()
+    }
+
+    fun verifyCancelUniqueWork(workName: String) {
+        verify { instance.cancelUniqueWork(workName) }
+    }
+}

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeWorkManagerProvider.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeWorkManagerProvider.kt
@@ -16,10 +16,20 @@
 
 package org.matrix.android.sdk.test.fakes
 
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
+import io.mockk.every
 import io.mockk.mockk
 import org.matrix.android.sdk.internal.di.WorkManagerProvider
 
 internal class FakeWorkManagerProvider {
 
     val instance = mockk<WorkManagerProvider>()
+
+    init {
+        val workManager = mockk<WorkManager>()
+        every { workManager.enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>()) } returns mockk()
+        every { workManager.cancelUniqueWork(any()) } returns mockk()
+        every { instance.workManager } returns workManager
+    }
 }

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeWorkManagerProvider.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeWorkManagerProvider.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.test.fakes
+
+import io.mockk.mockk
+import org.matrix.android.sdk.internal.di.WorkManagerProvider
+
+internal class FakeWorkManagerProvider {
+
+    val instance = mockk<WorkManagerProvider>()
+}

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeWorkManagerProvider.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeWorkManagerProvider.kt
@@ -16,20 +16,15 @@
 
 package org.matrix.android.sdk.test.fakes
 
-import androidx.work.OneTimeWorkRequest
-import androidx.work.WorkManager
 import io.mockk.every
 import io.mockk.mockk
 import org.matrix.android.sdk.internal.di.WorkManagerProvider
 
-internal class FakeWorkManagerProvider {
+internal class FakeWorkManagerProvider(
+        val fakeWorkManager: FakeWorkManager = FakeWorkManager(),
+) {
 
-    val instance = mockk<WorkManagerProvider>()
-
-    init {
-        val workManager = mockk<WorkManager>()
-        every { workManager.enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>()) } returns mockk()
-        every { workManager.cancelUniqueWork(any()) } returns mockk()
-        every { instance.workManager } returns workManager
+    val instance = mockk<WorkManagerProvider>().also {
+        every { it.workManager } returns fakeWorkManager.instance
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : unit tests

## Content

<!-- Describe shortly what has been changed -->
Adding unit tests to cover code of aggregation process of live location share events.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6155 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Run unit tests

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
