### PR TITLE
Missing unit test coverage 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
           emulator-build: 7425822
           script: | 
             ./gradlew unitTestsWithCoverage --stacktrace $CI_GRADLE_ARG_PROPERTIES
-            ./gradlew instrumentationTestsWithCoverage -Pandroid.testInstrumentationRunnerArguments.notPackage=im.vector.app.ui --stacktrace $CI_GRADLE_ARG_PROPERTIES
+            ./gradlew instrumentationTestsWithCoverage --stacktrace $CI_GRADLE_ARG_PROPERTIES
             ./gradlew generateCoverageReport --stacktrace $CI_GRADLE_ARG_PROPERTIES
 # NB: continue-on-error marks steps.tests.conclusion = 'success' but leaves stes.tests.outcome = 'failure'
       - name: Run all the codecoverage tests at once (retry if emulator failed)
@@ -67,7 +67,7 @@ jobs:
           emulator-build: 7425822
           script: |
             ./gradlew unitTestsWithCoverage --stacktrace $CI_GRADLE_ARG_PROPERTIES
-            ./gradlew instrumentationTestsWithCoverage -Pandroid.testInstrumentationRunnerArguments.notPackage=im.vector.app.ui --stacktrace $CI_GRADLE_ARG_PROPERTIES
+            ./gradlew instrumentationTestsWithCoverage --stacktrace $CI_GRADLE_ARG_PROPERTIES
             ./gradlew generateCoverageReport --stacktrace $CI_GRADLE_ARG_PROPERTIES
       - run: ./gradlew sonarqube $CI_GRADLE_ARG_PROPERTIES
         if: always() # we may have failed a previous step and retried, that's OK

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,10 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           emulator-build: 7425822
-          script: ./gradlew theCodeCoverageReport -Pandroid.testInstrumentationRunnerArguments.notPackage=im.vector.app.ui --stacktrace $CI_GRADLE_ARG_PROPERTIES
+          script: | 
+            ./gradlew unitTestsWithCoverage --stacktrace $CI_GRADLE_ARG_PROPERTIES
+            ./gradlew instrumentationTestsWithCoverage -Pandroid.testInstrumentationRunnerArguments.notPackage=im.vector.app.ui --stacktrace $CI_GRADLE_ARG_PROPERTIES
+            ./gradlew generateCoverageReport --stacktrace $CI_GRADLE_ARG_PROPERTIES
 # NB: continue-on-error marks steps.tests.conclusion = 'success' but leaves stes.tests.outcome = 'failure'
       - name: Run all the codecoverage tests at once (retry if emulator failed)
         uses: reactivecircus/android-emulator-runner@v2
@@ -62,7 +65,10 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           emulator-build: 7425822
-          script: ./gradlew theCodeCoverageReport -Pandroid.testInstrumentationRunnerArguments.notPackage=im.vector.app.ui --stacktrace $CI_GRADLE_ARG_PROPERTIES
+          script: |
+            ./gradlew unitTestsWithCoverage --stacktrace $CI_GRADLE_ARG_PROPERTIES
+            ./gradlew instrumentationTestsWithCoverage -Pandroid.testInstrumentationRunnerArguments.notPackage=im.vector.app.ui --stacktrace $CI_GRADLE_ARG_PROPERTIES
+            ./gradlew generateCoverageReport --stacktrace $CI_GRADLE_ARG_PROPERTIES
       - run: ./gradlew sonarqube $CI_GRADLE_ARG_PROPERTIES
         if: always() # we may have failed a previous step and retried, that's OK
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,7 @@ def launchTask = getGradle()
         .toString()
         .toLowerCase()
 
-if (launchTask.contains("codeCoverageReport".toLowerCase())) {
+if (launchTask.contains("coverage".toLowerCase())) {
     apply from: 'coverage.gradle'
 }
 
@@ -191,7 +191,7 @@ sonarqube {
         property "sonar.links.issue", "https://github.com/vector-im/element-android/issues"
         property "sonar.organization", "new_vector_ltd_organization"
         property "sonar.java.coveragePlugin", "jacoco"
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/reports/jacoco/theCodeCoverageReport/theCodeCoverageReport.xml"
+        property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/reports/jacoco/generateCoverageReport/generateCoverageReport.xml"
         property "sonar.login", project.hasProperty("SONAR_LOGIN") ? SONAR_LOGIN : "invalid"
     }
 }

--- a/coverage.gradle
+++ b/coverage.gradle
@@ -85,5 +85,6 @@ task unitTestsWithCoverage(type: GradleBuild) {
 
 task instrumentationTestsWithCoverage(type: GradleBuild) {
     startParameter.projectProperties.coverage = [enableTestCoverage:  true]
+    startParameter.projectProperties['android.testInstrumentationRunnerArguments.notPackage'] = 'im.vector.app.ui'
     tasks = [':vector:connectedGplayDebugAndroidTest', 'matrix-sdk-android:connectedDebugAndroidTest']
 }

--- a/coverage.gradle
+++ b/coverage.gradle
@@ -27,7 +27,7 @@ def initializeReport(report, projects, classExcludes) {
 
     report.executionData {
         fileTree(rootProject.rootDir.absolutePath).include(
-            "**/build/outputs/unit_test_code_coverage/**/*.exec",
+            "**/build/**/*.exec",
             "**/build/outputs/code_coverage/**/coverage.ec",
         )
     }
@@ -45,13 +45,11 @@ def initializeReport(report, projects, classExcludes) {
             switch (project) {
                 case { project.plugins.hasPlugin("com.android.application") }:
                     androidClassDirs.add("${project.buildDir}/tmp/kotlin-classes/gplayDebug")
-                    androidSourceDirs.add("${project.buildDir}/generated/source/kapt/gplayDebug")
                     androidSourceDirs.add("${project.projectDir}/src/main/kotlin")
                     androidSourceDirs.add("${project.projectDir}/src/main/java")
                     break
                 case { project.plugins.hasPlugin("com.android.library") }:
                     androidClassDirs.add("${project.buildDir}/tmp/kotlin-classes/debug")
-                    androidSourceDirs.add("${project.buildDir}/generated/source/kapt/debug")
                     androidSourceDirs.add("${project.projectDir}/src/main/kotlin")
                     androidSourceDirs.add("${project.projectDir}/src/main/java")
                     break
@@ -72,18 +70,20 @@ def collectProjects(predicate) {
     return subprojects.findAll { it.buildFile.isFile() && predicate(it) }
 }
 
-task theCodeCoverageReport(type: JacocoReport) {
+task generateCoverageReport(type: JacocoReport) {
     outputs.upToDateWhen { false }
     rootProject.apply plugin: 'jacoco'
-    tasks.withType(Test) {
-        jacoco.includeNoLocationClasses = true
-    }
-    def projects = collectProjects { ['vector','matrix-sdk-android'].contains(it.name) }
-    dependsOn {
-        [':vector:testGplayDebugUnitTest'] +
-        [':vector:connectedGplayDebugAndroidTest'] +
-        [':matrix-sdk-android:testDebugUnitTest'] +
-        [':matrix-sdk-android:connectedDebugAndroidTest']
-    }
+    def projects = collectProjects { ['vector', 'matrix-sdk-android'].contains(it.name) }
     initializeReport(it, projects, excludes)
+}
+
+task unitTestsWithCoverage(type: GradleBuild) {
+    // the 7.1.3 android gradle plugin has a bug where enableTestCoverage generates invalid coverage
+    startParameter.projectProperties.coverage = [enableTestCoverage:  false]
+    tasks = [':vector:testGplayDebugUnitTest', ':matrix-sdk-android:testDebugUnitTest']
+}
+
+task instrumentationTestsWithCoverage(type: GradleBuild) {
+    startParameter.projectProperties.coverage = [enableTestCoverage:  true]
+    tasks = [':vector:connectedGplayDebugAndroidTest', 'matrix-sdk-android:connectedDebugAndroidTest']
 }

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -79,7 +79,6 @@ android {
     buildTypes {
         debug {
             if (project.hasProperty("coverage")) {
-                println(coverage)
                 testCoverageEnabled = coverage.enableTestCoverage
             }
             // Set to true to log privacy or sensible data, such as token

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -5,6 +5,10 @@ apply plugin: 'kotlin-parcelize'
 apply plugin: 'realm-android'
 apply plugin: "org.jetbrains.dokka"
 
+if (project.hasProperty("coverage")) {
+    apply plugin: 'jacoco'
+}
+
 buildscript {
     repositories {
         // Do not use `mavenCentral()`, it prevents Dependabot from working properly
@@ -74,7 +78,10 @@ android {
 
     buildTypes {
         debug {
-            testCoverageEnabled true
+            if (project.hasProperty("coverage")) {
+                println(coverage)
+                testCoverageEnabled = coverage.enableTestCoverage
+            }
             // Set to true to log privacy or sensible data, such as token
             buildConfigField "boolean", "LOG_PRIVATE_DATA", project.property("vector.debugPrivateData")
             // Set to BODY instead of NONE to enable logging

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -9,6 +9,10 @@ apply plugin: 'com.likethesalad.stem'
 apply plugin: 'dagger.hilt.android.plugin'
 apply plugin: 'kotlinx-knit'
 
+if (project.hasProperty("coverage")) {
+    apply plugin: 'jacoco'
+}
+
 kapt {
     correctErrorTypes = true
 }
@@ -119,8 +123,6 @@ ext.abiVersionCodes = ["armeabi-v7a": 1, "arm64-v8a": 2, "x86": 3, "x86_64": 4].
 def buildNumber = System.env.BUILDKITE_BUILD_NUMBER as Integer ?: 0
 
 android {
-
-
     // Due to a bug introduced in Android gradle plugin 3.6.0, we have to specify the ndk version to use
     // Ref: https://issuetracker.google.com/issues/144111441
     ndkVersion "21.3.6528147"
@@ -145,7 +147,7 @@ android {
         versionName "${versionMajor}.${versionMinor}.${versionPatch}-sonar"
 
         // Generate a random app task affinity
-        manifestPlaceholders = [appTaskAffinitySuffix:"H_${gitRevision()}"]
+        manifestPlaceholders = [appTaskAffinitySuffix: "H_${gitRevision()}"]
 
         buildConfigField "String", "GIT_REVISION", "\"${gitRevision()}\""
         buildConfigField "String", "GIT_REVISION_DATE", "\"${gitRevisionDate()}\""
@@ -244,7 +246,10 @@ android {
             buildConfigField "boolean", "ENABLE_STRICT_MODE_LOGS", "false"
 
             signingConfig signingConfigs.debug
-            testCoverageEnabled true
+
+            if (project.hasProperty("coverage")) {
+                testCoverageEnabled = coverage.enableTestCoverage
+            }
         }
 
         release {


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Fixes #6299 missing unit test coverage  

- The current android gradle plugin we're using (7.1.3) has a bug which causes unit test coverage generated with `testCoverageEnabled` to be invalid, we can generate the coverage via jacoco instead.
- The fix is to split the unit tests and instrumentation tasks so that we can change the configuration and collect all the results
- Also disables instrumenting the code for debug builds which should speed up compilation a little~

## Motivation and context

The include unit test coverage in the sonar reports

## Screenshots / GIFs

https://github.com/vector-im/element-android/pull/6323

![2022-06-16T15:36:09,854306238+01:00](https://user-images.githubusercontent.com/1848238/174094331-856e828c-3278-4256-806b-6c5c4e8071f1.png)


## Tests

- with the gradle build option `testCoverageEnabled = true` run the unit tests `./gradlew testGplayDebugUnitTest`
- attempt to generate a jacoco report from the resulting `unit_test_coverage/*.exec` file
- notice no coverage is picked up

## Tested devices
N/A CI related

