### PR TITLE
[Timeline] - Collapse redacted events (PSG-523)

### DIFF
--- a/changelog.d/6487.feature
+++ b/changelog.d/6487.feature
@@ -1,0 +1,1 @@
+[Timeline] - Collapse redacted events

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
@@ -202,7 +202,7 @@ data class Event(
      * It will return a decrypted text message or an empty string otherwise.
      */
     fun getDecryptedTextSummary(): String? {
-        if (isRedacted()) return "Message Deleted"
+        if (isRedacted()) return "Message removed"
         val text = getDecryptedValue() ?: run {
             if (isPoll()) {
                 return getPollQuestion() ?: "created a poll."

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MergedHeaderItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MergedHeaderItemFactory.kt
@@ -46,8 +46,6 @@ import org.matrix.android.sdk.api.session.room.powerlevels.PowerLevelsHelper
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
 import javax.inject.Inject
 
-private const val MIN_NUMBER_OF_MERGED_EVENTS = 2
-
 class MergedHeaderItemFactory @Inject constructor(
         private val activeSessionHolder: ActiveSessionHolder,
         private val avatarRenderer: AvatarRenderer,
@@ -215,8 +213,7 @@ class MergedHeaderItemFactory @Inject constructor(
                 collapsedEventIds.removeAll(mergedEventIds)
             }
             val mergeId = mergedEventIds.joinToString(separator = "_") { it.toString() }
-            val summaryTitleResId = getSummaryTitleResId(event.root)
-            summaryTitleResId?.let { summaryTitle ->
+            getSummaryTitleResId(event.root)?.let { summaryTitle ->
                 val attributes = MergedSimilarEventsItem.Attributes(
                         summaryTitleResId = summaryTitle,
                         isCollapsed = isCollapsed,
@@ -344,5 +341,9 @@ class MergedHeaderItemFactory @Inject constructor(
 
     fun isCollapsed(localId: Long): Boolean {
         return collapsedEventIds.contains(localId)
+    }
+
+    companion object {
+        private const val MIN_NUMBER_OF_MERGED_EVENTS = 2
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MergedHeaderItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MergedHeaderItemFactory.kt
@@ -84,7 +84,7 @@ class MergedHeaderItemFactory @Inject constructor(
                 buildRoomCreationMergedSummary(currentPosition, items, partialState, event, eventIdToHighlight, requestModelBuild, callback)
             isStartOfSameTypeEventsSummary(event, nextEvent, addDaySeparator) ->
                 buildSameTypeEventsMergedSummary(currentPosition, items, partialState, event, eventIdToHighlight, requestModelBuild, callback)
-            isStartOfRedactedEventsSummary(event, nextEvent, addDaySeparator) ->
+            isStartOfRedactedEventsSummary(event, items, currentPosition, addDaySeparator) ->
                 buildRedactedEventsMergedSummary(currentPosition, items, partialState, event, eventIdToHighlight, requestModelBuild, callback)
             else -> null
         }
@@ -120,16 +120,21 @@ class MergedHeaderItemFactory @Inject constructor(
 
     /**
      * @param event the main timeline event
-     * @param nextEvent is an older event than event
+     * @param items all known items, sorted from newer event to oldest event
+     * @param currentPosition the current position
      * @param addDaySeparator true to add a day separator
      */
     private fun isStartOfRedactedEventsSummary(
             event: TimelineEvent,
-            nextEvent: TimelineEvent?,
+            items: List<TimelineEvent>,
+            currentPosition: Int,
             addDaySeparator: Boolean,
     ): Boolean {
+        val nextNonRedactionEvent = items
+                .subList(fromIndex = currentPosition + 1, toIndex = items.size)
+                .find { it.root.getClearType() != EventType.REDACTION }
         return event.root.isRedacted() &&
-                ((nextEvent?.root?.getClearType() != EventType.REDACTION && !nextEvent?.root?.isRedacted().orFalse()) || addDaySeparator)
+                (!nextNonRedactionEvent?.root?.isRedacted().orFalse() || addDaySeparator)
     }
 
     private fun buildSameTypeEventsMergedSummary(

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineDisplayableEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineDisplayableEvents.kt
@@ -54,11 +54,6 @@ object TimelineDisplayableEvents {
     ) + EventType.POLL_START + EventType.STATE_ROOM_BEACON_INFO
 }
 
-fun TimelineEvent.canBeMerged(): Boolean {
-    return root.getClearType() == EventType.STATE_ROOM_MEMBER ||
-            root.getClearType() == EventType.STATE_ROOM_SERVER_ACL
-}
-
 fun TimelineEvent.isRoomConfiguration(roomCreatorUserId: String?): Boolean {
     return root.isStateEvent() && when (root.getClearType()) {
         EventType.STATE_ROOM_GUEST_ACCESS,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineEventVisibilityHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineEventVisibilityHelper.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.home.room.detail.timeline.helper
 
 import im.vector.app.core.extensions.localDateTime
 import im.vector.app.core.resources.UserPreferencesProvider
+import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.RelationType
 import org.matrix.android.sdk.api.session.events.model.getRelationContent
@@ -30,25 +31,38 @@ import org.matrix.android.sdk.api.session.room.model.localecho.RoomLocalEcho
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
 import javax.inject.Inject
 
-class TimelineEventVisibilityHelper @Inject constructor(private val userPreferencesProvider: UserPreferencesProvider) {
+class TimelineEventVisibilityHelper @Inject constructor(
+        private val userPreferencesProvider: UserPreferencesProvider,
+) {
+
+    private interface PredicateToStopSearch {
+        /**
+         * Indicate whether a search on events should stop by comparing to given successive events.
+         * @param oldEvent the oldest event between the 2 events to compare
+         * @param newEvent the more recent event between the 2 events to compare
+         */
+        fun shouldStopSearch(oldEvent: Event, newEvent: Event): Boolean
+    }
 
     /**
-     * @param timelineEvents the events to search in
+     * @param timelineEvents the events to search in, sorted from oldest event to newer event
      * @param index the index to start computing (inclusive)
      * @param minSize the minimum number of same type events to have sequentially, otherwise will return an empty list
      * @param eventIdToHighlight used to compute visibility
      * @param rootThreadEventId the root thread event id if in a thread timeline
      * @param isFromThreadTimeline true if the timeline is a thread
+     * @param predicateToStop events are taken until this condition is met
      *
-     * @return a list of timeline events which have sequentially the same type following the next direction.
+     * @return a list of timeline events which meet sequentially the same criteria following the next direction.
      */
-    private fun nextSameTypeEvents(
+    private fun nextEventsUntil(
             timelineEvents: List<TimelineEvent>,
             index: Int,
             minSize: Int,
             eventIdToHighlight: String?,
             rootThreadEventId: String?,
-            isFromThreadTimeline: Boolean
+            isFromThreadTimeline: Boolean,
+            predicateToStop: PredicateToStopSearch
     ): List<TimelineEvent> {
         if (index >= timelineEvents.size - 1) {
             return emptyList()
@@ -65,13 +79,15 @@ class TimelineEventVisibilityHelper @Inject constructor(private val userPreferen
         } else {
             nextSubList.subList(0, indexOfNextDay)
         }
-        val indexOfFirstDifferentEventType = nextSameDayEvents.indexOfFirst { it.root.getClearType() != timelineEvent.root.getClearType() }
-        val sameTypeEvents = if (indexOfFirstDifferentEventType == -1) {
+        val indexOfFirstDifferentEvent = nextSameDayEvents.indexOfFirst {
+            predicateToStop.shouldStopSearch(oldEvent = timelineEvent.root, newEvent = it.root)
+        }
+        val similarEvents = if (indexOfFirstDifferentEvent == -1) {
             nextSameDayEvents
         } else {
-            nextSameDayEvents.subList(0, indexOfFirstDifferentEventType)
+            nextSameDayEvents.subList(0, indexOfFirstDifferentEvent)
         }
-        val filteredSameTypeEvents = sameTypeEvents.filter {
+        val filteredSimilarEvents = similarEvents.filter {
             shouldShowEvent(
                     timelineEvent = it,
                     highlightedEventId = eventIdToHighlight,
@@ -79,14 +95,11 @@ class TimelineEventVisibilityHelper @Inject constructor(private val userPreferen
                     rootThreadEventId = rootThreadEventId
             )
         }
-        if (filteredSameTypeEvents.size < minSize) {
-            return emptyList()
-        }
-        return filteredSameTypeEvents
+        return if (filteredSimilarEvents.size < minSize) emptyList() else filteredSimilarEvents
     }
 
     /**
-     * @param timelineEvents the events to search in
+     * @param timelineEvents the events to search in, sorted from newer event to oldest event
      * @param index the index to start computing (inclusive)
      * @param minSize the minimum number of same type events to have sequentially, otherwise will return an empty list
      * @param eventIdToHighlight used to compute visibility
@@ -107,7 +120,44 @@ class TimelineEventVisibilityHelper @Inject constructor(private val userPreferen
         return prevSub
                 .reversed()
                 .let {
-                    nextSameTypeEvents(it, 0, minSize, eventIdToHighlight, rootThreadEventId, isFromThreadTimeline)
+                    nextEventsUntil(it, 0, minSize, eventIdToHighlight, rootThreadEventId, isFromThreadTimeline, object : PredicateToStopSearch {
+                        override fun shouldStopSearch(oldEvent: Event, newEvent: Event): Boolean {
+                            return oldEvent.getClearType() != newEvent.getClearType()
+                        }
+                    })
+                }
+    }
+
+    /**
+     * @param timelineEvents the events to search in, sorted from newer event to oldest event
+     * @param index the index to start computing (inclusive)
+     * @param minSize the minimum number of same type events to have sequentially, otherwise will return an empty list
+     * @param eventIdToHighlight used to compute visibility
+     * @param rootThreadEventId the root thread eventId
+     * @param isFromThreadTimeline true if the timeline is a thread
+     *
+     * @return a list of timeline events which are all redacted following the prev direction.
+     */
+    fun prevRedactedEvents(
+            timelineEvents: List<TimelineEvent>,
+            index: Int,
+            minSize: Int,
+            eventIdToHighlight: String?,
+            rootThreadEventId: String?,
+            isFromThreadTimeline: Boolean
+    ): List<TimelineEvent> {
+        val prevSub = timelineEvents
+                .subList(0, index + 1)
+                // Ensure to not take the REDACTION event into account
+                .filter { it.root.getClearType() != EventType.REDACTION }
+        return prevSub
+                .reversed()
+                .let {
+                    nextEventsUntil(it, 0, minSize, eventIdToHighlight, rootThreadEventId, isFromThreadTimeline, object : PredicateToStopSearch {
+                        override fun shouldStopSearch(oldEvent: Event, newEvent: Event): Boolean {
+                            return oldEvent.isRedacted() && !newEvent.isRedacted()
+                        }
+                    })
                 }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineEventVisibilityHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineEventVisibilityHelper.kt
@@ -37,7 +37,7 @@ class TimelineEventVisibilityHelper @Inject constructor(
 
     private interface PredicateToStopSearch {
         /**
-         * Indicate whether a search on events should stop by comparing to given successive events.
+         * Indicate whether a search on events should stop by comparing 2 given successive events.
          * @param oldEvent the oldest event between the 2 events to compare
          * @param newEvent the more recent event between the 2 events to compare
          */
@@ -148,7 +148,7 @@ class TimelineEventVisibilityHelper @Inject constructor(
     ): List<TimelineEvent> {
         val prevSub = timelineEvents
                 .subList(0, index + 1)
-                // Ensure to not take the REDACTION event into account
+                // Ensure to not take the REDACTION events into account
                 .filter { it.root.getClearType() != EventType.REDACTION }
         return prevSub
                 .reversed()

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1608,7 +1608,7 @@
     <string name="message_view_reaction">View Reactions</string>
     <string name="reactions">Reactions</string>
 
-    <string name="event_redacted">Message deleted</string>
+    <string name="event_redacted">Message removed</string>
     <string name="settings_show_redacted">Show removed messages</string>
     <string name="settings_show_redacted_summary">Show a placeholder for removed messages</string>
     <string name="event_redacted_by_user_reason">Event deleted by user</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3103,4 +3103,8 @@
     <string name="live_location_labs_promotion_description">Please note: this is a labs feature using a temporary implementation. This means you will not be able to delete your location history, and advanced users will be able to see your location history even after you stop sharing your live location with this room.</string>
     <string name="live_location_labs_promotion_switch_title">Enable location sharing</string>
 
+    <plurals name="room_removed_messages">
+        <item quantity="one">%d message removed</item>
+        <item quantity="other">%d messages removed</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Collapsing multiple successive redacted events to save space on timeline. Refactoring a little the code to ease the readability.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6487 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->
<img src="https://user-images.githubusercontent.com/46314705/177949003-28941e84-a62f-4b0a-bae7-fe5e79fc78f4.png" width=300/> <img src="https://user-images.githubusercontent.com/46314705/179692460-c786350e-46a1-4547-aeae-de883ed33533.png" width=300/>

## Tests

<!-- Explain how you tested your development -->

- Go to a room
- Send multiple different types of messages
- Delete successive sent messages
- Check successive redacted messages are collapsed
- Check you can expand to see redacted messages individually

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
