### PR TITLE
App launch crash when migrating database from 29 -> 30 

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/migration/MigrateSessionTo030.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/migration/MigrateSessionTo030.kt
@@ -37,7 +37,8 @@ internal class MigrateSessionTo030(realm: DynamicRealm) : RealmMigrator(realm, 3
         chunks.forEach { chunk ->
             chunk.getList(ChunkEntityFields.TIMELINE_EVENTS.`$`).clearWith { timelineEvent ->
                 // Don't delete state events
-                if (timelineEvent.isNull(TimelineEventEntityFields.ROOT.STATE_KEY)) {
+                val stateField = TimelineEventEntityFields.ROOT.STATE_KEY
+                if (timelineEvent.hasField(stateField) && timelineEvent.isNull(stateField)) {
                     timelineEvent.getObject(TimelineEventEntityFields.ROOT.`$`)?.deleteFromRealm()
                     timelineEvent.deleteFromRealm()
                 }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Adds missing field check when migrating the database to v30

## Motivation and context

To fix a migration crash

## Screenshots / GIFs

No UI changes

## Tests

- Install v1.4.20 and sign in
- Install v1.4.23 on top of 1.4.20

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28