### PR TITLE
Feature/bca/verif resist no age

### DIFF
--- a/changelog.d/6328.bugfix
+++ b/changelog.d/6328.bugfix
@@ -1,0 +1,1 @@
+Fix | Some user verification requests couldn't be accepted/declined

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/verification/VerificationMessageProcessor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/verification/VerificationMessageProcessor.kt
@@ -62,7 +62,7 @@ internal class VerificationMessageProcessor @Inject constructor(
         // If the request is in the future by more than 5 minutes or more than 10 minutes in the past,
         // the message should be ignored by the receiver.
 
-        if (event.ageLocalTs != null && !VerificationService.isValidRequest(event.ageLocalTs, clock.epochMillis())) return Unit.also {
+        if (!VerificationService.isValidRequest(event.ageLocalTs, clock.epochMillis())) return Unit.also {
             Timber.d("## SAS Verification live observer: msgId: ${event.eventId} is outdated age:$event.ageLocalTs ms")
         }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ThreadSummaryHelper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ThreadSummaryHelper.kt
@@ -271,7 +271,7 @@ private fun HashMap<String, RoomMemberContent?>.addSenderState(realm: Realm, roo
  * Create an EventEntity for the root thread event or get an existing one.
  */
 private fun createEventEntity(realm: Realm, roomId: String, event: Event, currentTimeMillis: Long): EventEntity {
-    val ageLocalTs = event.unsignedData?.age?.let { currentTimeMillis - it }
+    val ageLocalTs = event.unsignedData?.age?.let { currentTimeMillis - it } ?: currentTimeMillis
     return event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, EventInsertType.PAGINATION)
 }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ThreadSummaryHelper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ThreadSummaryHelper.kt
@@ -271,7 +271,7 @@ private fun HashMap<String, RoomMemberContent?>.addSenderState(realm: Realm, roo
  * Create an EventEntity for the root thread event or get an existing one.
  */
 private fun createEventEntity(realm: Realm, roomId: String, event: Event, currentTimeMillis: Long): EventEntity {
-    val ageLocalTs = event.unsignedData?.age?.let { currentTimeMillis - it } ?: currentTimeMillis
+    val ageLocalTs = currentTimeMillis - (event.unsignedData?.age ?: 0)
     return event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, EventInsertType.PAGINATION)
 }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/EventMapper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/EventMapper.kt
@@ -130,7 +130,7 @@ internal fun EventEntity.asDomain(castJsonNumbers: Boolean = false): Event {
 internal fun Event.toEntity(
         roomId: String,
         sendState: SendState,
-        ageLocalTs: Long?,
+        ageLocalTs: Long,
         contentToInject: String? = null
 ): EventEntity {
     return EventMapper.map(this, roomId).apply {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/LoadRoomMembersTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/LoadRoomMembersTask.kt
@@ -114,7 +114,7 @@ internal class DefaultLoadRoomMembersTask @Inject constructor(
                 if (roomMemberEvent.eventId == null || roomMemberEvent.stateKey == null || roomMemberEvent.type == null) {
                     continue
                 }
-                val ageLocalTs = roomMemberEvent.unsignedData?.age?.let { now - it }
+                val ageLocalTs = roomMemberEvent.unsignedData?.age?.let { now - it } ?: now
                 val eventEntity = roomMemberEvent.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, EventInsertType.PAGINATION)
                 CurrentStateEventEntity.getOrCreate(
                         realm,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/LoadRoomMembersTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/LoadRoomMembersTask.kt
@@ -114,7 +114,7 @@ internal class DefaultLoadRoomMembersTask @Inject constructor(
                 if (roomMemberEvent.eventId == null || roomMemberEvent.stateKey == null || roomMemberEvent.type == null) {
                     continue
                 }
-                val ageLocalTs = roomMemberEvent.unsignedData?.age?.let { now - it } ?: now
+                val ageLocalTs = now - (roomMemberEvent.unsignedData?.age ?: 0)
                 val eventEntity = roomMemberEvent.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, EventInsertType.PAGINATION)
                 CurrentStateEventEntity.getOrCreate(
                         realm,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/relation/threads/FetchThreadTimelineTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/relation/threads/FetchThreadTimelineTask.kt
@@ -209,7 +209,8 @@ internal class DefaultFetchThreadTimelineTask @Inject constructor(
      * Create an EventEntity to be added in the TimelineEventEntity.
      */
     private fun createEventEntity(roomId: String, event: Event, realm: Realm): EventEntity {
-        val ageLocalTs = event.unsignedData?.age?.let { clock.epochMillis() - it }
+        val now = clock.epochMillis()
+        val ageLocalTs = event.unsignedData?.age?.let { now - it } ?: now
         return event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, EventInsertType.PAGINATION)
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/relation/threads/FetchThreadTimelineTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/relation/threads/FetchThreadTimelineTask.kt
@@ -210,7 +210,7 @@ internal class DefaultFetchThreadTimelineTask @Inject constructor(
      */
     private fun createEventEntity(roomId: String, event: Event, realm: Realm): EventEntity {
         val now = clock.epochMillis()
-        val ageLocalTs = event.unsignedData?.age?.let { now - it } ?: now
+        val ageLocalTs = now - (event.unsignedData?.age ?: 0)
         return event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, EventInsertType.PAGINATION)
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/GetEventTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/GetEventTask.kt
@@ -61,7 +61,7 @@ internal class DefaultGetEventTask @Inject constructor(
                     }
         }
 
-        event.ageLocalTs = event.unsignedData?.age?.let { clock.epochMillis() - it }
+        event.ageLocalTs = clock.epochMillis() - (event.unsignedData?.age ?: 0)
 
         return event
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEventPersistor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEventPersistor.kt
@@ -142,7 +142,7 @@ internal class TokenChunkEventPersistor @Inject constructor(
         val now = clock.epochMillis()
 
         stateEvents?.forEach { stateEvent ->
-            val ageLocalTs = stateEvent.unsignedData?.age?.let { now - it } ?: now
+            val ageLocalTs = now - (stateEvent.unsignedData?.age ?: 0)
             val stateEventEntity = stateEvent.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, EventInsertType.PAGINATION)
             currentChunk.addStateEvent(roomId, stateEventEntity, direction)
             if (stateEvent.type == EventType.STATE_ROOM_MEMBER && stateEvent.stateKey != null) {
@@ -155,7 +155,7 @@ internal class TokenChunkEventPersistor @Inject constructor(
                 if (event.eventId == null || event.senderId == null) {
                     return@forEach
                 }
-                val ageLocalTs = event.unsignedData?.age?.let { now - it } ?: now
+                val ageLocalTs = now - (event.unsignedData?.age ?: 0)
                 val eventEntity = event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, EventInsertType.PAGINATION)
                 if (event.type == EventType.STATE_ROOM_MEMBER && event.stateKey != null) {
                     val contentToUse = if (direction == PaginationDirection.BACKWARDS) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEventPersistor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TokenChunkEventPersistor.kt
@@ -142,7 +142,7 @@ internal class TokenChunkEventPersistor @Inject constructor(
         val now = clock.epochMillis()
 
         stateEvents?.forEach { stateEvent ->
-            val ageLocalTs = stateEvent.unsignedData?.age?.let { now - it }
+            val ageLocalTs = stateEvent.unsignedData?.age?.let { now - it } ?: now
             val stateEventEntity = stateEvent.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, EventInsertType.PAGINATION)
             currentChunk.addStateEvent(roomId, stateEventEntity, direction)
             if (stateEvent.type == EventType.STATE_ROOM_MEMBER && stateEvent.stateKey != null) {
@@ -155,7 +155,7 @@ internal class TokenChunkEventPersistor @Inject constructor(
                 if (event.eventId == null || event.senderId == null) {
                     return@forEach
                 }
-                val ageLocalTs = event.unsignedData?.age?.let { now - it }
+                val ageLocalTs = event.unsignedData?.age?.let { now - it } ?: now
                 val eventEntity = event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, EventInsertType.PAGINATION)
                 if (event.type == EventType.STATE_ROOM_MEMBER && event.stateKey != null) {
                     val contentToUse = if (direction == PaginationDirection.BACKWARDS) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
@@ -244,7 +244,7 @@ internal class RoomSyncHandler @Inject constructor(
                 if (event.eventId == null || event.stateKey == null || event.type == null) {
                     continue
                 }
-                val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it } ?: syncLocalTimestampMillis
+                val ageLocalTs = syncLocalTimestampMillis - (event.unsignedData?.age ?: 0)
                 val eventEntity = event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, insertType)
                 Timber.v("## received state event ${event.type} and key ${event.stateKey}")
                 CurrentStateEventEntity.getOrCreate(realm, roomId, event.stateKey, event.type).apply {
@@ -306,7 +306,7 @@ internal class RoomSyncHandler @Inject constructor(
                 if (event.stateKey == null || event.type == null) {
                     return@forEach
                 }
-                val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it } ?: syncLocalTimestampMillis
+                val ageLocalTs = syncLocalTimestampMillis - (event.unsignedData?.age ?: 0)
                 val eventEntity = event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, insertType)
                 CurrentStateEventEntity.getOrCreate(realm, roomId, event.stateKey, event.type).apply {
                     eventId = eventEntity.eventId
@@ -336,7 +336,7 @@ internal class RoomSyncHandler @Inject constructor(
             if (event.eventId == null || event.stateKey == null || event.type == null) {
                 continue
             }
-            val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it } ?: syncLocalTimestampMillis
+            val ageLocalTs = syncLocalTimestampMillis - (event.unsignedData?.age ?: 0)
             val eventEntity = event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, insertType)
             CurrentStateEventEntity.getOrCreate(realm, roomId, event.stateKey, event.type).apply {
                 eventId = event.eventId
@@ -348,7 +348,7 @@ internal class RoomSyncHandler @Inject constructor(
             if (event.eventId == null || event.senderId == null || event.type == null) {
                 continue
             }
-            val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it } ?: syncLocalTimestampMillis
+            val ageLocalTs = syncLocalTimestampMillis - (event.unsignedData?.age ?: 0)
             val eventEntity = event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, insertType)
             if (event.stateKey != null) {
                 CurrentStateEventEntity.getOrCreate(realm, roomId, event.stateKey, event.type).apply {
@@ -401,7 +401,7 @@ internal class RoomSyncHandler @Inject constructor(
         for (rawEvent in eventList) {
             // It's annoying roomId is not there, but lot of code rely on it.
             // And had to do it now as copy would delete all decryption results..
-            val ageLocalTs = rawEvent.unsignedData?.age?.let { syncLocalTimestampMillis - it } ?: syncLocalTimestampMillis
+            val ageLocalTs = syncLocalTimestampMillis - (rawEvent.unsignedData?.age ?: 0)
             val event = rawEvent.copy(roomId = roomId).also {
                 it.ageLocalTs = ageLocalTs
             }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
@@ -244,7 +244,7 @@ internal class RoomSyncHandler @Inject constructor(
                 if (event.eventId == null || event.stateKey == null || event.type == null) {
                     continue
                 }
-                val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it }
+                val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it } ?: syncLocalTimestampMillis
                 val eventEntity = event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, insertType)
                 Timber.v("## received state event ${event.type} and key ${event.stateKey}")
                 CurrentStateEventEntity.getOrCreate(realm, roomId, event.stateKey, event.type).apply {
@@ -306,7 +306,7 @@ internal class RoomSyncHandler @Inject constructor(
                 if (event.stateKey == null || event.type == null) {
                     return@forEach
                 }
-                val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it }
+                val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it } ?: syncLocalTimestampMillis
                 val eventEntity = event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, insertType)
                 CurrentStateEventEntity.getOrCreate(realm, roomId, event.stateKey, event.type).apply {
                     eventId = eventEntity.eventId
@@ -336,7 +336,7 @@ internal class RoomSyncHandler @Inject constructor(
             if (event.eventId == null || event.stateKey == null || event.type == null) {
                 continue
             }
-            val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it }
+            val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it } ?: syncLocalTimestampMillis
             val eventEntity = event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, insertType)
             CurrentStateEventEntity.getOrCreate(realm, roomId, event.stateKey, event.type).apply {
                 eventId = event.eventId
@@ -348,7 +348,7 @@ internal class RoomSyncHandler @Inject constructor(
             if (event.eventId == null || event.senderId == null || event.type == null) {
                 continue
             }
-            val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it }
+            val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it } ?: syncLocalTimestampMillis
             val eventEntity = event.toEntity(roomId, SendState.SYNCED, ageLocalTs).copyToRealmOrIgnore(realm, insertType)
             if (event.stateKey != null) {
                 CurrentStateEventEntity.getOrCreate(realm, roomId, event.stateKey, event.type).apply {
@@ -401,7 +401,10 @@ internal class RoomSyncHandler @Inject constructor(
         for (rawEvent in eventList) {
             // It's annoying roomId is not there, but lot of code rely on it.
             // And had to do it now as copy would delete all decryption results..
-            val event = rawEvent.copy(roomId = roomId)
+            val ageLocalTs = rawEvent.unsignedData?.age?.let { syncLocalTimestampMillis - it } ?: syncLocalTimestampMillis
+            val event = rawEvent.copy(roomId = roomId).also {
+                it.ageLocalTs = ageLocalTs
+            }
             if (event.eventId == null || event.senderId == null || event.type == null) {
                 continue
             }
@@ -423,7 +426,6 @@ internal class RoomSyncHandler @Inject constructor(
                 contentToInject = threadsAwarenessHandler.makeEventThreadAware(realm, roomId, event)
             }
 
-            val ageLocalTs = event.unsignedData?.age?.let { syncLocalTimestampMillis - it }
             val eventEntity = event.toEntity(roomId, SendState.SYNCED, ageLocalTs, contentToInject).copyToRealmOrIgnore(realm, insertType)
             if (event.stateKey != null) {
                 CurrentStateEventEntity.getOrCreate(realm, roomId, event.stateKey, event.type).apply {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/ThreadsAwarenessHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/ThreadsAwarenessHandler.kt
@@ -53,6 +53,7 @@ import org.matrix.android.sdk.internal.session.permalinks.PermalinkFactory
 import org.matrix.android.sdk.internal.session.room.send.LocalEchoEventFactory
 import org.matrix.android.sdk.internal.session.room.timeline.GetEventTask
 import org.matrix.android.sdk.internal.util.awaitTransaction
+import org.matrix.android.sdk.internal.util.time.Clock
 import javax.inject.Inject
 
 /**
@@ -64,7 +65,8 @@ internal class ThreadsAwarenessHandler @Inject constructor(
         private val permalinkFactory: PermalinkFactory,
         @SessionDatabase private val monarchy: Monarchy,
         private val lightweightSettingsStorage: LightweightSettingsStorage,
-        private val getEventTask: GetEventTask
+        private val getEventTask: GetEventTask,
+        private val clock: Clock,
 ) {
 
     // This caching is responsible to improve the performance when we receive a root event
@@ -120,7 +122,7 @@ internal class ThreadsAwarenessHandler @Inject constructor(
     private suspend fun fetchThreadsEvents(threadsToFetch: Map<String, String>) {
         val eventEntityList = threadsToFetch.mapNotNull { (eventId, roomId) ->
             fetchEvent(eventId, roomId)?.let {
-                it.toEntity(roomId, SendState.SYNCED, it.ageLocalTs)
+                it.toEntity(roomId, SendState.SYNCED, it.ageLocalTs ?: clock.epochMillis())
             }
         }
 

--- a/vector/src/main/java/im/vector/app/core/ui/list/ButtonPositiveDestructiveButtonBarItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/ButtonPositiveDestructiveButtonBarItem.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package im.vector.app.core.ui.list
+
+import com.airbnb.epoxy.EpoxyAttribute
+import com.airbnb.epoxy.EpoxyModelClass
+import com.google.android.material.button.MaterialButton
+import im.vector.app.R
+import im.vector.app.core.epoxy.ClickListener
+import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
+import im.vector.app.core.epoxy.onClick
+import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
+
+/**
+ * A generic button list item.
+ */
+@EpoxyModelClass(layout = R.layout.item_positive_destrutive_buttons)
+abstract class ButtonPositiveDestructiveButtonBarItem : VectorEpoxyModel<ButtonPositiveDestructiveButtonBarItem.Holder>() {
+
+    @EpoxyAttribute
+    var positiveText: EpoxyCharSequence? = null
+
+    @EpoxyAttribute
+    var destructiveText: EpoxyCharSequence? = null
+
+    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
+    var positiveButtonClickAction: ClickListener? = null
+
+    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
+    var destructiveButtonClickAction: ClickListener? = null
+
+    override fun bind(holder: Holder) {
+        super.bind(holder)
+        positiveText?.charSequence?.let { holder.positiveButton.text = it }
+        destructiveText?.charSequence?.let { holder.destructiveButton.text = it }
+
+        holder.positiveButton.onClick(positiveButtonClickAction)
+        holder.destructiveButton.onClick(destructiveButtonClickAction)
+    }
+
+    class Holder : VectorEpoxyHolder() {
+        val destructiveButton by bind<MaterialButton>(R.id.destructive_button)
+        val positiveButton by bind<MaterialButton>(R.id.positive_button)
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationAction.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationAction.kt
@@ -30,6 +30,8 @@ sealed class VerificationAction : VectorViewModelAction {
     data class GotItConclusion(val verified: Boolean) : VerificationAction()
     object SkipVerification : VerificationAction()
     object VerifyFromPassphrase : VerificationAction()
+    object ReadyPendingVerification : VerificationAction()
+    object CancelPendingVerification : VerificationAction()
     data class GotResultFromSsss(val cypherData: String, val alias: String) : VerificationAction()
     object CancelledFromSsss : VerificationAction()
     object SecuredStorageHasBeenReset : VerificationAction()

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationBottomSheetViewModel.kt
@@ -360,6 +360,27 @@ class VerificationBottomSheetViewModel @AssistedInject constructor(
                         as? SasVerificationTransaction)
                         ?.shortCodeDoesNotMatch()
             }
+            is VerificationAction.ReadyPendingVerification -> {
+                state.pendingRequest.invoke()?.let { request ->
+                    // will only be there for dm verif
+                    if (state.roomId != null) {
+                        session.cryptoService().verificationService()
+                                .readyPendingVerificationInDMs(
+                                        supportedVerificationMethodsProvider.provide(),
+                                        state.otherUserId,
+                                        state.roomId,
+                                        request.transactionId ?: ""
+                                )
+                    }
+                }
+            }
+            is VerificationAction.CancelPendingVerification -> {
+                state.pendingRequest.invoke()?.let {
+                    session.cryptoService().verificationService()
+                            .cancelVerificationRequest(it)
+                }
+                _viewEvents.post(VerificationBottomSheetViewEvents.Dismiss)
+            }
             is VerificationAction.GotItConclusion -> {
                 if (state.isVerificationRequired && !action.verified) {
                     // we should go back to first screen

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodController.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodController.kt
@@ -21,6 +21,7 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.bottomSheetDividerItem
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.StringProvider
+import im.vector.app.core.ui.list.genericButtonItem
 import im.vector.app.features.crypto.verification.epoxy.bottomSheetVerificationActionItem
 import im.vector.app.features.crypto.verification.epoxy.bottomSheetVerificationNoticeItem
 import im.vector.app.features.crypto.verification.epoxy.bottomSheetVerificationQrCodeItem
@@ -108,6 +109,20 @@ class VerificationChooseMethodController @Inject constructor(
                 iconColor(host.colorProvider.getColorFromAttribute(R.attr.vctr_content_primary))
                 listener { host.listener?.doVerifyBySas() }
             }
+        } else if (!state.isReadied) {
+            // a bit of a special case, if you tapped on the timeline cell but not on a button
+            genericButtonItem {
+                id("accept_request")
+                textColor(host.colorProvider.getColorFromAttribute(R.attr.colorPrimary))
+                text(host.stringProvider.getString(R.string.action_accept))
+                buttonClickAction { host.listener?.acceptRequest() }
+            }
+            genericButtonItem {
+                id("decline_request")
+                textColor(host.colorProvider.getColorFromAttribute(R.attr.colorError))
+                text(host.stringProvider.getString(R.string.action_decline))
+                buttonClickAction { host.listener?.declineRequest() }
+            }
         }
 
         if (state.isMe && state.canCrossSign) {
@@ -131,5 +146,7 @@ class VerificationChooseMethodController @Inject constructor(
         fun openCamera()
         fun doVerifyBySas()
         fun onClickOnWasNotMe()
+        fun acceptRequest()
+        fun declineRequest()
     }
 }

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodController.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodController.kt
@@ -109,7 +109,7 @@ class VerificationChooseMethodController @Inject constructor(
                 iconColor(host.colorProvider.getColorFromAttribute(R.attr.vctr_content_primary))
                 listener { host.listener?.doVerifyBySas() }
             }
-        } else if (!state.isReadied) {
+        } else if (!state.isReadySent) {
             // a bit of a special case, if you tapped on the timeline cell but not on a button
             buttonPositiveDestructiveButtonBarItem {
                 id("accept_decline")

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodController.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodController.kt
@@ -21,7 +21,7 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.bottomSheetDividerItem
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.StringProvider
-import im.vector.app.core.ui.list.genericButtonItem
+import im.vector.app.core.ui.list.buttonPositiveDestructiveButtonBarItem
 import im.vector.app.features.crypto.verification.epoxy.bottomSheetVerificationActionItem
 import im.vector.app.features.crypto.verification.epoxy.bottomSheetVerificationNoticeItem
 import im.vector.app.features.crypto.verification.epoxy.bottomSheetVerificationQrCodeItem
@@ -111,17 +111,12 @@ class VerificationChooseMethodController @Inject constructor(
             }
         } else if (!state.isReadied) {
             // a bit of a special case, if you tapped on the timeline cell but not on a button
-            genericButtonItem {
-                id("accept_request")
-                textColor(host.colorProvider.getColorFromAttribute(R.attr.colorPrimary))
-                text(host.stringProvider.getString(R.string.action_accept))
-                buttonClickAction { host.listener?.acceptRequest() }
-            }
-            genericButtonItem {
-                id("decline_request")
-                textColor(host.colorProvider.getColorFromAttribute(R.attr.colorError))
-                text(host.stringProvider.getString(R.string.action_decline))
-                buttonClickAction { host.listener?.declineRequest() }
+            buttonPositiveDestructiveButtonBarItem {
+                id("accept_decline")
+                positiveText(host.stringProvider.getString(R.string.action_accept).toEpoxyCharSequence())
+                destructiveText(host.stringProvider.getString(R.string.action_decline).toEpoxyCharSequence())
+                positiveButtonClickAction { host.listener?.acceptRequest() }
+                destructiveButtonClickAction { host.listener?.declineRequest() }
             }
         }
 

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodFragment.kt
@@ -100,6 +100,18 @@ class VerificationChooseMethodFragment @Inject constructor(
         sharedViewModel.itWasNotMe()
     }
 
+    override fun acceptRequest() {
+        withState(viewModel) {
+            sharedViewModel.handle(VerificationAction.ReadyPendingVerification)
+        }
+    }
+
+    override fun declineRequest() {
+        withState(viewModel) {
+            sharedViewModel.handle(VerificationAction.CancelPendingVerification)
+        }
+    }
+
     private fun doOpenQRCodeScanner() {
         QrCodeScannerActivity.startForResult(requireActivity(), scanActivityResultLauncher)
     }

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodFragment.kt
@@ -101,15 +101,11 @@ class VerificationChooseMethodFragment @Inject constructor(
     }
 
     override fun acceptRequest() {
-        withState(viewModel) {
-            sharedViewModel.handle(VerificationAction.ReadyPendingVerification)
-        }
+        sharedViewModel.handle(VerificationAction.ReadyPendingVerification)
     }
 
     override fun declineRequest() {
-        withState(viewModel) {
-            sharedViewModel.handle(VerificationAction.CancelPendingVerification)
-        }
+        sharedViewModel.handle(VerificationAction.CancelPendingVerification)
     }
 
     private fun doOpenQRCodeScanner() {

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodViewModel.kt
@@ -44,7 +44,8 @@ data class VerificationChooseMethodViewState(
         val qrCodeText: String? = null,
         val sasModeAvailable: Boolean = false,
         val isMe: Boolean = false,
-        val canCrossSign: Boolean = false
+        val canCrossSign: Boolean = false,
+        val isReadied: Boolean = false
 ) : MavericksState
 
 class VerificationChooseMethodViewModel @AssistedInject constructor(
@@ -81,7 +82,8 @@ class VerificationChooseMethodViewModel @AssistedInject constructor(
             copy(
                     otherCanShowQrCode = pvr?.otherCanShowQrCode().orFalse(),
                     otherCanScanQrCode = pvr?.otherCanScanQrCode().orFalse(),
-                    sasModeAvailable = pvr?.isSasSupported().orFalse()
+                    sasModeAvailable = pvr?.isSasSupported().orFalse(),
+                    isReadied = pvr?.isReady ?: false,
             )
         }
     }

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/choose/VerificationChooseMethodViewModel.kt
@@ -45,7 +45,7 @@ data class VerificationChooseMethodViewState(
         val sasModeAvailable: Boolean = false,
         val isMe: Boolean = false,
         val canCrossSign: Boolean = false,
-        val isReadied: Boolean = false
+        val isReadySent: Boolean = false
 ) : MavericksState
 
 class VerificationChooseMethodViewModel @AssistedInject constructor(
@@ -83,7 +83,7 @@ class VerificationChooseMethodViewModel @AssistedInject constructor(
                     otherCanShowQrCode = pvr?.otherCanShowQrCode().orFalse(),
                     otherCanScanQrCode = pvr?.otherCanScanQrCode().orFalse(),
                     sasModeAvailable = pvr?.isSasSupported().orFalse(),
-                    isReadied = pvr?.isReady ?: false,
+                    isReadySent = pvr?.isReady.orFalse(),
             )
         }
     }

--- a/vector/src/main/res/layout/item_positive_destrutive_buttons.xml
+++ b/vector/src/main/res/layout/item_positive_destrutive_buttons.xml
@@ -4,8 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="center_horizontal"
-    android:orientation="horizontal"
-    tools:visibility="visible">
+    android:orientation="horizontal">
 
     <Button
         android:id="@+id/destructive_button"
@@ -13,13 +12,13 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
-        android:text="@string/action_decline" />
+        tools:text="@string/action_decline" />
 
     <Button
         android:id="@+id/positive_button"
         style="@style/Widget.Vector.Button.Positive"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/action_accept" />
+        tools:text="@string/action_accept" />
 
 </LinearLayout>

--- a/vector/src/main/res/layout/item_positive_destrutive_buttons.xml
+++ b/vector/src/main/res/layout/item_positive_destrutive_buttons.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal"
+    android:orientation="horizontal"
+    tools:visibility="visible">
+
+    <Button
+        android:id="@+id/destructive_button"
+        style="@style/Widget.Vector.Button.Destructive"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:text="@string/action_decline" />
+
+    <Button
+        android:id="@+id/positive_button"
+        style="@style/Widget.Vector.Button.Positive"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/action_accept" />
+
+</LinearLayout>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Bugfix

## Content

<!-- Describe shortly what has been changed -->

Under certain condition, incoming verification are displayed in the UI without Accept/Decline button.
<img width="780" alt="image" src="https://user-images.githubusercontent.com/9841565/174097101-4e19879f-63d7-40b6-9515-8491901a054c.png">

Making it impossible to continue the verification.

This PR fixes the case when a verification request is ignored because deemed too in the past or too in the future.
This computation is based on ageLocalTs, that is computed from the `unsigned.age`. The processor and the timeline display had different test, the timeline was accepting null age and not processor.

To fix it, we now ensure that `ageLocalTs` is set even if no `unsigned.age` in the synced event.

I noticed that it was also possible to open the bottom sheet from typing on the verification tile and not on one of the button. I modified the bottom sheet to show accept/decline buttons when the request is not yet ready.
<img width="416" alt="image" src="https://user-images.githubusercontent.com/9841565/175894070-f7dddf05-64a3-41c2-b154-dcc67c7d59c6.png">

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

Tested against polyjuice for regressions.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
