### PR TITLE
FTUE - Homeserver edits not updating the selected server UI

### DIFF
--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -302,7 +302,9 @@ class OnboardingViewModel @AssistedInject constructor(
                                 authenticationDescription = awaitState().selectedAuthenticationState.description
                                         ?: AuthenticationDescription.Register(AuthenticationDescription.AuthenticationType.Other)
                         )
-                        RegistrationActionHandler.Result.StartRegistration -> _viewEvents.post(OnboardingViewEvents.DisplayStartRegistration)
+                        RegistrationActionHandler.Result.StartRegistration -> {
+                            overrideNextStage?.invoke() ?: _viewEvents.post(OnboardingViewEvents.DisplayStartRegistration)
+                        }
                         RegistrationActionHandler.Result.UnsupportedStage -> _viewEvents.post(OnboardingViewEvents.DisplayRegistrationFallback)
                         is RegistrationActionHandler.Result.SendEmailSuccess -> _viewEvents.post(OnboardingViewEvents.OnSendEmailSuccess(it.email))
                         is RegistrationActionHandler.Result.SendMsisdnSuccess -> _viewEvents.post(OnboardingViewEvents.OnSendMsisdnSuccess(it.msisdn.msisdn))

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -630,7 +630,7 @@ class OnboardingViewModelTest {
     private fun givenCanSuccessfullyUpdateHomeserver(homeserverUrl: String, resultingState: SelectedHomeserverState) {
         fakeHomeServerConnectionConfigFactory.givenConfigFor(homeserverUrl, A_HOMESERVER_CONFIG)
         fakeStartAuthenticationFlowUseCase.givenResult(A_HOMESERVER_CONFIG, StartAuthenticationResult(isHomeserverOutdated = false, resultingState))
-        givenRegistrationResultFor(RegisterAction.StartRegistration, ANY_CONTINUING_REGISTRATION_RESULT)
+        givenRegistrationResultFor(RegisterAction.StartRegistration, RegistrationActionHandler.Result.StartRegistration)
         fakeHomeServerHistoryService.expectUrlToBeAdded(A_HOMESERVER_CONFIG.homeServerUri.toString())
     }
 


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Adds missing edit continuation logic which fixes the edit flow not updating with the selection. 

- Updates the unit test to include the `StartRegistration` result type (which catches the broken behaviour)

## Motivation and context

To fix the broken homeserver edit feature, was likely introduced by a rebase regression

## Screenshots / GIFs

|Before|After|
|-|-|
|![before-server-selection](https://user-images.githubusercontent.com/1848238/177142521-5adce610-4826-4ca5-a9ce-a42e47770ddc.gif)|![after-homeserver-selection](https://user-images.githubusercontent.com/1848238/177142554-29c60ba4-eb45-4555-98d7-be60438f7962.gif)|
 

## Tests

<!-- Explain how you tested your development -->

- With the combined registration feature flag enabled
- Create a new account
- Edit the selected homeserver
- Notice the UI doesn't change and the back behaviour is inconsistent 

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 31 

