### PR TITLE
Handle case when device cannot be verified

### DIFF
--- a/changelog.d/6466.bugfix
+++ b/changelog.d/6466.bugfix
@@ -1,0 +1,1 @@
+When there is no way to verify a device (no 4S nor other device) propose to reset verification keys

--- a/vector/src/androidTest/java/im/vector/app/CantVerifyTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/CantVerifyTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app
+
+import android.view.View
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import im.vector.app.features.MainActivity
+import im.vector.app.ui.robot.ElementRobot
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class CantVerifyTest : VerificationTestBase() {
+
+    @get:Rule
+    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    private val elementRobot = ElementRobot()
+    var userName: String = "loginTest_${UUID.randomUUID()}"
+
+    @Test
+    fun checkCantVerifyPopup() {
+        // Let' create an account
+        // This first session will create cross signing keys then logout
+        elementRobot.signUp(userName)
+        Espresso.onView(ViewMatchers.isRoot()).perform(SleepViewAction.sleep(2000))
+
+        elementRobot.signout(false)
+        Espresso.onView(ViewMatchers.isRoot()).perform(SleepViewAction.sleep(2000))
+
+        // Let's login again now
+        // There are no methods to verify (no other devices, nor 4S)
+        // So it should ask to reset all
+        elementRobot.login(userName)
+
+        val activity = EspressoHelper.getCurrentActivity()!!
+        Espresso.onView(ViewMatchers.isRoot())
+                .perform(waitForView(ViewMatchers.withText(R.string.crosssigning_cannot_verify_this_session)))
+
+        // check that the text is correct
+        val popup = activity.findViewById<View>(com.tapadoo.alerter.R.id.llAlertBackground)!!
+        activity.runOnUiThread { popup.performClick() }
+
+        // ensure that it's the 4S setup bottomsheet
+        Espresso.onView(ViewMatchers.withId(R.id.bottomSheetFragmentContainer))
+                .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+
+        Espresso.onView(ViewMatchers.isRoot()).perform(SleepViewAction.sleep(2000))
+
+        Espresso.onView(ViewMatchers.withText(R.string.bottom_sheet_setup_secure_backup_title))
+                .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -238,7 +238,8 @@ class HomeActivity :
         homeActivityViewModel.observeViewEvents {
             when (it) {
                 is HomeActivityViewEvents.AskPasswordToInitCrossSigning -> handleAskPasswordToInitCrossSigning(it)
-                is HomeActivityViewEvents.OnNewSession -> handleOnNewSession(it)
+                is HomeActivityViewEvents.CurrentSessionNotVerified -> handleOnNewSession(it)
+                is HomeActivityViewEvents.CurrentSessionCannotBeVerified -> handleCantVerify(it)
                 HomeActivityViewEvents.PromptToEnableSessionPush -> handlePromptToEnablePush()
                 HomeActivityViewEvents.StartRecoverySetupFlow -> handleStartRecoverySetup()
                 is HomeActivityViewEvents.ForceVerification -> {
@@ -422,7 +423,7 @@ class HomeActivity :
         }
     }
 
-    private fun handleOnNewSession(event: HomeActivityViewEvents.OnNewSession) {
+    private fun handleOnNewSession(event: HomeActivityViewEvents.CurrentSessionNotVerified) {
         // We need to ask
         promptSecurityEvent(
                 event.userItem,
@@ -434,6 +435,17 @@ class HomeActivity :
             } else {
                 it.navigator.requestSelfSessionVerification(it)
             }
+        }
+    }
+
+    private fun handleCantVerify(event: HomeActivityViewEvents.CurrentSessionCannotBeVerified) {
+        // We need to ask
+        promptSecurityEvent(
+                event.userItem,
+                R.string.crosssigning_cannot_verify_this_session,
+                R.string.crosssigning_cannot_verify_this_session_desc
+        ) {
+            it.navigator.open4SSetup(it, SetupMode.PASSPHRASE_AND_NEEDED_SECRETS_RESET)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewEvents.kt
@@ -21,7 +21,13 @@ import org.matrix.android.sdk.api.util.MatrixItem
 
 sealed interface HomeActivityViewEvents : VectorViewEvents {
     data class AskPasswordToInitCrossSigning(val userItem: MatrixItem.UserItem?) : HomeActivityViewEvents
-    data class OnNewSession(val userItem: MatrixItem.UserItem?, val waitForIncomingRequest: Boolean = true) : HomeActivityViewEvents
+    data class CurrentSessionNotVerified(
+            val userItem: MatrixItem.UserItem?,
+            val waitForIncomingRequest: Boolean = true,
+    ) : HomeActivityViewEvents
+    data class CurrentSessionCannotBeVerified(
+            val userItem: MatrixItem.UserItem?,
+    ) : HomeActivityViewEvents
     data class OnCrossSignedInvalidated(val userItem: MatrixItem.UserItem) : HomeActivityViewEvents
     object PromptToEnableSessionPush : HomeActivityViewEvents
     object ShowAnalyticsOptIn : HomeActivityViewEvents

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -364,14 +364,30 @@ class HomeActivityViewModel @AssistedInject constructor(
                             // If 4S is forced, force verification
                             _viewEvents.post(HomeActivityViewEvents.ForceVerification(true))
                         } else {
-                            // New session
-                            _viewEvents.post(
-                                    HomeActivityViewEvents.OnNewSession(
-                                            session.getUser(session.myUserId)?.toMatrixItem(),
-                                            // Always send request instead of waiting for an incoming as per recent EW changes
-                                            false
-                                    )
-                            )
+                            // we wan't to check if there is a way to actually verify this session,
+                            // that means that there is another session to verify against, or
+                            // secure backup is setup
+                            val hasTargetDeviceToVerifyAgainst = session
+                                    .cryptoService()
+                                    .getUserDevices(session.myUserId)
+                                    .size >= 2 // this one + another
+                            val is4Ssetup = session.sharedSecretStorageService().isRecoverySetup()
+                            if (hasTargetDeviceToVerifyAgainst || is4Ssetup) {
+                                // New session
+                                _viewEvents.post(
+                                        HomeActivityViewEvents.CurrentSessionNotVerified(
+                                                session.getUser(session.myUserId)?.toMatrixItem(),
+                                                // Always send request instead of waiting for an incoming as per recent EW changes
+                                                false
+                                        )
+                                )
+                            } else {
+                                _viewEvents.post(
+                                        HomeActivityViewEvents.CurrentSessionCannotBeVerified(
+                                                session.getUser(session.myUserId)?.toMatrixItem(),
+                                        )
+                                )
+                            }
                         }
                     }
                 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
@@ -106,6 +106,18 @@ class DeviceVerificationInfoBottomSheetController @Inject constructor(
                                     .toEpoxyCharSequence()
                     )
                 }
+            } else {
+                genericItem {
+                    id("reset${cryptoDeviceInfo.deviceId}")
+                    style(ItemStyle.BIG_TEXT)
+                    titleIconResourceId(shield)
+                    title(host.stringProvider.getString(R.string.crosssigning_cannot_verify_this_session).toEpoxyCharSequence())
+                    description(
+                            host.stringProvider
+                                    .getString(R.string.crosssigning_cannot_verify_this_session_desc)
+                                    .toEpoxyCharSequence()
+                    )
+                }
             }
         } else {
             if (!currentSessionIsTrusted) {
@@ -141,19 +153,45 @@ class DeviceVerificationInfoBottomSheetController @Inject constructor(
             description("(${cryptoDeviceInfo.deviceId})".toEpoxyCharSequence())
         }
 
-        if (isMine && !currentSessionIsTrusted && data.canVerifySession) {
-            // Add complete security
-            bottomSheetDividerItem {
-                id("completeSecurityDiv")
-            }
-            bottomSheetVerificationActionItem {
-                id("completeSecurity")
-                title(host.stringProvider.getString(R.string.crosssigning_verify_this_session))
-                titleColor(host.colorProvider.getColorFromAttribute(R.attr.colorPrimary))
-                iconRes(R.drawable.ic_arrow_right)
-                iconColor(host.colorProvider.getColorFromAttribute(R.attr.colorPrimary))
-                listener {
-                    host.callback?.onAction(DevicesAction.CompleteSecurity)
+        if (isMine) {
+            if (!currentSessionIsTrusted) {
+                if (data.canVerifySession) {
+                    // Add complete security
+                    bottomSheetDividerItem {
+                        id("completeSecurityDiv")
+                    }
+                    bottomSheetVerificationActionItem {
+                        id("completeSecurity")
+                        title(host.stringProvider.getString(R.string.crosssigning_verify_this_session))
+                        titleColor(host.colorProvider.getColorFromAttribute(R.attr.colorPrimary))
+                        iconRes(R.drawable.ic_arrow_right)
+                        iconColor(host.colorProvider.getColorFromAttribute(R.attr.colorPrimary))
+                        listener {
+                            host.callback?.onAction(DevicesAction.CompleteSecurity)
+                        }
+                    }
+                } else {
+                    bottomSheetDividerItem {
+                        id("resetSecurityDiv")
+                    }
+                    bottomSheetVerificationActionItem {
+                        id("resetSecurity")
+                        title(host.stringProvider.getString(R.string.secure_backup_reset_all))
+                        titleColor(host.colorProvider.getColorFromAttribute(R.attr.colorPrimary))
+                        iconRes(R.drawable.ic_arrow_right)
+                        iconColor(host.colorProvider.getColorFromAttribute(R.attr.colorPrimary))
+                        listener {
+                            host.callback?.onAction(DevicesAction.ResetSecurity)
+                        }
+                    }
+                }
+            } else if (!isMine) {
+                if (currentSessionIsTrusted) {
+                    // we can propose to verify it
+                    val isVerified = cryptoDeviceInfo.trustLevel?.crossSigningVerified.orFalse()
+                    if (!isVerified) {
+                        addVerifyActions(cryptoDeviceInfo)
+                    }
                 }
             }
         } else if (!isMine) {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
@@ -194,7 +194,9 @@ class DeviceVerificationInfoBottomSheetController @Inject constructor(
                     }
                 }
             }
-        } else if (!isMine) {
+        } else
+        /** if (!isMine) **/
+        {
             if (currentSessionIsTrusted) {
                 // we can propose to verify it
                 val isVerified = cryptoDeviceInfo.trustLevel?.crossSigningVerified.orFalse()

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceVerificationInfoBottomSheetController.kt
@@ -185,14 +185,6 @@ class DeviceVerificationInfoBottomSheetController @Inject constructor(
                         }
                     }
                 }
-            } else if (!isMine) {
-                if (currentSessionIsTrusted) {
-                    // we can propose to verify it
-                    val isVerified = cryptoDeviceInfo.trustLevel?.crossSigningVerified.orFalse()
-                    if (!isVerified) {
-                        addVerifyActions(cryptoDeviceInfo)
-                    }
-                }
             }
         } else
         /** if (!isMine) **/

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DevicesAction.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DevicesAction.kt
@@ -30,6 +30,7 @@ sealed class DevicesAction : VectorViewModelAction {
     data class VerifyMyDevice(val deviceId: String) : DevicesAction()
     data class VerifyMyDeviceManually(val deviceId: String) : DevicesAction()
     object CompleteSecurity : DevicesAction()
+    object ResetSecurity : DevicesAction()
     data class MarkAsManuallyVerified(val cryptoDeviceInfo: CryptoDeviceInfo) : DevicesAction()
 
     object SsoAuthDone : DevicesAction()

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewEvents.kt
@@ -48,4 +48,6 @@ sealed class DevicesViewEvents : VectorViewEvents {
     ) : DevicesViewEvents()
 
     data class ShowManuallyVerify(val cryptoDeviceInfo: CryptoDeviceInfo) : DevicesViewEvents()
+
+    object PromptResetSecrets : DevicesViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
@@ -239,6 +239,7 @@ class DevicesViewModel @AssistedInject constructor(
                 uiaContinuation = null
                 pendingAuth = null
             }
+            DevicesAction.ResetSecurity -> _viewEvents.post(DevicesViewEvents.PromptResetSecrets)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/VectorSettingsDevicesFragment.kt
@@ -37,6 +37,7 @@ import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.databinding.DialogBaseEditTextBinding
 import im.vector.app.databinding.FragmentGenericRecyclerBinding
 import im.vector.app.features.auth.ReAuthActivity
+import im.vector.app.features.crypto.recover.SetupMode
 import im.vector.app.features.crypto.verification.VerificationBottomSheet
 import org.matrix.android.sdk.api.auth.data.LoginFlowTypes
 import org.matrix.android.sdk.api.session.crypto.model.DeviceInfo
@@ -88,6 +89,9 @@ class VectorSettingsDevicesFragment @Inject constructor(
                     ManuallyVerifyDialog.show(requireActivity(), it.cryptoDeviceInfo) {
                         viewModel.handle(DevicesAction.MarkAsManuallyVerified(it.cryptoDeviceInfo))
                     }
+                }
+                is DevicesViewEvents.PromptResetSecrets -> {
+                    navigator.open4SSetup(requireContext(), SetupMode.PASSPHRASE_AND_NEEDED_SECRETS_RESET)
                 }
             }
         }

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2351,7 +2351,9 @@
         <item quantity="other">%d active sessions</item>
     </plurals>
 
-    <string name="crosssigning_verify_this_session">Verify this login</string>
+    <string name="crosssigning_verify_this_session">Verify this device</string>
+    <string name="crosssigning_cannot_verify_this_session">Unable to verify this device</string>
+    <string name="crosssigning_cannot_verify_this_session_desc">You won\'t be able to access encrypted message history. Reset your Secure Message Backup and verification keys to start fresh.</string>
 
     <string name="verification_open_other_to_verify">Use an existing session to verify this one, granting it access to encrypted messages.</string>
 

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2353,7 +2353,7 @@
 
     <string name="crosssigning_verify_this_session">Verify this device</string>
     <string name="crosssigning_cannot_verify_this_session">Unable to verify this device</string>
-    <string name="crosssigning_cannot_verify_this_session_desc">You won\'t be able to access encrypted message history. Reset your Secure Message Backup and verification keys to start fresh.</string>
+    <string name="crosssigning_cannot_verify_this_session_desc">You won’t be able to access encrypted message history. Reset your Secure Message Backup and verification keys to start fresh.</string>
 
     <string name="verification_open_other_to_verify">Use an existing session to verify this one, granting it access to encrypted messages.</string>
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Bugfix

## Content

Fixes #6466

<!-- Describe shortly what has been changed -->

## Motivation and context

When there is no way to verify a new device, prompt and propose to reset verifications keys.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->


|Before|After|
|-|-|
|<img width="290" alt="image" src="https://user-images.githubusercontent.com/9841565/177367712-934e01ff-3e1a-47af-a887-844d2a807177.png">|<img width="418" alt="image" src="https://user-images.githubusercontent.com/9841565/177367420-98a44090-8331-4809-a218-2cee3089b44d.png">|

This can be performed from settings also
<img width="407" alt="image" src="https://user-images.githubusercontent.com/9841565/177367288-eb462e11-7631-4cc1-93dc-56869e7239a4.png">

A click on the popup will open the 4S setup bottomsheet

<img width="398" alt="image" src="https://user-images.githubusercontent.com/9841565/177367543-24f997ec-7a8e-452e-890c-1b986d82a9be.png">

## Tests

<!-- Explain how you tested your development -->

- Step 1: Create an account then logout
- Step 2: Login this account again

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
