### PR TITLE
Making bug report screenshots opt in instead of opt out

### DIFF
--- a/changelog.d/6261.misc
+++ b/changelog.d/6261.misc
@@ -1,0 +1,1 @@
+Making screenshots in bug reports opt in instead of opt out

--- a/vector/src/main/java/im/vector/app/features/rageshake/BugReportActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/rageshake/BugReportActivity.kt
@@ -259,7 +259,7 @@ class BugReportActivity : VectorBaseActivity<ActivityBugReportBinding>() {
     }
 
     private fun onSendScreenshotChanged() {
-        views.bugReportScreenshotPreview.isVisible = views.bugReportButtonIncludeScreenshot.isChecked && bugReporter.screenshot != null
+        views.bugReportScreenshotPreview.isVisible = bugReporter.screenshot != null
     }
 
     override fun onBackPressed() {

--- a/vector/src/main/res/layout/activity_bug_report.xml
+++ b/vector/src/main/res/layout/activity_bug_report.xml
@@ -154,7 +154,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="10dp"
                     android:layout_marginEnd="10dp"
-                    android:checked="true"
+                    android:checked="false"
                     android:text="@string/send_bug_report_include_screenshot" />
 
                 <ImageView


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Bug report defaults

## Content

Makes screenshots opt-in rather than opt-out as screenshots contain messages which the logs do not

## Motivation and context

Fixes #6261 

## Screenshots / GIFs

|Before|After|
|-|-|
|![Screenshot_20220613_180354](https://user-images.githubusercontent.com/1848238/173408197-8fe0b47b-c677-4d0a-a659-223c71b61fc4.png)|![Screenshot_20220613_181111](https://user-images.githubusercontent.com/1848238/173408214-405d7eaa-e428-431e-bfe8-b5d214b68ecf.png)|
 

## Tests

- Open a bug report
- Notice the send screenshot toggle is disabled

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28