### PR TITLE
Simple check to prevent frozen class modificaiton

### DIFF
--- a/tools/check/check_code_quality.sh
+++ b/tools/check/check_code_quality.sh
@@ -17,6 +17,21 @@
 #
 
 #######################################################################################################################
+# Check frozen class modification
+#######################################################################################################################
+
+echo "Check if frozen class modified"
+git diff "HEAD@{1}" --name-only | grep -e OlmInboundGroupSessionWrapper.kt -e OlmInboundGroupSessionWrapper2.kt
+FROZEN_CHANGED=$?
+if [ ${FROZEN_CHANGED} -eq 0 ]; then
+  echo "❌ FROZEN CLASS CHANGED ERROR"
+  exit 1
+else
+  echo "Frozen check OK"
+fi
+
+
+#######################################################################################################################
 # Check drawable quantity
 #######################################################################################################################
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change
- [x] Technical

Quick technical change to add a check to prevent the modification of some serializable classes.
Historically megolm session where serialized using java serialization mechanism but without proper version. Any change to those class will make it impossible for the app to load saved session.

This change adds a check to fail when such frozen class is modified.