### PR TITLE
Fixed issues with reporting sync state events from different threads

### DIFF
--- a/changelog.d/6341.bugfix
+++ b/changelog.d/6341.bugfix
@@ -1,0 +1,1 @@
+Fixed issues with reporting sync state events from different threads

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/sync/SyncService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/sync/SyncService.kt
@@ -60,9 +60,9 @@ interface SyncService {
     fun getSyncStateLive(): LiveData<SyncState>
 
     /**
-     * Get the [SyncRequestState] as a LiveData.
+     * Get the [SyncRequestState] as a SharedFlow.
      */
-    fun getSyncRequestStateLive(): LiveData<SyncRequestState>
+    fun getSyncRequestStateFlow(): SharedFlow<SyncRequestState>
 
     /**
      * This method returns a flow of SyncResponse. New value will be pushed through the sync thread.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/DefaultSyncService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/DefaultSyncService.kt
@@ -16,8 +16,6 @@
 
 package org.matrix.android.sdk.internal.session.sync
 
-import androidx.lifecycle.LiveData
-import org.matrix.android.sdk.api.session.sync.SyncRequestState
 import org.matrix.android.sdk.api.session.sync.SyncService
 import org.matrix.android.sdk.internal.di.SessionId
 import org.matrix.android.sdk.internal.di.WorkManagerProvider
@@ -75,9 +73,7 @@ internal class DefaultSyncService @Inject constructor(
 
     override fun getSyncState() = getSyncThread().currentState()
 
-    override fun getSyncRequestStateLive(): LiveData<SyncRequestState> {
-        return syncRequestStateTracker.syncRequestState
-    }
+    override fun getSyncRequestStateFlow() = syncRequestStateTracker.syncRequestState
 
     override fun hasAlreadySynced(): Boolean {
         return syncTokenStore.getLastToken() != null

--- a/vector/src/main/java/im/vector/app/AppStateHandler.kt
+++ b/vector/src/main/java/im/vector/app/AppStateHandler.kt
@@ -18,7 +18,6 @@ package im.vector.app
 
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.asFlow
 import arrow.core.Option
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.utils.BehaviorDataSource
@@ -147,8 +146,7 @@ class AppStateHandler @Inject constructor(
     }
 
     private fun observeSyncStatus(session: Session) {
-        session.syncService().getSyncRequestStateLive()
-                .asFlow()
+        session.syncService().getSyncRequestStateFlow()
                 .filterIsInstance<SyncRequestState.IncrementalSyncDone>()
                 .map { session.spaceService().getRootSpaceSummaries().size }
                 .distinctUntilChanged()

--- a/vector/src/main/java/im/vector/app/AutoRageShaker.kt
+++ b/vector/src/main/java/im/vector/app/AutoRageShaker.kt
@@ -17,7 +17,6 @@
 package im.vector.app
 
 import android.content.SharedPreferences
-import androidx.lifecycle.asFlow
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.features.rageshake.BugReporter
 import im.vector.app.features.rageshake.ReportType
@@ -261,8 +260,7 @@ class AutoRageShaker @Inject constructor(
         this.currentActiveSessionId = sessionId
 
         hasSynced = session.syncService().hasAlreadySynced()
-        session.syncService().getSyncRequestStateLive()
-                .asFlow()
+        session.syncService().getSyncRequestStateFlow()
                 .onEach {
                     hasSynced = it !is SyncRequestState.InitialSyncProgressing
                 }

--- a/vector/src/main/java/im/vector/app/features/analytics/accountdata/AnalyticsAccountDataViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/accountdata/AnalyticsAccountDataViewModel.kt
@@ -16,7 +16,6 @@
 
 package im.vector.app.features.analytics.accountdata
 
-import androidx.lifecycle.asFlow
 import com.airbnb.mvrx.MavericksViewModelFactory
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -66,7 +65,7 @@ class AnalyticsAccountDataViewModel @AssistedInject constructor(
 
     private fun observeInitSync() {
         combine(
-                session.syncService().getSyncRequestStateLive().asFlow(),
+                session.syncService().getSyncRequestStateFlow(),
                 analytics.getUserConsent(),
                 analytics.getAnalyticsId()
         ) { status, userConsent, analyticsId ->

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -16,7 +16,6 @@
 
 package im.vector.app.features.home
 
-import androidx.lifecycle.asFlow
 import com.airbnb.mvrx.Mavericks
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.ViewModelContext
@@ -218,8 +217,7 @@ class HomeActivityViewModel @AssistedInject constructor(
     private fun observeInitialSync() {
         val session = activeSessionHolder.getSafeActiveSession() ?: return
 
-        session.syncService().getSyncRequestStateLive()
-                .asFlow()
+        session.syncService().getSyncRequestStateFlow()
                 .onEach { status ->
                     when (status) {
                         is SyncRequestState.Idle -> {

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
@@ -199,8 +199,7 @@ class HomeDetailViewModel @AssistedInject constructor(
                     copy(syncState = syncState)
                 }
 
-        session.syncService().getSyncRequestStateLive()
-                .asFlow()
+        session.syncService().getSyncRequestStateFlow()
                 .filterIsInstance<SyncRequestState.IncrementalSyncRequestState>()
                 .setOnEach {
                     copy(incrementalSyncRequestState = it)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -18,7 +18,6 @@ package im.vector.app.features.home.room.detail
 
 import android.net.Uri
 import androidx.annotation.IdRes
-import androidx.lifecycle.asFlow
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
@@ -1130,8 +1129,7 @@ class TimelineViewModel @AssistedInject constructor(
                     copy(syncState = syncState)
                 }
 
-        session.syncService().getSyncRequestStateLive()
-                .asFlow()
+        session.syncService().getSyncRequestStateFlow()
                 .filterIsInstance<SyncRequestState.IncrementalSyncRequestState>()
                 .setOnEach {
                     copy(incrementalSyncRequestState = it)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Replaced `LiveData` with `Flow` for sync state reporting.

## Motivation and context

`SyncRequestStateTracker` instance is reused in different threads, because of the `Scope` annotation. If `LiveData::postValue` is called fast enough, some events can get lost, because only the last one is dispatched. 
So in my case I could reproduce loosing of `InitialSyncRequestState.Idle` due to sending `IncrementalSyncIdle` from another thread.

Signed-off-by: Artjom König artkoenig@gmail.com