### PR TITLE
Allow sharing text mimetype content via android's share menu

### DIFF
--- a/changelog.d/6285.feature
+++ b/changelog.d/6285.feature
@@ -1,0 +1,1 @@
+Allow sharing text based content via android's share menu (eg .ics files)

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentsHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentsHelper.kt
@@ -214,7 +214,7 @@ class AttachmentsHelper(val context: Context, val callback: Callback) : Restorab
                         it.toContentAttachmentData()
                     }
             )
-        } else if (type.startsWith("application") || type.startsWith("file") || type.startsWith("*")) {
+        } else if (type.startsWith("application") || type.startsWith("file") || type.startsWith("text") || type.startsWith("*")) {
             callback.onContentAttachmentsReady(
                     MultiPicker.get(MultiPicker.FILE).getIncomingFiles(context, intent).map {
                         it.toContentAttachmentData()


### PR DESCRIPTION
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Allows `text/*` content types to be shared via android share menu as file attachments. 

## Motivation and context

Fixes #6285 

## Screenshots / GIFs

|Before|After|
|-|-|
|![share-ics](https://user-images.githubusercontent.com/1848238/173403246-a72d1b80-ee7b-4e46-b048-4e237bf54a51.gif)|![after-share-calendar](https://user-images.githubusercontent.com/1848238/173403272-1e4ae5ea-59b6-40c4-8289-3c8ba9fec56f.gif)|

## Tests

- Attempt to share an .ics file to element from another app, like google chrome

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28

