### PR TITLE
Gallery picker can pick external images (not just videos)

### DIFF
--- a/changelog.d/6450.bugfix
+++ b/changelog.d/6450.bugfix
@@ -1,0 +1,1 @@
+Gallery picker can pick external images

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/MediaPicker.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/MediaPicker.kt
@@ -49,7 +49,7 @@ class MediaPicker : Picker<MultiPickerBaseMediaType>() {
         return Intent(Intent.ACTION_GET_CONTENT).apply {
             addCategory(Intent.CATEGORY_OPENABLE)
             putExtra(Intent.EXTRA_ALLOW_MULTIPLE, !single)
-            type = "video/*, image/*"
+            type = "*/*"
             val mimeTypes = arrayOf("image/*", "video/*")
             putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes)
         }


### PR DESCRIPTION
## Type of change

- Bugfix

## Content

Gallery picker can now pick external images. Previously, choosing an external application would only allow videos, not images. This was due to one of the mime type entries being interpreted incorrectly.

The scenarios for attaching files are as follows:

### Attach file

For comparison.

- "Recent" screen displays other file types and filters
- External gallery displays all image/video files
- External file manager displays all files

### Attach gallery (old)

- "Recent" screen only displays image/video files and filters - **right**
- External gallery only displays video files - **wrong**
- External file manager displays all files - **technically wrong but not a problem**

### Attach gallery (new)

- "Recent" screen only displays image/video files and filters - **right**
- External gallery displays all image/video files - **right**
- External file manger displays all files - **technically wrong but not a problem**

## Motivation and context

#5507

## Tested devices

- Physical, LineageOS 18.1 (Android 11)

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- N/A - UI change has been tested on both light and dark themes
- N/A - Accessibility has been taken into account.
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- N/A - Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- N/A - If you have modified the screen flow, or added new screens to the application

Signed-off-by: Cadence Ember <cloudrac3r@vivaldi.net>