### PR TITLE
Fix formatted_body being parsed as Markdown

### DIFF
--- a/changelog.d/6357.bugfix
+++ b/changelog.d/6357.bugfix
@@ -1,0 +1,1 @@
+Fix backslash escapes in formatted messages

--- a/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
@@ -34,10 +34,10 @@ import io.noties.markwon.html.HtmlPlugin
 import io.noties.markwon.inlineparser.HtmlInlineProcessor
 import io.noties.markwon.inlineparser.MarkwonInlineParser
 import io.noties.markwon.inlineparser.MarkwonInlineParserPlugin
-import java.util.Collections
 import org.commonmark.node.Node
 import org.commonmark.parser.Parser
 import timber.log.Timber
+import java.util.Collections
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
@@ -26,7 +26,6 @@ import im.vector.app.features.settings.VectorPreferences
 import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
 import io.noties.markwon.MarkwonPlugin
-import io.noties.markwon.MarkwonPlugin.Registry
 import io.noties.markwon.PrecomputedFutureTextSetterCompat
 import io.noties.markwon.ext.latex.JLatexMathPlugin
 import io.noties.markwon.ext.latex.JLatexMathTheme
@@ -37,7 +36,6 @@ import io.noties.markwon.inlineparser.MarkwonInlineParserPlugin
 import org.commonmark.node.Node
 import org.commonmark.parser.Parser
 import timber.log.Timber
-import java.util.Collections
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -75,17 +73,14 @@ class EventHtmlRenderer @Inject constructor(
     } else {
         builder
     }
-        .usePlugin(MarkwonInlineParserPlugin.create(MarkwonInlineParser.factoryBuilderNoDefaults()))
-        .usePlugin(object : AbstractMarkwonPlugin() {
-            override fun configure(registry: Registry) {
-                registry.require(MarkwonInlineParserPlugin::class.java, { plugin: MarkwonInlineParserPlugin ->
-                    plugin.factoryBuilder().addInlineProcessor(HtmlInlineProcessor())
-                })
-            }
-        })
+        .usePlugin(
+            MarkwonInlineParserPlugin.create(
+                MarkwonInlineParser.factoryBuilderNoDefaults().addInlineProcessor(HtmlInlineProcessor())
+            )
+        )
         .usePlugin(object : AbstractMarkwonPlugin() {
             override fun configureParser(builder: Parser.Builder) {
-                builder.enabledBlockTypes(Collections.emptySet())
+                builder.enabledBlockTypes(kotlin.collections.emptySet())
             }
         })
         .textSetter(PrecomputedFutureTextSetterCompat.create())


### PR DESCRIPTION
## Type of change

Bugfix

## Content

Background: Clients write Markdown and convert it to HTML before sending the event. All events are formatted as HTML. However, if an HTML formatted event happened to include markdown characters, Element Android would incorrectly render that markdown.

For example, an event with formatted_body: "*test*" should be displayed as literally *test* with no effects, but Element Android incorrectly displayed it as test in italics.

**This commit fixes this behaviour, making Element Android not parse Markdown in HTML messages.**

From the perspective of most users it will appear that backslash escapes now work properly (even though this wasn't the real issue).

## Motivation and context

https://github.com/vector-im/element-android/issues/5657

## Tests

I created 4 messages with the following formatted_body: `*normal*`, `<em>italics</em>`, `* normal`, `<ul><li>list</li></ul>` and I checked that they rendered the same on Android as they do on Desktop. (Desktop is in line with my expectations and does not appear to have any rendering bugs here.)

(I tried various more complex tests, but the ones mentioned above are the important ones that reproduce the behaviour and can be used to test this change.)

It might be good to have automated tests here but I don't know how to do those. If you want to do automated tests then I'll help you by submitting all the messages I used for testing as well as their expected outcomes. Markwon itself has a test suite so we could probably copy the structure of that.

But I'd honestly rather this PR was just merged soonish so that I don't have to be as annoyed while I'm using the app normally. 

## Tested devices

Physical OnePlus 5T, LineageOS 18.1 (Android 11)

## Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
-  Accessibility has been taken into account - N/A
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- Pull request includes screenshots or videos if containing UI changes - N/A
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- If you have modified the screen flow, or added new screens to the application - N/A

## Notes

Since the changelog.d file contents are most likely to be seen by end users, I put a more natural explanation of the problem in there. The technical explanation about formatted_body and how this problem is really caused is in the commit message. I hope this is all good.

Thanks everybody.

Signed-off-by: Cadence Ember <cloudrac3r@vivaldi.net>