### PR TITLE
Fix CI lint tasks unexpectedly crashing

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -140,7 +140,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Lint analysis
-        run: ./gradlew clean :vector:lint --stacktrace
+        run: ./gradlew clean :vector:lint --stacktrace $CI_GRADLE_ARG_PROPERTIES
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v3
@@ -173,7 +173,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Lint ${{ matrix.target }} release
-        run: ./gradlew clean lint${{ matrix.target }}Release --stacktrace
+        run: ./gradlew clean lint${{ matrix.target }}Release --stacktrace $CI_GRADLE_ARG_PROPERTIES
       - name: Upload ${{ matrix.target }} linting report
         if: always()
         uses: actions/upload-artifact@v3
@@ -193,7 +193,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run detekt
         run: |
-          ./gradlew detekt
+          ./gradlew detekt $CI_GRADLE_ARG_PROPERTIES
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Adds the missing CI arguments to the linting CI tasks, should stop the build from unexpected crashing (most likely due to running out of memory)

## Motivation and context

To fix the crashing linting CI tasks

## Screenshots / GIFs
No UI changes

## Tests
Let the CI evaluate a PR...

## Tested devices
N/A