### PR TITLE
Suppress webview / checkbox permission dialog

### DIFF
--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
@@ -311,7 +311,8 @@ class WidgetFragment @Inject constructor(
                 request = request,
                 context = requireContext(),
                 activity = requireActivity(),
-                activityResultLauncher = permissionResultLauncher
+                activityResultLauncher = permissionResultLauncher,
+                autoApprove = fragmentArgs.kind == WidgetKind.ELEMENT_CALL
         )
     }
 


### PR DESCRIPTION
This suppresses the web view / checkbox permission dialog and redirects straight to the system permission dialog (in case it's needed).