### PR TITLE
Promote live location labs flag [PSF-959]

### DIFF
--- a/changelog.d/6350.feature
+++ b/changelog.d/6350.feature
@@ -1,0 +1,1 @@
+Promote live location labs flag

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
@@ -41,7 +41,6 @@ import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.detail.timeline.helper.MatrixItemColorProvider
 import im.vector.app.features.location.live.duration.ChooseLiveDurationBottomSheet
 import im.vector.app.features.location.option.LocationSharingOption
-import im.vector.app.features.settings.VectorPreferences
 import org.matrix.android.sdk.api.util.MatrixItem
 import java.lang.ref.WeakReference
 import javax.inject.Inject
@@ -53,7 +52,6 @@ class LocationSharingFragment @Inject constructor(
         private val urlMapProvider: UrlMapProvider,
         private val avatarRenderer: AvatarRenderer,
         private val matrixItemColorProvider: MatrixItemColorProvider,
-        private val vectorPreferences: VectorPreferences,
 ) : VectorBaseFragment<FragmentLocationSharingBinding>(),
         LocationTargetChangeListener,
         VectorBaseBottomSheetDialogFragment.ResultListener {
@@ -223,13 +221,7 @@ class LocationSharingFragment @Inject constructor(
     private fun updateMap(state: LocationSharingViewState) {
         // first, update the options view
         val options: Set<LocationSharingOption> = when (state.areTargetAndUserLocationEqual) {
-            true -> {
-                if (vectorPreferences.labsEnableLiveLocation()) {
-                    setOf(LocationSharingOption.USER_CURRENT, LocationSharingOption.USER_LIVE)
-                } else {
-                    setOf(LocationSharingOption.USER_CURRENT)
-                }
-            }
+            true -> setOf(LocationSharingOption.USER_CURRENT, LocationSharingOption.USER_LIVE)
             false -> setOf(LocationSharingOption.PINNED)
             else -> emptySet()
         }

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
@@ -197,11 +197,14 @@ class LocationSharingFragment @Inject constructor(
 
     private val liveLocationLabsFlagPromotionListener = object : VectorBaseBottomSheetDialogFragment.ResultListener {
         override fun onBottomSheetResult(resultCode: Int, data: Any?) {
-            // Check if the user wants to enable the labs flag
-            if (resultCode == VectorBaseBottomSheetDialogFragment.ResultListener.RESULT_OK && (data as? Boolean) == true) {
-                vectorPreferences.setLiveLocationLabsEnabled()
-                startLiveLocationSharing()
-            }
+            handleLiveLocationLabsFlagPromotionResult(resultCode, data)
+        }
+    }
+
+    private fun handleLiveLocationLabsFlagPromotionResult(resultCode: Int, data: Any?) {
+        if (resultCode == VectorBaseBottomSheetDialogFragment.ResultListener.RESULT_OK && (data as? Boolean) == true) {
+            vectorPreferences.setLiveLocationLabsEnabled(isEnabled = true)
+            startLiveLocationSharing()
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/location/live/LiveLocationLabsFlagPromotionBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/LiveLocationLabsFlagPromotionBottomSheet.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.setFragmentResult
 import im.vector.app.core.platform.VectorBaseBottomSheetDialogFragment
 import im.vector.app.databinding.BottomSheetLiveLocationLabsFlagPromotionBinding
 
@@ -44,12 +45,18 @@ class LiveLocationLabsFlagPromotionBottomSheet :
     private fun initOkButton() {
         views.promoteLiveLocationFlagOkButton.debouncedClicks {
             val enableLabsFlag = views.promoteLiveLocationFlagSwitch.isChecked
-            resultListener?.onBottomSheetResult(ResultListener.RESULT_OK, enableLabsFlag)
+            setFragmentResult(REQUEST_KEY, Bundle().apply {
+                putBoolean(BUNDLE_KEY_LABS_APPROVAL, enableLabsFlag)
+            })
             dismiss()
         }
     }
 
     companion object {
+
+        const val REQUEST_KEY = "LiveLocationLabsFlagPromotionBottomSheetRequest"
+        const val BUNDLE_KEY_LABS_APPROVAL = "BUNDLE_KEY_LABS_APPROVAL"
+
         fun newInstance(): LiveLocationLabsFlagPromotionBottomSheet {
             return LiveLocationLabsFlagPromotionBottomSheet()
         }

--- a/vector/src/main/java/im/vector/app/features/location/live/LiveLocationLabsFlagPromotionBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/LiveLocationLabsFlagPromotionBottomSheet.kt
@@ -27,8 +27,10 @@ import im.vector.app.databinding.BottomSheetLiveLocationLabsFlagPromotionBinding
  * Bottom sheet to warn users that feature is still in active development. Users are able to enable labs flag by using the switch in this bottom sheet.
  * This should not be shown if the user already enabled the labs flag.
  */
-class LiveLocationLabsFlagPromotionBottomSheet
-    : VectorBaseBottomSheetDialogFragment<BottomSheetLiveLocationLabsFlagPromotionBinding>() {
+class LiveLocationLabsFlagPromotionBottomSheet :
+    VectorBaseBottomSheetDialogFragment<BottomSheetLiveLocationLabsFlagPromotionBinding>() {
+
+    override val showExpanded = true
 
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): BottomSheetLiveLocationLabsFlagPromotionBinding {
         return BottomSheetLiveLocationLabsFlagPromotionBinding.inflate(inflater, container, false)

--- a/vector/src/main/java/im/vector/app/features/location/live/LiveLocationLabsFlagPromotionBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/LiveLocationLabsFlagPromotionBottomSheet.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.location.live
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import im.vector.app.core.platform.VectorBaseBottomSheetDialogFragment
+import im.vector.app.databinding.BottomSheetLiveLocationLabsFlagPromotionBinding
+
+/**
+ * Bottom sheet to warn users that feature is still in active development. Users are able to enable labs flag by using the switch in this bottom sheet.
+ * This should not be shown if the user already enabled the labs flag.
+ */
+class LiveLocationLabsFlagPromotionBottomSheet
+    : VectorBaseBottomSheetDialogFragment<BottomSheetLiveLocationLabsFlagPromotionBinding>() {
+
+    override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): BottomSheetLiveLocationLabsFlagPromotionBinding {
+        return BottomSheetLiveLocationLabsFlagPromotionBinding.inflate(inflater, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initOkButton()
+    }
+
+    private fun initOkButton() {
+        views.promoteLiveLocationFlagOkButton.debouncedClicks {
+            val enableLabsFlag = views.promoteLiveLocationFlagSwitch.isChecked
+            resultListener?.onBottomSheetResult(ResultListener.RESULT_OK, enableLabsFlag)
+            dismiss()
+        }
+    }
+
+    companion object {
+        fun newInstance(resultListener: ResultListener): LiveLocationLabsFlagPromotionBottomSheet {
+            return LiveLocationLabsFlagPromotionBottomSheet().also {
+                it.resultListener = resultListener
+            }
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/location/live/LiveLocationLabsFlagPromotionBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/LiveLocationLabsFlagPromotionBottomSheet.kt
@@ -50,10 +50,8 @@ class LiveLocationLabsFlagPromotionBottomSheet :
     }
 
     companion object {
-        fun newInstance(resultListener: ResultListener): LiveLocationLabsFlagPromotionBottomSheet {
-            return LiveLocationLabsFlagPromotionBottomSheet().also {
-                it.resultListener = resultListener
-            }
+        fun newInstance(): LiveLocationLabsFlagPromotionBottomSheet {
+            return LiveLocationLabsFlagPromotionBottomSheet()
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -1047,6 +1047,12 @@ class VectorPreferences @Inject constructor(
         return defaultPrefs.getBoolean(SETTINGS_LABS_ENABLE_LIVE_LOCATION, false)
     }
 
+    fun setLiveLocationLabsEnabled() {
+        defaultPrefs.edit {
+            putBoolean(SETTINGS_LABS_ENABLE_LIVE_LOCATION, true)
+        }
+    }
+
     /**
      * Indicates whether or not thread messages are enabled.
      */

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -1047,9 +1047,9 @@ class VectorPreferences @Inject constructor(
         return defaultPrefs.getBoolean(SETTINGS_LABS_ENABLE_LIVE_LOCATION, false)
     }
 
-    fun setLiveLocationLabsEnabled() {
+    fun setLiveLocationLabsEnabled(isEnabled: Boolean) {
         defaultPrefs.edit {
-            putBoolean(SETTINGS_LABS_ENABLE_LIVE_LOCATION, true)
+            putBoolean(SETTINGS_LABS_ENABLE_LIVE_LOCATION, isEnabled)
         }
     }
 

--- a/vector/src/main/res/layout/bottom_sheet_live_location_labs_flag_promotion.xml
+++ b/vector/src/main/res/layout/bottom_sheet_live_location_labs_flag_promotion.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?colorSurface"
+    android:orientation="vertical"
+    android:paddingHorizontal="16dp"
+    android:paddingBottom="8dp">
+
+    <ImageView
+        android:layout_width="60dp"
+        android:layout_height="60dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="30dp"
+        android:background="@drawable/circle"
+        android:backgroundTint="?vctr_live_location"
+        android:importantForAccessibility="no"
+        android:padding="4dp"
+        android:src="@drawable/ic_attachment_location_live_white" />
+
+    <TextView
+        style="@style/TextAppearance.Vector.Headline.Medium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="24dp"
+        android:text="@string/live_location_labs_promotion_title" />
+
+    <TextView
+        style="@style/TextAppearance.Vector.Body"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="24dp"
+        android:gravity="center"
+        android:text="@string/live_location_labs_promotion_description" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/promoteLiveLocationFlagSwitch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="40dp"
+        android:text="@string/live_location_labs_promotion_switch_title"
+        app:switchPadding="8dp" />
+
+    <Button
+        android:id="@+id/promoteLiveLocationFlagOkButton"
+        style="@style/Widget.Vector.Button.Positive"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:text="@string/ok" />
+
+</LinearLayout>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3088,4 +3088,10 @@
     <string name="settings_troubleshoot_test_current_endpoint_failed">Cannot find the endpoint.</string>
     <string name="settings_troubleshoot_test_current_gateway_title">Gateway</string>
     <string name="settings_troubleshoot_test_current_gateway">Current gateway: %s</string>
+
+    <!-- Live Location Sharing Labs Flag Promotional BottomSheet -->
+    <string name="live_location_labs_promotion_title">Live location sharing</string>
+    <string name="live_location_labs_promotion_description">Please note: this is a labs feature using a temporary implementation. This means you will not be able to delete your location history, and advanced users will be able to see your location history even after you stop sharing your live location with this room.</string>
+    <string name="live_location_labs_promotion_switch_title">Enable location sharing</string>
+
 </resources>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
We want to show users the Live Location Sharing option with an informative dialog.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->
|Screenshot|
|-|
|![lls_promoting_labs_flag](https://user-images.githubusercontent.com/1254401/174619844-00eefb76-27bd-443a-8762-55512fd0871e.png)|

## Tests

<!-- Explain how you tested your development -->

- Disable the live location sharing labs setting if it is enabled
- In a room, choose the location sharing attachment option from the composer
- Choose "Share live location"
- You should see the dialog like the attached screenshot above
- If the user enables location sharing and clicks the OK button then the flag in labs settings should also be enabled
- Share a live location

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
