### PR TITLE
[Location sharing] - Stop any active live before starting a new one (PSF-942)

### DIFF
--- a/changelog.d/6364.feature
+++ b/changelog.d/6364.feature
@@ -1,0 +1,1 @@
+[Location sharing] - Stop any active live before starting a new one

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomModule.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/RoomModule.kt
@@ -51,10 +51,14 @@ import org.matrix.android.sdk.internal.session.room.directory.DefaultSetRoomDire
 import org.matrix.android.sdk.internal.session.room.directory.GetPublicRoomTask
 import org.matrix.android.sdk.internal.session.room.directory.GetRoomDirectoryVisibilityTask
 import org.matrix.android.sdk.internal.session.room.directory.SetRoomDirectoryVisibilityTask
+import org.matrix.android.sdk.internal.session.room.location.CheckIfExistingActiveLiveTask
+import org.matrix.android.sdk.internal.session.room.location.DefaultCheckIfExistingActiveLiveTask
+import org.matrix.android.sdk.internal.session.room.location.DefaultGetActiveBeaconInfoForUserTask
 import org.matrix.android.sdk.internal.session.room.location.DefaultSendLiveLocationTask
 import org.matrix.android.sdk.internal.session.room.location.DefaultSendStaticLocationTask
 import org.matrix.android.sdk.internal.session.room.location.DefaultStartLiveLocationShareTask
 import org.matrix.android.sdk.internal.session.room.location.DefaultStopLiveLocationShareTask
+import org.matrix.android.sdk.internal.session.room.location.GetActiveBeaconInfoForUserTask
 import org.matrix.android.sdk.internal.session.room.location.SendLiveLocationTask
 import org.matrix.android.sdk.internal.session.room.location.SendStaticLocationTask
 import org.matrix.android.sdk.internal.session.room.location.StartLiveLocationShareTask
@@ -319,4 +323,10 @@ internal abstract class RoomModule {
 
     @Binds
     abstract fun bindSendLiveLocationTask(task: DefaultSendLiveLocationTask): SendLiveLocationTask
+
+    @Binds
+    abstract fun bindGetActiveBeaconInfoForUserTask(task: DefaultGetActiveBeaconInfoForUserTask): GetActiveBeaconInfoForUserTask
+
+    @Binds
+    abstract fun bindCheckIfExistingActiveLiveTask(task: DefaultCheckIfExistingActiveLiveTask): CheckIfExistingActiveLiveTask
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/CheckIfExistingActiveLiveTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/CheckIfExistingActiveLiveTask.kt
@@ -28,7 +28,6 @@ internal interface CheckIfExistingActiveLiveTask : Task<CheckIfExistingActiveLiv
     )
 }
 
-// TODO unit tests
 internal class DefaultCheckIfExistingActiveLiveTask @Inject constructor(
         private val getActiveBeaconInfoForUserTask: GetActiveBeaconInfoForUserTask,
 ) : CheckIfExistingActiveLiveTask {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/CheckIfExistingActiveLiveTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/CheckIfExistingActiveLiveTask.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.room.location
+
+import org.matrix.android.sdk.api.extensions.orFalse
+import org.matrix.android.sdk.api.session.events.model.toModel
+import org.matrix.android.sdk.api.session.room.model.message.MessageBeaconInfoContent
+import org.matrix.android.sdk.internal.task.Task
+import javax.inject.Inject
+
+internal interface CheckIfExistingActiveLiveTask : Task<CheckIfExistingActiveLiveTask.Params, Boolean> {
+    data class Params(
+            val roomId: String,
+    )
+}
+
+// TODO unit tests
+internal class DefaultCheckIfExistingActiveLiveTask @Inject constructor(
+        private val getActiveBeaconInfoForUserTask: GetActiveBeaconInfoForUserTask,
+) : CheckIfExistingActiveLiveTask {
+
+    override suspend fun execute(params: CheckIfExistingActiveLiveTask.Params): Boolean {
+        val getActiveBeaconTaskParams = GetActiveBeaconInfoForUserTask.Params(
+                roomId = params.roomId
+        )
+        return getActiveBeaconInfoForUserTask.execute(getActiveBeaconTaskParams)
+                ?.getClearContent()
+                ?.toModel<MessageBeaconInfoContent>()
+                ?.isLive
+                .orFalse()
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingService.kt
@@ -41,7 +41,7 @@ internal class DefaultLocationSharingService @AssistedInject constructor(
         private val sendLiveLocationTask: SendLiveLocationTask,
         private val startLiveLocationShareTask: StartLiveLocationShareTask,
         private val stopLiveLocationShareTask: StopLiveLocationShareTask,
-        private val stopCheckIfExistingActiveLiveTask: CheckIfExistingActiveLiveTask,
+        private val checkIfExistingActiveLiveTask: CheckIfExistingActiveLiveTask,
         private val liveLocationShareAggregatedSummaryMapper: LiveLocationShareAggregatedSummaryMapper,
 ) : LocationSharingService {
 
@@ -75,7 +75,10 @@ internal class DefaultLocationSharingService @AssistedInject constructor(
     override suspend fun startLiveLocationShare(timeoutMillis: Long): UpdateLiveLocationShareResult {
         // Ensure to stop any active live before starting a new one
         if (checkIfExistingActiveLive()) {
-            stopLiveLocationShare()
+            val result = stopLiveLocationShare()
+            if (result is UpdateLiveLocationShareResult.Failure) {
+                return result
+            }
         }
         val params = StartLiveLocationShareTask.Params(
                 roomId = roomId,
@@ -88,7 +91,7 @@ internal class DefaultLocationSharingService @AssistedInject constructor(
         val params = CheckIfExistingActiveLiveTask.Params(
                 roomId = roomId
         )
-        return stopCheckIfExistingActiveLiveTask.execute(params)
+        return checkIfExistingActiveLiveTask.execute(params)
     }
 
     override suspend fun stopLiveLocationShare(): UpdateLiveLocationShareResult {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingService.kt
@@ -41,6 +41,7 @@ internal class DefaultLocationSharingService @AssistedInject constructor(
         private val sendLiveLocationTask: SendLiveLocationTask,
         private val startLiveLocationShareTask: StartLiveLocationShareTask,
         private val stopLiveLocationShareTask: StopLiveLocationShareTask,
+        private val stopCheckIfExistingActiveLiveTask: CheckIfExistingActiveLiveTask,
         private val liveLocationShareAggregatedSummaryMapper: LiveLocationShareAggregatedSummaryMapper,
 ) : LocationSharingService {
 
@@ -72,11 +73,22 @@ internal class DefaultLocationSharingService @AssistedInject constructor(
     }
 
     override suspend fun startLiveLocationShare(timeoutMillis: Long): UpdateLiveLocationShareResult {
+        // Ensure to stop any active live before starting a new one
+        if (checkIfExistingActiveLive()) {
+            stopLiveLocationShare()
+        }
         val params = StartLiveLocationShareTask.Params(
                 roomId = roomId,
                 timeoutMillis = timeoutMillis
         )
         return startLiveLocationShareTask.execute(params)
+    }
+
+    private suspend fun checkIfExistingActiveLive(): Boolean {
+        val params = CheckIfExistingActiveLiveTask.Params(
+                roomId = roomId
+        )
+        return stopCheckIfExistingActiveLiveTask.execute(params)
     }
 
     override suspend fun stopLiveLocationShare(): UpdateLiveLocationShareResult {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/GetActiveBeaconInfoForUserTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/GetActiveBeaconInfoForUserTask.kt
@@ -33,7 +33,6 @@ internal interface GetActiveBeaconInfoForUserTask : Task<GetActiveBeaconInfoForU
     )
 }
 
-// TODO unit tests
 internal class DefaultGetActiveBeaconInfoForUserTask @Inject constructor(
         @UserId private val userId: String,
         private val stateEventDataSource: StateEventDataSource,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/GetActiveBeaconInfoForUserTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/GetActiveBeaconInfoForUserTask.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.room.location
+
+import org.matrix.android.sdk.api.extensions.orFalse
+import org.matrix.android.sdk.api.query.QueryStringValue
+import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.api.session.events.model.EventType
+import org.matrix.android.sdk.api.session.events.model.toModel
+import org.matrix.android.sdk.api.session.room.model.message.MessageBeaconInfoContent
+import org.matrix.android.sdk.internal.di.UserId
+import org.matrix.android.sdk.internal.session.room.state.StateEventDataSource
+import org.matrix.android.sdk.internal.task.Task
+import javax.inject.Inject
+
+internal interface GetActiveBeaconInfoForUserTask : Task<GetActiveBeaconInfoForUserTask.Params, Event?> {
+    data class Params(
+            val roomId: String,
+    )
+}
+
+// TODO unit tests
+internal class DefaultGetActiveBeaconInfoForUserTask @Inject constructor(
+        @UserId private val userId: String,
+        private val stateEventDataSource: StateEventDataSource,
+) : GetActiveBeaconInfoForUserTask {
+
+    override suspend fun execute(params: GetActiveBeaconInfoForUserTask.Params): Event? {
+        return EventType.STATE_ROOM_BEACON_INFO
+                .mapNotNull {
+                    stateEventDataSource.getStateEvent(
+                            roomId = params.roomId,
+                            eventType = it,
+                            stateKey = QueryStringValue.Equals(userId)
+                    )
+                }
+                .firstOrNull { beaconInfoEvent ->
+                    beaconInfoEvent.getClearContent()?.toModel<MessageBeaconInfoContent>()?.isLive.orFalse()
+                }
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/StopLiveLocationShareTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/StopLiveLocationShareTask.kt
@@ -32,7 +32,6 @@ internal interface StopLiveLocationShareTask : Task<StopLiveLocationShareTask.Pa
     )
 }
 
-// TODO update unit tests
 internal class DefaultStopLiveLocationShareTask @Inject constructor(
         private val sendStateTask: SendStateTask,
         private val getActiveBeaconInfoForUserTask: GetActiveBeaconInfoForUserTask,

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultCheckIfExistingActiveLiveTaskTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultCheckIfExistingActiveLiveTaskTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.room.location
+
+import io.mockk.unmockkAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Test
+import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.api.session.events.model.toContent
+import org.matrix.android.sdk.api.session.room.model.message.MessageBeaconInfoContent
+import org.matrix.android.sdk.test.fakes.FakeGetActiveBeaconInfoForUserTask
+
+private const val A_USER_ID = "user-id"
+private const val A_ROOM_ID = "room-id"
+private const val A_TIMEOUT = 15_000L
+private const val AN_EPOCH = 1655210176L
+
+@ExperimentalCoroutinesApi
+class DefaultCheckIfExistingActiveLiveTaskTest {
+
+    private val fakeGetActiveBeaconInfoForUserTask = FakeGetActiveBeaconInfoForUserTask()
+
+    private val defaultCheckIfExistingActiveLiveTask = DefaultCheckIfExistingActiveLiveTask(
+            getActiveBeaconInfoForUserTask = fakeGetActiveBeaconInfoForUserTask
+    )
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `given parameters and existing active live event when calling the task then result is true`() = runTest {
+        val params = CheckIfExistingActiveLiveTask.Params(
+                roomId = A_ROOM_ID
+        )
+        val currentStateEvent = Event(
+                stateKey = A_USER_ID,
+                content = MessageBeaconInfoContent(
+                        timeout = A_TIMEOUT,
+                        isLive = true,
+                        unstableTimestampMillis = AN_EPOCH
+                ).toContent()
+        )
+        fakeGetActiveBeaconInfoForUserTask.givenExecuteReturns(currentStateEvent)
+
+        val result = defaultCheckIfExistingActiveLiveTask.execute(params)
+
+        result shouldBeEqualTo true
+        val expectedGetActiveBeaconParams = GetActiveBeaconInfoForUserTask.Params(
+                roomId = params.roomId
+        )
+        fakeGetActiveBeaconInfoForUserTask.verifyExecute(expectedGetActiveBeaconParams)
+    }
+
+    @Test
+    fun `given parameters and no existing active live event when calling the task then result is false`() = runTest {
+        val params = CheckIfExistingActiveLiveTask.Params(
+                roomId = A_ROOM_ID
+        )
+        val inactiveEvents = listOf(
+                // no event
+                null,
+                // null content
+                Event(
+                        stateKey = A_USER_ID,
+                        content = null
+                ),
+                // inactive live
+                Event(
+                        stateKey = A_USER_ID,
+                        content = MessageBeaconInfoContent(
+                                timeout = A_TIMEOUT,
+                                isLive = false,
+                                unstableTimestampMillis = AN_EPOCH
+                        ).toContent()
+                )
+        )
+
+        inactiveEvents.forEach { currentStateEvent ->
+            fakeGetActiveBeaconInfoForUserTask.givenExecuteReturns(currentStateEvent)
+
+            val result = defaultCheckIfExistingActiveLiveTask.execute(params)
+
+            result shouldBeEqualTo false
+        }
+    }
+}

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultGetActiveBeaconInfoForUserTaskTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultGetActiveBeaconInfoForUserTaskTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.room.location
+
+import io.mockk.unmockkAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Test
+import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.api.session.events.model.EventType
+import org.matrix.android.sdk.api.session.events.model.toContent
+import org.matrix.android.sdk.api.session.room.model.message.MessageBeaconInfoContent
+import org.matrix.android.sdk.test.fakes.FakeStateEventDataSource
+
+private const val A_USER_ID = "user-id"
+private const val A_ROOM_ID = "room-id"
+private const val A_TIMEOUT = 15_000L
+private const val AN_EPOCH = 1655210176L
+
+@ExperimentalCoroutinesApi
+class DefaultGetActiveBeaconInfoForUserTaskTest {
+
+    private val fakeStateEventDataSource = FakeStateEventDataSource()
+
+    private val defaultGetActiveBeaconInfoForUserTask = DefaultGetActiveBeaconInfoForUserTask(
+            userId = A_USER_ID,
+            stateEventDataSource = fakeStateEventDataSource.instance
+    )
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `given parameters and no error when calling the task then result is computed`() = runTest {
+        val currentStateEvent = Event(
+                stateKey = A_USER_ID,
+                content = MessageBeaconInfoContent(
+                        timeout = A_TIMEOUT,
+                        isLive = true,
+                        unstableTimestampMillis = AN_EPOCH
+                ).toContent()
+        )
+        fakeStateEventDataSource.givenGetStateEventReturns(currentStateEvent)
+        val params = GetActiveBeaconInfoForUserTask.Params(
+                roomId = A_ROOM_ID
+        )
+
+        val result = defaultGetActiveBeaconInfoForUserTask.execute(params)
+
+        result shouldBeEqualTo currentStateEvent
+        fakeStateEventDataSource.verifyGetStateEvent(
+                roomId = params.roomId,
+                eventType = EventType.STATE_ROOM_BEACON_INFO.first(),
+                stateKey = A_USER_ID
+        )
+    }
+}

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeGetActiveBeaconInfoForUserTask.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/test/fakes/FakeGetActiveBeaconInfoForUserTask.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.test.fakes
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.internal.session.room.location.GetActiveBeaconInfoForUserTask
+
+internal class FakeGetActiveBeaconInfoForUserTask : GetActiveBeaconInfoForUserTask by mockk() {
+
+    fun givenExecuteReturns(event: Event?) {
+        coEvery { execute(any()) } returns event
+    }
+
+    fun verifyExecute(params: GetActiveBeaconInfoForUserTask.Params) {
+        coVerify { execute(params) }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingService.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingService.kt
@@ -173,14 +173,14 @@ class LocationSharingService : VectorService(), LocationTracker.Callback {
 
     private fun tryToDestroyMe() {
         if (startInProgress.not() && roomArgsMap.isEmpty()) {
-            Timber.i("### LocationSharingService. Destroying self, time is up for all rooms")
+            Timber.i("Destroying self, time is up for all rooms")
             stopSelf()
         }
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        Timber.i("### LocationSharingService.onDestroy")
+        Timber.i("onDestroy")
         jobs.forEach { it.cancel() }
         jobs.clear()
         locationTracker.removeCallback(this)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
When starting a new live location share in a room, a check has been added to stop any current active live location share.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6364 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

2 devices are needed

- Ensure to enable the lab flag for live location sharing on both devices
- Sign in with the same account on both devices
- Start a live location share on one device
- Check it appears correctly in the room for both devices
- Start a live location on the other device
- Check the previous live is stopped
- Check the location sharing service is stopped on the first device
- Check the location sharing service is started on the second device
- Check the new live appears correctly in the room

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11, 10

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
