### PR TITLE
Fixes inconsistent rooms in home behaviour

### DIFF
--- a/changelog.d/6510.bugfix
+++ b/changelog.d/6510.bugfix
@@ -1,0 +1,1 @@
+Fixes inconsistency with rooms within spaces showing or disappearing from home

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -1020,20 +1020,32 @@ class VectorPreferences @Inject constructor(
         }
     }
 
-    private fun labsSpacesOnlyOrphansInHome(): Boolean {
-        return defaultPrefs.getBoolean(SETTINGS_LABS_SPACES_HOME_AS_ORPHAN, false)
-    }
-
     fun labsAutoReportUISI(): Boolean {
         return defaultPrefs.getBoolean(SETTINGS_LABS_AUTO_REPORT_UISI, false)
     }
 
     fun prefSpacesShowAllRoomInHome(): Boolean {
-        return defaultPrefs.getBoolean(
-                SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME,
-                // migration of old property
-                !labsSpacesOnlyOrphansInHome()
-        )
+        val defaultValue = false
+        return when {
+            defaultPrefs.contains(SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME) -> {
+                defaultPrefs.getBoolean(SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME, defaultValue)
+            }
+            defaultPrefs.contains(SETTINGS_LABS_SPACES_HOME_AS_ORPHAN) -> migrateOrphansInSpacesToShowAllInHome()
+            else -> defaultValue
+        }
+    }
+
+    private fun migrateOrphansInSpacesToShowAllInHome(): Boolean {
+        val showAllRoomsInHome = !labsSpacesOnlyOrphansInHome()
+        defaultPrefs.edit {
+            putBoolean(SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME, showAllRoomsInHome)
+            remove(SETTINGS_LABS_SPACES_HOME_AS_ORPHAN)
+        }
+        return showAllRoomsInHome
+    }
+
+    private fun labsSpacesOnlyOrphansInHome(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_LABS_SPACES_HOME_AS_ORPHAN, false)
     }
 
     /*

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -158,7 +158,6 @@ class VectorPreferences @Inject constructor(
         private const val SETTINGS_ENABLE_SEND_VOICE_FEATURE_PREFERENCE_KEY = "SETTINGS_ENABLE_SEND_VOICE_FEATURE_PREFERENCE_KEY"
 
         const val SETTINGS_LABS_ALLOW_EXTENDED_LOGS = "SETTINGS_LABS_ALLOW_EXTENDED_LOGS"
-        const val SETTINGS_LABS_SPACES_HOME_AS_ORPHAN = "SETTINGS_LABS_SPACES_HOME_AS_ORPHAN"
         const val SETTINGS_LABS_AUTO_REPORT_UISI = "SETTINGS_LABS_AUTO_REPORT_UISI"
         const val SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME = "SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME"
 
@@ -1025,27 +1024,7 @@ class VectorPreferences @Inject constructor(
     }
 
     fun prefSpacesShowAllRoomInHome(): Boolean {
-        val defaultValue = false
-        return when {
-            defaultPrefs.contains(SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME) -> {
-                defaultPrefs.getBoolean(SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME, defaultValue)
-            }
-            defaultPrefs.contains(SETTINGS_LABS_SPACES_HOME_AS_ORPHAN) -> migrateOrphansInSpacesToShowAllInHome()
-            else -> defaultValue
-        }
-    }
-
-    private fun migrateOrphansInSpacesToShowAllInHome(): Boolean {
-        val showAllRoomsInHome = !labsSpacesOnlyOrphansInHome()
-        defaultPrefs.edit {
-            putBoolean(SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME, showAllRoomsInHome)
-            remove(SETTINGS_LABS_SPACES_HOME_AS_ORPHAN)
-        }
-        return showAllRoomsInHome
-    }
-
-    private fun labsSpacesOnlyOrphansInHome(): Boolean {
-        return defaultPrefs.getBoolean(SETTINGS_LABS_SPACES_HOME_AS_ORPHAN, false)
+        return defaultPrefs.getBoolean(SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME, false)
     }
 
     /*


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Only making use of the legacy `SETTINGS_LABS_SPACES_HOME_AS_ORPHAN` if it exists and the new key does not
- Manually deletes the legacy `SETTINGS_LABS_SPACES_HOME_AS_ORPHAN` after migrating to `SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME`

## Motivation and context

Fixes #6510 Inconsistent _rooms in home_ behaviour

The app incorrectly returns the `Show all rooms in home` preference as enabled when it's meant to be disabled by default. This is caused by the migration logic from the previous flag not taking into account if the preference existed, causing us to always default to enabled. 

Will also fix some flakiness in the UI Tests!

## Screenshots / GIFs

|Before|After|
|-|-|
|![before-space-rooms](https://user-images.githubusercontent.com/1848238/177974006-113fcccf-e47b-4202-ba1a-46ac9cdf36df.gif)|![after-spaces-room](https://user-images.githubusercontent.com/1848238/177974060-6cd5617d-95dd-4449-80d1-47ed516da8ac.gif)|
 

## Tests

- Have an account with a space and a room in that space
- With a fresh install, log in and notice the room within the space is showing in home
- Open the settings -> preference screen (don't change any toggles)
- Quit and relaunch the app, notice the room from the space is no longer showing in home

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 29