### PR TITLE
Expose pusher profile tag in advanced settings

### DIFF
--- a/changelog.d/6369.feature
+++ b/changelog.d/6369.feature
@@ -1,0 +1,2 @@
+ Expose pusher profile tag in advanced settings
+ 

--- a/vector/src/main/java/im/vector/app/features/settings/push/PushGatewayItem.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/push/PushGatewayItem.kt
@@ -48,6 +48,7 @@ abstract class PushGatewayItem : EpoxyModelWithHolder<PushGatewayItem.Holder>() 
         holder.appName.text = pusher.appDisplayName
         holder.url.setTextOrHide(pusher.data.url, hideWhenBlank = true, holder.urlTitle)
         holder.format.setTextOrHide(pusher.data.format, hideWhenBlank = true, holder.formatTitle)
+        holder.profileTag.setTextOrHide(pusher.profileTag, hideWhenBlank = true, holder.profileTagTitle)
         holder.deviceName.text = pusher.deviceDisplayName
         holder.removeButton.setOnClickListener {
             interactions.onRemovePushTapped(pusher)
@@ -60,6 +61,8 @@ abstract class PushGatewayItem : EpoxyModelWithHolder<PushGatewayItem.Holder>() 
         val deviceName by bind<TextView>(R.id.pushGatewayDeviceNameValue)
         val formatTitle by bind<View>(R.id.pushGatewayFormat)
         val format by bind<TextView>(R.id.pushGatewayFormatValue)
+        val profileTagTitle by bind<TextView>(R.id.pushGatewayProfileTag)
+        val profileTag by bind<TextView>(R.id.pushGatewayProfileTagValue)
         val urlTitle by bind<View>(R.id.pushGatewayURL)
         val url by bind<TextView>(R.id.pushGatewayURLValue)
         val appName by bind<TextView>(R.id.pushGatewayAppNameValue)

--- a/vector/src/main/res/layout/item_pushgateway.xml
+++ b/vector/src/main/res/layout/item_pushgateway.xml
@@ -32,7 +32,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp"
-        android:textStyle=""
         tools:text="im.vector.app.android" />
 
     <TextView
@@ -50,7 +49,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp"
-        android:textStyle=""
         tools:text="fBbCDxVa-n8:APA91bE0wGY4ijpj-LQkkmjJYhNp2vA_9Xvabh02xaTKua9WA9wpNZwxfHdsbIDWthVXKPFTNcCl75ek1kqMGOggnUwnSCj-8ReF4G69pZVUhz-" />
 
     <TextView
@@ -68,7 +66,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp"
-        android:textStyle=""
         tools:text="EBMDOLFJD" />
 
     <TextView
@@ -86,7 +83,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp"
-        android:textStyle=""
         tools:text="EBMDOLFJD" />
 
     <TextView
@@ -104,7 +100,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp"
-        android:textStyle=""
         tools:text="EBMDOLFJD" />
 
     <TextView
@@ -122,7 +117,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp"
-        android:textStyle=""
         tools:text="event_id_only" />
 
     <TextView
@@ -139,8 +133,7 @@
         style="@style/Widget.Vector.TextView.Body"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:textStyle="" />
+        android:layout_marginBottom="16dp" />
 
     <Button
         android:id="@+id/pushGatewayDeleteButton"

--- a/vector/src/main/res/layout/item_pushgateway.xml
+++ b/vector/src/main/res/layout/item_pushgateway.xml
@@ -125,6 +125,23 @@
         android:textStyle=""
         tools:text="event_id_only" />
 
+    <TextView
+        android:id="@+id/pushGatewayProfileTag"
+        style="@style/Widget.Vector.TextView.Body"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="4dp"
+        android:text="@string/push_gateway_item_profile_tag"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/pushGatewayProfileTagValue"
+        style="@style/Widget.Vector.TextView.Body"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:textStyle="" />
+
     <Button
         android:id="@+id/pushGatewayDeleteButton"
         android:layout_width="wrap_content"

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1657,6 +1657,7 @@
     <string name="push_gateway_item_device_name">session_name:</string>
     <string name="push_gateway_item_url">Url:</string>
     <string name="push_gateway_item_format">Format:</string>
+    <string name="push_gateway_item_profile_tag">Profile tag:</string>
 
     <string name="preference_voice_and_video">Voice &amp; Video</string>
     <string name="preference_root_help_about">Help &amp; About</string>


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

This makes the current pusher's profile tag visible in the advanced settings.

## Motivation and context

For debugging notifications, it's helpful to know the profile tag.

## Screenshots / GIFs

|Before|After|
|-|-|
| ![Screenshot_20220623_105413](https://user-images.githubusercontent.com/1137962/175259349-7efdce06-e315-43cf-b9ec-f73150c5692e.png) | ![Screenshot_20220623_104538](https://user-images.githubusercontent.com/1137962/175258259-2a14536d-1503-4c68-a356-b8fa371aaf03.png) |

## Tests

Navigate into Settings > Advanced Settings > Notification Targets

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 12

## Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
