### PR TITLE
[Poll] - Wrong votes in closed poll after removing 2 previous polls (PSG-590)

### DIFF
--- a/changelog.d/6430.bugfix
+++ b/changelog.d/6430.bugfix
@@ -1,0 +1,1 @@
+[Poll] Fixes visible and wrong votes in closed poll after removing 2 previous polls

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/PollOptionView.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/PollOptionView.kt
@@ -82,6 +82,7 @@ class PollOptionView @JvmOverloads constructor(
     private fun renderPollUndisclosed(state: PollOptionViewState.PollUndisclosed) {
         views.optionCheckImageView.isVisible = true
         views.optionWinnerImageView.isVisible = false
+        hideVotes()
         renderVoteSelection(state.isSelected)
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Hiding explicitely the votes views when rendering a poll with undisclosed state.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6430 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->
<img src="https://user-images.githubusercontent.com/46314705/176686416-559e6e6c-8d5a-41f8-a332-3a76be62ff0a.gif" width=300 />

## Tests

<!-- Explain how you tested your development -->

- Go to a room
- Create a poll 1 (closed or opened)
- Create a poll 2 (closed or opened)
- Remove poll 1
- Remove poll 2
- Create a closed poll
- Check the votes are not visible
- Vote
- End the poll
- Check the ended view is correct

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
