### PR TITLE
Replacing epoxy item annotation layout references with getDefaultLayoutId

### DIFF
--- a/changelog.d/6389.misc
+++ b/changelog.d/6389.misc
@@ -1,0 +1,1 @@
+Replacing Epoxy annotation layout id references with getDefaultLayoutId

--- a/library/jsonviewer/build.gradle
+++ b/library/jsonviewer/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'com.jakewharton.butterknife'
 
 buildscript {
     repositories {
@@ -14,9 +13,6 @@ buildscript {
         maven {
             url 'https://repo1.maven.org/maven2'
         }
-    }
-    dependencies {
-        classpath 'com.jakewharton:butterknife-gradle-plugin:10.2.3'
     }
 }
 

--- a/library/jsonviewer/src/main/java/org/billcarsonfr/jsonviewer/ValueItem.kt
+++ b/library/jsonviewer/src/main/java/org/billcarsonfr/jsonviewer/ValueItem.kt
@@ -29,7 +29,7 @@ import com.airbnb.epoxy.EpoxyModelClass
 import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 
-@EpoxyModelClass(layout = R2.layout.item_jv_base_value)
+@EpoxyModelClass
 internal abstract class ValueItem : EpoxyModelWithHolder<ValueItem.Holder>() {
 
     @EpoxyAttribute
@@ -43,6 +43,8 @@ internal abstract class ValueItem : EpoxyModelWithHolder<ValueItem.Holder>() {
 
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
     var itemClickListener: View.OnClickListener? = null
+
+    override fun getDefaultLayout() = R.layout.item_jv_base_value
 
     override fun bind(holder: Holder) {
         super.bind(holder)

--- a/vector/src/debug/java/im/vector/app/features/debug/features/BooleanFeatureItem.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/BooleanFeatureItem.kt
@@ -23,11 +23,12 @@ import android.widget.Spinner
 import android.widget.TextView
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
+import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = im.vector.app.R.layout.item_feature)
-abstract class BooleanFeatureItem : VectorEpoxyModel<BooleanFeatureItem.Holder>() {
+@EpoxyModelClass
+abstract class BooleanFeatureItem : VectorEpoxyModel<BooleanFeatureItem.Holder>(R.layout.item_feature) {
 
     @EpoxyAttribute
     lateinit var feature: Feature.BooleanFeature

--- a/vector/src/debug/java/im/vector/app/features/debug/features/EnumFeatureItem.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/EnumFeatureItem.kt
@@ -23,11 +23,12 @@ import android.widget.Spinner
 import android.widget.TextView
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
+import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = im.vector.app.R.layout.item_feature)
-abstract class EnumFeatureItem : VectorEpoxyModel<EnumFeatureItem.Holder>() {
+@EpoxyModelClass
+abstract class EnumFeatureItem : VectorEpoxyModel<EnumFeatureItem.Holder>(R.layout.item_feature) {
 
     @EpoxyAttribute
     lateinit var feature: Feature.EnumFeature<*>

--- a/vector/src/debug/java/im/vector/app/features/debug/sas/SasEmojiItem.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/sas/SasEmojiItem.kt
@@ -21,14 +21,15 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
+import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import me.gujun.android.span.image
 import me.gujun.android.span.span
 import org.matrix.android.sdk.api.session.crypto.verification.EmojiRepresentation
 
-@EpoxyModelClass(layout = im.vector.app.R.layout.item_sas_emoji)
-abstract class SasEmojiItem : VectorEpoxyModel<SasEmojiItem.Holder>() {
+@EpoxyModelClass
+abstract class SasEmojiItem : VectorEpoxyModel<SasEmojiItem.Holder>(R.layout.item_sas_emoji) {
 
     @EpoxyAttribute
     var index: Int = 0
@@ -51,9 +52,9 @@ abstract class SasEmojiItem : VectorEpoxyModel<SasEmojiItem.Holder>() {
     }
 
     class Holder : VectorEpoxyHolder() {
-        val indexView by bind<TextView>(im.vector.app.R.id.sas_emoji_index)
-        val emojiView by bind<TextView>(im.vector.app.R.id.sas_emoji)
-        val textView by bind<TextView>(im.vector.app.R.id.sas_emoji_text)
-        val idView by bind<TextView>(im.vector.app.R.id.sas_emoji_text_id)
+        val indexView by bind<TextView>(R.id.sas_emoji_index)
+        val emojiView by bind<TextView>(R.id.sas_emoji)
+        val textView by bind<TextView>(R.id.sas_emoji_text)
+        val idView by bind<TextView>(R.id.sas_emoji_text_id)
     }
 }

--- a/vector/src/main/java/im/vector/app/core/epoxy/BottomSheetDividerItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/BottomSheetDividerItem.kt
@@ -18,7 +18,7 @@ package im.vector.app.core.epoxy
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 
-@EpoxyModelClass(layout = R.layout.item_divider_on_surface)
-abstract class BottomSheetDividerItem : VectorEpoxyModel<BottomSheetDividerItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetDividerItem : VectorEpoxyModel<BottomSheetDividerItem.Holder>(R.layout.item_divider_on_surface) {
     class Holder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/core/epoxy/CheckBoxItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/CheckBoxItem.kt
@@ -22,8 +22,8 @@ import com.airbnb.epoxy.EpoxyModelClass
 import com.google.android.material.checkbox.MaterialCheckBox
 import im.vector.app.R
 
-@EpoxyModelClass(layout = R.layout.item_checkbox)
-abstract class CheckBoxItem : VectorEpoxyModel<CheckBoxItem.Holder>() {
+@EpoxyModelClass
+abstract class CheckBoxItem : VectorEpoxyModel<CheckBoxItem.Holder>(R.layout.item_checkbox) {
 
     @EpoxyAttribute
     var checked: Boolean = false

--- a/vector/src/main/java/im/vector/app/core/epoxy/DividerItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/DividerItem.kt
@@ -18,7 +18,7 @@ package im.vector.app.core.epoxy
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 
-@EpoxyModelClass(layout = R.layout.item_divider)
-abstract class DividerItem : VectorEpoxyModel<DividerItem.Holder>() {
+@EpoxyModelClass
+abstract class DividerItem : VectorEpoxyModel<DividerItem.Holder>(R.layout.item_divider) {
     class Holder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/core/epoxy/ErrorWithRetryItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/ErrorWithRetryItem.kt
@@ -23,8 +23,8 @@ import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 
-@EpoxyModelClass(layout = R.layout.item_error_retry)
-abstract class ErrorWithRetryItem : VectorEpoxyModel<ErrorWithRetryItem.Holder>() {
+@EpoxyModelClass
+abstract class ErrorWithRetryItem : VectorEpoxyModel<ErrorWithRetryItem.Holder>(R.layout.item_error_retry) {
 
     @EpoxyAttribute
     var text: String? = null

--- a/vector/src/main/java/im/vector/app/core/epoxy/ExpandableTextItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/ExpandableTextItem.kt
@@ -28,8 +28,8 @@ import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.core.extensions.copyOnLongClick
 
-@EpoxyModelClass(layout = R.layout.item_expandable_textview)
-abstract class ExpandableTextItem : VectorEpoxyModel<ExpandableTextItem.Holder>() {
+@EpoxyModelClass
+abstract class ExpandableTextItem : VectorEpoxyModel<ExpandableTextItem.Holder>(R.layout.item_expandable_textview) {
 
     @EpoxyAttribute
     lateinit var content: String

--- a/vector/src/main/java/im/vector/app/core/epoxy/HelpFooterItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/HelpFooterItem.kt
@@ -21,8 +21,8 @@ import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 
-@EpoxyModelClass(layout = R.layout.item_help_footer)
-abstract class HelpFooterItem : VectorEpoxyModel<HelpFooterItem.Holder>() {
+@EpoxyModelClass
+abstract class HelpFooterItem : VectorEpoxyModel<HelpFooterItem.Holder>(R.layout.item_help_footer) {
 
     @EpoxyAttribute
     var text: String? = null

--- a/vector/src/main/java/im/vector/app/core/epoxy/LoadingItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/LoadingItem.kt
@@ -24,8 +24,8 @@ import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_loading)
-abstract class LoadingItem : VectorEpoxyModel<LoadingItem.Holder>() {
+@EpoxyModelClass
+abstract class LoadingItem : VectorEpoxyModel<LoadingItem.Holder>(R.layout.item_loading) {
 
     @EpoxyAttribute var loadingText: String? = null
     @EpoxyAttribute var showLoader: Boolean = true

--- a/vector/src/main/java/im/vector/app/core/epoxy/NoResultItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/NoResultItem.kt
@@ -21,8 +21,8 @@ import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 
-@EpoxyModelClass(layout = R.layout.item_no_result)
-abstract class NoResultItem : VectorEpoxyModel<NoResultItem.Holder>() {
+@EpoxyModelClass
+abstract class NoResultItem : VectorEpoxyModel<NoResultItem.Holder>(R.layout.item_no_result) {
 
     @EpoxyAttribute
     var text: String? = null

--- a/vector/src/main/java/im/vector/app/core/epoxy/SquareLoadingItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/SquareLoadingItem.kt
@@ -19,8 +19,8 @@ package im.vector.app.core.epoxy
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 
-@EpoxyModelClass(layout = R.layout.item_loading_square)
-abstract class SquareLoadingItem : VectorEpoxyModel<SquareLoadingItem.Holder>() {
+@EpoxyModelClass
+abstract class SquareLoadingItem : VectorEpoxyModel<SquareLoadingItem.Holder>(R.layout.item_loading_square) {
 
     class Holder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/core/epoxy/TimelineEmptyItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/TimelineEmptyItem.kt
@@ -22,8 +22,8 @@ import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.features.home.room.detail.timeline.item.ItemWithEvents
 
-@EpoxyModelClass(layout = R.layout.item_timeline_empty)
-abstract class TimelineEmptyItem : VectorEpoxyModel<TimelineEmptyItem.Holder>(), ItemWithEvents {
+@EpoxyModelClass
+abstract class TimelineEmptyItem : VectorEpoxyModel<TimelineEmptyItem.Holder>(R.layout.item_timeline_empty), ItemWithEvents {
 
     @EpoxyAttribute lateinit var eventId: String
     @EpoxyAttribute var notBlank: Boolean = false

--- a/vector/src/main/java/im/vector/app/core/epoxy/VectorEpoxyModel.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/VectorEpoxyModel.kt
@@ -17,6 +17,7 @@
 package im.vector.app.core.epoxy
 
 import androidx.annotation.CallSuper
+import androidx.annotation.LayoutRes
 import com.airbnb.epoxy.EpoxyModelWithHolder
 import com.airbnb.epoxy.VisibilityState
 import kotlinx.coroutines.CoroutineScope
@@ -27,11 +28,15 @@ import kotlinx.coroutines.cancelChildren
 /**
  * EpoxyModelWithHolder which can listen to visibility state change.
  */
-abstract class VectorEpoxyModel<H : VectorEpoxyHolder> : EpoxyModelWithHolder<H>() {
+abstract class VectorEpoxyModel<H : VectorEpoxyHolder>(
+        @LayoutRes private val layoutId: Int
+) : EpoxyModelWithHolder<H>() {
 
     protected val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     private var onModelVisibilityStateChangedListener: OnVisibilityStateChangedListener? = null
+
+    final override fun getDefaultLayout() = layoutId
 
     @CallSuper
     override fun bind(holder: H) {

--- a/vector/src/main/java/im/vector/app/core/epoxy/ZeroItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/ZeroItem.kt
@@ -23,8 +23,8 @@ import im.vector.app.R
  * Item of size (0, 0).
  * It can be useful to avoid automatic scroll of RecyclerView with Epoxy controller, when the first valuable item changes.
  */
-@EpoxyModelClass(layout = R.layout.item_zero)
-abstract class ZeroItem : VectorEpoxyModel<ZeroItem.Holder>() {
+@EpoxyModelClass
+abstract class ZeroItem : VectorEpoxyModel<ZeroItem.Holder>(R.layout.item_zero) {
 
     class Holder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetActionItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetActionItem.kt
@@ -39,8 +39,8 @@ import im.vector.app.features.themes.ThemeUtils
 /**
  * A action for bottom sheet.
  */
-@EpoxyModelClass(layout = R.layout.item_bottom_sheet_action)
-abstract class BottomSheetActionItem : VectorEpoxyModel<BottomSheetActionItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetActionItem : VectorEpoxyModel<BottomSheetActionItem.Holder>(R.layout.item_bottom_sheet_action) {
 
     @EpoxyAttribute
     @DrawableRes

--- a/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetMessagePreviewItem.kt
@@ -43,8 +43,8 @@ import org.matrix.android.sdk.api.util.MatrixItem
 /**
  * A message preview for bottom sheet.
  */
-@EpoxyModelClass(layout = R.layout.item_bottom_sheet_message_preview)
-abstract class BottomSheetMessagePreviewItem : VectorEpoxyModel<BottomSheetMessagePreviewItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetMessagePreviewItem : VectorEpoxyModel<BottomSheetMessagePreviewItem.Holder>(R.layout.item_bottom_sheet_message_preview) {
 
     @EpoxyAttribute
     lateinit var avatarRenderer: AvatarRenderer

--- a/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetQuickReactionsItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetQuickReactionsItem.kt
@@ -29,8 +29,8 @@ import im.vector.app.core.epoxy.onClick
 /**
  * A quick reaction list for bottom sheet.
  */
-@EpoxyModelClass(layout = R.layout.item_bottom_sheet_quick_reaction)
-abstract class BottomSheetQuickReactionsItem : VectorEpoxyModel<BottomSheetQuickReactionsItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetQuickReactionsItem : VectorEpoxyModel<BottomSheetQuickReactionsItem.Holder>(R.layout.item_bottom_sheet_quick_reaction) {
 
     @EpoxyAttribute
     lateinit var fontProvider: EmojiCompatFontProvider

--- a/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetRadioActionItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetRadioActionItem.kt
@@ -33,8 +33,8 @@ import im.vector.app.core.extensions.setTextOrHide
 /**
  * A action for bottom sheet.
  */
-@EpoxyModelClass(layout = R.layout.item_bottom_sheet_radio)
-abstract class BottomSheetRadioActionItem : VectorEpoxyModel<BottomSheetRadioActionItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetRadioActionItem : VectorEpoxyModel<BottomSheetRadioActionItem.Holder>(R.layout.item_bottom_sheet_radio) {
 
     @EpoxyAttribute
     var title: String? = null

--- a/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetRoomPreviewItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetRoomPreviewItem.kt
@@ -39,8 +39,8 @@ import org.matrix.android.sdk.api.util.MatrixItem
 /**
  * A room preview for bottom sheet.
  */
-@EpoxyModelClass(layout = R.layout.item_bottom_sheet_room_preview)
-abstract class BottomSheetRoomPreviewItem : VectorEpoxyModel<BottomSheetRoomPreviewItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetRoomPreviewItem : VectorEpoxyModel<BottomSheetRoomPreviewItem.Holder>(R.layout.item_bottom_sheet_room_preview) {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var matrixItem: MatrixItem

--- a/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetSendStateItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/bottomsheet/BottomSheetSendStateItem.kt
@@ -29,8 +29,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 /**
  * A send state for bottom sheet.
  */
-@EpoxyModelClass(layout = R.layout.item_bottom_sheet_message_status)
-abstract class BottomSheetSendStateItem : VectorEpoxyModel<BottomSheetSendStateItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetSendStateItem : VectorEpoxyModel<BottomSheetSendStateItem.Holder>(R.layout.item_bottom_sheet_message_status) {
 
     @EpoxyAttribute
     var showProgress: Boolean = false

--- a/vector/src/main/java/im/vector/app/core/epoxy/profiles/BaseProfileMatrixItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/profiles/BaseProfileMatrixItem.kt
@@ -17,6 +17,7 @@
 package im.vector.app.core.epoxy.profiles
 
 import androidx.annotation.CallSuper
+import androidx.annotation.LayoutRes
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import im.vector.app.core.epoxy.ClickListener
@@ -28,7 +29,7 @@ import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel
 import org.matrix.android.sdk.api.util.MatrixItem
 
-abstract class BaseProfileMatrixItem<T : ProfileMatrixItem.Holder> : VectorEpoxyModel<T>() {
+abstract class BaseProfileMatrixItem<T : ProfileMatrixItem.Holder>(@LayoutRes layoutId: Int) : VectorEpoxyModel<T>(layoutId) {
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var matrixItem: MatrixItem
     @EpoxyAttribute var editable: Boolean = true

--- a/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileActionItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileActionItem.kt
@@ -33,8 +33,8 @@ import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.themes.ThemeUtils
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_profile_action)
-abstract class ProfileActionItem : VectorEpoxyModel<ProfileActionItem.Holder>() {
+@EpoxyModelClass
+abstract class ProfileActionItem : VectorEpoxyModel<ProfileActionItem.Holder>(R.layout.item_profile_action) {
 
     @EpoxyAttribute
     lateinit var title: String

--- a/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileMatrixItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileMatrixItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.ui.views.PresenceStateImageView
 import im.vector.app.core.ui.views.ShieldImageView
 
-@EpoxyModelClass(layout = R.layout.item_profile_matrix_item)
-abstract class ProfileMatrixItem : BaseProfileMatrixItem<ProfileMatrixItem.Holder>() {
+@EpoxyModelClass
+abstract class ProfileMatrixItem : BaseProfileMatrixItem<ProfileMatrixItem.Holder>(R.layout.item_profile_matrix_item) {
 
     open class Holder : VectorEpoxyHolder() {
         val titleView by bind<TextView>(R.id.matrixItemTitle)

--- a/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileMatrixItemWithPowerLevel.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileMatrixItemWithPowerLevel.kt
@@ -23,7 +23,7 @@ import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_profile_matrix_item)
+@EpoxyModelClass
 abstract class ProfileMatrixItemWithPowerLevel : ProfileMatrixItem() {
 
     @EpoxyAttribute var ignoredUser: Boolean = false

--- a/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileMatrixItemWithPowerLevel.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileMatrixItemWithPowerLevel.kt
@@ -20,7 +20,6 @@ package im.vector.app.core.epoxy.profiles
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import im.vector.app.R
 import im.vector.app.core.extensions.setTextOrHide
 
 @EpoxyModelClass

--- a/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileMatrixItemWithPowerLevelWithPresence.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileMatrixItemWithPowerLevelWithPresence.kt
@@ -19,7 +19,6 @@ package im.vector.app.core.epoxy.profiles
 
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import im.vector.app.R
 import org.matrix.android.sdk.api.session.presence.model.UserPresence
 
 @EpoxyModelClass

--- a/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileMatrixItemWithPowerLevelWithPresence.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileMatrixItemWithPowerLevelWithPresence.kt
@@ -22,7 +22,7 @@ import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import org.matrix.android.sdk.api.session.presence.model.UserPresence
 
-@EpoxyModelClass(layout = R.layout.item_profile_matrix_item)
+@EpoxyModelClass
 abstract class ProfileMatrixItemWithPowerLevelWithPresence : ProfileMatrixItemWithPowerLevel() {
 
     @EpoxyAttribute var showPresence: Boolean = true

--- a/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileMatrixItemWithProgress.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileMatrixItemWithProgress.kt
@@ -23,8 +23,8 @@ import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 
-@EpoxyModelClass(layout = R.layout.item_profile_matrix_item_progress)
-abstract class ProfileMatrixItemWithProgress : BaseProfileMatrixItem<ProfileMatrixItemWithProgress.Holder>() {
+@EpoxyModelClass
+abstract class ProfileMatrixItemWithProgress : BaseProfileMatrixItem<ProfileMatrixItemWithProgress.Holder>(R.layout.item_profile_matrix_item_progress) {
 
     @EpoxyAttribute var inProgress: Boolean = true
 

--- a/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileSectionItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/profiles/ProfileSectionItem.kt
@@ -23,8 +23,8 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_profile_section)
-abstract class ProfileSectionItem : VectorEpoxyModel<ProfileSectionItem.Holder>() {
+@EpoxyModelClass
+abstract class ProfileSectionItem : VectorEpoxyModel<ProfileSectionItem.Holder>(R.layout.item_profile_section) {
 
     @EpoxyAttribute
     lateinit var title: String

--- a/vector/src/main/java/im/vector/app/core/epoxy/profiles/notifications/NotificationSettingsFooterItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/profiles/notifications/NotificationSettingsFooterItem.kt
@@ -25,8 +25,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.extensions.setTextWithColoredPart
 
-@EpoxyModelClass(layout = R.layout.item_notifications_footer)
-abstract class NotificationSettingsFooterItem : VectorEpoxyModel<NotificationSettingsFooterItem.Holder>() {
+@EpoxyModelClass
+abstract class NotificationSettingsFooterItem : VectorEpoxyModel<NotificationSettingsFooterItem.Holder>(R.layout.item_notifications_footer) {
 
     @EpoxyAttribute
     var encrypted: Boolean = false

--- a/vector/src/main/java/im/vector/app/core/epoxy/profiles/notifications/RadioButtonItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/profiles/notifications/RadioButtonItem.kt
@@ -29,8 +29,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setAttributeTintedImageResource
 
-@EpoxyModelClass(layout = R.layout.item_radio)
-abstract class RadioButtonItem : VectorEpoxyModel<RadioButtonItem.Holder>() {
+@EpoxyModelClass
+abstract class RadioButtonItem : VectorEpoxyModel<RadioButtonItem.Holder>(R.layout.item_radio) {
 
     @EpoxyAttribute
     var title: String? = null

--- a/vector/src/main/java/im/vector/app/core/epoxy/profiles/notifications/TextHeaderItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/profiles/notifications/TextHeaderItem.kt
@@ -24,8 +24,8 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_text_header)
-abstract class TextHeaderItem : VectorEpoxyModel<TextHeaderItem.Holder>() {
+@EpoxyModelClass
+abstract class TextHeaderItem : VectorEpoxyModel<TextHeaderItem.Holder>(R.layout.item_text_header) {
 
     @EpoxyAttribute
     var text: String? = null

--- a/vector/src/main/java/im/vector/app/core/ui/bottomsheet/BottomSheetTitleItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/bottomsheet/BottomSheetTitleItem.kt
@@ -27,8 +27,8 @@ import im.vector.app.core.extensions.setTextOrHide
 /**
  * A title for bottom sheet, with an optional subtitle. It does not include the bottom separator.
  */
-@EpoxyModelClass(layout = R.layout.item_bottom_sheet_title)
-abstract class BottomSheetTitleItem : VectorEpoxyModel<BottomSheetTitleItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetTitleItem : VectorEpoxyModel<BottomSheetTitleItem.Holder>(R.layout.item_bottom_sheet_title) {
 
     @EpoxyAttribute
     lateinit var title: String

--- a/vector/src/main/java/im/vector/app/core/ui/list/ButtonPositiveDestructiveButtonBarItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/ButtonPositiveDestructiveButtonBarItem.kt
@@ -28,8 +28,10 @@ import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 /**
  * A generic button list item.
  */
-@EpoxyModelClass(layout = R.layout.item_positive_destrutive_buttons)
-abstract class ButtonPositiveDestructiveButtonBarItem : VectorEpoxyModel<ButtonPositiveDestructiveButtonBarItem.Holder>() {
+@EpoxyModelClass
+abstract class ButtonPositiveDestructiveButtonBarItem : VectorEpoxyModel<ButtonPositiveDestructiveButtonBarItem.Holder>(
+        R.layout.item_positive_destrutive_buttons
+) {
 
     @EpoxyAttribute
     var positiveText: EpoxyCharSequence? = null

--- a/vector/src/main/java/im/vector/app/core/ui/list/GenericButtonItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/GenericButtonItem.kt
@@ -33,8 +33,8 @@ import im.vector.app.features.themes.ThemeUtils
 /**
  * A generic button list item.
  */
-@EpoxyModelClass(layout = R.layout.item_generic_button)
-abstract class GenericButtonItem : VectorEpoxyModel<GenericButtonItem.Holder>() {
+@EpoxyModelClass
+abstract class GenericButtonItem : VectorEpoxyModel<GenericButtonItem.Holder>(R.layout.item_generic_button) {
 
     @EpoxyAttribute
     var text: String? = null

--- a/vector/src/main/java/im/vector/app/core/ui/list/GenericEmptyWithActionItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/GenericEmptyWithActionItem.kt
@@ -35,8 +35,8 @@ import im.vector.app.core.extensions.setTextOrHide
 /**
  * A generic list item to display when there is no results, with an optional CTA.
  */
-@EpoxyModelClass(layout = R.layout.item_generic_empty_state)
-abstract class GenericEmptyWithActionItem : VectorEpoxyModel<GenericEmptyWithActionItem.Holder>() {
+@EpoxyModelClass
+abstract class GenericEmptyWithActionItem : VectorEpoxyModel<GenericEmptyWithActionItem.Holder>(R.layout.item_generic_empty_state) {
 
     @EpoxyAttribute
     var title: String? = null

--- a/vector/src/main/java/im/vector/app/core/ui/list/GenericFooterItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/GenericFooterItem.kt
@@ -35,8 +35,8 @@ import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
  * Can display an accessory on the right, that can be an image or an indeterminate progress.
  * If provided with an action, will display a button at the bottom of the list item.
  */
-@EpoxyModelClass(layout = R.layout.item_generic_footer)
-abstract class GenericFooterItem : VectorEpoxyModel<GenericFooterItem.Holder>() {
+@EpoxyModelClass
+abstract class GenericFooterItem : VectorEpoxyModel<GenericFooterItem.Holder>(R.layout.item_generic_footer) {
 
     @EpoxyAttribute
     var text: EpoxyCharSequence? = null

--- a/vector/src/main/java/im/vector/app/core/ui/list/GenericHeaderItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/GenericHeaderItem.kt
@@ -28,8 +28,8 @@ import im.vector.app.features.themes.ThemeUtils
 /**
  * A generic list item header left aligned with notice color.
  */
-@EpoxyModelClass(layout = R.layout.item_generic_header)
-abstract class GenericHeaderItem : VectorEpoxyModel<GenericHeaderItem.Holder>() {
+@EpoxyModelClass
+abstract class GenericHeaderItem : VectorEpoxyModel<GenericHeaderItem.Holder>(R.layout.item_generic_header) {
 
     @EpoxyAttribute
     var text: String? = null

--- a/vector/src/main/java/im/vector/app/core/ui/list/GenericItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/GenericItem.kt
@@ -38,8 +38,8 @@ import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
  * Can display an accessory on the right, that can be an image or an indeterminate progress.
  * If provided with an action, will display a button at the bottom of the list item.
  */
-@EpoxyModelClass(layout = R.layout.item_generic_list)
-abstract class GenericItem : VectorEpoxyModel<GenericItem.Holder>() {
+@EpoxyModelClass
+abstract class GenericItem : VectorEpoxyModel<GenericItem.Holder>(R.layout.item_generic_list) {
 
     @EpoxyAttribute
     var title: EpoxyCharSequence? = null

--- a/vector/src/main/java/im/vector/app/core/ui/list/GenericLoaderItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/GenericLoaderItem.kt
@@ -24,8 +24,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 /**
  * A generic list item header left aligned with notice color.
  */
-@EpoxyModelClass(layout = R.layout.item_generic_loader)
-abstract class GenericLoaderItem : VectorEpoxyModel<GenericLoaderItem.Holder>() {
+@EpoxyModelClass
+abstract class GenericLoaderItem : VectorEpoxyModel<GenericLoaderItem.Holder>(R.layout.item_generic_loader) {
 
     // Maybe/Later add some style configuration, SMALL/BIG ?
 

--- a/vector/src/main/java/im/vector/app/core/ui/list/GenericPillItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/GenericPillItem.kt
@@ -36,8 +36,8 @@ import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 /**
  * A generic list item with a rounded corner background and an optional icon.
  */
-@EpoxyModelClass(layout = R.layout.item_generic_pill_footer)
-abstract class GenericPillItem : VectorEpoxyModel<GenericPillItem.Holder>() {
+@EpoxyModelClass
+abstract class GenericPillItem : VectorEpoxyModel<GenericPillItem.Holder>(R.layout.item_generic_pill_footer) {
 
     @EpoxyAttribute
     var text: EpoxyCharSequence? = null

--- a/vector/src/main/java/im/vector/app/core/ui/list/GenericPositiveButtonItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/GenericPositiveButtonItem.kt
@@ -29,8 +29,8 @@ import im.vector.app.core.epoxy.onClick
 /**
  * A generic button list item.
  */
-@EpoxyModelClass(layout = R.layout.item_positive_button)
-abstract class GenericPositiveButtonItem : VectorEpoxyModel<GenericPositiveButtonItem.Holder>() {
+@EpoxyModelClass
+abstract class GenericPositiveButtonItem : VectorEpoxyModel<GenericPositiveButtonItem.Holder>(R.layout.item_positive_button) {
 
     @EpoxyAttribute
     var text: String? = null

--- a/vector/src/main/java/im/vector/app/core/ui/list/GenericProgressBarItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/GenericProgressBarItem.kt
@@ -25,8 +25,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 /**
  * A generic progress bar item.
  */
-@EpoxyModelClass(layout = R.layout.item_generic_progress)
-abstract class GenericProgressBarItem : VectorEpoxyModel<GenericProgressBarItem.Holder>() {
+@EpoxyModelClass
+abstract class GenericProgressBarItem : VectorEpoxyModel<GenericProgressBarItem.Holder>(R.layout.item_generic_progress) {
 
     @EpoxyAttribute
     var progress: Int = 0

--- a/vector/src/main/java/im/vector/app/core/ui/list/GenericWithValueItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/GenericWithValueItem.kt
@@ -38,8 +38,8 @@ import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
  * Can display an accessory on the right, that can be an image or an indeterminate progress.
  * If provided with an action, will display a button at the bottom of the list item.
  */
-@EpoxyModelClass(layout = R.layout.item_generic_with_value)
-abstract class GenericWithValueItem : VectorEpoxyModel<GenericWithValueItem.Holder>() {
+@EpoxyModelClass
+abstract class GenericWithValueItem : VectorEpoxyModel<GenericWithValueItem.Holder>(R.layout.item_generic_with_value) {
 
     @EpoxyAttribute
     var title: EpoxyCharSequence? = null

--- a/vector/src/main/java/im/vector/app/core/ui/list/VerticalMarginItem.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/list/VerticalMarginItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 /**
  * A generic item with empty space.
  */
-@EpoxyModelClass(layout = R.layout.item_vertical_margin)
-abstract class VerticalMarginItem : VectorEpoxyModel<VerticalMarginItem.Holder>() {
+@EpoxyModelClass
+abstract class VerticalMarginItem : VectorEpoxyModel<VerticalMarginItem.Holder>(R.layout.item_vertical_margin) {
 
     @EpoxyAttribute
     var heightInPx: Int = 0

--- a/vector/src/main/java/im/vector/app/features/attachments/preview/AttachmentPreviewItems.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/preview/AttachmentPreviewItems.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.attachments.preview
 
 import android.view.View
 import android.widget.ImageView
+import androidx.annotation.LayoutRes
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
@@ -29,7 +30,7 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.platform.CheckableImageView
 import org.matrix.android.sdk.api.session.content.ContentAttachmentData
 
-abstract class AttachmentPreviewItem<H : AttachmentPreviewItem.Holder> : VectorEpoxyModel<H>() {
+abstract class AttachmentPreviewItem<H : AttachmentPreviewItem.Holder>(@LayoutRes layoutId: Int) : VectorEpoxyModel<H>(layoutId) {
 
     abstract val attachment: ContentAttachmentData
 
@@ -52,8 +53,8 @@ abstract class AttachmentPreviewItem<H : AttachmentPreviewItem.Holder> : VectorE
     }
 }
 
-@EpoxyModelClass(layout = R.layout.item_attachment_miniature_preview)
-abstract class AttachmentMiniaturePreviewItem : AttachmentPreviewItem<AttachmentMiniaturePreviewItem.Holder>() {
+@EpoxyModelClass
+abstract class AttachmentMiniaturePreviewItem : AttachmentPreviewItem<AttachmentMiniaturePreviewItem.Holder>(R.layout.item_attachment_miniature_preview) {
 
     @EpoxyAttribute override lateinit var attachment: ContentAttachmentData
 
@@ -78,8 +79,8 @@ abstract class AttachmentMiniaturePreviewItem : AttachmentPreviewItem<Attachment
     }
 }
 
-@EpoxyModelClass(layout = R.layout.item_attachment_big_preview)
-abstract class AttachmentBigPreviewItem : AttachmentPreviewItem<AttachmentBigPreviewItem.Holder>() {
+@EpoxyModelClass
+abstract class AttachmentBigPreviewItem : AttachmentPreviewItem<AttachmentBigPreviewItem.Holder>(R.layout.item_attachment_big_preview) {
 
     @EpoxyAttribute override lateinit var attachment: ContentAttachmentData
 

--- a/vector/src/main/java/im/vector/app/features/autocomplete/AutocompleteHeaderItem.kt
+++ b/vector/src/main/java/im/vector/app/features/autocomplete/AutocompleteHeaderItem.kt
@@ -23,8 +23,8 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_autocomplete_header_item)
-abstract class AutocompleteHeaderItem : VectorEpoxyModel<AutocompleteHeaderItem.Holder>() {
+@EpoxyModelClass
+abstract class AutocompleteHeaderItem : VectorEpoxyModel<AutocompleteHeaderItem.Holder>(R.layout.item_autocomplete_header_item) {
 
     @EpoxyAttribute var title: String? = null
 

--- a/vector/src/main/java/im/vector/app/features/autocomplete/AutocompleteMatrixItem.kt
+++ b/vector/src/main/java/im/vector/app/features/autocomplete/AutocompleteMatrixItem.kt
@@ -30,8 +30,8 @@ import im.vector.app.features.displayname.getBestName
 import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_autocomplete_matrix_item)
-abstract class AutocompleteMatrixItem : VectorEpoxyModel<AutocompleteMatrixItem.Holder>() {
+@EpoxyModelClass
+abstract class AutocompleteMatrixItem : VectorEpoxyModel<AutocompleteMatrixItem.Holder>(R.layout.item_autocomplete_matrix_item) {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var matrixItem: MatrixItem

--- a/vector/src/main/java/im/vector/app/features/autocomplete/command/AutocompleteCommandItem.kt
+++ b/vector/src/main/java/im/vector/app/features/autocomplete/command/AutocompleteCommandItem.kt
@@ -25,8 +25,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 
-@EpoxyModelClass(layout = R.layout.item_autocomplete_command)
-abstract class AutocompleteCommandItem : VectorEpoxyModel<AutocompleteCommandItem.Holder>() {
+@EpoxyModelClass
+abstract class AutocompleteCommandItem : VectorEpoxyModel<AutocompleteCommandItem.Holder>(R.layout.item_autocomplete_command) {
 
     @EpoxyAttribute
     var name: String? = null

--- a/vector/src/main/java/im/vector/app/features/autocomplete/emoji/AutocompleteEmojiItem.kt
+++ b/vector/src/main/java/im/vector/app/features/autocomplete/emoji/AutocompleteEmojiItem.kt
@@ -28,8 +28,8 @@ import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 import im.vector.app.features.reactions.data.EmojiItem
 
-@EpoxyModelClass(layout = R.layout.item_autocomplete_emoji)
-abstract class AutocompleteEmojiItem : VectorEpoxyModel<AutocompleteEmojiItem.Holder>() {
+@EpoxyModelClass
+abstract class AutocompleteEmojiItem : VectorEpoxyModel<AutocompleteEmojiItem.Holder>(R.layout.item_autocomplete_emoji) {
 
     @EpoxyAttribute
     lateinit var emojiItem: EmojiItem

--- a/vector/src/main/java/im/vector/app/features/autocomplete/emoji/AutocompleteMoreResultItem.kt
+++ b/vector/src/main/java/im/vector/app/features/autocomplete/emoji/AutocompleteMoreResultItem.kt
@@ -21,8 +21,8 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_autocomplete_more_result)
-abstract class AutocompleteMoreResultItem : VectorEpoxyModel<AutocompleteMoreResultItem.Holder>() {
+@EpoxyModelClass
+abstract class AutocompleteMoreResultItem : VectorEpoxyModel<AutocompleteMoreResultItem.Holder>(R.layout.item_autocomplete_more_result) {
 
     class Holder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/features/contactsbook/ContactDetailItem.kt
+++ b/vector/src/main/java/im/vector/app/features/contactsbook/ContactDetailItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_contact_detail)
-abstract class ContactDetailItem : VectorEpoxyModel<ContactDetailItem.Holder>() {
+@EpoxyModelClass
+abstract class ContactDetailItem : VectorEpoxyModel<ContactDetailItem.Holder>(R.layout.item_contact_detail) {
 
     @EpoxyAttribute lateinit var threePid: String
     @EpoxyAttribute var matrixId: String? = null

--- a/vector/src/main/java/im/vector/app/features/contactsbook/ContactItem.kt
+++ b/vector/src/main/java/im/vector/app/features/contactsbook/ContactItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.features.home.AvatarRenderer
 
-@EpoxyModelClass(layout = R.layout.item_contact_main)
-abstract class ContactItem : VectorEpoxyModel<ContactItem.Holder>() {
+@EpoxyModelClass
+abstract class ContactItem : VectorEpoxyModel<ContactItem.Holder>(R.layout.item_contact_main) {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var mappedContact: MappedContact

--- a/vector/src/main/java/im/vector/app/features/crypto/keysbackup/settings/KeysBackupSettingFooterItem.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysbackup/settings/KeysBackupSettingFooterItem.kt
@@ -27,8 +27,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_keys_backup_settings_button_footer)
-abstract class KeysBackupSettingFooterItem : VectorEpoxyModel<KeysBackupSettingFooterItem.Holder>() {
+@EpoxyModelClass
+abstract class KeysBackupSettingFooterItem : VectorEpoxyModel<KeysBackupSettingFooterItem.Holder>(R.layout.item_keys_backup_settings_button_footer) {
 
     @EpoxyAttribute
     var textButton1: String? = null

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetSelfWaitItem.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetSelfWaitItem.kt
@@ -24,7 +24,7 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 /**
  * A action for bottom sheet.
  */
-@EpoxyModelClass(layout = R.layout.item_verification_wait)
-abstract class BottomSheetSelfWaitItem : VectorEpoxyModel<BottomSheetSelfWaitItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetSelfWaitItem : VectorEpoxyModel<BottomSheetSelfWaitItem.Holder>(R.layout.item_verification_wait) {
     class Holder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationActionItem.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationActionItem.kt
@@ -34,8 +34,8 @@ import im.vector.app.core.extensions.setTextOrHide
 /**
  * A action for bottom sheet.
  */
-@EpoxyModelClass(layout = R.layout.item_verification_action)
-abstract class BottomSheetVerificationActionItem : VectorEpoxyModel<BottomSheetVerificationActionItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetVerificationActionItem : VectorEpoxyModel<BottomSheetVerificationActionItem.Holder>(R.layout.item_verification_action) {
 
     @EpoxyAttribute
     @DrawableRes

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationBigImageItem.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationBigImageItem.kt
@@ -27,8 +27,8 @@ import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel
 /**
  * A action for bottom sheet.
  */
-@EpoxyModelClass(layout = R.layout.item_verification_big_image)
-abstract class BottomSheetVerificationBigImageItem : VectorEpoxyModel<BottomSheetVerificationBigImageItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetVerificationBigImageItem : VectorEpoxyModel<BottomSheetVerificationBigImageItem.Holder>(R.layout.item_verification_big_image) {
 
     @EpoxyAttribute
     lateinit var roomEncryptionTrustLevel: RoomEncryptionTrustLevel

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationDecimalCodeItem.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationDecimalCodeItem.kt
@@ -26,8 +26,10 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 /**
  * A action for bottom sheet.
  */
-@EpoxyModelClass(layout = R.layout.item_verification_decimal_code)
-abstract class BottomSheetVerificationDecimalCodeItem : VectorEpoxyModel<BottomSheetVerificationDecimalCodeItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetVerificationDecimalCodeItem : VectorEpoxyModel<BottomSheetVerificationDecimalCodeItem.Holder>(
+        R.layout.item_verification_decimal_code
+) {
 
     @EpoxyAttribute
     var code: String = ""

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationEmojisItem.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationEmojisItem.kt
@@ -34,8 +34,8 @@ import org.matrix.android.sdk.api.session.crypto.verification.EmojiRepresentatio
 /**
  * A emoji list for bottom sheet.
  */
-@EpoxyModelClass(layout = R.layout.item_verification_emojis)
-abstract class BottomSheetVerificationEmojisItem : VectorEpoxyModel<BottomSheetVerificationEmojisItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetVerificationEmojisItem : VectorEpoxyModel<BottomSheetVerificationEmojisItem.Holder>(R.layout.item_verification_emojis) {
 
     @EpoxyAttribute lateinit var emojiRepresentation0: EmojiRepresentation
     @EpoxyAttribute lateinit var emojiRepresentation1: EmojiRepresentation

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationNoticeItem.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationNoticeItem.kt
@@ -27,8 +27,8 @@ import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 /**
  * A action for bottom sheet.
  */
-@EpoxyModelClass(layout = R.layout.item_verification_notice)
-abstract class BottomSheetVerificationNoticeItem : VectorEpoxyModel<BottomSheetVerificationNoticeItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetVerificationNoticeItem : VectorEpoxyModel<BottomSheetVerificationNoticeItem.Holder>(R.layout.item_verification_notice) {
 
     @EpoxyAttribute
     lateinit var notice: EpoxyCharSequence

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationQrCodeItem.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationQrCodeItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.ui.views.QrCodeImageView
 /**
  * An Epoxy item displaying a QR code.
  */
-@EpoxyModelClass(layout = R.layout.item_verification_qr_code)
-abstract class BottomSheetVerificationQrCodeItem : VectorEpoxyModel<BottomSheetVerificationQrCodeItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetVerificationQrCodeItem : VectorEpoxyModel<BottomSheetVerificationQrCodeItem.Holder>(R.layout.item_verification_qr_code) {
 
     @EpoxyAttribute
     lateinit var data: String

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationWaitingItem.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/epoxy/BottomSheetVerificationWaitingItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 /**
  * A action for bottom sheet.
  */
-@EpoxyModelClass(layout = R.layout.item_verification_waiting)
-abstract class BottomSheetVerificationWaitingItem : VectorEpoxyModel<BottomSheetVerificationWaitingItem.Holder>() {
+@EpoxyModelClass
+abstract class BottomSheetVerificationWaitingItem : VectorEpoxyModel<BottomSheetVerificationWaitingItem.Holder>(R.layout.item_verification_waiting) {
 
     @EpoxyAttribute
     var title: String = ""

--- a/vector/src/main/java/im/vector/app/features/discovery/DiscoveryPolicyItem.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/DiscoveryPolicyItem.kt
@@ -19,7 +19,6 @@ package im.vector.app.features.discovery
 import android.widget.TextView
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder

--- a/vector/src/main/java/im/vector/app/features/discovery/DiscoveryPolicyItem.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/DiscoveryPolicyItem.kt
@@ -23,11 +23,12 @@ import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_discovery_policy)
-abstract class DiscoveryPolicyItem : EpoxyModelWithHolder<DiscoveryPolicyItem.Holder>() {
+@EpoxyModelClass
+abstract class DiscoveryPolicyItem : VectorEpoxyModel<DiscoveryPolicyItem.Holder>(R.layout.item_discovery_policy) {
 
     @EpoxyAttribute
     var name: String? = null

--- a/vector/src/main/java/im/vector/app/features/discovery/SettingsButtonItem.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/SettingsButtonItem.kt
@@ -19,7 +19,6 @@ import android.widget.Button
 import androidx.annotation.StringRes
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder

--- a/vector/src/main/java/im/vector/app/features/discovery/SettingsButtonItem.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/SettingsButtonItem.kt
@@ -23,13 +23,14 @@ import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.attributes.ButtonStyle
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 import im.vector.app.core.resources.ColorProvider
 
-@EpoxyModelClass(layout = R.layout.item_settings_button)
-abstract class SettingsButtonItem : EpoxyModelWithHolder<SettingsButtonItem.Holder>() {
+@EpoxyModelClass
+abstract class SettingsButtonItem : VectorEpoxyModel<SettingsButtonItem.Holder>(R.layout.item_settings_button) {
 
     @EpoxyAttribute
     lateinit var colorProvider: ColorProvider

--- a/vector/src/main/java/im/vector/app/features/discovery/SettingsCenteredImageItem.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/SettingsCenteredImageItem.kt
@@ -19,12 +19,12 @@ import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_settings_centered_image)
-abstract class SettingsCenteredImageItem : EpoxyModelWithHolder<SettingsCenteredImageItem.Holder>() {
+@EpoxyModelClass
+abstract class SettingsCenteredImageItem : VectorEpoxyModel<SettingsCenteredImageItem.Holder>(R.layout.item_settings_centered_image) {
 
     @EpoxyAttribute
     @DrawableRes

--- a/vector/src/main/java/im/vector/app/features/discovery/SettingsContinueCancelItem.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/SettingsContinueCancelItem.kt
@@ -18,14 +18,14 @@ package im.vector.app.features.discovery
 import android.widget.Button
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 
-@EpoxyModelClass(layout = R.layout.item_settings_continue_cancel)
-abstract class SettingsContinueCancelItem : EpoxyModelWithHolder<SettingsContinueCancelItem.Holder>() {
+@EpoxyModelClass
+abstract class SettingsContinueCancelItem : VectorEpoxyModel<SettingsContinueCancelItem.Holder>(R.layout.item_settings_continue_cancel) {
 
     @EpoxyAttribute
     var continueText: String? = null

--- a/vector/src/main/java/im/vector/app/features/discovery/SettingsEditTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/SettingsEditTextItem.kt
@@ -22,15 +22,15 @@ import android.widget.TextView
 import androidx.core.widget.doOnTextChanged
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import com.google.android.material.textfield.TextInputLayout
 import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.extensions.setTextOrHide
 import im.vector.app.core.extensions.showKeyboard
 
-@EpoxyModelClass(layout = R.layout.item_settings_edit_text)
-abstract class SettingsEditTextItem : EpoxyModelWithHolder<SettingsEditTextItem.Holder>() {
+@EpoxyModelClass
+abstract class SettingsEditTextItem : VectorEpoxyModel<SettingsEditTextItem.Holder>(R.layout.item_settings_edit_text) {
 
     @EpoxyAttribute var hint: String? = null
     @EpoxyAttribute var value: String? = null

--- a/vector/src/main/java/im/vector/app/features/discovery/SettingsInfoItem.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/SettingsInfoItem.kt
@@ -20,15 +20,15 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_settings_helper_info)
-abstract class SettingsInfoItem : EpoxyModelWithHolder<SettingsInfoItem.Holder>() {
+@EpoxyModelClass
+abstract class SettingsInfoItem : VectorEpoxyModel<SettingsInfoItem.Holder>(R.layout.item_settings_helper_info) {
 
     @EpoxyAttribute
     var helperText: String? = null

--- a/vector/src/main/java/im/vector/app/features/discovery/SettingsInformationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/SettingsInformationItem.kt
@@ -19,12 +19,12 @@ import android.widget.TextView
 import androidx.annotation.ColorInt
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_settings_information)
-abstract class SettingsInformationItem : EpoxyModelWithHolder<SettingsInformationItem.Holder>() {
+@EpoxyModelClass
+abstract class SettingsInformationItem : VectorEpoxyModel<SettingsInformationItem.Holder>(R.layout.item_settings_information) {
 
     @EpoxyAttribute
     lateinit var message: String

--- a/vector/src/main/java/im/vector/app/features/discovery/SettingsItem.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/SettingsItem.kt
@@ -20,16 +20,16 @@ import androidx.annotation.StringRes
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import com.google.android.material.switchmaterial.SwitchMaterial
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_settings_simple_item)
-abstract class SettingsItem : EpoxyModelWithHolder<SettingsItem.Holder>() {
+@EpoxyModelClass
+abstract class SettingsItem : VectorEpoxyModel<SettingsItem.Holder>(R.layout.item_settings_simple_item) {
 
     @EpoxyAttribute
     var title: String? = null

--- a/vector/src/main/java/im/vector/app/features/discovery/SettingsProgressItem.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/SettingsProgressItem.kt
@@ -16,12 +16,12 @@
 package im.vector.app.features.discovery
 
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_settings_progress)
-abstract class SettingsProgressItem : EpoxyModelWithHolder<SettingsProgressItem.Holder>() {
+@EpoxyModelClass
+abstract class SettingsProgressItem : VectorEpoxyModel<SettingsProgressItem.Holder>(R.layout.item_settings_progress) {
 
     class Holder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/features/discovery/SettingsSectionTitleItem.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/SettingsSectionTitleItem.kt
@@ -19,13 +19,13 @@ import android.widget.TextView
 import androidx.annotation.StringRes
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_settings_section_title)
-abstract class SettingsSectionTitleItem : EpoxyModelWithHolder<SettingsSectionTitleItem.Holder>() {
+@EpoxyModelClass
+abstract class SettingsSectionTitleItem : VectorEpoxyModel<SettingsSectionTitleItem.Holder>(R.layout.item_settings_section_title) {
 
     @EpoxyAttribute
     var title: String? = null

--- a/vector/src/main/java/im/vector/app/features/discovery/SettingsTextButtonSingleLineItem.kt
+++ b/vector/src/main/java/im/vector/app/features/discovery/SettingsTextButtonSingleLineItem.kt
@@ -25,11 +25,11 @@ import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import com.google.android.material.switchmaterial.SwitchMaterial
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.attributes.ButtonStyle
 import im.vector.app.core.epoxy.attributes.ButtonType
 import im.vector.app.core.epoxy.attributes.IconMode
@@ -39,8 +39,8 @@ import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.features.themes.ThemeUtils
 
-@EpoxyModelClass(layout = R.layout.item_settings_button_single_line)
-abstract class SettingsTextButtonSingleLineItem : EpoxyModelWithHolder<SettingsTextButtonSingleLineItem.Holder>() {
+@EpoxyModelClass
+abstract class SettingsTextButtonSingleLineItem : VectorEpoxyModel<SettingsTextButtonSingleLineItem.Holder>(R.layout.item_settings_button_single_line) {
 
     @EpoxyAttribute
     lateinit var colorProvider: ColorProvider

--- a/vector/src/main/java/im/vector/app/features/form/FormAdvancedToggleItem.kt
+++ b/vector/src/main/java/im/vector/app/features/form/FormAdvancedToggleItem.kt
@@ -28,8 +28,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.features.themes.ThemeUtils
 
-@EpoxyModelClass(layout = R.layout.item_form_advanced_toggle)
-abstract class FormAdvancedToggleItem : VectorEpoxyModel<FormAdvancedToggleItem.Holder>() {
+@EpoxyModelClass
+abstract class FormAdvancedToggleItem : VectorEpoxyModel<FormAdvancedToggleItem.Holder>(R.layout.item_form_advanced_toggle) {
 
     @EpoxyAttribute lateinit var title: String
     @EpoxyAttribute var expanded: Boolean = false

--- a/vector/src/main/java/im/vector/app/features/form/FormEditTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/form/FormEditTextItem.kt
@@ -34,8 +34,8 @@ import im.vector.app.core.epoxy.addTextChangedListenerOnce
 import im.vector.app.core.epoxy.setValueOnce
 import im.vector.app.core.platform.SimpleTextWatcher
 
-@EpoxyModelClass(layout = R.layout.item_form_text_input)
-abstract class FormEditTextItem : VectorEpoxyModel<FormEditTextItem.Holder>() {
+@EpoxyModelClass
+abstract class FormEditTextItem : VectorEpoxyModel<FormEditTextItem.Holder>(R.layout.item_form_text_input) {
 
     @EpoxyAttribute
     var hint: String? = null

--- a/vector/src/main/java/im/vector/app/features/form/FormEditTextWithButtonItem.kt
+++ b/vector/src/main/java/im/vector/app/features/form/FormEditTextWithButtonItem.kt
@@ -32,8 +32,8 @@ import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.epoxy.setValueOnce
 import im.vector.app.core.platform.SimpleTextWatcher
 
-@EpoxyModelClass(layout = R.layout.item_form_text_input_with_button)
-abstract class FormEditTextWithButtonItem : VectorEpoxyModel<FormEditTextWithButtonItem.Holder>() {
+@EpoxyModelClass
+abstract class FormEditTextWithButtonItem : VectorEpoxyModel<FormEditTextWithButtonItem.Holder>(R.layout.item_form_text_input_with_button) {
 
     @EpoxyAttribute
     var hint: String? = null

--- a/vector/src/main/java/im/vector/app/features/form/FormEditTextWithDeleteItem.kt
+++ b/vector/src/main/java/im/vector/app/features/form/FormEditTextWithDeleteItem.kt
@@ -34,8 +34,8 @@ import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextIfDifferent
 import im.vector.app.core.platform.SimpleTextWatcher
 
-@EpoxyModelClass(layout = R.layout.item_form_text_input_with_delete)
-abstract class FormEditTextWithDeleteItem : VectorEpoxyModel<FormEditTextWithDeleteItem.Holder>() {
+@EpoxyModelClass
+abstract class FormEditTextWithDeleteItem : VectorEpoxyModel<FormEditTextWithDeleteItem.Holder>(R.layout.item_form_text_input_with_delete) {
 
     @EpoxyAttribute
     var hint: String? = null

--- a/vector/src/main/java/im/vector/app/features/form/FormEditableAvatarItem.kt
+++ b/vector/src/main/java/im/vector/app/features/form/FormEditableAvatarItem.kt
@@ -21,18 +21,18 @@ import android.widget.ImageView
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import com.bumptech.glide.request.RequestOptions
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.glide.GlideApp
 import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_editable_avatar)
-abstract class FormEditableAvatarItem : EpoxyModelWithHolder<FormEditableAvatarItem.Holder>() {
+@EpoxyModelClass
+abstract class FormEditableAvatarItem : VectorEpoxyModel<FormEditableAvatarItem.Holder>(R.layout.item_editable_avatar) {
 
     @EpoxyAttribute
     var avatarRenderer: AvatarRenderer? = null

--- a/vector/src/main/java/im/vector/app/features/form/FormEditableSquareAvatarItem.kt
+++ b/vector/src/main/java/im/vector/app/features/form/FormEditableSquareAvatarItem.kt
@@ -22,20 +22,20 @@ import android.widget.ImageView
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import com.bumptech.glide.load.MultiTransformation
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.glide.GlideApp
 import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_editable_square_avatar)
-abstract class FormEditableSquareAvatarItem : EpoxyModelWithHolder<FormEditableSquareAvatarItem.Holder>() {
+@EpoxyModelClass
+abstract class FormEditableSquareAvatarItem : VectorEpoxyModel<FormEditableSquareAvatarItem.Holder>(R.layout.item_editable_square_avatar) {
 
     @EpoxyAttribute
     var avatarRenderer: AvatarRenderer? = null

--- a/vector/src/main/java/im/vector/app/features/form/FormMultiLineEditTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/form/FormMultiLineEditTextItem.kt
@@ -30,8 +30,8 @@ import im.vector.app.core.epoxy.addTextChangedListenerOnce
 import im.vector.app.core.epoxy.setValueOnce
 import im.vector.app.core.platform.SimpleTextWatcher
 
-@EpoxyModelClass(layout = R.layout.item_form_multiline_text_input)
-abstract class FormMultiLineEditTextItem : VectorEpoxyModel<FormMultiLineEditTextItem.Holder>() {
+@EpoxyModelClass
+abstract class FormMultiLineEditTextItem : VectorEpoxyModel<FormMultiLineEditTextItem.Holder>(R.layout.item_form_multiline_text_input) {
 
     @EpoxyAttribute
     var hint: String? = null

--- a/vector/src/main/java/im/vector/app/features/form/FormSubmitButtonItem.kt
+++ b/vector/src/main/java/im/vector/app/features/form/FormSubmitButtonItem.kt
@@ -19,15 +19,15 @@ import android.widget.Button
 import androidx.annotation.StringRes
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_form_submit_button)
-abstract class FormSubmitButtonItem : EpoxyModelWithHolder<FormSubmitButtonItem.Holder>() {
+@EpoxyModelClass
+abstract class FormSubmitButtonItem : VectorEpoxyModel<FormSubmitButtonItem.Holder>(R.layout.item_form_submit_button) {
 
     @EpoxyAttribute
     var enabled: Boolean = true

--- a/vector/src/main/java/im/vector/app/features/form/FormSwitchItem.kt
+++ b/vector/src/main/java/im/vector/app/features/form/FormSwitchItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.setValueOnce
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_form_switch)
-abstract class FormSwitchItem : VectorEpoxyModel<FormSwitchItem.Holder>() {
+@EpoxyModelClass
+abstract class FormSwitchItem : VectorEpoxyModel<FormSwitchItem.Holder>(R.layout.item_form_switch) {
 
     @EpoxyAttribute
     var listener: ((Boolean) -> Unit)? = null

--- a/vector/src/main/java/im/vector/app/features/grouplist/GroupSummaryItem.kt
+++ b/vector/src/main/java/im/vector/app/features/grouplist/GroupSummaryItem.kt
@@ -30,8 +30,8 @@ import im.vector.app.core.platform.CheckableConstraintLayout
 import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_group)
-abstract class GroupSummaryItem : VectorEpoxyModel<GroupSummaryItem.Holder>() {
+@EpoxyModelClass
+abstract class GroupSummaryItem : VectorEpoxyModel<GroupSummaryItem.Holder>(R.layout.item_group) {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var matrixItem: MatrixItem

--- a/vector/src/main/java/im/vector/app/features/grouplist/HomeSpaceSummaryItem.kt
+++ b/vector/src/main/java/im/vector/app/features/grouplist/HomeSpaceSummaryItem.kt
@@ -34,8 +34,8 @@ import im.vector.app.core.platform.CheckableConstraintLayout
 import im.vector.app.features.home.room.list.UnreadCounterBadgeView
 import im.vector.app.features.themes.ThemeUtils
 
-@EpoxyModelClass(layout = R.layout.item_space)
-abstract class HomeSpaceSummaryItem : VectorEpoxyModel<HomeSpaceSummaryItem.Holder>() {
+@EpoxyModelClass
+abstract class HomeSpaceSummaryItem : VectorEpoxyModel<HomeSpaceSummaryItem.Holder>(R.layout.item_space) {
 
     @EpoxyAttribute var selected: Boolean = false
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var listener: ClickListener? = null

--- a/vector/src/main/java/im/vector/app/features/home/room/breadcrumbs/BreadcrumbsItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/breadcrumbs/BreadcrumbsItem.kt
@@ -32,8 +32,8 @@ import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.list.UnreadCounterBadgeView
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_breadcrumbs)
-abstract class BreadcrumbsItem : VectorEpoxyModel<BreadcrumbsItem.Holder>() {
+@EpoxyModelClass
+abstract class BreadcrumbsItem : VectorEpoxyModel<BreadcrumbsItem.Holder>(R.layout.item_breadcrumbs) {
 
     @EpoxyAttribute var hasTypingUsers: Boolean = false
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/readreceipts/DisplayReadReceiptItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/readreceipts/DisplayReadReceiptItem.kt
@@ -21,17 +21,17 @@ import android.widget.TextView
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.features.displayname.getBestName
 import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_display_read_receipt)
-abstract class DisplayReadReceiptItem : EpoxyModelWithHolder<DisplayReadReceiptItem.Holder>() {
+@EpoxyModelClass
+abstract class DisplayReadReceiptItem : VectorEpoxyModel<DisplayReadReceiptItem.Holder>(R.layout.item_display_read_receipt) {
 
     @EpoxyAttribute lateinit var matrixItem: MatrixItem
     @EpoxyAttribute var timestamp: String? = null

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchResultItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/search/SearchResultItem.kt
@@ -34,8 +34,8 @@ import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 import org.matrix.android.sdk.api.session.threads.ThreadDetails
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_search_result)
-abstract class SearchResultItem : VectorEpoxyModel<SearchResultItem.Holder>() {
+@EpoxyModelClass
+abstract class SearchResultItem : VectorEpoxyModel<SearchResultItem.Holder>(R.layout.item_search_result) {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute var formattedDate: String? = null

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsBaseMessageItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsBaseMessageItem.kt
@@ -23,6 +23,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.IdRes
+import androidx.annotation.LayoutRes
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.content.ContextCompat.getDrawable
 import androidx.core.view.isVisible
@@ -49,7 +50,7 @@ private const val MAX_REACTIONS_TO_SHOW = 8
  * Manages associated click listeners and send status.
  * Should not be used as this, use a subclass.
  */
-abstract class AbsBaseMessageItem<H : AbsBaseMessageItem.Holder> : BaseEventItem<H>() {
+abstract class AbsBaseMessageItem<H : AbsBaseMessageItem.Holder>(@LayoutRes layoutId: Int) : BaseEventItem<H>(layoutId) {
 
     abstract val baseAttributes: Attributes
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageItem.kt
@@ -43,7 +43,9 @@ import org.matrix.android.sdk.api.util.MatrixItem
  * Base timeline item that adds an optional information bar with the sender avatar, name, time, send state.
  * Adds associated click listeners (on avatar, displayname).
  */
-abstract class AbsMessageItem<H : AbsMessageItem.Holder>(@LayoutRes layoutId: Int) : AbsBaseMessageItem<H>(layoutId) {
+abstract class AbsMessageItem<H : AbsMessageItem.Holder>(
+        @LayoutRes layoutId: Int = R.layout.item_timeline_event_base
+) : AbsBaseMessageItem<H>(layoutId) {
 
     override val baseAttributes: AbsBaseMessageItem.Attributes
         get() = attributes

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageItem.kt
@@ -24,6 +24,7 @@ import android.widget.ProgressBar
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.annotation.IdRes
+import androidx.annotation.LayoutRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
@@ -42,7 +43,7 @@ import org.matrix.android.sdk.api.util.MatrixItem
  * Base timeline item that adds an optional information bar with the sender avatar, name, time, send state.
  * Adds associated click listeners (on avatar, displayname).
  */
-abstract class AbsMessageItem<H : AbsMessageItem.Holder> : AbsBaseMessageItem<H>() {
+abstract class AbsMessageItem<H : AbsMessageItem.Holder>(@LayoutRes layoutId: Int) : AbsBaseMessageItem<H>(layoutId) {
 
     override val baseAttributes: AbsBaseMessageItem.Attributes
         get() = attributes

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
@@ -20,6 +20,7 @@ import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.IdRes
+import androidx.annotation.LayoutRes
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import com.airbnb.epoxy.EpoxyAttribute
@@ -36,7 +37,7 @@ import im.vector.app.features.home.room.detail.timeline.helper.LocationPinProvid
 import im.vector.app.features.home.room.detail.timeline.style.TimelineMessageLayout
 import im.vector.app.features.home.room.detail.timeline.style.granularRoundedCorners
 
-abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder> : AbsMessageItem<H>() {
+abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder>(@LayoutRes layoutId: Int) : AbsMessageItem<H>(layoutId) {
 
     @EpoxyAttribute
     var locationUrl: String? = null

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageLocationItem.kt
@@ -37,7 +37,9 @@ import im.vector.app.features.home.room.detail.timeline.helper.LocationPinProvid
 import im.vector.app.features.home.room.detail.timeline.style.TimelineMessageLayout
 import im.vector.app.features.home.room.detail.timeline.style.granularRoundedCorners
 
-abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder>(@LayoutRes layoutId: Int) : AbsMessageItem<H>(layoutId) {
+abstract class AbsMessageLocationItem<H : AbsMessageLocationItem.Holder>(
+        @LayoutRes layoutId: Int = R.layout.item_timeline_event_base
+) : AbsMessageItem<H>(layoutId) {
 
     @EpoxyAttribute
     var locationUrl: String? = null

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/BaseEventItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/BaseEventItem.kt
@@ -20,6 +20,7 @@ import android.view.ViewStub
 import android.widget.RelativeLayout
 import androidx.annotation.CallSuper
 import androidx.annotation.IdRes
+import androidx.annotation.LayoutRes
 import androidx.core.view.updateLayoutParams
 import com.airbnb.epoxy.EpoxyAttribute
 import im.vector.app.R
@@ -30,7 +31,7 @@ import im.vector.app.core.platform.CheckableView
 /**
  * Children must override getViewType().
  */
-abstract class BaseEventItem<H : BaseEventItem.BaseHolder> : VectorEpoxyModel<H>(), ItemWithEvents {
+abstract class BaseEventItem<H : BaseEventItem.BaseHolder>(@LayoutRes layoutId: Int) : VectorEpoxyModel<H>(layoutId), ItemWithEvents {
 
     // To use for instance when opening a permalink with an eventId
     @EpoxyAttribute

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/BasedMergedItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/BasedMergedItem.kt
@@ -19,11 +19,12 @@ package im.vector.app.features.home.room.detail.timeline.item
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.IdRes
+import androidx.annotation.LayoutRes
 import im.vector.app.R
 import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.util.MatrixItem
 
-abstract class BasedMergedItem<H : BasedMergedItem.Holder> : BaseEventItem<H>() {
+abstract class BasedMergedItem<H : BasedMergedItem.Holder>(@LayoutRes layoutId: Int) : BaseEventItem<H>(layoutId) {
 
     abstract val attributes: Attributes
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/BlankItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/BlankItem.kt
@@ -20,7 +20,7 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_blank_stub)
-abstract class BlankItem : VectorEpoxyModel<BlankItem.BlankHolder>() {
+@EpoxyModelClass
+abstract class BlankItem : VectorEpoxyModel<BlankItem.BlankHolder>(R.layout.item_timeline_event_blank_stub) {
     class BlankHolder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/CallTileTimelineItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/CallTileTimelineItem.kt
@@ -39,8 +39,8 @@ import im.vector.app.features.home.room.detail.timeline.MessageColorProvider
 import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base_state)
-abstract class CallTileTimelineItem : AbsBaseMessageItem<CallTileTimelineItem.Holder>() {
+@EpoxyModelClass
+abstract class CallTileTimelineItem : AbsBaseMessageItem<CallTileTimelineItem.Holder>(R.layout.item_timeline_event_base_state) {
 
     override val baseAttributes: AbsBaseMessageItem.Attributes
         get() = attributes

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/DaySeparatorItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/DaySeparatorItem.kt
@@ -19,12 +19,12 @@ package im.vector.app.features.home.room.detail.timeline.item
 import android.widget.TextView
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_day_separator)
-abstract class DaySeparatorItem : EpoxyModelWithHolder<DaySeparatorItem.Holder>() {
+@EpoxyModelClass
+abstract class DaySeparatorItem : VectorEpoxyModel<DaySeparatorItem.Holder>(R.layout.item_timeline_event_day_separator) {
 
     @EpoxyAttribute lateinit var formattedDay: String
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/DefaultItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/DefaultItem.kt
@@ -24,8 +24,8 @@ import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.features.home.AvatarRenderer
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base_noinfo)
-abstract class DefaultItem : BaseEventItem<DefaultItem.Holder>() {
+@EpoxyModelClass
+abstract class DefaultItem : BaseEventItem<DefaultItem.Holder>(R.layout.item_timeline_event_base_noinfo) {
 
     @EpoxyAttribute
     lateinit var attributes: Attributes

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MergedRoomCreationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MergedRoomCreationItem.kt
@@ -42,8 +42,8 @@ import me.gujun.android.span.span
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 import org.matrix.android.sdk.api.util.toMatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base_noinfo)
-abstract class MergedRoomCreationItem : BasedMergedItem<MergedRoomCreationItem.Holder>() {
+@EpoxyModelClass
+abstract class MergedRoomCreationItem : BasedMergedItem<MergedRoomCreationItem.Holder>(R.layout.item_timeline_event_base_noinfo) {
 
     @EpoxyAttribute
     override lateinit var attributes: Attributes

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MergedSimilarEventsItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MergedSimilarEventsItem.kt
@@ -27,8 +27,8 @@ import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.features.home.AvatarRenderer
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base_noinfo)
-abstract class MergedSimilarEventsItem : BasedMergedItem<MergedSimilarEventsItem.Holder>() {
+@EpoxyModelClass
+abstract class MergedSimilarEventsItem : BasedMergedItem<MergedSimilarEventsItem.Holder>(R.layout.item_timeline_event_base_noinfo) {
 
     override fun getViewStubId() = STUB_ID
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageAudioItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageAudioItem.kt
@@ -38,7 +38,7 @@ import im.vector.app.features.home.room.detail.timeline.style.TimelineMessageLay
 import im.vector.app.features.themes.ThemeUtils
 
 @EpoxyModelClass
-abstract class MessageAudioItem : AbsMessageItem<MessageAudioItem.Holder>(R.layout.item_timeline_event_base) {
+abstract class MessageAudioItem : AbsMessageItem<MessageAudioItem.Holder>() {
 
     @EpoxyAttribute
     var filename: String = ""

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageAudioItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageAudioItem.kt
@@ -37,8 +37,8 @@ import im.vector.app.features.home.room.detail.timeline.helper.ContentUploadStat
 import im.vector.app.features.home.room.detail.timeline.style.TimelineMessageLayout
 import im.vector.app.features.themes.ThemeUtils
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base)
-abstract class MessageAudioItem : AbsMessageItem<MessageAudioItem.Holder>() {
+@EpoxyModelClass
+abstract class MessageAudioItem : AbsMessageItem<MessageAudioItem.Holder>(R.layout.item_timeline_event_base) {
 
     @EpoxyAttribute
     var filename: String = ""

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageFileItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageFileItem.kt
@@ -35,7 +35,7 @@ import im.vector.app.features.home.room.detail.timeline.style.TimelineMessageLay
 import im.vector.app.features.themes.ThemeUtils
 
 @EpoxyModelClass
-abstract class MessageFileItem : AbsMessageItem<MessageFileItem.Holder>(R.layout.item_timeline_event_base) {
+abstract class MessageFileItem : AbsMessageItem<MessageFileItem.Holder>() {
 
     @EpoxyAttribute
     var filename: String = ""

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageFileItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageFileItem.kt
@@ -34,8 +34,8 @@ import im.vector.app.features.home.room.detail.timeline.helper.ContentUploadStat
 import im.vector.app.features.home.room.detail.timeline.style.TimelineMessageLayout
 import im.vector.app.features.themes.ThemeUtils
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base)
-abstract class MessageFileItem : AbsMessageItem<MessageFileItem.Holder>() {
+@EpoxyModelClass
+abstract class MessageFileItem : AbsMessageItem<MessageFileItem.Holder>(R.layout.item_timeline_event_base) {
 
     @EpoxyAttribute
     var filename: String = ""

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageImageVideoItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageImageVideoItem.kt
@@ -36,8 +36,8 @@ import im.vector.app.features.home.room.detail.timeline.style.granularRoundedCor
 import im.vector.app.features.media.ImageContentRenderer
 import org.matrix.android.sdk.api.session.room.model.message.MessageType
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base)
-abstract class MessageImageVideoItem : AbsMessageItem<MessageImageVideoItem.Holder>() {
+@EpoxyModelClass
+abstract class MessageImageVideoItem : AbsMessageItem<MessageImageVideoItem.Holder>(R.layout.item_timeline_event_base) {
 
     @EpoxyAttribute
     lateinit var mediaData: ImageContentRenderer.Data

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageImageVideoItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageImageVideoItem.kt
@@ -37,7 +37,7 @@ import im.vector.app.features.media.ImageContentRenderer
 import org.matrix.android.sdk.api.session.room.model.message.MessageType
 
 @EpoxyModelClass
-abstract class MessageImageVideoItem : AbsMessageItem<MessageImageVideoItem.Holder>(R.layout.item_timeline_event_base) {
+abstract class MessageImageVideoItem : AbsMessageItem<MessageImageVideoItem.Holder>() {
 
     @EpoxyAttribute
     lateinit var mediaData: ImageContentRenderer.Data

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationInactiveItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationInactiveItem.kt
@@ -23,7 +23,7 @@ import im.vector.app.R
 
 @EpoxyModelClass
 abstract class MessageLiveLocationInactiveItem :
-        AbsMessageItem<MessageLiveLocationInactiveItem.Holder>(R.layout.item_timeline_event_base),
+        AbsMessageItem<MessageLiveLocationInactiveItem.Holder>(),
         LiveLocationShareStatusItem by DefaultLiveLocationShareStatusItem() {
 
     @EpoxyAttribute

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationInactiveItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationInactiveItem.kt
@@ -21,9 +21,9 @@ import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base)
+@EpoxyModelClass
 abstract class MessageLiveLocationInactiveItem :
-        AbsMessageItem<MessageLiveLocationInactiveItem.Holder>(),
+        AbsMessageItem<MessageLiveLocationInactiveItem.Holder>(R.layout.item_timeline_event_base),
         LiveLocationShareStatusItem by DefaultLiveLocationShareStatusItem() {
 
     @EpoxyAttribute

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationItem.kt
@@ -30,8 +30,8 @@ import im.vector.app.features.location.live.LocationLiveMessageBannerView
 import im.vector.app.features.location.live.LocationLiveMessageBannerViewState
 import org.threeten.bp.LocalDateTime
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base)
-abstract class MessageLiveLocationItem : AbsMessageLocationItem<MessageLiveLocationItem.Holder>() {
+@EpoxyModelClass
+abstract class MessageLiveLocationItem : AbsMessageLocationItem<MessageLiveLocationItem.Holder>(R.layout.item_timeline_event_base) {
 
     @EpoxyAttribute
     var currentUserId: String? = null

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationItem.kt
@@ -31,7 +31,7 @@ import im.vector.app.features.location.live.LocationLiveMessageBannerViewState
 import org.threeten.bp.LocalDateTime
 
 @EpoxyModelClass
-abstract class MessageLiveLocationItem : AbsMessageLocationItem<MessageLiveLocationItem.Holder>(R.layout.item_timeline_event_base) {
+abstract class MessageLiveLocationItem : AbsMessageLocationItem<MessageLiveLocationItem.Holder>() {
 
     @EpoxyAttribute
     var currentUserId: String? = null

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationStartItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationStartItem.kt
@@ -21,9 +21,9 @@ import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base)
+@EpoxyModelClass
 abstract class MessageLiveLocationStartItem :
-        AbsMessageItem<MessageLiveLocationStartItem.Holder>(),
+        AbsMessageItem<MessageLiveLocationStartItem.Holder>(R.layout.item_timeline_event_base),
         LiveLocationShareStatusItem by DefaultLiveLocationShareStatusItem() {
 
     @EpoxyAttribute

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationStartItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLiveLocationStartItem.kt
@@ -23,7 +23,7 @@ import im.vector.app.R
 
 @EpoxyModelClass
 abstract class MessageLiveLocationStartItem :
-        AbsMessageItem<MessageLiveLocationStartItem.Holder>(R.layout.item_timeline_event_base),
+        AbsMessageItem<MessageLiveLocationStartItem.Holder>(),
         LiveLocationShareStatusItem by DefaultLiveLocationShareStatusItem() {
 
     @EpoxyAttribute

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLocationItem.kt
@@ -19,8 +19,8 @@ package im.vector.app.features.home.room.detail.timeline.item
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base)
-abstract class MessageLocationItem : AbsMessageLocationItem<MessageLocationItem.Holder>() {
+@EpoxyModelClass
+abstract class MessageLocationItem : AbsMessageLocationItem<MessageLocationItem.Holder>(R.layout.item_timeline_event_base) {
 
     override fun getViewStubId() = STUB_ID
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLocationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageLocationItem.kt
@@ -20,7 +20,7 @@ import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 
 @EpoxyModelClass
-abstract class MessageLocationItem : AbsMessageLocationItem<MessageLocationItem.Holder>(R.layout.item_timeline_event_base) {
+abstract class MessageLocationItem : AbsMessageLocationItem<MessageLocationItem.Holder>() {
 
     override fun getViewStubId() = STUB_ID
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -37,8 +37,8 @@ import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 import io.noties.markwon.MarkwonPlugin
 import org.matrix.android.sdk.api.extensions.orFalse
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base)
-abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
+@EpoxyModelClass
+abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>(R.layout.item_timeline_event_base) {
 
     @EpoxyAttribute
     var searchForPills: Boolean = false

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -38,7 +38,7 @@ import io.noties.markwon.MarkwonPlugin
 import org.matrix.android.sdk.api.extensions.orFalse
 
 @EpoxyModelClass
-abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>(R.layout.item_timeline_event_base) {
+abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
 
     @EpoxyAttribute
     var searchForPills: Boolean = false

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceItem.kt
@@ -37,8 +37,8 @@ import im.vector.app.features.home.room.detail.timeline.style.TimelineMessageLay
 import im.vector.app.features.themes.ThemeUtils
 import im.vector.app.features.voice.AudioWaveformView
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base)
-abstract class MessageVoiceItem : AbsMessageItem<MessageVoiceItem.Holder>() {
+@EpoxyModelClass
+abstract class MessageVoiceItem : AbsMessageItem<MessageVoiceItem.Holder>(R.layout.item_timeline_event_base) {
 
     interface WaveformTouchListener {
         fun onWaveformTouchedUp(percentage: Float)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceItem.kt
@@ -38,7 +38,7 @@ import im.vector.app.features.themes.ThemeUtils
 import im.vector.app.features.voice.AudioWaveformView
 
 @EpoxyModelClass
-abstract class MessageVoiceItem : AbsMessageItem<MessageVoiceItem.Holder>(R.layout.item_timeline_event_base) {
+abstract class MessageVoiceItem : AbsMessageItem<MessageVoiceItem.Holder>() {
 
     interface WaveformTouchListener {
         fun onWaveformTouchedUp(percentage: Float)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/NoticeItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/NoticeItem.kt
@@ -30,8 +30,8 @@ import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base_noinfo)
-abstract class NoticeItem : BaseEventItem<NoticeItem.Holder>() {
+@EpoxyModelClass
+abstract class NoticeItem : BaseEventItem<NoticeItem.Holder>(R.layout.item_timeline_event_base_noinfo) {
 
     @EpoxyAttribute
     lateinit var attributes: Attributes

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/PollItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/PollItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.features.home.room.detail.RoomDetailAction
 import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base)
-abstract class PollItem : AbsMessageItem<PollItem.Holder>() {
+@EpoxyModelClass
+abstract class PollItem : AbsMessageItem<PollItem.Holder>(R.layout.item_timeline_event_base) {
 
     @EpoxyAttribute
     var pollQuestion: EpoxyCharSequence? = null

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/PollItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/PollItem.kt
@@ -27,7 +27,7 @@ import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 
 @EpoxyModelClass
-abstract class PollItem : AbsMessageItem<PollItem.Holder>(R.layout.item_timeline_event_base) {
+abstract class PollItem : AbsMessageItem<PollItem.Holder>() {
 
     @EpoxyAttribute
     var pollQuestion: EpoxyCharSequence? = null

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/ReadReceiptsItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/ReadReceiptsItem.kt
@@ -19,16 +19,16 @@ package im.vector.app.features.home.room.detail.timeline.item
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.ui.views.ReadReceiptsView
 import im.vector.app.features.home.AvatarRenderer
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_read_receipts)
-abstract class ReadReceiptsItem : EpoxyModelWithHolder<ReadReceiptsItem.Holder>(), ItemWithEvents {
+@EpoxyModelClass
+abstract class ReadReceiptsItem : VectorEpoxyModel<ReadReceiptsItem.Holder>(R.layout.item_timeline_event_read_receipts), ItemWithEvents {
 
     @EpoxyAttribute lateinit var eventId: String
     @EpoxyAttribute lateinit var readReceipts: List<ReadReceiptData>

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/RedactedMessageItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/RedactedMessageItem.kt
@@ -19,8 +19,8 @@ package im.vector.app.features.home.room.detail.timeline.item
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base)
-abstract class RedactedMessageItem : AbsMessageItem<RedactedMessageItem.Holder>() {
+@EpoxyModelClass
+abstract class RedactedMessageItem : AbsMessageItem<RedactedMessageItem.Holder>(R.layout.item_timeline_event_base) {
 
     override fun getViewStubId() = STUB_ID
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/RedactedMessageItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/RedactedMessageItem.kt
@@ -20,7 +20,7 @@ import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 
 @EpoxyModelClass
-abstract class RedactedMessageItem : AbsMessageItem<RedactedMessageItem.Holder>(R.layout.item_timeline_event_base) {
+abstract class RedactedMessageItem : AbsMessageItem<RedactedMessageItem.Holder>() {
 
     override fun getViewStubId() = STUB_ID
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/RoomCreateItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/RoomCreateItem.kt
@@ -25,8 +25,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 import me.saket.bettermovementmethod.BetterLinkMovementMethod
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_create)
-abstract class RoomCreateItem : VectorEpoxyModel<RoomCreateItem.Holder>() {
+@EpoxyModelClass
+abstract class RoomCreateItem : VectorEpoxyModel<RoomCreateItem.Holder>(R.layout.item_timeline_event_create) {
 
     @EpoxyAttribute lateinit var text: EpoxyCharSequence
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/StatusTileTimelineItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/StatusTileTimelineItem.kt
@@ -31,8 +31,8 @@ import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.detail.timeline.MessageColorProvider
 import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base_state)
-abstract class StatusTileTimelineItem : AbsBaseMessageItem<StatusTileTimelineItem.Holder>() {
+@EpoxyModelClass
+abstract class StatusTileTimelineItem : AbsBaseMessageItem<StatusTileTimelineItem.Holder>(R.layout.item_timeline_event_base_state) {
 
     override val baseAttributes: AbsBaseMessageItem.Attributes
         get() = attributes

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/TimelineReadMarkerItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/TimelineReadMarkerItem.kt
@@ -21,8 +21,8 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_timeline_read_marker)
-abstract class TimelineReadMarkerItem : VectorEpoxyModel<TimelineReadMarkerItem.Holder>() {
+@EpoxyModelClass
+abstract class TimelineReadMarkerItem : VectorEpoxyModel<TimelineReadMarkerItem.Holder>(R.layout.item_timeline_read_marker) {
 
     class Holder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/VerificationRequestItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/VerificationRequestItem.kt
@@ -39,8 +39,8 @@ import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 import org.matrix.android.sdk.api.session.crypto.verification.VerificationService
 import org.matrix.android.sdk.api.session.crypto.verification.VerificationState
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base_state)
-abstract class VerificationRequestItem : AbsBaseMessageItem<VerificationRequestItem.Holder>() {
+@EpoxyModelClass
+abstract class VerificationRequestItem : AbsBaseMessageItem<VerificationRequestItem.Holder>(R.layout.item_timeline_event_base_state) {
 
     override val baseAttributes: AbsBaseMessageItem.Attributes
         get() = attributes

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/WidgetTileTimelineItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/WidgetTileTimelineItem.kt
@@ -32,8 +32,8 @@ import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.detail.timeline.MessageColorProvider
 import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 
-@EpoxyModelClass(layout = R.layout.item_timeline_event_base_state)
-abstract class WidgetTileTimelineItem : AbsBaseMessageItem<WidgetTileTimelineItem.Holder>() {
+@EpoxyModelClass
+abstract class WidgetTileTimelineItem : AbsBaseMessageItem<WidgetTileTimelineItem.Holder>(R.layout.item_timeline_event_base_state) {
 
     override val baseAttributes: AbsBaseMessageItem.Attributes
         get() = attributes

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/reactions/ReactionInfoSimpleItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/reactions/ReactionInfoSimpleItem.kt
@@ -20,18 +20,18 @@ import android.widget.TextView
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 
 /**
  * Item displaying an emoji reaction (single line with emoji, author, time).
  */
-@EpoxyModelClass(layout = R.layout.item_simple_reaction_info)
-abstract class ReactionInfoSimpleItem : EpoxyModelWithHolder<ReactionInfoSimpleItem.Holder>() {
+@EpoxyModelClass
+abstract class ReactionInfoSimpleItem : VectorEpoxyModel<ReactionInfoSimpleItem.Holder>(R.layout.item_simple_reaction_info) {
 
     @EpoxyAttribute
     lateinit var reactionKey: EpoxyCharSequence

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/widget/RoomWidgetItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/widget/RoomWidgetItem.kt
@@ -22,7 +22,6 @@ import androidx.annotation.DrawableRes
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/widget/RoomWidgetItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/widget/RoomWidgetItem.kt
@@ -26,13 +26,14 @@ import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.widgets.model.Widget
 import java.net.URL
 
-@EpoxyModelClass(layout = R.layout.item_room_widget)
-abstract class RoomWidgetItem : EpoxyModelWithHolder<RoomWidgetItem.Holder>() {
+@EpoxyModelClass
+abstract class RoomWidgetItem : VectorEpoxyModel<RoomWidgetItem.Holder>(R.layout.item_room_widget) {
 
     @EpoxyAttribute lateinit var widget: Widget
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var widgetClicked: ClickListener? = null

--- a/vector/src/main/java/im/vector/app/features/home/room/filtered/FilteredRoomFooterItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/filtered/FilteredRoomFooterItem.kt
@@ -25,8 +25,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 
-@EpoxyModelClass(layout = R.layout.item_room_filter_footer)
-abstract class FilteredRoomFooterItem : VectorEpoxyModel<FilteredRoomFooterItem.Holder>() {
+@EpoxyModelClass
+abstract class FilteredRoomFooterItem : VectorEpoxyModel<FilteredRoomFooterItem.Holder>(R.layout.item_room_filter_footer) {
 
     @EpoxyAttribute
     var listener: Listener? = null

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomCategoryItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomCategoryItem.kt
@@ -29,8 +29,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.features.themes.ThemeUtils
 
-@EpoxyModelClass(layout = R.layout.item_room_category)
-abstract class RoomCategoryItem : VectorEpoxyModel<RoomCategoryItem.Holder>() {
+@EpoxyModelClass
+abstract class RoomCategoryItem : VectorEpoxyModel<RoomCategoryItem.Holder>(R.layout.item_room_category) {
 
     @EpoxyAttribute lateinit var title: String
     @EpoxyAttribute var itemCount: Int = 0

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomInvitationItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomInvitationItem.kt
@@ -34,8 +34,8 @@ import im.vector.app.features.invite.InviteButtonStateBinder
 import org.matrix.android.sdk.api.session.room.members.ChangeMembershipState
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_room_invitation)
-abstract class RoomInvitationItem : VectorEpoxyModel<RoomInvitationItem.Holder>() {
+@EpoxyModelClass
+abstract class RoomInvitationItem : VectorEpoxyModel<RoomInvitationItem.Holder>(R.layout.item_room_invitation) {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var matrixItem: MatrixItem

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItem.kt
@@ -43,8 +43,8 @@ import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel
 import org.matrix.android.sdk.api.session.presence.model.UserPresence
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_room)
-abstract class RoomSummaryItem : VectorEpoxyModel<RoomSummaryItem.Holder>() {
+@EpoxyModelClass
+abstract class RoomSummaryItem : VectorEpoxyModel<RoomSummaryItem.Holder>(R.layout.item_room) {
 
     @EpoxyAttribute
     lateinit var typingMessage: String

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemCentered.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemCentered.kt
@@ -40,8 +40,8 @@ import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel
 import org.matrix.android.sdk.api.session.presence.model.UserPresence
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_room_centered)
-abstract class RoomSummaryItemCentered : VectorEpoxyModel<RoomSummaryItemCentered.Holder>() {
+@EpoxyModelClass
+abstract class RoomSummaryItemCentered : VectorEpoxyModel<RoomSummaryItemCentered.Holder>(R.layout.item_room_centered) {
 
     @EpoxyAttribute
     lateinit var avatarRenderer: AvatarRenderer

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemPlaceHolder.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemPlaceHolder.kt
@@ -21,7 +21,7 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_room_placeholder)
-abstract class RoomSummaryItemPlaceHolder : VectorEpoxyModel<RoomSummaryItemPlaceHolder.Holder>() {
+@EpoxyModelClass
+abstract class RoomSummaryItemPlaceHolder : VectorEpoxyModel<RoomSummaryItemPlaceHolder.Holder>(R.layout.item_room_placeholder) {
     class Holder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/SpaceChildInfoItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/SpaceChildInfoItem.kt
@@ -40,8 +40,8 @@ import me.gujun.android.span.image
 import me.gujun.android.span.span
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_explore_space_child)
-abstract class SpaceChildInfoItem : VectorEpoxyModel<SpaceChildInfoItem.Holder>() {
+@EpoxyModelClass
+abstract class SpaceChildInfoItem : VectorEpoxyModel<SpaceChildInfoItem.Holder>(R.layout.item_explore_space_child) {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var matrixItem: MatrixItem

--- a/vector/src/main/java/im/vector/app/features/home/room/list/SpaceDirectoryFilterNoResults.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/SpaceDirectoryFilterNoResults.kt
@@ -21,7 +21,7 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_space_directory_filter_no_results)
-abstract class SpaceDirectoryFilterNoResults : VectorEpoxyModel<SpaceDirectoryFilterNoResults.Holder>() {
+@EpoxyModelClass
+abstract class SpaceDirectoryFilterNoResults : VectorEpoxyModel<SpaceDirectoryFilterNoResults.Holder>(R.layout.item_space_directory_filter_no_results) {
     class Holder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/threads/list/model/ThreadListItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/threads/list/model/ThreadListItem.kt
@@ -37,8 +37,8 @@ import im.vector.app.features.themes.ThemeUtils
 import org.matrix.android.sdk.api.session.threads.ThreadNotificationState
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_thread)
-abstract class ThreadListItem : VectorEpoxyModel<ThreadListItem.Holder>() {
+@EpoxyModelClass
+abstract class ThreadListItem : VectorEpoxyModel<ThreadListItem.Holder>(R.layout.item_thread) {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var matrixItem: MatrixItem

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationBottomSheetController.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationBottomSheetController.kt
@@ -26,8 +26,6 @@ import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.resources.toTimestamp
 import im.vector.app.core.time.Clock
 import im.vector.app.features.home.AvatarRenderer
-import im.vector.app.features.location.live.map.bottomsheet.LiveLocationUserItem
-import im.vector.app.features.location.live.map.bottomsheet.liveLocationUserItem
 import javax.inject.Inject
 
 class LiveLocationBottomSheetController @Inject constructor(

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationUserItem.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationUserItem.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.location.live.map.bottomsheet
+package im.vector.app.features.location.live.map
 
 import android.widget.Button
 import android.widget.ImageView
@@ -34,8 +34,8 @@ import im.vector.lib.core.utils.timer.CountUpTimer
 import org.matrix.android.sdk.api.util.MatrixItem
 import org.threeten.bp.Duration
 
-@EpoxyModelClass(layout = R.layout.item_live_location_users_bottom_sheet)
-abstract class LiveLocationUserItem : VectorEpoxyModel<LiveLocationUserItem.Holder>() {
+@EpoxyModelClass
+abstract class LiveLocationUserItem : VectorEpoxyModel<LiveLocationUserItem.Holder>(R.layout.item_live_location_users_bottom_sheet) {
 
     interface Callback {
         fun onUserSelected(userId: String)

--- a/vector/src/main/java/im/vector/app/features/login/terms/PolicyItem.kt
+++ b/vector/src/main/java/im/vector/app/features/login/terms/PolicyItem.kt
@@ -28,7 +28,7 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setHorizontalPadding
 
-@EpoxyModelClass(layout = R.layout.item_policy)
+@EpoxyModelClass
 abstract class PolicyItem : EpoxyModelWithHolder<PolicyItem.Holder>() {
     @EpoxyAttribute
     var checked: Boolean = false
@@ -47,6 +47,8 @@ abstract class PolicyItem : EpoxyModelWithHolder<PolicyItem.Holder>() {
 
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
     var clickListener: ClickListener? = null
+
+    override fun getDefaultLayout() = R.layout.item_policy
 
     override fun bind(holder: Holder) {
         super.bind(holder)

--- a/vector/src/main/java/im/vector/app/features/login/terms/PolicyItem.kt
+++ b/vector/src/main/java/im/vector/app/features/login/terms/PolicyItem.kt
@@ -21,15 +21,15 @@ import android.widget.CompoundButton
 import android.widget.TextView
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setHorizontalPadding
 
 @EpoxyModelClass
-abstract class PolicyItem : EpoxyModelWithHolder<PolicyItem.Holder>() {
+abstract class PolicyItem : VectorEpoxyModel<PolicyItem.Holder>(R.layout.item_policy) {
     @EpoxyAttribute
     var checked: Boolean = false
 
@@ -47,8 +47,6 @@ abstract class PolicyItem : EpoxyModelWithHolder<PolicyItem.Holder>() {
 
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
     var clickListener: ClickListener? = null
-
-    override fun getDefaultLayout() = R.layout.item_policy
 
     override fun bind(holder: Holder) {
         super.bind(holder)

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/SplashCarouselItem.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/SplashCarouselItem.kt
@@ -24,8 +24,8 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_splash_carousel)
-abstract class SplashCarouselItem : VectorEpoxyModel<SplashCarouselItem.Holder>() {
+@EpoxyModelClass
+abstract class SplashCarouselItem : VectorEpoxyModel<SplashCarouselItem.Holder>(R.layout.item_splash_carousel) {
 
     @EpoxyAttribute
     lateinit var item: SplashCarouselState.Item

--- a/vector/src/main/java/im/vector/app/features/poll/create/PollTypeSelectionItem.kt
+++ b/vector/src/main/java/im/vector/app/features/poll/create/PollTypeSelectionItem.kt
@@ -24,8 +24,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import org.matrix.android.sdk.api.session.room.model.message.PollType
 
-@EpoxyModelClass(layout = R.layout.item_poll_type_selection)
-abstract class PollTypeSelectionItem : VectorEpoxyModel<PollTypeSelectionItem.Holder>() {
+@EpoxyModelClass
+abstract class PollTypeSelectionItem : VectorEpoxyModel<PollTypeSelectionItem.Holder>(R.layout.item_poll_type_selection) {
 
     @EpoxyAttribute
     var pollType: PollType = PollType.DISCLOSED_UNSTABLE

--- a/vector/src/main/java/im/vector/app/features/reactions/EmojiSearchResultItem.kt
+++ b/vector/src/main/java/im/vector/app/features/reactions/EmojiSearchResultItem.kt
@@ -23,12 +23,13 @@ import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 import im.vector.app.features.reactions.data.EmojiItem
 
-@EpoxyModelClass(layout = R.layout.item_emoji_result)
-abstract class EmojiSearchResultItem : EpoxyModelWithHolder<EmojiSearchResultItem.Holder>() {
+@EpoxyModelClass
+abstract class EmojiSearchResultItem : VectorEpoxyModel<EmojiSearchResultItem.Holder>(R.layout.item_emoji_result) {
 
     @EpoxyAttribute
     lateinit var emojiItem: EmojiItem

--- a/vector/src/main/java/im/vector/app/features/reactions/EmojiSearchResultItem.kt
+++ b/vector/src/main/java/im/vector/app/features/reactions/EmojiSearchResultItem.kt
@@ -19,7 +19,6 @@ import android.graphics.Typeface
 import android.widget.TextView
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/PublicRoomItem.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/PublicRoomItem.kt
@@ -31,8 +31,8 @@ import im.vector.app.core.platform.ButtonStateView
 import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_public_room)
-abstract class PublicRoomItem : VectorEpoxyModel<PublicRoomItem.Holder>() {
+@EpoxyModelClass
+abstract class PublicRoomItem : VectorEpoxyModel<PublicRoomItem.Holder>(R.layout.item_public_room) {
 
     @EpoxyAttribute
     lateinit var avatarRenderer: AvatarRenderer

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/UnknownRoomItem.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/UnknownRoomItem.kt
@@ -29,8 +29,8 @@ import im.vector.app.core.epoxy.onClick
 import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_unknown_room)
-abstract class UnknownRoomItem : VectorEpoxyModel<UnknownRoomItem.Holder>() {
+@EpoxyModelClass
+abstract class UnknownRoomItem : VectorEpoxyModel<UnknownRoomItem.Holder>(R.layout.item_unknown_room) {
 
     @EpoxyAttribute
     lateinit var avatarRenderer: AvatarRenderer

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/picker/RoomDirectoryItem.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/picker/RoomDirectoryItem.kt
@@ -32,8 +32,8 @@ import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 import im.vector.app.core.glide.GlideApp
 
-@EpoxyModelClass(layout = R.layout.item_room_directory)
-abstract class RoomDirectoryItem : VectorEpoxyModel<RoomDirectoryItem.Holder>() {
+@EpoxyModelClass
+abstract class RoomDirectoryItem : VectorEpoxyModel<RoomDirectoryItem.Holder>(R.layout.item_room_directory) {
 
     @EpoxyAttribute
     var directoryAvatarUrl: String? = null

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/picker/RoomDirectoryServerItem.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/picker/RoomDirectoryServerItem.kt
@@ -28,8 +28,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_room_directory_server)
-abstract class RoomDirectoryServerItem : VectorEpoxyModel<RoomDirectoryServerItem.Holder>() {
+@EpoxyModelClass
+abstract class RoomDirectoryServerItem : VectorEpoxyModel<RoomDirectoryServerItem.Holder>(R.layout.item_room_directory_server) {
 
     @EpoxyAttribute
     var serverName: String? = null

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/joinrule/SpaceJoinRuleItem.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/joinrule/SpaceJoinRuleItem.kt
@@ -33,8 +33,8 @@ import im.vector.app.core.utils.DebouncedClickListener
 import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_bottom_sheet_joinrule_restricted)
-abstract class SpaceJoinRuleItem : VectorEpoxyModel<SpaceJoinRuleItem.Holder>() {
+@EpoxyModelClass
+abstract class SpaceJoinRuleItem : VectorEpoxyModel<SpaceJoinRuleItem.Holder>(R.layout.item_bottom_sheet_joinrule_restricted) {
 
     @EpoxyAttribute
     var selected: Boolean = false

--- a/vector/src/main/java/im/vector/app/features/roomprofile/uploads/files/UploadsFileItem.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/uploads/files/UploadsFileItem.kt
@@ -25,8 +25,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_uploads_file)
-abstract class UploadsFileItem : VectorEpoxyModel<UploadsFileItem.Holder>() {
+@EpoxyModelClass
+abstract class UploadsFileItem : VectorEpoxyModel<UploadsFileItem.Holder>(R.layout.item_uploads_file) {
 
     @EpoxyAttribute var title: String? = null
     @EpoxyAttribute var subtitle: String? = null

--- a/vector/src/main/java/im/vector/app/features/roomprofile/uploads/media/UploadsImageItem.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/uploads/media/UploadsImageItem.kt
@@ -27,8 +27,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.features.media.ImageContentRenderer
 
-@EpoxyModelClass(layout = R.layout.item_uploads_image)
-abstract class UploadsImageItem : VectorEpoxyModel<UploadsImageItem.Holder>() {
+@EpoxyModelClass
+abstract class UploadsImageItem : VectorEpoxyModel<UploadsImageItem.Holder>(R.layout.item_uploads_image) {
 
     @EpoxyAttribute lateinit var imageContentRenderer: ImageContentRenderer
     @EpoxyAttribute lateinit var data: ImageContentRenderer.Data

--- a/vector/src/main/java/im/vector/app/features/roomprofile/uploads/media/UploadsVideoItem.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/uploads/media/UploadsVideoItem.kt
@@ -28,8 +28,8 @@ import im.vector.app.core.epoxy.onClick
 import im.vector.app.features.media.ImageContentRenderer
 import im.vector.app.features.media.VideoContentRenderer
 
-@EpoxyModelClass(layout = R.layout.item_uploads_video)
-abstract class UploadsVideoItem : VectorEpoxyModel<UploadsVideoItem.Holder>() {
+@EpoxyModelClass
+abstract class UploadsVideoItem : VectorEpoxyModel<UploadsVideoItem.Holder>(R.layout.item_uploads_video) {
 
     @EpoxyAttribute lateinit var imageContentRenderer: ImageContentRenderer
     @EpoxyAttribute lateinit var data: VideoContentRenderer.Data

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceItem.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceItem.kt
@@ -37,8 +37,8 @@ import org.matrix.android.sdk.api.session.crypto.model.DeviceInfo
 /**
  * A list item for Device.
  */
-@EpoxyModelClass(layout = R.layout.item_device)
-abstract class DeviceItem : VectorEpoxyModel<DeviceItem.Holder>() {
+@EpoxyModelClass
+abstract class DeviceItem : VectorEpoxyModel<DeviceItem.Holder>(R.layout.item_device) {
 
     @EpoxyAttribute
     lateinit var deviceInfo: DeviceInfo

--- a/vector/src/main/java/im/vector/app/features/settings/ignored/UserItem.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/ignored/UserItem.kt
@@ -32,8 +32,8 @@ import org.matrix.android.sdk.api.util.MatrixItem
 /**
  * A list item for User.
  */
-@EpoxyModelClass(layout = R.layout.item_user)
-abstract class UserItem : VectorEpoxyModel<UserItem.Holder>() {
+@EpoxyModelClass
+abstract class UserItem : VectorEpoxyModel<UserItem.Holder>(R.layout.item_user) {
 
     @EpoxyAttribute
     lateinit var avatarRenderer: AvatarRenderer

--- a/vector/src/main/java/im/vector/app/features/settings/locale/LocaleItem.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/locale/LocaleItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_locale)
-abstract class LocaleItem : VectorEpoxyModel<LocaleItem.Holder>() {
+@EpoxyModelClass
+abstract class LocaleItem : VectorEpoxyModel<LocaleItem.Holder>(R.layout.item_locale) {
 
     @EpoxyAttribute var title: String? = null
     @EpoxyAttribute var subtitle: String? = null

--- a/vector/src/main/java/im/vector/app/features/settings/push/PushGatewayItem.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/push/PushGatewayItem.kt
@@ -20,14 +20,14 @@ import android.view.View
 import android.widget.TextView
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.extensions.setTextOrHide
 import org.matrix.android.sdk.api.session.pushers.Pusher
 
-@EpoxyModelClass(layout = R.layout.item_pushgateway)
-abstract class PushGatewayItem : EpoxyModelWithHolder<PushGatewayItem.Holder>() {
+@EpoxyModelClass
+abstract class PushGatewayItem : VectorEpoxyModel<PushGatewayItem.Holder>(R.layout.item_pushgateway) {
 
     @EpoxyAttribute
     lateinit var pusher: Pusher

--- a/vector/src/main/java/im/vector/app/features/settings/push/PushRuleItem.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/push/PushRuleItem.kt
@@ -25,16 +25,16 @@ import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.features.notifications.toNotificationAction
 import im.vector.app.features.themes.ThemeUtils
 import org.matrix.android.sdk.api.session.pushrules.getActions
 import org.matrix.android.sdk.api.session.pushrules.rest.PushRule
 
-@EpoxyModelClass(layout = R.layout.item_pushrule_raw)
-abstract class PushRuleItem : EpoxyModelWithHolder<PushRuleItem.Holder>() {
+@EpoxyModelClass
+abstract class PushRuleItem : VectorEpoxyModel<PushRuleItem.Holder>(R.layout.item_pushrule_raw) {
 
     @EpoxyAttribute
     lateinit var pushRule: PushRule

--- a/vector/src/main/java/im/vector/app/features/settings/threepids/ThreePidItem.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/threepids/ThreePidItem.kt
@@ -22,14 +22,14 @@ import androidx.annotation.DrawableRes
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 
-@EpoxyModelClass(layout = R.layout.item_settings_three_pid)
-abstract class ThreePidItem : EpoxyModelWithHolder<ThreePidItem.Holder>() {
+@EpoxyModelClass
+abstract class ThreePidItem : VectorEpoxyModel<ThreePidItem.Holder>(R.layout.item_settings_three_pid) {
 
     @EpoxyAttribute
     var title: String? = null

--- a/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginCenterButtonItem.kt
+++ b/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginCenterButtonItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_login_centered_button)
-abstract class LoginCenterButtonItem : VectorEpoxyModel<LoginCenterButtonItem.Holder>() {
+@EpoxyModelClass
+abstract class LoginCenterButtonItem : VectorEpoxyModel<LoginCenterButtonItem.Holder>(R.layout.item_login_centered_button) {
 
     @EpoxyAttribute var text: String? = null
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var listener: ClickListener? = null

--- a/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginErrorWithRetryItem.kt
+++ b/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginErrorWithRetryItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 
-@EpoxyModelClass(layout = R.layout.item_login_error_retry)
-abstract class LoginErrorWithRetryItem : VectorEpoxyModel<LoginErrorWithRetryItem.Holder>() {
+@EpoxyModelClass
+abstract class LoginErrorWithRetryItem : VectorEpoxyModel<LoginErrorWithRetryItem.Holder>(R.layout.item_login_error_retry) {
 
     @EpoxyAttribute
     var text: String? = null

--- a/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginHeaderItem.kt
+++ b/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginHeaderItem.kt
@@ -21,7 +21,7 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_login_header)
-abstract class LoginHeaderItem : VectorEpoxyModel<LoginHeaderItem.Holder>() {
+@EpoxyModelClass
+abstract class LoginHeaderItem : VectorEpoxyModel<LoginHeaderItem.Holder>(R.layout.item_login_header) {
     class Holder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginPasswordFormItem.kt
+++ b/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginPasswordFormItem.kt
@@ -35,8 +35,8 @@ import im.vector.app.core.epoxy.setValueOnce
 import im.vector.app.core.platform.SimpleTextWatcher
 import im.vector.app.core.resources.StringProvider
 
-@EpoxyModelClass(layout = R.layout.item_login_password_form)
-abstract class LoginPasswordFormItem : VectorEpoxyModel<LoginPasswordFormItem.Holder>() {
+@EpoxyModelClass
+abstract class LoginPasswordFormItem : VectorEpoxyModel<LoginPasswordFormItem.Holder>(R.layout.item_login_password_form) {
 
     @EpoxyAttribute var passwordValue: String = ""
     @EpoxyAttribute var submitEnabled: Boolean = false

--- a/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginRedButtonItem.kt
+++ b/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginRedButtonItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_login_red_button)
-abstract class LoginRedButtonItem : VectorEpoxyModel<LoginRedButtonItem.Holder>() {
+@EpoxyModelClass
+abstract class LoginRedButtonItem : VectorEpoxyModel<LoginRedButtonItem.Holder>(R.layout.item_login_red_button) {
 
     @EpoxyAttribute var text: String? = null
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var listener: ClickListener? = null

--- a/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginTextItem.kt
@@ -24,8 +24,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_login_text)
-abstract class LoginTextItem : VectorEpoxyModel<LoginTextItem.Holder>() {
+@EpoxyModelClass
+abstract class LoginTextItem : VectorEpoxyModel<LoginTextItem.Holder>(R.layout.item_login_text) {
 
     @EpoxyAttribute var text: String? = null
 

--- a/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginTitleItem.kt
+++ b/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginTitleItem.kt
@@ -24,8 +24,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_login_title)
-abstract class LoginTitleItem : VectorEpoxyModel<LoginTitleItem.Holder>() {
+@EpoxyModelClass
+abstract class LoginTitleItem : VectorEpoxyModel<LoginTitleItem.Holder>(R.layout.item_login_title) {
 
     @EpoxyAttribute var text: String? = null
 

--- a/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginTitleSmallItem.kt
+++ b/vector/src/main/java/im/vector/app/features/signout/soft/epoxy/LoginTitleSmallItem.kt
@@ -24,8 +24,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_login_title_small)
-abstract class LoginTitleSmallItem : VectorEpoxyModel<LoginTitleSmallItem.Holder>() {
+@EpoxyModelClass
+abstract class LoginTitleSmallItem : VectorEpoxyModel<LoginTitleSmallItem.Holder>(R.layout.item_login_title_small) {
 
     @EpoxyAttribute var text: String? = null
 

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceAddItem.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceAddItem.kt
@@ -24,8 +24,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 
-@EpoxyModelClass(layout = R.layout.item_space_add)
-abstract class SpaceAddItem : VectorEpoxyModel<SpaceAddItem.Holder>() {
+@EpoxyModelClass
+abstract class SpaceAddItem : VectorEpoxyModel<SpaceAddItem.Holder>(R.layout.item_space_add) {
 
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var listener: ClickListener? = null
 

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceBetaHeaderItem.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceBetaHeaderItem.kt
@@ -21,7 +21,7 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_space_beta_header)
-abstract class SpaceBetaHeaderItem : VectorEpoxyModel<SpaceBetaHeaderItem.Holder>() {
+@EpoxyModelClass
+abstract class SpaceBetaHeaderItem : VectorEpoxyModel<SpaceBetaHeaderItem.Holder>(R.layout.item_space_beta_header) {
     class Holder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryItem.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceSummaryItem.kt
@@ -36,8 +36,8 @@ import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.list.UnreadCounterBadgeView
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_space)
-abstract class SpaceSummaryItem : VectorEpoxyModel<SpaceSummaryItem.Holder>() {
+@EpoxyModelClass
+abstract class SpaceSummaryItem : VectorEpoxyModel<SpaceSummaryItem.Holder>(R.layout.item_space) {
 
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var matrixItem: MatrixItem

--- a/vector/src/main/java/im/vector/app/features/spaces/SubSpaceSummaryItem.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SubSpaceSummaryItem.kt
@@ -34,8 +34,8 @@ import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.list.UnreadCounterBadgeView
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_sub_space)
-abstract class SubSpaceSummaryItem : VectorEpoxyModel<SubSpaceSummaryItem.Holder>() {
+@EpoxyModelClass
+abstract class SubSpaceSummaryItem : VectorEpoxyModel<SubSpaceSummaryItem.Holder>(R.layout.item_sub_space) {
 
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var matrixItem: MatrixItem

--- a/vector/src/main/java/im/vector/app/features/spaces/manage/RoomManageSelectionItem.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/manage/RoomManageSelectionItem.kt
@@ -31,8 +31,8 @@ import im.vector.app.features.displayname.getBestName
 import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_room_to_manage_in_space)
-abstract class RoomManageSelectionItem : VectorEpoxyModel<RoomManageSelectionItem.Holder>() {
+@EpoxyModelClass
+abstract class RoomManageSelectionItem : VectorEpoxyModel<RoomManageSelectionItem.Holder>(R.layout.item_room_to_manage_in_space) {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var matrixItem: MatrixItem

--- a/vector/src/main/java/im/vector/app/features/spaces/manage/RoomSelectionItem.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/manage/RoomSelectionItem.kt
@@ -30,8 +30,8 @@ import im.vector.app.features.displayname.getBestName
 import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_room_to_add_in_space)
-abstract class RoomSelectionItem : VectorEpoxyModel<RoomSelectionItem.Holder>() {
+@EpoxyModelClass
+abstract class RoomSelectionItem : VectorEpoxyModel<RoomSelectionItem.Holder>(R.layout.item_room_to_add_in_space) {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var matrixItem: MatrixItem

--- a/vector/src/main/java/im/vector/app/features/spaces/manage/RoomSelectionPlaceHolderItem.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/manage/RoomSelectionPlaceHolderItem.kt
@@ -21,7 +21,7 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_room_to_add_in_space_placeholder)
-abstract class RoomSelectionPlaceHolderItem : VectorEpoxyModel<RoomSelectionPlaceHolderItem.Holder>() {
+@EpoxyModelClass
+abstract class RoomSelectionPlaceHolderItem : VectorEpoxyModel<RoomSelectionPlaceHolderItem.Holder>(R.layout.item_room_to_add_in_space_placeholder) {
     class Holder : VectorEpoxyHolder()
 }

--- a/vector/src/main/java/im/vector/app/features/spaces/preview/RoomChildItem.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/preview/RoomChildItem.kt
@@ -27,8 +27,8 @@ import im.vector.app.core.extensions.setTextOrHide
 import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_space_roomchild)
-abstract class RoomChildItem : VectorEpoxyModel<RoomChildItem.Holder>() {
+@EpoxyModelClass
+abstract class RoomChildItem : VectorEpoxyModel<RoomChildItem.Holder>(R.layout.item_space_roomchild) {
 
     @EpoxyAttribute
     lateinit var roomId: String

--- a/vector/src/main/java/im/vector/app/features/spaces/preview/SpaceTopSummaryItem.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/preview/SpaceTopSummaryItem.kt
@@ -24,8 +24,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_space_top_summary)
-abstract class SpaceTopSummaryItem : VectorEpoxyModel<SpaceTopSummaryItem.Holder>() {
+@EpoxyModelClass
+abstract class SpaceTopSummaryItem : VectorEpoxyModel<SpaceTopSummaryItem.Holder>(R.layout.item_space_top_summary) {
 
     @EpoxyAttribute
     var topic: String? = null

--- a/vector/src/main/java/im/vector/app/features/spaces/preview/SubSpaceItem.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/preview/SubSpaceItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.features.home.AvatarRenderer
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_space_subspace)
-abstract class SubSpaceItem : VectorEpoxyModel<SubSpaceItem.Holder>() {
+@EpoxyModelClass
+abstract class SubSpaceItem : VectorEpoxyModel<SubSpaceItem.Holder>(R.layout.item_space_subspace) {
 
     @EpoxyAttribute
     lateinit var roomId: String

--- a/vector/src/main/java/im/vector/app/features/terms/TermItem.kt
+++ b/vector/src/main/java/im/vector/app/features/terms/TermItem.kt
@@ -21,14 +21,14 @@ import android.widget.CompoundButton
 import android.widget.TextView
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import com.airbnb.epoxy.EpoxyModelWithHolder
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 
-@EpoxyModelClass(layout = R.layout.item_tos)
-abstract class TermItem : EpoxyModelWithHolder<TermItem.Holder>() {
+@EpoxyModelClass
+abstract class TermItem : VectorEpoxyModel<TermItem.Holder>(R.layout.item_tos) {
 
     @EpoxyAttribute
     var checked: Boolean = false

--- a/vector/src/main/java/im/vector/app/features/userdirectory/ActionItem.kt
+++ b/vector/src/main/java/im/vector/app/features/userdirectory/ActionItem.kt
@@ -28,8 +28,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_contact_action)
-abstract class ActionItem : VectorEpoxyModel<ActionItem.Holder>() {
+@EpoxyModelClass
+abstract class ActionItem : VectorEpoxyModel<ActionItem.Holder>(R.layout.item_contact_action) {
 
     @EpoxyAttribute var title: String? = null
     @EpoxyAttribute @DrawableRes var actionIconRes: Int? = null

--- a/vector/src/main/java/im/vector/app/features/userdirectory/ContactDetailItem.kt
+++ b/vector/src/main/java/im/vector/app/features/userdirectory/ContactDetailItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 
-@EpoxyModelClass(layout = R.layout.item_contact_detail)
-abstract class ContactDetailItem : VectorEpoxyModel<ContactDetailItem.Holder>() {
+@EpoxyModelClass
+abstract class ContactDetailItem : VectorEpoxyModel<ContactDetailItem.Holder>(R.layout.item_contact_detail) {
 
     @EpoxyAttribute lateinit var threePid: String
     @EpoxyAttribute var matrixId: String? = null

--- a/vector/src/main/java/im/vector/app/features/userdirectory/ContactItem.kt
+++ b/vector/src/main/java/im/vector/app/features/userdirectory/ContactItem.kt
@@ -26,8 +26,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.features.home.AvatarRenderer
 
-@EpoxyModelClass(layout = R.layout.item_contact_main)
-abstract class ContactItem : VectorEpoxyModel<ContactItem.Holder>() {
+@EpoxyModelClass
+abstract class ContactItem : VectorEpoxyModel<ContactItem.Holder>(R.layout.item_contact_main) {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var mappedContact: MappedContact

--- a/vector/src/main/java/im/vector/app/features/userdirectory/InviteByEmailItem.kt
+++ b/vector/src/main/java/im/vector/app/features/userdirectory/InviteByEmailItem.kt
@@ -27,8 +27,8 @@ import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.features.home.AvatarRenderer
 
-@EpoxyModelClass(layout = R.layout.item_invite_by_mail)
-abstract class InviteByEmailItem : VectorEpoxyModel<InviteByEmailItem.Holder>() {
+@EpoxyModelClass
+abstract class InviteByEmailItem : VectorEpoxyModel<InviteByEmailItem.Holder>(R.layout.item_invite_by_mail) {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var foundItem: ThreePidUser

--- a/vector/src/main/java/im/vector/app/features/userdirectory/UserDirectoryLetterHeaderItem.kt
+++ b/vector/src/main/java/im/vector/app/features/userdirectory/UserDirectoryLetterHeaderItem.kt
@@ -23,8 +23,8 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_user_directory_letter_header)
-abstract class UserDirectoryLetterHeaderItem : VectorEpoxyModel<UserDirectoryLetterHeaderItem.Holder>() {
+@EpoxyModelClass
+abstract class UserDirectoryLetterHeaderItem : VectorEpoxyModel<UserDirectoryLetterHeaderItem.Holder>(R.layout.item_user_directory_letter_header) {
 
     @EpoxyAttribute var letter: String = ""
 

--- a/vector/src/main/java/im/vector/app/features/userdirectory/UserDirectoryUserItem.kt
+++ b/vector/src/main/java/im/vector/app/features/userdirectory/UserDirectoryUserItem.kt
@@ -31,8 +31,8 @@ import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.themes.ThemeUtils
 import org.matrix.android.sdk.api.util.MatrixItem
 
-@EpoxyModelClass(layout = R.layout.item_known_user)
-abstract class UserDirectoryUserItem : VectorEpoxyModel<UserDirectoryUserItem.Holder>() {
+@EpoxyModelClass
+abstract class UserDirectoryUserItem : VectorEpoxyModel<UserDirectoryUserItem.Holder>(R.layout.item_known_user) {
 
     @EpoxyAttribute lateinit var avatarRenderer: AvatarRenderer
     @EpoxyAttribute lateinit var matrixItem: MatrixItem

--- a/vector/src/main/java/im/vector/app/features/userdirectory/UserListHeaderItem.kt
+++ b/vector/src/main/java/im/vector/app/features/userdirectory/UserListHeaderItem.kt
@@ -23,8 +23,8 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
 import im.vector.app.core.epoxy.VectorEpoxyModel
 
-@EpoxyModelClass(layout = R.layout.item_user_list_header)
-abstract class UserListHeaderItem : VectorEpoxyModel<UserListHeaderItem.Holder>() {
+@EpoxyModelClass
+abstract class UserListHeaderItem : VectorEpoxyModel<UserListHeaderItem.Holder>(R.layout.item_user_list_header) {
 
     @EpoxyAttribute var header: String = ""
 


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Replaces the R.layout references from the epoxy model annotations as library R files are not marked as final meaning their values can't be used in annotations. The android gradle plugin also warns that with version 8.0 this will be the default behaviour for application modules going forwards. 

## Motivation and context

Closes #6389

## Screenshots / GIFs
No UI changes

## Tests

- Login in and navigation around the app

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28

