### PR TITLE
UI test stabilization

### DIFF
--- a/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -159,7 +159,7 @@ class UiAllScreensSanityTest {
         elementRobot.newRoom {
             createNewRoom {
                 crawl()
-                createRoom {
+                createRoom(roomName = "thread room") {
                     val message = "Hello This message will be a thread!"
                     postMessage(message)
                     replyToThread(message)

--- a/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -99,29 +99,32 @@ class UiAllScreensSanityTest {
 
         testThreadScreens()
 
+        val spaceName = UUID.randomUUID().toString()
         elementRobot.space {
             createSpace {
-                crawl()
+                createAndCrawl(spaceName)
             }
-            val spaceName = UUID.randomUUID().toString()
+            val publicSpace = UUID.randomUUID().toString()
             createSpace {
-                createPublicSpace(spaceName)
+                createPublicSpace(publicSpace)
             }
 
-            spaceMenu(spaceName) {
+            spaceMenu(publicSpace) {
                 spaceMembers()
                 spaceSettings {
                     crawl()
                 }
                 exploreRooms()
 
-                invitePeople().also { openMenu(spaceName) }
-                addRoom().also { openMenu(spaceName) }
-                addSpace().also { openMenu(spaceName) }
+                invitePeople().also { openMenu(publicSpace) }
+                addRoom().also { openMenu(publicSpace) }
+                addSpace().also { openMenu(publicSpace) }
 
                 leaveSpace()
             }
         }
+
+        elementRobot.space { selectSpace(spaceName) }
 
         elementRobot.withDeveloperMode {
             settings {

--- a/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -104,21 +104,21 @@ class UiAllScreensSanityTest {
             createSpace {
                 createAndCrawl(spaceName)
             }
-            val publicSpace = UUID.randomUUID().toString()
+            val publicSpaceName = UUID.randomUUID().toString()
             createSpace {
-                createPublicSpace(publicSpace)
+                createPublicSpace(publicSpaceName)
             }
 
-            spaceMenu(publicSpace) {
+            spaceMenu(publicSpaceName) {
                 spaceMembers()
                 spaceSettings {
                     crawl()
                 }
                 exploreRooms()
 
-                invitePeople().also { openMenu(publicSpace) }
-                addRoom().also { openMenu(publicSpace) }
-                addSpace().also { openMenu(publicSpace) }
+                invitePeople().also { openMenu(publicSpaceName) }
+                addRoom().also { openMenu(publicSpaceName) }
+                addSpace().also { openMenu(publicSpaceName) }
 
                 leaveSpace()
             }

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/CreateNewRoomRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/CreateNewRoomRobot.kt
@@ -17,14 +17,11 @@
 package im.vector.app.ui.robot
 
 import androidx.test.espresso.Espresso.closeSoftKeyboard
-import androidx.test.espresso.Espresso.onData
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions.replaceText
-import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withHint
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.adevinta.android.barista.assertion.BaristaListAssertions
 import com.adevinta.android.barista.interaction.BaristaClickInteractions
 import com.adevinta.android.barista.interaction.BaristaListInteractions

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/CreateNewRoomRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/CreateNewRoomRobot.kt
@@ -16,8 +16,15 @@
 
 package im.vector.app.ui.robot
 
+import androidx.test.espresso.Espresso.closeSoftKeyboard
+import androidx.test.espresso.Espresso.onData
+import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withHint
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.adevinta.android.barista.assertion.BaristaListAssertions
 import com.adevinta.android.barista.interaction.BaristaClickInteractions
 import com.adevinta.android.barista.interaction.BaristaListInteractions
@@ -25,14 +32,20 @@ import im.vector.app.R
 import im.vector.app.espresso.tools.waitUntilActivityVisible
 import im.vector.app.espresso.tools.waitUntilViewVisible
 import im.vector.app.features.home.room.detail.RoomDetailActivity
+import org.hamcrest.CoreMatchers.allOf
 
 class CreateNewRoomRobot(
         var createdRoom: Boolean = false
 ) {
 
-    fun createRoom(block: RoomDetailRobot.() -> Unit) {
+    fun createRoom(roomName: String? = null, block: RoomDetailRobot.() -> Unit) {
         createdRoom = true
         BaristaListAssertions.assertListItemCount(R.id.createRoomForm, 12)
+        roomName?.let {
+            onView(allOf(withId(R.id.formTextInputTextInputEditText), withHint(R.string.create_room_name_hint)))
+                    .perform(replaceText(roomName))
+            closeSoftKeyboard()
+        }
         BaristaListInteractions.clickListItemChild(R.id.createRoomForm, 11, R.id.form_submit_button)
         waitUntilActivityVisible<RoomDetailActivity> {
             waitUntilViewVisible(withId(R.id.composerEditText))

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
@@ -17,6 +17,7 @@
 package im.vector.app.ui.robot
 
 import android.view.View
+import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions
@@ -91,8 +92,7 @@ class ElementRobot {
         waitUntilActivityVisible<CreateDirectRoomActivity> {
             waitUntilViewVisible(withId(R.id.userListSearch))
         }
-        // close keyboard
-        pressBack()
+        closeSoftKeyboard()
         block(NewDirectMessageRobot())
         pressBack()
         waitUntilViewVisible(withId(R.id.bottomNavigationView))

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/MessageMenuRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/MessageMenuRobot.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.ui.robot
 
+import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -59,6 +60,7 @@ class MessageMenuRobot(
         clickOn(R.string.message_add_reaction)
         // Wait for emoji to load, it's async now
         waitUntilActivityVisible<EmojiReactionPickerActivity> {
+            closeSoftKeyboard()
             waitUntilViewVisible(withId(R.id.emojiRecyclerView))
             waitUntilViewVisible(withText("😀"))
         }

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/RoomDetailRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/RoomDetailRobot.kt
@@ -154,7 +154,9 @@ class RoomDetailRobot {
 
     fun openThreadSummaries() {
         clickMenu(R.id.menu_timeline_thread_list)
-        waitUntilViewVisible(withId(R.id.threadListRecyclerView))
+        withRetry {
+            waitUntilViewVisible(withId(R.id.threadListRecyclerView))
+        }
     }
 
     fun selectThreadSummariesFilter() {

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/RoomDetailRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/RoomDetailRobot.kt
@@ -17,6 +17,7 @@
 package im.vector.app.ui.robot
 
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions
@@ -44,6 +45,7 @@ class RoomDetailRobot {
 
     fun postMessage(content: String) {
         writeTo(R.id.composerEditText, content)
+        closeSoftKeyboard()
         waitUntilViewVisible(withId(R.id.sendButton))
         clickOn(R.id.sendButton)
         waitUntilViewVisible(withText(content))
@@ -68,6 +70,7 @@ class RoomDetailRobot {
         }
         val threadMessage = "Hello universe - long message to avoid espresso tapping edited!"
         writeTo(R.id.composerEditText, threadMessage)
+        closeSoftKeyboard()
         waitUntilViewVisible(withId(R.id.sendButton))
         clickOn(R.id.sendButton)
     }
@@ -105,6 +108,7 @@ class RoomDetailRobot {
         // TODO Cancel action
         val edit = "Hello universe - long message to avoid espresso tapping edited!"
         writeTo(R.id.composerEditText, edit)
+        closeSoftKeyboard()
         // Wait a bit for the keyboard layout to update
         waitUntilViewVisible(withId(R.id.sendButton))
         clickOn(R.id.sendButton)

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/space/SpaceCreateRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/space/SpaceCreateRobot.kt
@@ -32,7 +32,6 @@ import im.vector.app.espresso.tools.waitUntilDialogVisible
 import im.vector.app.espresso.tools.waitUntilViewVisible
 import im.vector.app.features.home.HomeActivity
 import im.vector.app.features.spaces.manage.SpaceManageActivity
-import java.util.UUID
 
 class SpaceCreateRobot {
 

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/space/SpaceCreateRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/space/SpaceCreateRobot.kt
@@ -36,11 +36,11 @@ import java.util.UUID
 
 class SpaceCreateRobot {
 
-    fun crawl() {
+    fun createAndCrawl(name: String) {
         // public
         clickOn(R.id.publicButton)
         waitUntilViewVisible(withId(R.id.recyclerView))
-        onView(ViewMatchers.withHint(R.string.create_room_name_hint)).perform(ViewActions.replaceText(UUID.randomUUID().toString()))
+        onView(ViewMatchers.withHint(R.string.create_room_name_hint)).perform(ViewActions.replaceText(name))
         clickOn(R.id.nextButton)
         waitUntilViewVisible(withId(R.id.recyclerView))
         pressBack()

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/space/SpaceMenuRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/space/SpaceMenuRobot.kt
@@ -16,13 +16,9 @@
 
 package im.vector.app.ui.robot.space
 
-import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
-import com.adevinta.android.barista.internal.viewaction.ClickChildAction
 import im.vector.app.R
 import im.vector.app.clickOnSheet
 import im.vector.app.espresso.tools.waitUntilActivityVisible
@@ -33,21 +29,8 @@ import im.vector.app.features.roomprofile.RoomProfileActivity
 import im.vector.app.features.spaces.SpaceExploreActivity
 import im.vector.app.features.spaces.leave.SpaceLeaveAdvancedActivity
 import im.vector.app.features.spaces.manage.SpaceManageActivity
-import org.hamcrest.Matchers
 
 class SpaceMenuRobot {
-
-    fun openMenu(spaceName: String) {
-        waitUntilViewVisible(ViewMatchers.withId(R.id.groupListView))
-        onView(ViewMatchers.withId(R.id.groupListView))
-                .perform(
-                        RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
-                                ViewMatchers.hasDescendant(Matchers.allOf(ViewMatchers.withId(R.id.groupNameView), ViewMatchers.withText(spaceName))),
-                                ClickChildAction.clickChildWithId(R.id.groupTmpLeave)
-                        ).atPosition(0)
-                )
-        waitUntilDialogVisible(ViewMatchers.withId(R.id.spaceNameView))
-    }
 
     fun invitePeople() = apply {
         clickOnSheet(R.id.invitePeople)

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/space/SpaceRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/space/SpaceRobot.kt
@@ -16,9 +16,17 @@
 
 package im.vector.app.ui.robot.space
 
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.adevinta.android.barista.interaction.BaristaDrawerInteractions.openDrawer
+import com.adevinta.android.barista.internal.viewaction.ClickChildAction
 import im.vector.app.R
+import im.vector.app.espresso.tools.waitUntilDialogVisible
+import im.vector.app.espresso.tools.waitUntilViewVisible
+import org.hamcrest.Matchers
 
 class SpaceRobot {
 
@@ -34,5 +42,23 @@ class SpaceRobot {
             openMenu(spaceName)
             block()
         }
+    }
+
+    fun openMenu(spaceName: String) {
+        waitUntilViewVisible(ViewMatchers.withId(R.id.groupListView))
+        Espresso.onView(ViewMatchers.withId(R.id.groupListView))
+                .perform(
+                        RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
+                                ViewMatchers.hasDescendant(Matchers.allOf(ViewMatchers.withId(R.id.groupNameView), ViewMatchers.withText(spaceName))),
+                                ClickChildAction.clickChildWithId(R.id.groupTmpLeave)
+                        ).atPosition(0)
+                )
+        waitUntilDialogVisible(ViewMatchers.withId(R.id.spaceNameView))
+    }
+
+    fun selectSpace(spaceName: String) {
+        openDrawer()
+        waitUntilViewVisible(ViewMatchers.withId(R.id.groupListView))
+        clickOn(spaceName)
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Always attempts to close the soft keyboard
- Avoids creating multiple rooms with the same name (empty room)

## Motivation and context

To get `./gradlew connectedGplayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=im.vector.app.ui.UiAllScreensSanityTest` to consistently pass locally across different emulators

This check also caught #6511  

## Tests

No business logic changes

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 28, 31v2