### PR TITLE
[Poll] - Add a description under undisclosed poll when not ended (PSB-134)

### DIFF
--- a/changelog.d/6423.misc
+++ b/changelog.d/6423.misc
@@ -1,0 +1,1 @@
+[Poll] - Add a description under undisclosed poll when not ended

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -244,7 +244,7 @@ class MessageItemFactory @Inject constructor(
                 .eventId(informationData.eventId)
                 .pollQuestion(createPollQuestion(informationData, pollViewState.question, callback))
                 .canVote(pollViewState.canVote)
-                .totalVotesText(pollViewState.totalVotes)
+                .votesStatus(pollViewState.votesStatus)
                 .optionViewStates(pollViewState.optionViewStates)
                 .edited(informationData.hasBeenEdited)
                 .highlighted(highlight)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/PollItemViewStateFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/PollItemViewStateFactory.kt
@@ -65,7 +65,7 @@ class PollItemViewStateFactory @Inject constructor(
     private fun createSendingPollViewState(question: String, pollCreationInfo: PollCreationInfo?): PollViewState {
         return PollViewState(
                 question = question,
-                totalVotes = stringProvider.getString(R.string.poll_no_votes_cast),
+                votesStatus = stringProvider.getString(R.string.poll_no_votes_cast),
                 canVote = false,
                 optionViewStates = pollCreationInfo?.answers?.map { answer ->
                     PollOptionViewState.PollSending(
@@ -85,7 +85,7 @@ class PollItemViewStateFactory @Inject constructor(
     ): PollViewState {
         return PollViewState(
                 question = question,
-                totalVotes = stringProvider.getQuantityString(R.plurals.poll_total_vote_count_after_ended, totalVotes, totalVotes),
+                votesStatus = stringProvider.getQuantityString(R.plurals.poll_total_vote_count_after_ended, totalVotes, totalVotes),
                 canVote = false,
                 optionViewStates = pollCreationInfo?.answers?.map { answer ->
                     val voteSummary = pollResponseSummary?.getVoteSummaryOfAnOption(answer.id ?: "")
@@ -107,7 +107,7 @@ class PollItemViewStateFactory @Inject constructor(
     ): PollViewState {
         return PollViewState(
                 question = question,
-                totalVotes = stringProvider.getString(R.string.poll_undisclosed_not_ended),
+                votesStatus = stringProvider.getString(R.string.poll_undisclosed_not_ended),
                 canVote = true,
                 optionViewStates = pollCreationInfo?.answers?.map { answer ->
                     val isMyVote = pollResponseSummary?.myVote == answer.id
@@ -128,7 +128,7 @@ class PollItemViewStateFactory @Inject constructor(
     ): PollViewState {
         return PollViewState(
                 question = question,
-                totalVotes = stringProvider.getQuantityString(R.plurals.poll_total_vote_count_before_ended_and_voted, totalVotes, totalVotes),
+                votesStatus = stringProvider.getQuantityString(R.plurals.poll_total_vote_count_before_ended_and_voted, totalVotes, totalVotes),
                 canVote = true,
                 optionViewStates = pollCreationInfo?.answers?.map { answer ->
                     val isMyVote = pollResponseSummary?.myVote == answer.id
@@ -152,7 +152,7 @@ class PollItemViewStateFactory @Inject constructor(
         }
         return PollViewState(
                 question = question,
-                totalVotes = totalVotesText,
+                votesStatus = totalVotesText,
                 canVote = true,
                 optionViewStates = pollCreationInfo?.answers?.map { answer ->
                     PollOptionViewState.PollReady(

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/PollItemViewStateFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/PollItemViewStateFactory.kt
@@ -107,7 +107,7 @@ class PollItemViewStateFactory @Inject constructor(
     ): PollViewState {
         return PollViewState(
                 question = question,
-                totalVotes = "",
+                totalVotes = stringProvider.getString(R.string.poll_undisclosed_not_ended),
                 canVote = true,
                 optionViewStates = pollCreationInfo?.answers?.map { answer ->
                     val isMyVote = pollResponseSummary?.myVote == answer.id

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/PollItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/PollItem.kt
@@ -42,7 +42,7 @@ abstract class PollItem : AbsMessageItem<PollItem.Holder>() {
     var canVote: Boolean = false
 
     @EpoxyAttribute
-    var totalVotesText: String? = null
+    var votesStatus: String? = null
 
     @EpoxyAttribute
     var edited: Boolean = false
@@ -58,7 +58,7 @@ abstract class PollItem : AbsMessageItem<PollItem.Holder>() {
         renderSendState(holder.view, holder.questionTextView)
 
         holder.questionTextView.text = pollQuestion?.charSequence
-        holder.totalVotesTextView.text = totalVotesText
+        holder.votesStatusTextView.text = votesStatus
 
         while (holder.optionsContainer.childCount < optionViewStates.size) {
             holder.optionsContainer.addView(PollOptionView(holder.view.context))
@@ -88,7 +88,7 @@ abstract class PollItem : AbsMessageItem<PollItem.Holder>() {
     class Holder : AbsMessageItem.Holder(STUB_ID) {
         val questionTextView by bind<TextView>(R.id.questionTextView)
         val optionsContainer by bind<LinearLayout>(R.id.optionsContainer)
-        val totalVotesTextView by bind<TextView>(R.id.optionsTotalVotesTextView)
+        val votesStatusTextView by bind<TextView>(R.id.optionsVotesStatusTextView)
     }
 
     companion object {

--- a/vector/src/main/java/im/vector/app/features/poll/PollViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/poll/PollViewState.kt
@@ -19,8 +19,8 @@ package im.vector.app.features.poll
 import im.vector.app.features.home.room.detail.timeline.item.PollOptionViewState
 
 data class PollViewState(
-    val question: String,
-    val totalVotes: String,
-    val canVote: Boolean,
-    val optionViewStates: List<PollOptionViewState>?,
+        val question: String,
+        val votesStatus: String,
+        val canVote: Boolean,
+        val optionViewStates: List<PollOptionViewState>?,
 )

--- a/vector/src/main/res/layout/item_timeline_event_poll.xml
+++ b/vector/src/main/res/layout/item_timeline_event_poll.xml
@@ -33,7 +33,7 @@
         app:layout_constraintTop_toBottomOf="@id/questionTextView" />
 
     <TextView
-        android:id="@+id/optionsTotalVotesTextView"
+        android:id="@+id/optionsVotesStatusTextView"
         style="@style/Widget.Vector.TextView.Caption"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2980,6 +2980,7 @@
         <item quantity="other">Based on %1$d votes</item>
     </plurals>
     <string name="poll_no_votes_cast">No votes cast</string>
+    <string name="poll_undisclosed_not_ended">Results will be visible when the poll is ended</string>
     <plurals name="poll_total_vote_count_before_ended_and_not_voted">
         <item quantity="one">%1$d vote cast. Vote to the see the results</item>
         <item quantity="other">%1$d votes cast. Vote to the see the results</item>

--- a/vector/src/test/java/im/vector/app/features/home/room/detail/timeline/factory/PollItemViewStateFactoryTest.kt
+++ b/vector/src/test/java/im/vector/app/features/home/room/detail/timeline/factory/PollItemViewStateFactoryTest.kt
@@ -91,7 +91,7 @@ class PollItemViewStateFactoryTest {
 
         pollViewState shouldBeEqualTo PollViewState(
                 question = A_POLL_CONTENT.getBestPollCreationInfo()?.question?.getBestQuestion() ?: "",
-                totalVotes = stringProvider.instance.getString(R.string.poll_no_votes_cast),
+                votesStatus = stringProvider.instance.getString(R.string.poll_no_votes_cast),
                 canVote = false,
                 optionViewStates = A_POLL_CONTENT.getBestPollCreationInfo()?.answers?.map { answer ->
                     PollOptionViewState.PollSending(
@@ -117,7 +117,7 @@ class PollItemViewStateFactoryTest {
 
         pollViewState shouldBeEqualTo PollViewState(
                 question = A_POLL_CONTENT.getBestPollCreationInfo()?.question?.getBestQuestion() ?: "",
-                totalVotes = stringProvider.instance.getQuantityString(R.plurals.poll_total_vote_count_after_ended, 0, 0),
+                votesStatus = stringProvider.instance.getQuantityString(R.plurals.poll_total_vote_count_after_ended, 0, 0),
                 canVote = false,
                 optionViewStates = A_POLL_CONTENT.getBestPollCreationInfo()?.answers?.map { answer ->
                     PollOptionViewState.PollEnded(
@@ -143,7 +143,7 @@ class PollItemViewStateFactoryTest {
 
         pollViewState shouldBeEqualTo PollViewState(
                 question = A_POLL_CONTENT.getBestPollCreationInfo()?.question?.getBestQuestion() ?: "",
-                totalVotes = stringProvider.instance.getString(R.string.poll_undisclosed_not_ended),
+                votesStatus = stringProvider.instance.getString(R.string.poll_undisclosed_not_ended),
                 canVote = true,
                 optionViewStates = A_POLL_CONTENT.getBestPollCreationInfo()?.answers?.map { answer ->
                     PollOptionViewState.PollUndisclosed(
@@ -179,7 +179,7 @@ class PollItemViewStateFactoryTest {
 
         pollViewState shouldBeEqualTo PollViewState(
                 question = A_POLL_CONTENT.getBestPollCreationInfo()?.question?.getBestQuestion() ?: "",
-                totalVotes = stringProvider.instance.getQuantityString(R.plurals.poll_total_vote_count_before_ended_and_voted, 1, 1),
+                votesStatus = stringProvider.instance.getQuantityString(R.plurals.poll_total_vote_count_before_ended_and_voted, 1, 1),
                 canVote = true,
                 optionViewStates = A_POLL_CONTENT.getBestPollCreationInfo()?.answers?.mapIndexed { index, answer ->
                     PollOptionViewState.PollVoted(
@@ -210,7 +210,7 @@ class PollItemViewStateFactoryTest {
 
         pollViewState shouldBeEqualTo PollViewState(
                 question = A_POLL_CONTENT.getBestPollCreationInfo()?.question?.getBestQuestion() ?: "",
-                totalVotes = stringProvider.instance.getString(R.string.poll_no_votes_cast),
+                votesStatus = stringProvider.instance.getString(R.string.poll_no_votes_cast),
                 canVote = true,
                 optionViewStates = A_POLL_CONTENT.getBestPollCreationInfo()?.answers?.map { answer ->
                     PollOptionViewState.PollReady(

--- a/vector/src/test/java/im/vector/app/features/home/room/detail/timeline/factory/PollItemViewStateFactoryTest.kt
+++ b/vector/src/test/java/im/vector/app/features/home/room/detail/timeline/factory/PollItemViewStateFactoryTest.kt
@@ -143,7 +143,7 @@ class PollItemViewStateFactoryTest {
 
         pollViewState shouldBeEqualTo PollViewState(
                 question = A_POLL_CONTENT.getBestPollCreationInfo()?.question?.getBestQuestion() ?: "",
-                totalVotes = "",
+                totalVotes = stringProvider.instance.getString(R.string.poll_undisclosed_not_ended),
                 canVote = true,
                 optionViewStates = A_POLL_CONTENT.getBestPollCreationInfo()?.answers?.map { answer ->
                     PollOptionViewState.PollUndisclosed(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Enhancement

## Content

Add a description "Results will be visible when the poll is ended" under undisclosed and not ended poll.

## Motivation and context

Closes #6423 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

<img src="https://user-images.githubusercontent.com/46314705/176637570-127eaccf-8d24-4ef0-bcc4-ab5dcc31cf04.png" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/176637575-926dce0e-f4c1-4831-a1f3-90be80632cc6.png" width=300 /> 

## Tests

<!-- Explain how you tested your development -->

- Go to a room
- Create an closed poll
- Check the description under the poll is correct
- Vote
- End the poll
- Check the description under the poll is correct

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
