### PR TITLE
Use stable endpoint for alias management

### DIFF
--- a/changelog.d/6288.bugfix
+++ b/changelog.d/6288.bugfix
@@ -1,0 +1,1 @@
+Use stable endpoint for alias management instead of MSC2432. Contributed by Nico.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/network/ApiPath.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/network/ApiPath.kt
@@ -162,7 +162,7 @@ enum class ApiPath(val path: String, val method: String) {
     KICK_USER(NetworkConstants.URI_API_PREFIX_PATH_R0 + "rooms/{roomId}/kick", "POST"),
     REDACT_EVENT(NetworkConstants.URI_API_PREFIX_PATH_R0 + "rooms/{roomId}/redact/{eventId}/{txnId}", "PUT"),
     REPORT_CONTENT(NetworkConstants.URI_API_PREFIX_PATH_R0 + "rooms/{roomId}/report/{eventId}", "POST"),
-    GET_ALIASES(NetworkConstants.URI_API_PREFIX_PATH_UNSTABLE + "org.matrix.msc2432/rooms/{roomId}/aliases", "GET"),
+    GET_ALIASES(NetworkConstants.URI_API_PREFIX_PATH_R0 + "rooms/{roomId}/aliases", "GET"),
     SEND_TYPING_STATE(NetworkConstants.URI_API_PREFIX_PATH_R0 + "rooms/{roomId}/typing/{userId}", "PUT"),
     PUT_TAG(NetworkConstants.URI_API_PREFIX_PATH_R0 + "user/{userId}/rooms/{roomId}/tags/{tag}", "PUT"),
     DELETE_TAG(NetworkConstants.URI_API_PREFIX_PATH_R0 + "user/{userId}/rooms/{roomId}/tags/{tag}", "DELETE"),

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomAPI.kt
@@ -377,7 +377,7 @@ internal interface RoomAPI {
      * Get a list of aliases maintained by the local server for the given room.
      * Ref: https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-rooms-roomid-aliases
      */
-    @GET(NetworkConstants.URI_API_PREFIX_PATH_UNSTABLE + "org.matrix.msc2432/rooms/{roomId}/aliases")
+    @GET(NetworkConstants.URI_API_PREFIX_PATH_R0 + "rooms/{roomId}/aliases")
     suspend fun getAliases(@Path("roomId") roomId: String): GetAliasesResponse
 
     /**

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/alias/GetRoomLocalAliasesTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/alias/GetRoomLocalAliasesTask.kt
@@ -34,7 +34,6 @@ internal class DefaultGetRoomLocalAliasesTask @Inject constructor(
 ) : GetRoomLocalAliasesTask {
 
     override suspend fun execute(params: GetRoomLocalAliasesTask.Params): List<String> {
-        // We do not check for "org.matrix.msc2432", so the API may be missing
         val response = executeRequest(globalErrorReceiver) {
             roomAPI.getAliases(roomId = params.roomId)
         }


### PR DESCRIPTION
This increases compatibility with homeservers and allows them to remove
Element Android specific workaround.

fixes #4830
see https://github.com/ruma/ruma/pull/936
see https://github.com/matrix-org/synapse/issues/8334
see https://github.com/matrix-org/synapse/pull/9224

Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
It makes Element Android (as the last client still relying on the MSC endpoint) use the stable endpoint to list aliases. Fixes #4830

# THIS HAS NOT BEEN TESTED SINCE I DON'T HAVE ANY ELEMENT COMPATIBLE DEVICE AND I AM TOO LAZY TO SET UP A DEVELOPMENT ENVIRONMENT FOR THIS.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Servers shouldn't have to implement MSCs, that have long been merged, to allow Element Android to run on them. This allows the removal of workarounds (or the unstable endpoints) in several server implementations and makes development of new servers easier.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
