### PR TITLE
Ensure clearWith lambda is deleting all the list item

### DIFF
--- a/changelog.d/6392.misc
+++ b/changelog.d/6392.misc
@@ -1,0 +1,1 @@
+Ensure `RealmList<T>.clearWith()` extension is correctly used.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/extensions/RealmExtensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/extensions/RealmExtensions.kt
@@ -20,6 +20,7 @@ import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.RealmObjectSchema
 import org.matrix.android.sdk.internal.database.model.HomeServerCapabilitiesEntityFields
+import org.matrix.android.sdk.internal.util.fatalError
 
 internal fun RealmObject.assertIsManaged() {
     check(isManaged) { "${javaClass.simpleName} entity should be managed to use this function" }
@@ -27,14 +28,19 @@ internal fun RealmObject.assertIsManaged() {
 
 /**
  * Clear a RealmList by deleting all its items calling the provided lambda.
+ * The lambda is supposed to delete the item, which means that after this operation, the list will be empty.
  */
 internal fun <T> RealmList<T>.clearWith(delete: (T) -> Unit) {
-    while (!isEmpty()) {
-        val previousSize = size
-        first()?.let { delete.invoke(it) }
-        if (previousSize != size + 1) {
-            error("`clearWith` MUST delete all elements of the RealmList")
-        }
+    map { item ->
+        // Create a lambda for all items of the list
+        { delete(item) }
+    }.forEach { lambda ->
+        // Then invoke all the lambda
+        lambda.invoke()
+    }
+
+    if (!isEmpty()) {
+        fatalError("`clearWith` MUST delete all elements of the RealmList")
     }
 }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/extensions/RealmExtensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/extensions/RealmExtensions.kt
@@ -39,7 +39,7 @@ internal fun <T> RealmList<T>.clearWith(delete: (T) -> Unit) {
         lambda.invoke()
     }
 
-    if (!isEmpty()) {
+    if (isNotEmpty()) {
         fatalError("`clearWith` MUST delete all elements of the RealmList")
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/extensions/RealmExtensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/extensions/RealmExtensions.kt
@@ -30,7 +30,11 @@ internal fun RealmObject.assertIsManaged() {
  */
 internal fun <T> RealmList<T>.clearWith(delete: (T) -> Unit) {
     while (!isEmpty()) {
+        val previousSize = size
         first()?.let { delete.invoke(it) }
+        if (previousSize != size + 1) {
+            error("`clearWith` MUST delete all elements of the RealmList")
+        }
     }
 }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/fatal.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/util/fatal.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.util
+
+import org.matrix.android.sdk.BuildConfig
+import timber.log.Timber
+
+/**
+ * Throws in debug, only log in production.
+ * As this method does not always throw, next statement should be a return.
+*/
+internal fun fatalError(message: String) {
+    if (BuildConfig.DEBUG) {
+        error(message)
+    } else {
+        Timber.e(message)
+    }
+}


### PR DESCRIPTION
Else we will get an infinite loop. This specific error will help to figure out what is happening.

Tested locally with a Realm schema upgrade:

```kotlin
internal class MigrateSessionTo032(realm: DynamicRealm) : RealmMigrator(realm, 32) {

    override fun doMigrate(realm: DynamicRealm) {
        val chunks = realm.where("ChunkEntity")
                .findAll()

        chunks.forEach { chunk ->
            chunk.getList(ChunkEntityFields.TIMELINE_EVENTS.`$`).clearWith {
                // NO OP, let the app crash!
            }
        }
    }
}
```

And got this crash with stacktrace in log:

```shell
java.lang.RuntimeException: Unable to create application im.vector.app.VectorApplication: java.lang.IllegalStateException: `clearWith` MUST delete all elements of the RealmList
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6465)
        at android.app.ActivityThread.access$1300(ActivityThread.java:219)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1859)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
     Caused by: java.lang.IllegalStateException: `clearWith` MUST delete all elements of the RealmList
        at org.matrix.android.sdk.internal.extensions.RealmExtensionsKt.clearWith(RealmExtensions.kt:36)
        at org.matrix.android.sdk.internal.database.migration.MigrateSessionTo032.doMigrate(MigrateSessionTo032.kt:31)
        ...
```

With this code:

```kotlin
            chunk.getList(ChunkEntityFields.TIMELINE_EVENTS.`$`).clearWith {
                it.deleteFromRealm()
            }
```

No crash is observed and the DB is properly migrated.