### PR TITLE
Fixing wrong error message when signing in with wrong credentials

### DIFF
--- a/changelog.d/6371.bugfix
+++ b/changelog.d/6371.bugfix
@@ -1,0 +1,1 @@
+Fixes wrong error message when signing in with wrong credentials

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthLoginFragment.kt
@@ -286,7 +286,7 @@ class FtueAuthLoginFragment @Inject constructor() : AbstractSSOFtueAuthFragment<
             throwable.isWeakPassword() || throwable.isInvalidPassword() -> {
                 views.passwordFieldTil.error = errorFormatter.toHumanReadable(throwable)
             }
-            throwable.isRegistrationDisabled() -> {
+            isSignupMode && throwable.isRegistrationDisabled() -> {
                 MaterialAlertDialogBuilder(requireActivity())
                         .setTitle(R.string.dialog_title_error)
                         .setMessage(getString(R.string.login_registration_disabled))


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes #6371 Wrong error message when signing in with wrong credentials

- Takes into account if we're in the sign up / in mode when inferring the registration disabled errors. Disabled registration uses the same error code as invalid credentials. 

## Motivation and context

To avoid confusing the user!

## Screenshots / GIFs

|Before|After|
|-|-|
|![Screenshot_20220623_181959](https://user-images.githubusercontent.com/1848238/175357604-c4d69435-4833-432b-8f7a-0366279b386d.png)|![Screenshot_20220623_181805](https://user-images.githubusercontent.com/1848238/175357240-a55e47ee-52a4-4aa1-a0cc-a9709fef8033.png)|

## Tests

- Attempt to log in with invalid credentials
- Notice an error message about registration being disabled

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28