### PR TITLE
Fixes large images crashing when opened in timeline

### DIFF
--- a/changelog.d/6290.bugfix
+++ b/changelog.d/6290.bugfix
@@ -1,0 +1,1 @@
+Fixed crash when opening large images in the timeline

--- a/vector/src/main/java/im/vector/app/features/media/ImageContentRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/media/ImageContentRenderer.kt
@@ -167,7 +167,9 @@ class ImageContentRenderer @Inject constructor(
                     .load(resolvedUrl)
         }
 
-        req.fitCenter().into(target)
+        req
+                .fitCenter()
+                .into(target)
     }
 
     fun renderForSharedElementTransition(data: Data, imageView: ImageView, callback: ((Boolean) -> Unit)? = null) {

--- a/vector/src/main/java/im/vector/app/features/media/ImageContentRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/media/ImageContentRenderer.kt
@@ -18,7 +18,6 @@ package im.vector.app.features.media
 
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
-import android.net.Uri
 import android.os.Parcelable
 import android.view.View
 import android.widget.ImageView
@@ -31,8 +30,6 @@ import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.CustomViewTarget
 import com.bumptech.glide.request.target.Target
-import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.ORIENTATION_USE_EXIF
-import com.github.piasy.biv.view.BigImageView
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.files.LocalFilesHelper
@@ -47,8 +44,6 @@ import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.content.ContentUrlResolver
 import org.matrix.android.sdk.api.session.crypto.attachments.ElementToDecrypt
 import org.matrix.android.sdk.api.session.media.PreviewUrlData
-import timber.log.Timber
-import java.io.File
 import javax.inject.Inject
 import kotlin.math.min
 
@@ -142,7 +137,6 @@ class ImageContentRenderer @Inject constructor(
                     else it.dontAnimate()
                 }
                 .transform(cornerTransformation)
-                // .thumbnail(0.3f)
                 .into(imageView)
     }
 
@@ -173,47 +167,9 @@ class ImageContentRenderer @Inject constructor(
                     .load(resolvedUrl)
         }
 
-        req.override(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
-                .fitCenter()
-                .into(target)
+        req.fitCenter().into(target)
     }
 
-    fun renderFitTarget(data: Data, mode: Mode, imageView: ImageView, callback: ((Boolean) -> Unit)? = null) {
-        val size = processSize(data, mode)
-
-        // a11y
-        imageView.contentDescription = data.filename
-
-        createGlideRequest(data, mode, imageView, size)
-                .listener(object : RequestListener<Drawable> {
-                    override fun onLoadFailed(
-                            e: GlideException?,
-                            model: Any?,
-                            target: Target<Drawable>?,
-                            isFirstResource: Boolean
-                    ): Boolean {
-                        callback?.invoke(false)
-                        return false
-                    }
-
-                    override fun onResourceReady(
-                            resource: Drawable?,
-                            model: Any?,
-                            target: Target<Drawable>?,
-                            dataSource: DataSource?,
-                            isFirstResource: Boolean
-                    ): Boolean {
-                        callback?.invoke(true)
-                        return false
-                    }
-                })
-                .fitCenter()
-                .into(imageView)
-    }
-
-    /**
-     * onlyRetrieveFromCache is true!
-     */
     fun renderForSharedElementTransition(data: Data, imageView: ImageView, callback: ((Boolean) -> Unit)? = null) {
         // a11y
         imageView.contentDescription = data.filename
@@ -254,7 +210,6 @@ class ImageContentRenderer @Inject constructor(
                 return false
             }
         })
-                .onlyRetrieveFromCache(true)
                 .fitCenter()
                 .into(imageView)
     }
@@ -290,32 +245,6 @@ class ImageContentRenderer @Inject constructor(
                         }
                     }
         }
-    }
-
-    fun render(data: Data, imageView: BigImageView) {
-        // a11y
-        imageView.contentDescription = data.filename
-
-        val (width, height) = processSize(data, Mode.THUMBNAIL)
-        val contentUrlResolver = activeSessionHolder.getActiveSession().contentUrlResolver()
-        val fullSize = resolveUrl(data)
-        val thumbnail = contentUrlResolver.resolveThumbnail(data.url, width, height, ContentUrlResolver.ThumbnailMethod.SCALE)
-
-        if (fullSize.isNullOrBlank() || thumbnail.isNullOrBlank()) {
-            Timber.w("Invalid urls")
-            return
-        }
-
-        imageView.setImageLoaderCallback(object : DefaultImageLoaderCallback {
-            override fun onSuccess(image: File?) {
-                imageView.ssiv?.orientation = ORIENTATION_USE_EXIF
-            }
-        })
-
-        imageView.showImage(
-                Uri.parse(thumbnail),
-                Uri.parse(fullSize)
-        )
     }
 
     private fun resolveUrl(data: Data) =


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes large images crashing when opened in the timeline

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/2642
Also closes https://github.com/vector-im/element-android/issues/1951
Also closes https://github.com/vector-im/element-android/issues/6190
Also closes https://github.com/matrix-org/internal-config/issues/1184

Error:
`java.lang.RuntimeException: Canvas: trying to draw too large(111132000bytes) bitmap.`

Caused when the image is rendered in `AttachmentViewerActivity`. We were overriding the size to scale the bitmap to be much larger than it already is. Upon investigation, this provides no benefit in increasing the quality of the opened image.

An `onlyRetrieveFromCache` line was removed to as this prevented the image transition from happening and seems to give little benefit to performance.

Some unused functions and old comments were also removed

Other checks performed:
- Image is still downloaded in full size

## Screenshots / GIFs

https://user-images.githubusercontent.com/20701752/173331014-194307bb-f87f-4129-8f7e-8fc4065c0a55.mp4

(app used to crash when clicking the image on the timeline)

## Tests

<!-- Explain how you tested your development -->

- Send a large image to yourself (ideally over 10MB, however crashes were observed with images over 1MB)
- Open it in the timeline
- See no crash and that image opens up smoothly with transition
- See smaller sized images open as normal

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
