### PR TITLE
FTUE - Minor tweaks

### DIFF
--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthAccountCreatedFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthAccountCreatedFragment.kt
@@ -58,7 +58,7 @@ class FtueAuthAccountCreatedFragment @Inject constructor(
         views.personalizeButtonGroup.isVisible = canPersonalize
         views.takeMeHomeButtonGroup.isVisible = !canPersonalize
 
-        if (!hasPlayedConfetti && !canPersonalize && requireContext().isAnimationEnabled()) {
+        if (!hasPlayedConfetti && requireContext().isAnimationEnabled()) {
             hasPlayedConfetti = true
             views.viewKonfetti.isVisible = true
             views.viewKonfetti.play()

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPersonalizationCompleteFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthPersonalizationCompleteFragment.kt
@@ -20,17 +20,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isVisible
-import im.vector.app.core.animations.play
-import im.vector.app.core.utils.isAnimationEnabled
 import im.vector.app.databinding.FragmentFtuePersonalizationCompleteBinding
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewEvents
 import javax.inject.Inject
 
 class FtueAuthPersonalizationCompleteFragment @Inject constructor() : AbstractFtueAuthFragment<FragmentFtuePersonalizationCompleteBinding>() {
-
-    private var hasPlayedConfetti = false
 
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentFtuePersonalizationCompleteBinding {
         return FragmentFtuePersonalizationCompleteBinding.inflate(inflater, container, false)
@@ -43,12 +38,6 @@ class FtueAuthPersonalizationCompleteFragment @Inject constructor() : AbstractFt
 
     private fun setupViews() {
         views.personalizationCompleteCta.debouncedClicks { viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnTakeMeHome)) }
-
-        if (!hasPlayedConfetti && requireContext().isAnimationEnabled()) {
-            hasPlayedConfetti = true
-            views.viewKonfetti.isVisible = true
-            views.viewKonfetti.play()
-        }
     }
 
     override fun resetViewModel() {

--- a/vector/src/main/res/layout/fragment_ftue_personalization_complete.xml
+++ b/vector/src/main/res/layout/fragment_ftue_personalization_complete.xml
@@ -106,10 +106,4 @@
         app:layout_constraintHeight_percent="0.05"
         app:layout_constraintTop_toBottomOf="@id/personalizationCompleteCta" />
 
-    <im.vector.app.core.ui.views.CompatKonfetti
-        android:id="@+id/viewKonfetti"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Type of change

- [x] WIP Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Making the confetti celebration during the FTUE onboarding always appearing during the account creation breaker. Previously we would show the confetti after the optionally personalisation steps.

- Hiding the connect to server button as we'll revisit for the V2 implementation #5782 

## Motivation and context

- We want all users to see the confetti during account creation 
- We want to avoid showing previous flows

## Screenshots / GIFs

##### Confetti move

| BEFORE | AFTER |
| --- | --- |
|![before-account-created](https://user-images.githubusercontent.com/1848238/173326338-2965e3fa-1ec7-4207-9e35-f787e803b8b3.gif)|![after-account-created](https://user-images.githubusercontent.com/1848238/173326331-ada5df52-1ee0-47ee-930f-b7db2b906e90.gif)

##### Hidden connect to server

| BEFORE | AFTER |
| --- | --- |
|![Screenshot_20220613_111152](https://user-images.githubusercontent.com/1848238/173337878-79ca1b02-eedd-487d-82a0-5e9f2a81bd71.png)|![Screenshot_20220613_111400](https://user-images.githubusercontent.com/1848238/173337875-d659b841-4b4f-4ccf-8aa4-4747221a110d.png)

## Tests

- With the combined register flag enabled 
- Complete the account registration 
- Notice the confetti when asked to personalise or go home

- With the combined register flag enabled 
- When selecting the app use case
- Notice there's no connect to server button

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 31