### PR TITLE
[Location Share] - Adding missing prefix "u=" for uncertainty in geo URI (PSF-945)

### DIFF
--- a/changelog.d/6375.bugfix
+++ b/changelog.d/6375.bugfix
@@ -1,0 +1,1 @@
+[Location Share] - Adding missing prefix "u=" for uncertainty in geo URI

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/LocationInfo.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/LocationInfo.kt
@@ -22,7 +22,7 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class LocationInfo(
         /**
-         * Required. RFC5870 formatted geo uri 'geo:latitude,longitude;uncertainty' like 'geo:40.05,29.24;u=30' representing this location.
+         * Required. RFC5870 formatted geo uri 'geo:latitude,longitude;u=uncertainty' like 'geo:40.05,29.24;u=30' representing this location.
          */
         @Json(name = "uri") val geoUri: String? = null,
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/LocationInfo.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/LocationInfo.kt
@@ -22,7 +22,7 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class LocationInfo(
         /**
-         * Required. RFC5870 formatted geo uri 'geo:latitude,longitude;uncertainty' like 'geo:40.05,29.24;30' representing this location.
+         * Required. RFC5870 formatted geo uri 'geo:latitude,longitude;uncertainty' like 'geo:40.05,29.24;u=30' representing this location.
          */
         @Json(name = "uri") val geoUri: String? = null,
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/MessageLocationContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/MessageLocationContent.kt
@@ -35,7 +35,7 @@ data class MessageLocationContent(
         @Json(name = "body") override val body: String,
 
         /**
-         * Required. RFC5870 formatted geo uri 'geo:latitude,longitude;uncertainty' like 'geo:40.05,29.24;30' representing this location.
+         * Required. RFC5870 formatted geo uri 'geo:latitude,longitude;uncertainty' like 'geo:40.05,29.24;u=30' representing this location.
          */
         @Json(name = "geo_uri") val geoUri: String,
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/MessageLocationContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/MessageLocationContent.kt
@@ -35,7 +35,7 @@ data class MessageLocationContent(
         @Json(name = "body") override val body: String,
 
         /**
-         * Required. RFC5870 formatted geo uri 'geo:latitude,longitude;uncertainty' like 'geo:40.05,29.24;u=30' representing this location.
+         * Required. RFC5870 formatted geo uri 'geo:latitude,longitude;u=uncertainty' like 'geo:40.05,29.24;u=30' representing this location.
          */
         @Json(name = "geo_uri") val geoUri: String,
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoEventFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoEventFactory.kt
@@ -708,7 +708,7 @@ internal class LocalEchoEventFactory @Inject constructor(
     }
 
     /**
-     * Returns RFC5870 formatted geo uri 'geo:latitude,longitude;uncertainty' like 'geo:40.05,29.24;30'
+     * Returns RFC5870 formatted geo uri 'geo:latitude,longitude;u=uncertainty' like 'geo:40.05,29.24;u=30'
      * Uncertainty of the location is in meters and not required.
      */
     private fun buildGeoUri(latitude: Double, longitude: Double, uncertainty: Double?): String {
@@ -718,7 +718,7 @@ internal class LocalEchoEventFactory @Inject constructor(
             append(",")
             append(longitude)
             uncertainty?.let {
-                append(";")
+                append(";u=")
                 append(it)
             }
         }

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/aggregation/livelocation/LiveLocationAggregationProcessorTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/aggregation/livelocation/LiveLocationAggregationProcessorTest.kt
@@ -46,7 +46,7 @@ private const val A_TIMEOUT_MILLIS = 15 * 60 * 1000L
 private const val A_LATITUDE = 40.05
 private const val A_LONGITUDE = 29.24
 private const val A_UNCERTAINTY = 30.0
-private const val A_GEO_URI = "geo:$A_LATITUDE,$A_LONGITUDE;$A_UNCERTAINTY"
+private const val A_GEO_URI = "geo:$A_LATITUDE,$A_LONGITUDE;u=$A_UNCERTAINTY"
 
 internal class LiveLocationAggregationProcessorTest {
 

--- a/vector/src/main/java/im/vector/app/features/location/LocationData.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationData.kt
@@ -30,7 +30,7 @@ data class LocationData(
 
 /**
  * Creates location data from a MessageLocationContent.
- * "geo:40.05,29.24;30" -> LocationData(40.05, 29.24, 30)
+ * "geo:40.05,29.24;u=30" -> LocationData(40.05, 29.24, 30)
  * @return location data or null if geo uri is not valid
  */
 fun MessageLocationContent.toLocationData(): LocationData? {
@@ -39,7 +39,7 @@ fun MessageLocationContent.toLocationData(): LocationData? {
 
 /**
  * Creates location data from a geoUri String.
- * "geo:40.05,29.24;30" -> LocationData(40.05, 29.24, 30)
+ * "geo:40.05,29.24;u=30" -> LocationData(40.05, 29.24, 30)
  * @return location data or null if geo uri is null or not valid
  */
 fun String?.toLocationData(): LocationData? {

--- a/vector/src/test/java/im/vector/app/features/location/LocationDataTest.kt
+++ b/vector/src/test/java/im/vector/app/features/location/LocationDataTest.kt
@@ -28,19 +28,22 @@ import org.matrix.android.sdk.api.session.room.model.message.MessageLocationCont
 class LocationDataTest {
     @Test
     fun validCases() {
-        parseGeo("geo:12.34,56.78;13.56") shouldBeEqualTo
+        parseGeo("geo:12.34,56.78;u=13.56") shouldBeEqualTo
                 LocationData(latitude = 12.34, longitude = 56.78, uncertainty = 13.56)
         parseGeo("geo:12.34,56.78") shouldBeEqualTo
                 LocationData(latitude = 12.34, longitude = 56.78, uncertainty = null)
         // Error is ignored in case of invalid uncertainty
-        parseGeo("geo:12.34,56.78;13.5z6") shouldBeEqualTo
+        parseGeo("geo:12.34,56.78;u=13.5z6") shouldBeEqualTo
                 LocationData(latitude = 12.34, longitude = 56.78, uncertainty = null)
-        parseGeo("geo:12.34,56.78;13. 56") shouldBeEqualTo
+        parseGeo("geo:12.34,56.78;u=13. 56") shouldBeEqualTo
                 LocationData(latitude = 12.34, longitude = 56.78, uncertainty = null)
         // Space are ignored (trim)
-        parseGeo("geo: 12.34,56.78;13.56") shouldBeEqualTo
+        parseGeo("geo: 12.34,56.78;u=13.56") shouldBeEqualTo
                 LocationData(latitude = 12.34, longitude = 56.78, uncertainty = 13.56)
-        parseGeo("geo:12.34,56.78; 13.56") shouldBeEqualTo
+        parseGeo("geo:12.34,56.78; u=13.56") shouldBeEqualTo
+                LocationData(latitude = 12.34, longitude = 56.78, uncertainty = 13.56)
+        // missing "u=" for uncertainty is ignored
+        parseGeo("geo:12.34,56.78;13.56") shouldBeEqualTo
                 LocationData(latitude = 12.34, longitude = 56.78, uncertainty = 13.56)
     }
 
@@ -50,17 +53,17 @@ class LocationDataTest {
         parseGeo("geo").shouldBeNull()
         parseGeo("geo:").shouldBeNull()
         parseGeo("geo:12.34").shouldBeNull()
-        parseGeo("geo:12.34;13.56").shouldBeNull()
-        parseGeo("gea:12.34,56.78;13.56").shouldBeNull()
-        parseGeo("geo:12.x34,56.78;13.56").shouldBeNull()
-        parseGeo("geo:12.34,56.7y8;13.56").shouldBeNull()
+        parseGeo("geo:12.34;u=13.56").shouldBeNull()
+        parseGeo("gea:12.34,56.78;u=13.56").shouldBeNull()
+        parseGeo("geo:12.x34,56.78;u=13.56").shouldBeNull()
+        parseGeo("geo:12.34,56.7y8;u=13.56").shouldBeNull()
         // Spaces are not ignored if inside the numbers
-        parseGeo("geo:12.3 4,56.78;13.56").shouldBeNull()
-        parseGeo("geo:12.34,56.7 8;13.56").shouldBeNull()
+        parseGeo("geo:12.3 4,56.78;u=13.56").shouldBeNull()
+        parseGeo("geo:12.34,56.7 8;u=13.56").shouldBeNull()
         // Or in the protocol part
-        parseGeo(" geo:12.34,56.78;13.56").shouldBeNull()
-        parseGeo("ge o:12.34,56.78;13.56").shouldBeNull()
-        parseGeo("geo :12.34,56.78;13.56").shouldBeNull()
+        parseGeo(" geo:12.34,56.78;u=13.56").shouldBeNull()
+        parseGeo("ge o:12.34,56.78;u=13.56").shouldBeNull()
+        parseGeo("geo :12.34,56.78;u=13.56").shouldBeNull()
     }
 
     @Test
@@ -77,7 +80,7 @@ class LocationDataTest {
 
     @Test
     fun unstablePrefixTest() {
-        val geoUri = "geo :12.34,56.78;13.56"
+        val geoUri = "geo :12.34,56.78;u=13.56"
 
         val contentWithUnstablePrefixes = MessageLocationContent(body = "", geoUri = "", unstableLocationInfo = LocationInfo(geoUri = geoUri))
         contentWithUnstablePrefixes.getBestLocationInfo()?.geoUri.shouldBeEqualTo(geoUri)

--- a/vector/src/test/java/im/vector/app/features/location/LocationDataTest.kt
+++ b/vector/src/test/java/im/vector/app/features/location/LocationDataTest.kt
@@ -32,6 +32,10 @@ class LocationDataTest {
                 LocationData(latitude = 12.34, longitude = 56.78, uncertainty = 13.56)
         parseGeo("geo:12.34,56.78") shouldBeEqualTo
                 LocationData(latitude = 12.34, longitude = 56.78, uncertainty = null)
+    }
+
+    @Test
+    fun lenientCases() {
         // Error is ignored in case of invalid uncertainty
         parseGeo("geo:12.34,56.78;u=13.5z6") shouldBeEqualTo
                 LocationData(latitude = 12.34, longitude = 56.78, uncertainty = null)
@@ -80,7 +84,7 @@ class LocationDataTest {
 
     @Test
     fun unstablePrefixTest() {
-        val geoUri = "geo :12.34,56.78;u=13.56"
+        val geoUri = "aGeoUri"
 
         val contentWithUnstablePrefixes = MessageLocationContent(body = "", geoUri = "", unstableLocationInfo = LocationInfo(geoUri = geoUri))
         contentWithUnstablePrefixes.getBestLocationInfo()?.geoUri.shouldBeEqualTo(geoUri)

--- a/vector/src/test/java/im/vector/app/features/location/live/map/UserLiveLocationViewStateMapperTest.kt
+++ b/vector/src/test/java/im/vector/app/features/location/live/map/UserLiveLocationViewStateMapperTest.kt
@@ -46,7 +46,7 @@ private const val A_LOCATION_TIMESTAMP = 122L
 private const val A_LATITUDE = 40.05
 private const val A_LONGITUDE = 29.24
 private const val A_UNCERTAINTY = 30.0
-private const val A_GEO_URI = "geo:$A_LATITUDE,$A_LONGITUDE;$A_UNCERTAINTY"
+private const val A_GEO_URI = "geo:$A_LATITUDE,$A_LONGITUDE;u=$A_UNCERTAINTY"
 
 class UserLiveLocationViewStateMapperTest {
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Adding a missing prefix "u=" for uncertainty value when building a geo uri.

## Motivation and context

Closes #6375 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Enable live location share flag in labs settings
- Share a static location (user or pinned) in a room
- Check the location is correctly shared
- Start a live location share in a room
- Check the live is correctly running in the room
- Stop the live
- Check the live is correctly ended

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
