### PR TITLE
Display specific message when verif code malformed

### DIFF
--- a/changelog.d/6395.bugfix
+++ b/changelog.d/6395.bugfix
@@ -1,0 +1,1 @@
+Display specific message when verification QR code is malformed

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/verification/qrcode/DefaultQrCodeVerificationTransaction.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/verification/qrcode/DefaultQrCodeVerificationTransaction.kt
@@ -84,7 +84,7 @@ internal class DefaultQrCodeVerificationTransaction(
         // Perform some checks
         if (otherQrCodeData.transactionId != transactionId) {
             Timber.d("## Verification QR: Invalid transaction actual ${otherQrCodeData.transactionId} expected:$transactionId")
-            cancel(CancelCode.QrCodeInvalid)
+            cancel(CancelCode.UnknownTransaction)
             return
         }
 

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/conclusion/VerificationConclusionController.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/conclusion/VerificationConclusionController.kt
@@ -86,6 +86,14 @@ class VerificationConclusionController @Inject constructor(
 
                 bottomGotIt()
             }
+            ConclusionState.INVALID_QR_CODE -> {
+                bottomSheetVerificationNoticeItem {
+                    id("invalid_qr")
+                    notice(host.stringProvider.getString(R.string.verify_invalid_qr_notice).toEpoxyCharSequence())
+                }
+
+                bottomGotIt()
+            }
             ConclusionState.CANCELLED -> {
                 bottomSheetVerificationNoticeItem {
                     id("notice_cancelled")

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/conclusion/VerificationConclusionViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/conclusion/VerificationConclusionViewModel.kt
@@ -32,7 +32,8 @@ data class VerificationConclusionViewState(
 enum class ConclusionState {
     SUCCESS,
     WARNING,
-    CANCELLED
+    CANCELLED,
+    INVALID_QR_CODE
 }
 
 class VerificationConclusionViewModel(initialState: VerificationConclusionViewState) :
@@ -44,7 +45,9 @@ class VerificationConclusionViewModel(initialState: VerificationConclusionViewSt
             val args = viewModelContext.args<VerificationConclusionFragment.Args>()
 
             return when (safeValueOf(args.cancelReason)) {
-                CancelCode.QrCodeInvalid,
+                CancelCode.QrCodeInvalid -> {
+                    VerificationConclusionViewState(ConclusionState.INVALID_QR_CODE, args.isMe)
+                }
                 CancelCode.MismatchedUser,
                 CancelCode.MismatchedSas,
                 CancelCode.MismatchedCommitment,

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2361,6 +2361,7 @@
     </string>
 
     <string name="verify_cancelled_notice">Verification has been cancelled. You can start verification again.</string>
+    <string name="verify_invalid_qr_notice">This QR code looks malformed. Please try to verify with another method.</string>
     <string name="verification_cancelled">Verification Cancelled</string>
 
     <string name="recovery_passphrase">Recovery Passphrase</string>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Bugfix

## Content

<!-- Describe shortly what has been changed -->

When scanning an invalid (malformed) QR code during a user verification, the application will display the compromised warning modal. It looks like this warning is a bit too much compared to other reason like mismatched keys or users.
And given that some mobile clients can have issues decoding some QR code it's worth it to create a specific screen.

So now instead a specific warning is shown for QR code format issues

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|<img width="269" alt="image" src="https://user-images.githubusercontent.com/9841565/176155997-04723a25-67dd-4ec7-8d91-4f37bf0071d9.png">|<img width="272" alt="image" src="https://user-images.githubusercontent.com/9841565/176155938-5f18f7e8-845e-4081-9fa2-c918a4b779ea.png">|


## Tests

<!-- Explain how you tested your development -->

- Step 1

- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
