### PR TITLE
Fix HTML entities being displayed in messages

### DIFF
--- a/changelog.d/6442.bugfix
+++ b/changelog.d/6442.bugfix
@@ -1,0 +1,1 @@
+Fix HTML entities being displayed in messages

--- a/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
@@ -14,6 +14,15 @@
  * limitations under the License.
  */
 
+/*
+ * This file renders the formatted_body of an event to a formatted Android Spannable.
+ * The core of this work is done with Markwon, a general-purpose Markdown+HTML formatter.
+ * Since formatted_body is HTML only, Markwon is configured to only handle HTML, not Markdown.
+ * The EventHtmlRenderer class is next used in the method buildFormattedTextItem
+ * in the file MessageItemFactory.kt.
+ * Effectively, this is used in the chat messages view and the room list message previews.
+ */
+
 package im.vector.app.features.html
 
 import android.content.Context
@@ -30,6 +39,7 @@ import io.noties.markwon.PrecomputedFutureTextSetterCompat
 import io.noties.markwon.ext.latex.JLatexMathPlugin
 import io.noties.markwon.ext.latex.JLatexMathTheme
 import io.noties.markwon.html.HtmlPlugin
+import io.noties.markwon.inlineparser.EntityInlineProcessor
 import io.noties.markwon.inlineparser.HtmlInlineProcessor
 import io.noties.markwon.inlineparser.MarkwonInlineParser
 import io.noties.markwon.inlineparser.MarkwonInlineParserPlugin
@@ -54,8 +64,10 @@ class EventHtmlRenderer @Inject constructor(
             .usePlugin(HtmlPlugin.create(htmlConfigure))
 
     private val markwon = if (vectorPreferences.latexMathsIsEnabled()) {
+        // If latex maths is enabled in app preferences, refomat it so Markwon recognises it
+        // It needs to be in this specific format: https://noties.io/Markwon/docs/v4/ext-latex
         builder
-                .usePlugin(object : AbstractMarkwonPlugin() { // Markwon expects maths to be in a specific format: https://noties.io/Markwon/docs/v4/ext-latex
+                .usePlugin(object : AbstractMarkwonPlugin() {
                     override fun processMarkdown(markdown: String): String {
                         return markdown
                                 .replace(Regex("""<span\s+data-mx-maths="([^"]*)">.*?</span>""")) { matchResult ->
@@ -86,6 +98,9 @@ class EventHtmlRenderer @Inject constructor(
         )
         .usePlugin(object : AbstractMarkwonPlugin() {
             override fun configureParser(builder: Parser.Builder) {
+                /* Configuring the Markwon block formatting processor.
+                 * Default settings are all Markdown blocks. Turn those off.
+                 */
                 builder.enabledBlockTypes(kotlin.collections.emptySet())
             }
         })

--- a/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
@@ -75,7 +75,13 @@ class EventHtmlRenderer @Inject constructor(
     }
         .usePlugin(
             MarkwonInlineParserPlugin.create(
-                MarkwonInlineParser.factoryBuilderNoDefaults().addInlineProcessor(HtmlInlineProcessor())
+                /* Configuring the Markwon inline formatting processor.
+                 * Default settings are all Markdown features. Turn those off, only using the
+                 * inline HTML processor and HTML entities processor.
+                 */
+                MarkwonInlineParser.factoryBuilderNoDefaults()
+                    .addInlineProcessor(HtmlInlineProcessor()) // use inline HTML processor
+                    .addInlineProcessor(EntityInlineProcessor()) // use HTML entities processor
             )
         )
         .usePlugin(object : AbstractMarkwonPlugin() {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- Bugfix

## Content

HTML entities are now displayed as the characters they represent.

## Motivation and context

Fixes #6445. This was a regression from #6357.

## Tests

My test case was an event with `"formatted_body": "&ZeroWidthSpace; ♫ We&apos;re on easy street ♫"`. If successful, when displayed in Element Android, it should look like "♫ We're on easy street ♫".

I also looked at the tests I used in #6357.

## Screenshots

```json
{
  "body": "raw",
  "formatted_body": "&ZeroWidthSpace; ♫ We&apos;re on easy street ♫",
   "msgtype": "m.text",
   "format": "org.matrix.custom.html"
}
```

| BEFORE | AFTER | 
| --- | --- |
|![Screenshot_20220704_142338](https://user-images.githubusercontent.com/1848238/177163927-d5e62525-74d6-4668-8136-06a72349d868.png)|![Screenshot_20220704_141944](https://user-images.githubusercontent.com/1848238/177163932-c7cc5f30-5ce4-4e6c-a643-b2beddf6a853.png)


## Tested devices

- Physical, LineageOS 18.1 (Android 11)

## Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
- N/A - UI change has been tested on both light and dark themes
- N/A -  Accessibility has been taken into account
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- N/A - Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- N/A - If you have modified the screen flow, or added new screens to the application

Signed-off-by: Cadence Ember <cloudrac3r@vivaldi.net>

EDIT: @ouchadam - Added before/after screenshots