### PR TITLE
Avoid multiple PR from Dependabot when Flipper is upgraded.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,6 +21,7 @@ def markwon = "4.6.2"
 def moshi = "1.13.0"
 def lifecycle = "2.4.1"
 def flowBinding = "1.2.0"
+def flipper = "0.151.1"
 def epoxy = "4.6.2"
 def mavericks = "2.7.0"
 def glide = "4.13.2"
@@ -90,6 +91,10 @@ ext.libs = [
                 'hilt'                    : "com.google.dagger:hilt-android:$dagger",
                 'hiltAndroidTesting'      : "com.google.dagger:hilt-android-testing:$dagger",
                 'hiltCompiler'            : "com.google.dagger:hilt-compiler:$dagger"
+        ],
+        flipper     : [
+                'flipper'                 : "com.facebook.flipper:flipper:$flipper",
+                'flipperNetworkPlugin'    : "com.facebook.flipper:flipper-network-plugin:$flipper",
         ],
         squareup    : [
                 'moshi'                  : "com.squareup.moshi:moshi:$moshi",

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -534,10 +534,10 @@ dependencies {
     }
 
     // Flipper, debug builds only
-    debugImplementation('com.facebook.flipper:flipper:0.151.1') {
+    debugImplementation(libs.flipper.flipper) {
         exclude group: 'com.facebook.fbjni', module: 'fbjni'
     }
-    debugImplementation('com.facebook.flipper:flipper-network-plugin:0.151.1') {
+    debugImplementation(libs.flipper.flipperNetworkPlugin) {
         exclude group: 'com.facebook.fbjni', module: 'fbjni'
     }
     debugImplementation 'com.facebook.soloader:soloader:0.10.3'


### PR DESCRIPTION
Will avoid multiple PR like #6386 and #6387

Does not deserve a changelog.