### PR TITLE
[Location sharing] - Reply action on a live message (PSG-343)

### DIFF
--- a/changelog.d/6401.feature
+++ b/changelog.d/6401.feature
@@ -1,0 +1,1 @@
+[Location sharing] - Reply action on a live message

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/location/LocationSharingService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/location/LocationSharingService.kt
@@ -48,9 +48,10 @@ interface LocationSharingService {
     /**
      * Starts sharing live location in the room.
      * @param timeoutMillis timeout of the live in milliseconds
+     * @param description description of the live for text fallback
      * @return the result of the update of the live
      */
-    suspend fun startLiveLocationShare(timeoutMillis: Long): UpdateLiveLocationShareResult
+    suspend fun startLiveLocationShare(timeoutMillis: Long, description: String): UpdateLiveLocationShareResult
 
     /**
      * Stops sharing live location in the room.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingService.kt
@@ -72,7 +72,7 @@ internal class DefaultLocationSharingService @AssistedInject constructor(
         return sendLiveLocationTask.execute(params)
     }
 
-    override suspend fun startLiveLocationShare(timeoutMillis: Long): UpdateLiveLocationShareResult {
+    override suspend fun startLiveLocationShare(timeoutMillis: Long, description: String): UpdateLiveLocationShareResult {
         // Ensure to stop any active live before starting a new one
         if (checkIfExistingActiveLive()) {
             val result = stopLiveLocationShare()
@@ -82,7 +82,8 @@ internal class DefaultLocationSharingService @AssistedInject constructor(
         }
         val params = StartLiveLocationShareTask.Params(
                 roomId = roomId,
-                timeoutMillis = timeoutMillis
+                timeoutMillis = timeoutMillis,
+                description = description
         )
         return startLiveLocationShareTask.execute(params)
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/StartLiveLocationShareTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/StartLiveLocationShareTask.kt
@@ -30,6 +30,7 @@ internal interface StartLiveLocationShareTask : Task<StartLiveLocationShareTask.
     data class Params(
             val roomId: String,
             val timeoutMillis: Long,
+            val description: String,
     )
 }
 
@@ -41,6 +42,7 @@ internal class DefaultStartLiveLocationShareTask @Inject constructor(
 
     override suspend fun execute(params: StartLiveLocationShareTask.Params): UpdateLiveLocationShareResult {
         val beaconContent = MessageBeaconInfoContent(
+                body = params.description,
                 timeout = params.timeoutMillis,
                 isLive = true,
                 unstableTimestampMillis = clock.epochMillis()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoEventFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoEventFactory.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.media.MediaMetadataRetriever
 import androidx.exifinterface.media.ExifInterface
+import org.matrix.android.sdk.api.extensions.ensureNotEmpty
 import org.matrix.android.sdk.api.session.content.ContentAttachmentData
 import org.matrix.android.sdk.api.session.events.model.Content
 import org.matrix.android.sdk.api.session.events.model.Event
@@ -700,6 +701,7 @@ internal class LocalEchoEventFactory @Inject constructor(
             MessageType.MSGTYPE_AUDIO -> return TextContent("sent an audio file.")
             MessageType.MSGTYPE_IMAGE -> return TextContent("sent an image.")
             MessageType.MSGTYPE_VIDEO -> return TextContent("sent a video.")
+            MessageType.MSGTYPE_BEACON_INFO -> return TextContent(content.body.ensureNotEmpty() ?: "shared live location.")
             MessageType.MSGTYPE_POLL_START -> {
                 return TextContent((content as? MessagePollContent)?.getBestPollCreationInfo()?.question?.getBestQuestion() ?: "")
             }

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingServiceTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingServiceTest.kt
@@ -51,6 +51,7 @@ private const val A_LATITUDE = 1.4
 private const val A_LONGITUDE = 40.0
 private const val AN_UNCERTAINTY = 5.0
 private const val A_TIMEOUT = 15_000L
+private const val A_DESCRIPTION = "description"
 
 @ExperimentalCoroutinesApi
 internal class DefaultLocationSharingServiceTest {
@@ -137,7 +138,7 @@ internal class DefaultLocationSharingServiceTest {
         coEvery { stopLiveLocationShareTask.execute(any()) } returns UpdateLiveLocationShareResult.Success("stopped-event-id")
         coEvery { startLiveLocationShareTask.execute(any()) } returns UpdateLiveLocationShareResult.Success(AN_EVENT_ID)
 
-        val result = defaultLocationSharingService.startLiveLocationShare(A_TIMEOUT)
+        val result = defaultLocationSharingService.startLiveLocationShare(A_TIMEOUT, A_DESCRIPTION)
 
         result shouldBeEqualTo UpdateLiveLocationShareResult.Success(AN_EVENT_ID)
         val expectedCheckExistingParams = CheckIfExistingActiveLiveTask.Params(
@@ -150,7 +151,8 @@ internal class DefaultLocationSharingServiceTest {
         coVerify { stopLiveLocationShareTask.execute(expectedStopParams) }
         val expectedStartParams = StartLiveLocationShareTask.Params(
                 roomId = A_ROOM_ID,
-                timeoutMillis = A_TIMEOUT
+                timeoutMillis = A_TIMEOUT,
+                description = A_DESCRIPTION
         )
         coVerify { startLiveLocationShareTask.execute(expectedStartParams) }
     }

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingServiceTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingServiceTest.kt
@@ -163,7 +163,7 @@ internal class DefaultLocationSharingServiceTest {
         val error = Throwable()
         coEvery { stopLiveLocationShareTask.execute(any()) } returns UpdateLiveLocationShareResult.Failure(error)
 
-        val result = defaultLocationSharingService.startLiveLocationShare(A_TIMEOUT)
+        val result = defaultLocationSharingService.startLiveLocationShare(A_TIMEOUT, A_DESCRIPTION)
 
         result shouldBeEqualTo UpdateLiveLocationShareResult.Failure(error)
         val expectedCheckExistingParams = CheckIfExistingActiveLiveTask.Params(
@@ -181,7 +181,7 @@ internal class DefaultLocationSharingServiceTest {
         coEvery { checkIfExistingActiveLiveTask.execute(any()) } returns false
         coEvery { startLiveLocationShareTask.execute(any()) } returns UpdateLiveLocationShareResult.Success(AN_EVENT_ID)
 
-        val result = defaultLocationSharingService.startLiveLocationShare(A_TIMEOUT)
+        val result = defaultLocationSharingService.startLiveLocationShare(A_TIMEOUT, A_DESCRIPTION)
 
         result shouldBeEqualTo UpdateLiveLocationShareResult.Success(AN_EVENT_ID)
         val expectedCheckExistingParams = CheckIfExistingActiveLiveTask.Params(
@@ -190,7 +190,8 @@ internal class DefaultLocationSharingServiceTest {
         coVerify { checkIfExistingActiveLiveTask.execute(expectedCheckExistingParams) }
         val expectedStartParams = StartLiveLocationShareTask.Params(
                 roomId = A_ROOM_ID,
-                timeoutMillis = A_TIMEOUT
+                timeoutMillis = A_TIMEOUT,
+                description = A_DESCRIPTION
         )
         coVerify { startLiveLocationShareTask.execute(expectedStartParams) }
     }

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultStartLiveLocationShareTaskTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultStartLiveLocationShareTaskTest.kt
@@ -34,6 +34,7 @@ import org.matrix.android.sdk.test.fakes.FakeSendStateTask
 private const val A_USER_ID = "user-id"
 private const val A_ROOM_ID = "room-id"
 private const val AN_EVENT_ID = "event-id"
+private const val A_DESCRIPTION = "description"
 private const val A_TIMEOUT = 15_000L
 private const val AN_EPOCH = 1655210176L
 
@@ -58,7 +59,8 @@ internal class DefaultStartLiveLocationShareTaskTest {
     fun `given parameters and no error when calling the task then result is success`() = runTest {
         val params = StartLiveLocationShareTask.Params(
                 roomId = A_ROOM_ID,
-                timeoutMillis = A_TIMEOUT
+                timeoutMillis = A_TIMEOUT,
+                description = A_DESCRIPTION
         )
         fakeClock.givenEpoch(AN_EPOCH)
         fakeSendStateTask.givenExecuteRetryReturns(AN_EVENT_ID)
@@ -67,6 +69,7 @@ internal class DefaultStartLiveLocationShareTaskTest {
 
         result shouldBeEqualTo UpdateLiveLocationShareResult.Success(AN_EVENT_ID)
         val expectedBeaconContent = MessageBeaconInfoContent(
+                body = A_DESCRIPTION,
                 timeout = params.timeoutMillis,
                 isLive = true,
                 unstableTimestampMillis = AN_EPOCH
@@ -87,7 +90,8 @@ internal class DefaultStartLiveLocationShareTaskTest {
     fun `given parameters and an empty returned event id when calling the task then result is failure`() = runTest {
         val params = StartLiveLocationShareTask.Params(
                 roomId = A_ROOM_ID,
-                timeoutMillis = A_TIMEOUT
+                timeoutMillis = A_TIMEOUT,
+                description = A_DESCRIPTION
         )
         fakeClock.givenEpoch(AN_EPOCH)
         fakeSendStateTask.givenExecuteRetryReturns("")
@@ -101,7 +105,8 @@ internal class DefaultStartLiveLocationShareTaskTest {
     fun `given parameters and error during event sending when calling the task then result is failure`() = runTest {
         val params = StartLiveLocationShareTask.Params(
                 roomId = A_ROOM_ID,
-                timeoutMillis = A_TIMEOUT
+                timeoutMillis = A_TIMEOUT,
+                description = A_DESCRIPTION
         )
         fakeClock.givenEpoch(AN_EPOCH)
         val error = Throwable()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1259,6 +1259,7 @@ class TimelineFragment @Inject constructor(
         val nonFormattedBody = when (messageContent) {
             is MessageAudioContent -> getAudioContentBodyText(messageContent)
             is MessagePollContent -> messageContent.getBestPollCreationInfo()?.question?.getBestQuestion()
+            is MessageBeaconInfoContent -> getString(R.string.sent_live_location)
             else -> messageContent?.body.orEmpty()
         }
         var formattedBody: CharSequence? = null

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/CheckIfCanReplyEventUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/CheckIfCanReplyEventUseCase.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home.room.detail.timeline.action
+
+import org.matrix.android.sdk.api.session.events.model.EventType
+import org.matrix.android.sdk.api.session.room.model.message.MessageContent
+import org.matrix.android.sdk.api.session.room.model.message.MessageType
+import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
+import javax.inject.Inject
+
+class CheckIfCanReplyEventUseCase @Inject constructor() {
+
+    fun execute(event: TimelineEvent, messageContent: MessageContent?, actionPermissions: ActionPermissions): Boolean {
+        // Only EventType.MESSAGE, EventType.POLL_START and EventType.STATE_ROOM_BEACON_INFO event types are supported for the moment
+        if (event.root.getClearType() !in EventType.STATE_ROOM_BEACON_INFO + EventType.POLL_START + EventType.MESSAGE) return false
+        if (!actionPermissions.canSendMessage) return false
+        return when (messageContent?.msgType) {
+            MessageType.MSGTYPE_TEXT,
+            MessageType.MSGTYPE_NOTICE,
+            MessageType.MSGTYPE_EMOTE,
+            MessageType.MSGTYPE_IMAGE,
+            MessageType.MSGTYPE_VIDEO,
+            MessageType.MSGTYPE_AUDIO,
+            MessageType.MSGTYPE_FILE,
+            MessageType.MSGTYPE_POLL_START,
+            MessageType.MSGTYPE_BEACON_INFO,
+            MessageType.MSGTYPE_LOCATION -> true
+            else -> false
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
@@ -80,7 +80,8 @@ class MessageActionsViewModel @AssistedInject constructor(
         private val errorFormatter: ErrorFormatter,
         private val stringProvider: StringProvider,
         private val pillsPostProcessorFactory: PillsPostProcessor.Factory,
-        private val vectorPreferences: VectorPreferences
+        private val vectorPreferences: VectorPreferences,
+        private val checkIfCanReplyEventUseCase: CheckIfCanReplyEventUseCase,
 ) : VectorViewModel<MessageActionState, MessageActionsAction, EmptyViewEvents>(initialState) {
 
     private val informationData = initialState.informationData
@@ -436,21 +437,7 @@ class MessageActionsViewModel @AssistedInject constructor(
     }
 
     private fun canReply(event: TimelineEvent, messageContent: MessageContent?, actionPermissions: ActionPermissions): Boolean {
-        // Only EventType.MESSAGE and EventType.POLL_START event types are supported for the moment
-        if (event.root.getClearType() !in EventType.POLL_START + EventType.MESSAGE) return false
-        if (!actionPermissions.canSendMessage) return false
-        return when (messageContent?.msgType) {
-            MessageType.MSGTYPE_TEXT,
-            MessageType.MSGTYPE_NOTICE,
-            MessageType.MSGTYPE_EMOTE,
-            MessageType.MSGTYPE_IMAGE,
-            MessageType.MSGTYPE_VIDEO,
-            MessageType.MSGTYPE_AUDIO,
-            MessageType.MSGTYPE_FILE,
-            MessageType.MSGTYPE_POLL_START,
-            MessageType.MSGTYPE_LOCATION -> true
-            else -> false
-        }
+        return checkIfCanReplyEventUseCase.execute(event, messageContent, actionPermissions)
     }
 
     /**

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingService.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingService.kt
@@ -21,6 +21,7 @@ import android.os.Binder
 import android.os.IBinder
 import android.os.Parcelable
 import dagger.hilt.android.AndroidEntryPoint
+import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.services.VectorService
 import im.vector.app.features.location.live.GetLiveLocationShareSummaryUseCase
@@ -112,7 +113,10 @@ class LocationSharingService : VectorService(), LocationTracker.Callback {
         val updateLiveResult = session
                 .getRoom(roomArgs.roomId)
                 ?.locationSharingService()
-                ?.startLiveLocationShare(timeoutMillis = roomArgs.durationMillis)
+                ?.startLiveLocationShare(
+                        timeoutMillis = roomArgs.durationMillis,
+                        description = getString(R.string.sent_live_location)
+                )
 
         updateLiveResult
                 ?.let { result ->

--- a/vector/src/test/java/im/vector/app/features/home/room/detail/timeline/action/CheckIfCanReplyEventUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/home/room/detail/timeline/action/CheckIfCanReplyEventUseCaseTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home.room.detail.timeline.action
+
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.api.session.events.model.EventType
+import org.matrix.android.sdk.api.session.room.model.message.MessageContent
+import org.matrix.android.sdk.api.session.room.model.message.MessageType
+import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
+
+class CheckIfCanReplyEventUseCaseTest {
+
+    private val checkIfCanReplyEventUseCase = CheckIfCanReplyEventUseCase()
+
+    @Test
+    fun `given sending message is not allowed when use case is executed then result is false`() {
+        val event = givenAnEvent(eventType = EventType.MESSAGE)
+        val messageContent = givenAMessageContent(MessageType.MSGTYPE_AUDIO)
+        val actionPermissions = givenActionPermissions(canSendMessage = false)
+
+        val result = checkIfCanReplyEventUseCase.execute(event, messageContent, actionPermissions)
+
+        result shouldBeEqualTo false
+    }
+
+    @Test
+    fun `given reply is allowed for the event type when use case is executed then result is true`() {
+        val eventTypes = EventType.STATE_ROOM_BEACON_INFO + EventType.POLL_START + EventType.MESSAGE
+
+        eventTypes.forEach { eventType ->
+            val event = givenAnEvent(eventType)
+            val messageContent = givenAMessageContent(MessageType.MSGTYPE_AUDIO)
+            val actionPermissions = givenActionPermissions(canSendMessage = true)
+
+            val result = checkIfCanReplyEventUseCase.execute(event, messageContent, actionPermissions)
+
+            result shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `given reply is not allowed for the event type when use case is executed then result is false`() {
+        val event = givenAnEvent(EventType.CALL_ANSWER)
+        val messageContent = givenAMessageContent(MessageType.MSGTYPE_AUDIO)
+        val actionPermissions = givenActionPermissions(canSendMessage = true)
+
+        val result = checkIfCanReplyEventUseCase.execute(event, messageContent, actionPermissions)
+
+        result shouldBeEqualTo false
+    }
+
+    @Test
+    fun `given reply is allowed for the message type when use case is executed then result is true`() {
+        val messageTypes = listOf(
+                MessageType.MSGTYPE_TEXT,
+                MessageType.MSGTYPE_NOTICE,
+                MessageType.MSGTYPE_EMOTE,
+                MessageType.MSGTYPE_IMAGE,
+                MessageType.MSGTYPE_VIDEO,
+                MessageType.MSGTYPE_AUDIO,
+                MessageType.MSGTYPE_FILE,
+                MessageType.MSGTYPE_POLL_START,
+                MessageType.MSGTYPE_BEACON_INFO,
+                MessageType.MSGTYPE_LOCATION
+        )
+
+        messageTypes.forEach { messageType ->
+            val event = givenAnEvent(EventType.MESSAGE)
+            val messageContent = givenAMessageContent(messageType)
+            val actionPermissions = givenActionPermissions(canSendMessage = true)
+
+            val result = checkIfCanReplyEventUseCase.execute(event, messageContent, actionPermissions)
+
+            result shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `given reply is not allowed for the message type when use case is executed then result is false`() {
+        val event = givenAnEvent(EventType.MESSAGE)
+        val messageContent = givenAMessageContent(MessageType.MSGTYPE_BEACON_LOCATION_DATA)
+        val actionPermissions = givenActionPermissions(canSendMessage = true)
+
+        val result = checkIfCanReplyEventUseCase.execute(event, messageContent, actionPermissions)
+
+        result shouldBeEqualTo false
+    }
+
+    private fun givenAnEvent(eventType: String): TimelineEvent {
+        val eventId = "event-id"
+        return TimelineEvent(
+                root = Event(
+                        eventId = eventId,
+                        type = eventType
+                ),
+                localId = 123L,
+                eventId = eventId,
+                displayIndex = 1,
+                ownedByThreadChunk = false,
+                senderInfo = mockk()
+        )
+    }
+
+    private fun givenAMessageContent(messageType: String): MessageContent {
+        return mockk<MessageContent>().also {
+            every { it.msgType } returns messageType
+        }
+    }
+
+    private fun givenActionPermissions(canSendMessage: Boolean): ActionPermissions {
+        return ActionPermissions(canSendMessage = canSendMessage)
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Adding a reply action on a live location share message.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6401

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

<img src="https://user-images.githubusercontent.com/46314705/176451707-f8f525cf-5e89-4eda-9039-bf47b02bb611.png" width=300/> <img src="https://user-images.githubusercontent.com/46314705/176451700-bfb12bbe-37aa-417d-9324-256c3832b7fb.png" width=300/>

## Tests

<!-- Explain how you tested your development -->

- Enable the live location share flag in Settings -> Labs
- Go to a room
- Start sharing a live location share
- With another account long press the message
- Check "reply" action is available
- Press reply
- Send a reply message
- Check the reply message is correctly displayed
- Check we navigate to and highlight the replied live location share message when pressing the reply message

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
