### PR TITLE
Rename Android Service to use `AndroidService` suffix

### DIFF
--- a/changelog.d/6458.misc
+++ b/changelog.d/6458.misc
@@ -1,0 +1,1 @@
+Rename Android Service to use `AndroidService` suffix

--- a/coverage.gradle
+++ b/coverage.gradle
@@ -7,6 +7,7 @@ def excludes = [
 '**/*Activity*',
 '**/*Fragment*',
 '**/*Application*',
+'**/*AndroidService*',
 
 // We would like to exclude android widgets as well but our naming is inconsistent
 

--- a/vector/src/fdroid/AndroidManifest.xml
+++ b/vector/src/fdroid/AndroidManifest.xml
@@ -43,7 +43,7 @@
         </receiver>
 
         <service
-            android:name=".fdroid.service.GuardService"
+            android:name=".fdroid.service.GuardAndroidService"
             android:exported="false"
             tools:ignore="Instantiatable" />
 

--- a/vector/src/fdroid/java/im/vector/app/fdroid/service/FDroidGuardServiceStarter.kt
+++ b/vector/src/fdroid/java/im/vector/app/fdroid/service/FDroidGuardServiceStarter.kt
@@ -33,7 +33,7 @@ class FDroidGuardServiceStarter @Inject constructor(
         if (preferences.isBackgroundSyncEnabled()) {
             try {
                 Timber.i("## Sync: starting GuardService")
-                val intent = Intent(appContext, GuardService::class.java)
+                val intent = Intent(appContext, GuardAndroidService::class.java)
                 ContextCompat.startForegroundService(appContext, intent)
             } catch (ex: Throwable) {
                 Timber.e("## Sync: ERROR starting GuardService")
@@ -42,7 +42,7 @@ class FDroidGuardServiceStarter @Inject constructor(
     }
 
     override fun stop() {
-        val intent = Intent(appContext, GuardService::class.java)
+        val intent = Intent(appContext, GuardAndroidService::class.java)
         appContext.stopService(intent)
     }
 }

--- a/vector/src/fdroid/java/im/vector/app/fdroid/service/GuardAndroidService.kt
+++ b/vector/src/fdroid/java/im/vector/app/fdroid/service/GuardAndroidService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2021 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,46 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package im.vector.app.features.call.webrtc
+package im.vector.app.fdroid.service
 
 import android.content.Intent
-import android.os.Binder
-import android.os.IBinder
 import dagger.hilt.android.AndroidEntryPoint
-import im.vector.app.core.services.VectorService
-import im.vector.app.core.time.Clock
+import im.vector.app.R
+import im.vector.app.core.services.VectorAndroidService
 import im.vector.app.features.notifications.NotificationUtils
 import javax.inject.Inject
 
+/**
+ * This no-op foreground service acts as a deterrent to the system eagerly killing the app process.
+ *
+ * Keeping the app process alive avoids some OEMs ignoring scheduled WorkManager and AlarmManager tasks
+ * when the app is not in the foreground.
+ */
 @AndroidEntryPoint
-class ScreenCaptureService : VectorService() {
+class GuardAndroidService : VectorAndroidService() {
 
     @Inject lateinit var notificationUtils: NotificationUtils
-    @Inject lateinit var clock: Clock
-    private val binder = LocalBinder()
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        showStickyNotification()
-
+        val notificationSubtitleRes = R.string.notification_listening_for_notifications
+        val notification = notificationUtils.buildForegroundServiceNotification(notificationSubtitleRes, false)
+        startForeground(NotificationUtils.NOTIFICATION_ID_FOREGROUND_SERVICE, notification)
         return START_STICKY
-    }
-
-    private fun showStickyNotification() {
-        val notificationId = clock.epochMillis().toInt()
-        val notification = notificationUtils.buildScreenSharingNotification()
-        startForeground(notificationId, notification)
-    }
-
-    override fun onBind(intent: Intent?): IBinder {
-        return binder
-    }
-
-    fun stopService() {
-        stopSelf()
-    }
-
-    inner class LocalBinder : Binder() {
-        fun getService(): ScreenCaptureService = this@ScreenCaptureService
     }
 }

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -351,7 +351,7 @@
         <!-- Services -->
 
         <service
-            android:name=".core.services.CallService"
+            android:name=".core.services.CallAndroidService"
             android:exported="false">
             <!-- in order to get headset button events -->
             <intent-filter>
@@ -366,7 +366,7 @@
             tools:ignore="Instantiatable" />
 
         <service
-            android:name=".features.call.telecom.VectorConnectionService"
+            android:name=".features.call.telecom.VectorConnectionAndroidService"
             android:exported="false"
             android:permission="android.permission.BIND_TELECOM_CONNECTION_SERVICE">
             <intent-filter>
@@ -375,12 +375,12 @@
         </service>
 
         <service
-            android:name=".features.location.LocationSharingService"
+            android:name=".features.location.LocationSharingAndroidService"
             android:exported="false"
             android:foregroundServiceType="location" />
 
         <service
-            android:name=".features.call.webrtc.ScreenCaptureService"
+            android:name=".features.call.webrtc.ScreenCaptureAndroidService"
             android:exported="false"
             android:foregroundServiceType="mediaProjection"
             tools:targetApi="Q" />

--- a/vector/src/main/java/im/vector/app/core/services/CallAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/core/services/CallAndroidService.kt
@@ -51,7 +51,7 @@ private val loggerTag = LoggerTag("CallService", LoggerTag.VOIP)
  * Foreground service to manage calls.
  */
 @AndroidEntryPoint
-class CallService : VectorService() {
+class CallAndroidService : VectorAndroidService() {
 
     private val connections = mutableMapOf<String, CallConnection>()
     private val knownCalls = mutableMapOf<String, CallInformation>()
@@ -98,7 +98,7 @@ class CallService : VectorService() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Timber.tag(loggerTag.value).v("onStartCommand $intent")
         if (mediaSession == null) {
-            mediaSession = MediaSessionCompat(applicationContext, CallService::class.java.name).apply {
+            mediaSession = MediaSessionCompat(applicationContext, CallAndroidService::class.java.name).apply {
                 setCallback(mediaSessionButtonCallback)
             }
         }
@@ -326,7 +326,7 @@ class CallService : VectorService() {
                 callId: String,
                 isInBackground: Boolean
         ) {
-            val intent = Intent(context, CallService::class.java)
+            val intent = Intent(context, CallAndroidService::class.java)
                     .apply {
                         action = ACTION_INCOMING_RINGING_CALL
                         putExtra(EXTRA_CALL_ID, callId)
@@ -339,7 +339,7 @@ class CallService : VectorService() {
                 context: Context,
                 callId: String
         ) {
-            val intent = Intent(context, CallService::class.java)
+            val intent = Intent(context, CallAndroidService::class.java)
                     .apply {
                         action = ACTION_OUTGOING_RINGING_CALL
                         putExtra(EXTRA_CALL_ID, callId)
@@ -351,7 +351,7 @@ class CallService : VectorService() {
                 context: Context,
                 callId: String
         ) {
-            val intent = Intent(context, CallService::class.java)
+            val intent = Intent(context, CallAndroidService::class.java)
                     .apply {
                         action = ACTION_ONGOING_CALL
                         putExtra(EXTRA_CALL_ID, callId)
@@ -365,7 +365,7 @@ class CallService : VectorService() {
                 endCallReason: EndCallReason,
                 rejected: Boolean
         ) {
-            val intent = Intent(context, CallService::class.java)
+            val intent = Intent(context, CallAndroidService::class.java)
                     .apply {
                         action = ACTION_CALL_TERMINATED
                         putExtra(EXTRA_CALL_ID, callId)
@@ -377,8 +377,8 @@ class CallService : VectorService() {
     }
 
     inner class CallServiceBinder : Binder() {
-        fun getCallService(): CallService {
-            return this@CallService
+        fun getCallService(): CallAndroidService {
+            return this@CallAndroidService
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/core/services/VectorAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/core/services/VectorAndroidService.kt
@@ -22,9 +22,9 @@ import android.os.IBinder
 import timber.log.Timber
 
 /**
- * Parent class for all services.
+ * Parent class for all Android Services.
  */
-abstract class VectorService : Service() {
+abstract class VectorAndroidService : Service() {
 
     /**
      * Tells if the service self destroyed.

--- a/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
@@ -59,7 +59,7 @@ import im.vector.app.features.call.dialpad.CallDialPadBottomSheet
 import im.vector.app.features.call.dialpad.DialPadFragment
 import im.vector.app.features.call.transfer.CallTransferActivity
 import im.vector.app.features.call.utils.EglUtils
-import im.vector.app.features.call.webrtc.ScreenCaptureService
+import im.vector.app.features.call.webrtc.ScreenCaptureAndroidService
 import im.vector.app.features.call.webrtc.ScreenCaptureServiceConnection
 import im.vector.app.features.call.webrtc.WebRtcCall
 import im.vector.app.features.call.webrtc.WebRtcCallManager
@@ -663,7 +663,7 @@ class VectorCallActivity : VectorBaseActivity<ActivityCallBinding>(), CallContro
     private fun startScreenSharingService(activityResult: ActivityResult) {
         ContextCompat.startForegroundService(
                 this,
-                Intent(this, ScreenCaptureService::class.java)
+                Intent(this, ScreenCaptureAndroidService::class.java)
         )
         bindToScreenCaptureService(activityResult)
     }

--- a/vector/src/main/java/im/vector/app/features/call/telecom/VectorConnectionAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/features/call/telecom/VectorConnectionAndroidService.kt
@@ -29,7 +29,7 @@ import android.telecom.PhoneAccountHandle
 import android.telecom.StatusHints
 import android.telecom.TelecomManager
 import androidx.annotation.RequiresApi
-import im.vector.app.core.services.CallService
+import im.vector.app.core.services.CallAndroidService
 
 /**
  * No active calls in other apps
@@ -47,7 +47,7 @@ import im.vector.app.core.services.CallService
  *            the parameter followed by a call to the destroy() method if the user rejects the incoming call.
  *</pre>
  */
-@RequiresApi(Build.VERSION_CODES.M) class VectorConnectionService : ConnectionService() {
+@RequiresApi(Build.VERSION_CODES.M) class VectorConnectionAndroidService : ConnectionService() {
 
     /**
      * The telecom subsystem calls this method in response to your app calling placeCall(Uri, Bundle) to create a new outgoing call.
@@ -69,14 +69,14 @@ import im.vector.app.core.services.CallService
         connection.setCallerDisplayName("Element Caller", TelecomManager.PRESENTATION_ALLOWED)
         connection.statusHints = StatusHints("Testing Hint...", null, null)
 
-        bindService(Intent(applicationContext, CallService::class.java), CallServiceConnection(connection), 0)
+        bindService(Intent(applicationContext, CallAndroidService::class.java), CallServiceConnection(connection), 0)
         connection.setInitializing()
         return connection
     }
 
     inner class CallServiceConnection(private val callConnection: CallConnection) : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
-            val callSrvBinder = binder as CallService.CallServiceBinder
+            val callSrvBinder = binder as CallAndroidService.CallServiceBinder
             callSrvBinder.getCallService().addConnection(callConnection)
             unbindService(this)
         }

--- a/vector/src/main/java/im/vector/app/features/call/webrtc/ScreenCaptureServiceConnection.kt
+++ b/vector/src/main/java/im/vector/app/features/call/webrtc/ScreenCaptureServiceConnection.kt
@@ -32,7 +32,7 @@ class ScreenCaptureServiceConnection @Inject constructor(
     }
 
     private var isBound = false
-    private var screenCaptureService: ScreenCaptureService? = null
+    private var screenCaptureAndroidService: ScreenCaptureAndroidService? = null
     private var callback: Callback? = null
 
     fun bind(callback: Callback) {
@@ -41,25 +41,25 @@ class ScreenCaptureServiceConnection @Inject constructor(
         if (isBound) {
             callback.onServiceConnected()
         } else {
-            Intent(context, ScreenCaptureService::class.java).also { intent ->
+            Intent(context, ScreenCaptureAndroidService::class.java).also { intent ->
                 context.bindService(intent, this, 0)
             }
         }
     }
 
     fun stopScreenCapturing() {
-        screenCaptureService?.stopService()
+        screenCaptureAndroidService?.stopService()
     }
 
     override fun onServiceConnected(className: ComponentName, binder: IBinder) {
-        screenCaptureService = (binder as ScreenCaptureService.LocalBinder).getService()
+        screenCaptureAndroidService = (binder as ScreenCaptureAndroidService.LocalBinder).getService()
         isBound = true
         callback?.onServiceConnected()
     }
 
     override fun onServiceDisconnected(className: ComponentName) {
         isBound = false
-        screenCaptureService = null
+        screenCaptureAndroidService = null
         callback = null
     }
 }

--- a/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCall.kt
+++ b/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCall.kt
@@ -19,7 +19,7 @@ package im.vector.app.features.call.webrtc
 import android.content.Context
 import android.hardware.camera2.CameraManager
 import androidx.core.content.getSystemService
-import im.vector.app.core.services.CallService
+import im.vector.app.core.services.CallAndroidService
 import im.vector.app.core.utils.PublishDataSource
 import im.vector.app.core.utils.TextUtils.formatDuration
 import im.vector.app.features.call.CameraEventsHandlerAdapter
@@ -477,7 +477,7 @@ class WebRtcCall(
         val turnServerResponse = getTurnServer()
         // Update service state
         withContext(Dispatchers.Main) {
-            CallService.onPendingCall(
+            CallAndroidService.onPendingCall(
                     context = context,
                     callId = mxCall.callId
             )

--- a/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCallManager.kt
+++ b/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCallManager.kt
@@ -22,7 +22,7 @@ import androidx.lifecycle.LifecycleOwner
 import im.vector.app.ActiveSessionDataSource
 import im.vector.app.BuildConfig
 import im.vector.app.core.pushers.UnifiedPushHelper
-import im.vector.app.core.services.CallService
+import im.vector.app.core.services.CallAndroidService
 import im.vector.app.features.analytics.AnalyticsTracker
 import im.vector.app.features.analytics.plan.CallEnded
 import im.vector.app.features.analytics.plan.CallStarted
@@ -254,7 +254,7 @@ class WebRtcCallManager @Inject constructor(
             Timber.tag(loggerTag.value).v("On call ended for unknown call $callId")
         }
         webRtcCall.trackCallEnded()
-        CallService.onCallTerminated(context, callId, endCallReason, rejected)
+        CallAndroidService.onCallTerminated(context, callId, endCallReason, rejected)
         callsByRoomId[webRtcCall.signalingRoomId]?.remove(webRtcCall)
         callsByRoomId[webRtcCall.nativeRoomId]?.remove(webRtcCall)
         transferees.remove(callId)
@@ -305,7 +305,7 @@ class WebRtcCallManager @Inject constructor(
         if (transferee != null) {
             transferees[webRtcCall.callId] = transferee
         }
-        CallService.onOutgoingCallRinging(
+        CallAndroidService.onOutgoingCallRinging(
                 context = context.applicationContext,
                 callId = mxCall.callId
         )
@@ -370,7 +370,7 @@ class WebRtcCallManager @Inject constructor(
             offerSdp = callInviteContent.offer
         }
         // Start background service with notification
-        CallService.onIncomingCallRinging(
+        CallAndroidService.onIncomingCallRinging(
                 context = context,
                 callId = mxCall.callId,
                 isInBackground = isInBackground
@@ -395,7 +395,7 @@ class WebRtcCallManager @Inject constructor(
                 }
         val mxCall = call.mxCall
         // Update service state
-        CallService.onPendingCall(
+        CallAndroidService.onPendingCall(
                 context = context,
                 callId = mxCall.callId
         )

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingAndroidService.kt
@@ -23,7 +23,7 @@ import android.os.Parcelable
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
-import im.vector.app.core.services.VectorService
+import im.vector.app.core.services.VectorAndroidService
 import im.vector.app.features.location.live.GetLiveLocationShareSummaryUseCase
 import im.vector.app.features.notifications.NotificationUtils
 import im.vector.app.features.session.coroutineScope
@@ -42,7 +42,7 @@ import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class LocationSharingService : VectorService(), LocationTracker.Callback {
+class LocationSharingAndroidService : VectorAndroidService(), LocationTracker.Callback {
 
     @Parcelize
     data class RoomArgs(
@@ -80,7 +80,7 @@ class LocationSharingService : VectorService(), LocationTracker.Callback {
 
         launchWithActiveSession { session ->
             val job = locationTracker.locations
-                    .onEach(this@LocationSharingService::onLocationUpdate)
+                    .onEach(this@LocationSharingAndroidService::onLocationUpdate)
                     .launchIn(session.coroutineScope)
             jobs.add(job)
         }
@@ -225,7 +225,7 @@ class LocationSharingService : VectorService(), LocationTracker.Callback {
     }
 
     inner class LocalBinder : Binder() {
-        fun getService(): LocationSharingService = this@LocationSharingService
+        fun getService(): LocationSharingAndroidService = this@LocationSharingAndroidService
     }
 
     interface Callback {

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
@@ -179,10 +179,10 @@ class LocationSharingFragment @Inject constructor(
     }
 
     private fun handleStartLiveLocationService(event: LocationSharingViewEvents.StartLiveLocationService) {
-        val args = LocationSharingService.RoomArgs(event.sessionId, event.roomId, event.durationMillis)
+        val args = LocationSharingAndroidService.RoomArgs(event.sessionId, event.roomId, event.durationMillis)
 
-        Intent(requireContext(), LocationSharingService::class.java)
-                .putExtra(LocationSharingService.EXTRA_ROOM_ARGS, args)
+        Intent(requireContext(), LocationSharingAndroidService::class.java)
+                .putExtra(LocationSharingAndroidService.EXTRA_ROOM_ARGS, args)
                 .also {
                     ContextCompat.startForegroundService(requireContext(), it)
                 }

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingServiceConnection.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingServiceConnection.kt
@@ -27,7 +27,8 @@ import javax.inject.Singleton
 @Singleton
 class LocationSharingServiceConnection @Inject constructor(
         private val context: Context
-) : ServiceConnection, LocationSharingService.Callback {
+) : ServiceConnection,
+        LocationSharingAndroidService.Callback {
 
     interface Callback {
         fun onLocationServiceRunning()
@@ -37,7 +38,7 @@ class LocationSharingServiceConnection @Inject constructor(
 
     private val callbacks = mutableSetOf<Callback>()
     private var isBound = false
-    private var locationSharingService: LocationSharingService? = null
+    private var locationSharingAndroidService: LocationSharingAndroidService? = null
 
     fun bind(callback: Callback) {
         addCallback(callback)
@@ -45,7 +46,7 @@ class LocationSharingServiceConnection @Inject constructor(
         if (isBound) {
             callback.onLocationServiceRunning()
         } else {
-            Intent(context, LocationSharingService::class.java).also { intent ->
+            Intent(context, LocationSharingAndroidService::class.java).also { intent ->
                 context.bindService(intent, this, 0)
             }
         }
@@ -56,7 +57,7 @@ class LocationSharingServiceConnection @Inject constructor(
     }
 
     override fun onServiceConnected(className: ComponentName, binder: IBinder) {
-        locationSharingService = (binder as LocationSharingService.LocalBinder).getService().also {
+        locationSharingAndroidService = (binder as LocationSharingAndroidService.LocalBinder).getService().also {
             it.callback = this
         }
         isBound = true
@@ -65,8 +66,8 @@ class LocationSharingServiceConnection @Inject constructor(
 
     override fun onServiceDisconnected(className: ComponentName) {
         isBound = false
-        locationSharingService?.callback = null
-        locationSharingService = null
+        locationSharingAndroidService?.callback = null
+        locationSharingAndroidService = null
         onCallbackActionNoArg(Callback::onLocationServiceStopped)
     }
 

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
@@ -50,7 +50,7 @@ import im.vector.app.R
 import im.vector.app.core.extensions.createIgnoredUri
 import im.vector.app.core.platform.PendingIntentCompat
 import im.vector.app.core.resources.StringProvider
-import im.vector.app.core.services.CallService
+import im.vector.app.core.services.CallAndroidService
 import im.vector.app.core.time.Clock
 import im.vector.app.core.utils.startNotificationChannelSettingsIntent
 import im.vector.app.features.call.VectorCallActivity
@@ -512,7 +512,7 @@ class NotificationUtils @Inject constructor(
     /**
      * Build notification for the CallService, when a call is missed.
      */
-    fun buildCallMissedNotification(callInformation: CallService.CallInformation): Notification {
+    fun buildCallMissedNotification(callInformation: CallAndroidService.CallInformation): Notification {
         val builder = NotificationCompat.Builder(context, SILENT_NOTIFICATION_CHANNEL_ID)
                 .setContentTitle(callInformation.opponentMatrixItem?.getBestName() ?: callInformation.opponentUserId)
                 .apply {


### PR DESCRIPTION
To limit confusion with our Matrix SDK Services