### PR TITLE
Fixing concurrent `dispatchTo` crash

### DIFF
--- a/changelog.d/5821.bugfix
+++ b/changelog.d/5821.bugfix
@@ -1,0 +1,1 @@
+Fixes concurrent modification crash when signing out or launching the app

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionListeners.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionListeners.kt
@@ -19,12 +19,13 @@ package org.matrix.android.sdk.internal.session
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.Session
 import timber.log.Timber
+import java.util.concurrent.CopyOnWriteArraySet
 import javax.inject.Inject
 
 @SessionScope
 internal class SessionListeners @Inject constructor() {
 
-    private val listeners = mutableSetOf<Session.Listener>()
+    private val listeners = CopyOnWriteArraySet<Session.Listener>()
 
     fun addListener(listener: Session.Listener) {
         synchronized(listeners) {


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes #5821 & #6080

- Uses a _safe to concurrently modify_ structure for the `SessionListeners` list

## Motivation and context

We have a few implementations of the `SessionListener` which remove themselves from the `SessionListeners` in `onSessionStopped` ([SessionScopedProperty](https://github.com/vector-im/element-android/blob/develop/vector/src/main/java/im/vector/app/features/session/SessionScopedProperty.kt#L39), [InvitesAcceptor](https://github.com/vector-im/element-android/blob/develop/vector/src/main/java/im/vector/app/features/invite/InvitesAcceptor.kt#L146)) , this is a problem because we iterate through all the listeners in order to call `onSessionStopped`, resulting in a concurrent modification exception.

The error itself seems to be race condition presenting itself intermittently due to `synchronised` usages allowing the next main looper to be used, I'm only able to reproduce locally by directly including a listener which removes itself ASAP but the crash is quite common in the Play console

```kotlin
// Session.close()
sessionListeners.addListener(object : Session.Listener {
    override fun onSessionStopped(session: Session) {
        sessionListeners.removeListener(this)
    }
})
```
 
The fix is to use a structure which allows concurrent modification, in this case a `CopyOnWriteArraySet` which does have an extra performance cost _but_ at the point of modification (rather than iteration) which we don't do very often.

## Screenshots / GIFs

|Before|After|
|-|-|
|![before-dispatchto](https://user-images.githubusercontent.com/1848238/175015211-a6e5f8a5-5d2f-4163-982e-3a491e4aa1b1.gif)|![after-dispatchto](https://user-images.githubusercontent.com/1848238/175015224-fc2474ca-6354-4488-9abf-9daf28f612c6.gif)|

## Tests

- In the code, add a new session listener which removes itself `onSessionStopped`
- Notice a crash when signing out

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28