### PR TITLE
Fix flaky tests for voice recording feature

### DIFF
--- a/changelog.d/6329.misc
+++ b/changelog.d/6329.misc
@@ -1,0 +1,1 @@
+Fix flaky test in voice recording feature.

--- a/vector/src/androidTest/java/im/vector/app/core/utils/WaitUntil.kt
+++ b/vector/src/androidTest/java/im/vector/app/core/utils/WaitUntil.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.utils
+
+import kotlinx.coroutines.delay
+import org.amshove.kluent.fail
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Tries a [condition] several times until it returns true or a [timeout] is reached waiting for some [retryDelay] time between retries.
+ * On timeout it fails with an [errorMessage].
+ */
+suspend fun waitUntilCondition(
+        errorMessage: String,
+        timeout: Duration = 1.seconds,
+        retryDelay: Duration = 50.milliseconds,
+        condition: () -> Boolean,
+) {
+    val start = System.currentTimeMillis()
+    do {
+        if (condition()) return
+        delay(retryDelay.inWholeMilliseconds)
+    } while (System.currentTimeMillis() - start < timeout.inWholeMilliseconds)
+    fail(errorMessage)
+}
+
+/**
+ * Tries a [block] several times until it runs with no errors or a [timeout] is reached waiting for some [retryDelay] time between retries.
+ * On timeout it fails with a custom [errorMessage] or a caught [AssertionError].
+ */
+suspend fun waitUntil(
+        errorMessage: String? = null,
+        timeout: Duration = 1.seconds,
+        retryDelay: Duration = 50.milliseconds,
+        block: () -> Unit,
+) {
+    var error: AssertionError?
+    val start = System.currentTimeMillis()
+    do {
+        try {
+            block()
+            return
+        } catch (e: AssertionError) {
+            error = e
+        }
+        delay(retryDelay.inWholeMilliseconds)
+    } while (System.currentTimeMillis() - start < timeout.inWholeMilliseconds)
+    if (errorMessage != null) {
+        fail(errorMessage)
+    } else {
+        throw error!!
+    }
+}

--- a/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderLTests.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderLTests.kt
@@ -21,6 +21,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import io.mockk.spyk
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldExist
 import org.amshove.kluent.shouldNotBeNull
@@ -42,8 +43,7 @@ class VoiceRecorderLTests {
         getVoiceMessageFile().shouldBeNull()
 
         startRecord("some_room_id")
-
-        getVoiceMessageFile().shouldNotBeNullAndExist()
+        runBlocking { waitUntilRecordingFileExists() }
 
         stopRecord()
     }
@@ -53,6 +53,7 @@ class VoiceRecorderLTests {
         getVoiceMessageFile().shouldBeNull()
 
         startRecord("some_room_id")
+        runBlocking { waitUntilRecordingFileExists() }
         stopRecord()
 
         getVoiceMessageFile().shouldNotBeNullAndExist()
@@ -61,8 +62,7 @@ class VoiceRecorderLTests {
     @Test
     fun cancelRecordRemovesFile() = with(recorder) {
         startRecord("some_room_id")
-        val file = recorder.getVoiceMessageFile()
-        file.shouldNotBeNullAndExist()
+        val file = runBlocking { waitUntilRecordingFileExists() }
 
         cancelRecord()
 

--- a/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderTestExt.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderTestExt.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.voice
+
+import im.vector.app.core.utils.waitUntil
+import org.amshove.kluent.shouldExist
+import org.amshove.kluent.shouldNotBeNull
+import java.io.File
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+// Give voice recorders some time to start recording and create the audio file
+suspend fun VoiceRecorder.waitUntilRecordingFileExists(timeout: Duration = 1.seconds, delay: Duration = 10.milliseconds): File? {
+    waitUntil(timeout = timeout, retryDelay = delay) {
+        getVoiceMessageFile().run {
+            shouldNotBeNull()
+            shouldExist()
+        }
+    }
+    return getVoiceMessageFile()
+}

--- a/vector/src/main/java/im/vector/app/features/voice/AbstractVoiceRecorder.kt
+++ b/vector/src/main/java/im/vector/app/features/voice/AbstractVoiceRecorder.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.voice
 import android.content.Context
 import android.media.MediaRecorder
 import android.os.Build
+import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.content.ContentAttachmentData
 import org.matrix.android.sdk.api.util.md5
 import java.io.File
@@ -80,7 +81,7 @@ abstract class AbstractVoiceRecorder(
     override fun stopRecord() {
         // Can throw when the record is less than 1 second.
         mediaRecorder?.let {
-            it.stop()
+            tryOrNull { it.stop() }
             it.reset()
             it.release()
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Added a couple of methods to `vector`'s  instrumented tests to retry a check several times, applied this to VoiceRecorder tests.

Fixes #6329 .

## Motivation and context

VoiceRecorder instrumented tests are a bit flaky as they depend on Audio/MediaRecorder and some JNI code. With this code we'll retry those several times instead of failing on the first try.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
