### PR TITLE
Improve lock screen implementation with extra security measures

### DIFF
--- a/changelog.d/6522.feature
+++ b/changelog.d/6522.feature
@@ -1,0 +1,1 @@
+Improve lock screen implementation with extra security measures

--- a/vector/src/androidTest/java/im/vector/app/features/pin/lockscreen/biometrics/BiometricHelperTests.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/pin/lockscreen/biometrics/BiometricHelperTests.kt
@@ -27,6 +27,7 @@ import androidx.biometric.BiometricManager.BIOMETRIC_SUCCESS
 import androidx.biometric.BiometricPrompt
 import androidx.lifecycle.lifecycleScope
 import androidx.test.core.app.ActivityScenario
+import androidx.test.filters.SdkSuppress
 import androidx.test.platform.app.InstrumentationRegistry
 import im.vector.app.TestBuildVersionSdkIntProvider
 import im.vector.app.features.pin.lockscreen.configuration.LockScreenConfiguration
@@ -200,6 +201,7 @@ class BiometricHelperTests {
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.R) // Due to some issues with mockk and CryptoObject initialization
     @Test
     fun authenticateInDeviceWithIssuesShowsFallbackPromptDialog() = runTest {
         buildVersionSdkIntProvider.value = Build.VERSION_CODES.M
@@ -236,6 +238,7 @@ class BiometricHelperTests {
     }
 
     @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.R) // Due to some issues with mockk and CryptoObject initialization
     fun authenticateCreatesSystemKeyIfNeededOnSuccessOnAndroidM() = runTest {
         buildVersionSdkIntProvider.value = Build.VERSION_CODES.M
         every { lockScreenKeyRepository.isSystemKeyValid() } returns true

--- a/vector/src/androidTest/java/im/vector/app/features/pin/lockscreen/crypto/KeyStoreCryptoTests.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/pin/lockscreen/crypto/KeyStoreCryptoTests.kt
@@ -43,7 +43,9 @@ class KeyStoreCryptoTests {
     private val versionProvider = TestBuildVersionSdkIntProvider().also { it.value = Build.VERSION_CODES.M }
     private val secretStoringUtils = spyk(SecretStoringUtils(context, keyStore, versionProvider))
     private val keyStoreCrypto = spyk(
-            KeyStoreCrypto(alias, false, context, versionProvider, keyStore, secretStoringUtils)
+            KeyStoreCrypto(alias, false, context, versionProvider, keyStore).also {
+                it.secretStoringUtils = secretStoringUtils
+            }
     )
 
     @After
@@ -146,10 +148,10 @@ class KeyStoreCryptoTests {
 
     @Test
     fun getCryptoObjectUsesCipherFromSecretStoringUtils() {
-        keyStoreCrypto.getCryptoObject()
+        keyStoreCrypto.getAuthCryptoObject()
         verify { secretStoringUtils.getEncryptCipher(any()) }
 
         every { secretStoringUtils.getEncryptCipher(any()) } throws KeyPermanentlyInvalidatedException()
-        invoking { keyStoreCrypto.getCryptoObject() } shouldThrow KeyPermanentlyInvalidatedException::class
+        invoking { keyStoreCrypto.getAuthCryptoObject() } shouldThrow KeyPermanentlyInvalidatedException::class
     }
 }

--- a/vector/src/main/java/im/vector/app/features/pin/lockscreen/biometrics/BiometricHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/lockscreen/biometrics/BiometricHelper.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.util.BuildVersionSdkIntProvider
 import java.security.KeyStore
+import javax.crypto.Cipher
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
@@ -74,22 +75,19 @@ class BiometricHelper @Inject constructor(
      * Returns true if a weak biometric method (i.e.: some face or iris unlock implementations) can be used.
      */
     val canUseWeakBiometricAuth: Boolean
-        get() =
-            configuration.isWeakBiometricsEnabled && biometricManager.canAuthenticate(BIOMETRIC_WEAK) == BIOMETRIC_SUCCESS
+        get() = configuration.isWeakBiometricsEnabled && biometricManager.canAuthenticate(BIOMETRIC_WEAK) == BIOMETRIC_SUCCESS
 
     /**
      * Returns true if a strong biometric method (i.e.: fingerprint, some face or iris unlock implementations) can be used.
      */
     val canUseStrongBiometricAuth: Boolean
-        get() =
-            configuration.isStrongBiometricsEnabled && biometricManager.canAuthenticate(BIOMETRIC_STRONG) == BIOMETRIC_SUCCESS
+        get() = configuration.isStrongBiometricsEnabled && biometricManager.canAuthenticate(BIOMETRIC_STRONG) == BIOMETRIC_SUCCESS
 
     /**
      * Returns true if the device credentials can be used to unlock (system pin code, password, pattern, etc.).
      */
     val canUseDeviceCredentialsAuth: Boolean
-        get() =
-            configuration.isDeviceCredentialUnlockEnabled && biometricManager.canAuthenticate(DEVICE_CREDENTIAL) == BIOMETRIC_SUCCESS
+        get() = configuration.isDeviceCredentialUnlockEnabled && biometricManager.canAuthenticate(DEVICE_CREDENTIAL) == BIOMETRIC_SUCCESS
 
     /**
      * Returns true if any system authentication method (biometric weak/strong or device credentials) can be used.
@@ -120,7 +118,7 @@ class BiometricHelper @Inject constructor(
      */
     @MainThread
     fun enableAuthentication(activity: FragmentActivity): Flow<Boolean> {
-        return authenticateInternal(activity, checkSystemKeyExists = false, cryptoObject = null)
+        return authenticateInternal(activity, checkSystemKeyExists = false, cryptoObject = getAuthCryptoObject())
     }
 
     /**
@@ -140,7 +138,7 @@ class BiometricHelper @Inject constructor(
      */
     @MainThread
     fun authenticate(activity: FragmentActivity): Flow<Boolean> {
-        return authenticateInternal(activity, checkSystemKeyExists = true, cryptoObject = null)
+        return authenticateInternal(activity, checkSystemKeyExists = true, cryptoObject = getAuthCryptoObject())
     }
 
     /**
@@ -157,9 +155,9 @@ class BiometricHelper @Inject constructor(
     @SuppressLint("NewApi")
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun authenticateInternal(
-            activity: FragmentActivity,
-            checkSystemKeyExists: Boolean,
-            cryptoObject: BiometricPrompt.CryptoObject? = null,
+        activity: FragmentActivity,
+        checkSystemKeyExists: Boolean,
+        cryptoObject: BiometricPrompt.CryptoObject,
     ): Flow<Boolean> {
         if (checkSystemKeyExists && !isSystemAuthEnabledAndValid) return flowOf(false)
 
@@ -193,9 +191,9 @@ class BiometricHelper @Inject constructor(
 
     @VisibleForTesting(otherwise = PRIVATE)
     internal fun authenticateWithPromptInternal(
-            activity: FragmentActivity,
-            cryptoObject: BiometricPrompt.CryptoObject? = null,
-            channel: Channel<Boolean>,
+        activity: FragmentActivity,
+        cryptoObject: BiometricPrompt.CryptoObject,
+        channel: Channel<Boolean>,
     ): BiometricPrompt {
         val executor = ContextCompat.getMainExecutor(context)
         val callback = createSuspendingAuthCallback(channel, executor.asCoroutineDispatcher())
@@ -214,15 +212,12 @@ class BiometricHelper @Inject constructor(
                 }
                 .setAllowedAuthenticators(authenticators)
                 .build()
+
         return BiometricPrompt(activity, executor, callback).also {
             showFallbackFragmentIfNeeded(activity, channel.receiveAsFlow(), executor.asCoroutineDispatcher()) {
                 // For some reason this seems to be needed unless we want to receive a fragment transaction exception
                 delay(1L)
-                if (cryptoObject != null) {
-                    it.authenticate(promptInfo, cryptoObject)
-                } else {
-                    it.authenticate(promptInfo)
-                }
+                it.authenticate(promptInfo, cryptoObject)
             }
         }
     }
@@ -270,12 +265,27 @@ class BiometricHelper @Inject constructor(
         }
 
         override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
-            scope.launch {
-                channel.send(true)
-                // Success is a terminal event, should close both the Channel and the CoroutineScope to free resources.
-                channel.close()
-                scope.cancel()
+            val cipher = result.cryptoObject?.cipher
+            if (isCipherValid(cipher)) {
+                scope.launch {
+                    channel.send(true)
+                    // Success is a terminal event, should close both the Channel and the CoroutineScope to free resources.
+                    channel.close()
+                    scope.cancel()
+                }
+            } else {
+                scope.launch {
+                    channel.close(IllegalStateException("System key was not valid after authentication."))
+                    scope.cancel()
+                }
             }
+        }
+
+        private fun isCipherValid(cipher: Cipher?): Boolean {
+            if (cipher == null) return false
+            return runCatching {
+                cipher.doFinal("biometric_challenge".toByteArray())
+            }.isSuccess
         }
     }
 
@@ -320,6 +330,9 @@ class BiometricHelper @Inject constructor(
 
     @VisibleForTesting(otherwise = PRIVATE)
     internal fun createAuthChannel(): Channel<Boolean> = Channel(capacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    internal fun getAuthCryptoObject(): BiometricPrompt.CryptoObject = lockScreenKeyRepository.getSystemKeyAuthCryptoObject()
 
     companion object {
         private const val FALLBACK_BIOMETRIC_FRAGMENT_TAG = "fragment.biometric_fallback"

--- a/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/KeyStoreCrypto.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/KeyStoreCrypto.kt
@@ -18,11 +18,11 @@ package im.vector.app.features.pin.lockscreen.crypto
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.hardware.biometrics.BiometricPrompt
 import android.os.Build
 import android.security.keystore.KeyPermanentlyInvalidatedException
 import android.util.Base64
-import androidx.annotation.RequiresApi
+import androidx.annotation.VisibleForTesting
+import androidx.biometric.BiometricPrompt
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -40,14 +40,15 @@ class KeyStoreCrypto @AssistedInject constructor(
         context: Context,
         private val buildVersionSdkIntProvider: BuildVersionSdkIntProvider,
         private val keyStore: KeyStore,
-        // It's easier to test it this way
-        private val secretStoringUtils: SecretStoringUtils = SecretStoringUtils(context, keyStore, buildVersionSdkIntProvider, keyNeedsUserAuthentication)
 ) {
 
     @AssistedFactory
     interface Factory {
         fun provide(alias: String, keyNeedsUserAuthentication: Boolean): KeyStoreCrypto
     }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal var secretStoringUtils: SecretStoringUtils = SecretStoringUtils(context, keyStore, buildVersionSdkIntProvider, keyNeedsUserAuthentication)
 
     /**
      * Ensures a [Key] for the [alias] exists and validates it.
@@ -137,6 +138,5 @@ class KeyStoreCrypto @AssistedInject constructor(
      * @throws KeyPermanentlyInvalidatedException if key is invalidated.
      */
     @Throws(KeyPermanentlyInvalidatedException::class)
-    @RequiresApi(Build.VERSION_CODES.P)
-    fun getCryptoObject() = BiometricPrompt.CryptoObject(secretStoringUtils.getEncryptCipher(alias))
+    fun getAuthCryptoObject() = BiometricPrompt.CryptoObject(secretStoringUtils.getEncryptCipher(alias))
 }

--- a/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/LockScreenKeyRepository.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/LockScreenKeyRepository.kt
@@ -19,21 +19,21 @@ package im.vector.app.features.pin.lockscreen.crypto
 import android.os.Build
 import android.security.keystore.KeyPermanentlyInvalidatedException
 import androidx.annotation.RequiresApi
-import im.vector.app.features.settings.VectorPreferences
-import timber.log.Timber
+import androidx.biometric.BiometricPrompt
+import im.vector.app.features.pin.lockscreen.di.BiometricKeyAlias
+import im.vector.app.features.pin.lockscreen.di.PinCodeKeyAlias
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * Class in charge of managing both the PIN code key and the system authentication keys.
  */
-class LockScreenKeyRepository(
-        baseName: String,
-        private val pinCodeMigrator: PinCodeMigrator,
-        private val vectorPreferences: VectorPreferences,
+@Singleton
+class LockScreenKeyRepository @Inject constructor(
+        @PinCodeKeyAlias private val pinCodeKeyAlias: String,
+        @BiometricKeyAlias private val systemKeyAlias: String,
         private val keyStoreCryptoFactory: KeyStoreCrypto.Factory,
 ) {
-
-    private val pinCodeKeyAlias = "$baseName.pin_code"
-    private val systemKeyAlias = "$baseName.system"
 
     private val pinCodeCrypto: KeyStoreCrypto by lazy {
         keyStoreCryptoFactory.provide(pinCodeKeyAlias, keyNeedsUserAuthentication = false)
@@ -86,19 +86,7 @@ class LockScreenKeyRepository(
     fun isSystemKeyValid() = systemKeyCrypto.hasValidKey()
 
     /**
-     * Migrates the PIN code key and encrypted value to use a more secure cipher, also creates a new system key if needed.
+     * Returns a [BiometricPrompt.CryptoObject] for the system key.
      */
-    suspend fun migrateKeysIfNeeded() {
-        if (pinCodeMigrator.isMigrationNeeded()) {
-            pinCodeMigrator.migrate(pinCodeKeyAlias)
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && vectorPreferences.useBiometricsToUnlock()) {
-                try {
-                    ensureSystemKey()
-                } catch (e: KeyPermanentlyInvalidatedException) {
-                    Timber.e("Could not automatically create biometric key.", e)
-                }
-            }
-        }
-    }
+    fun getSystemKeyAuthCryptoObject() = systemKeyCrypto.getAuthCryptoObject()
 }

--- a/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/LockScreenKeysMigrator.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/LockScreenKeysMigrator.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.pin.lockscreen.crypto
+
+import android.annotation.SuppressLint
+import android.os.Build
+import im.vector.app.features.pin.lockscreen.crypto.migrations.LegacyPinCodeMigrator
+import im.vector.app.features.pin.lockscreen.crypto.migrations.MissingSystemKeyMigrator
+import im.vector.app.features.pin.lockscreen.crypto.migrations.SystemKeyV1Migrator
+import org.matrix.android.sdk.api.util.BuildVersionSdkIntProvider
+import javax.inject.Inject
+
+/**
+ * Performs all migrations needed for the lock screen keys.
+ */
+class LockScreenKeysMigrator @Inject constructor(
+        private val legacyPinCodeMigrator: LegacyPinCodeMigrator,
+        private val missingSystemKeyMigrator: MissingSystemKeyMigrator,
+        private val systemKeyV1Migrator: SystemKeyV1Migrator,
+        private val versionProvider: BuildVersionSdkIntProvider,
+) {
+    /**
+     * Performs any needed migrations in order.
+     */
+    @SuppressLint("NewApi")
+    suspend fun migrateIfNeeded() {
+        if (legacyPinCodeMigrator.isMigrationNeeded()) {
+            legacyPinCodeMigrator.migrate()
+            missingSystemKeyMigrator.migrate()
+        }
+
+        if (systemKeyV1Migrator.isMigrationNeeded() && versionProvider.get() >= Build.VERSION_CODES.M) {
+            systemKeyV1Migrator.migrate()
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/migrations/MissingSystemKeyMigrator.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/migrations/MissingSystemKeyMigrator.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.pin.lockscreen.crypto.migrations
+
+import android.annotation.SuppressLint
+import android.os.Build
+import android.security.keystore.KeyPermanentlyInvalidatedException
+import im.vector.app.features.pin.lockscreen.crypto.KeyStoreCrypto
+import im.vector.app.features.pin.lockscreen.di.BiometricKeyAlias
+import im.vector.app.features.settings.VectorPreferences
+import org.matrix.android.sdk.api.util.BuildVersionSdkIntProvider
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * Creates a new system/biometric key when migrating from the old PFLockScreen implementation.
+ */
+class MissingSystemKeyMigrator @Inject constructor(
+        @BiometricKeyAlias private val systemKeyAlias: String,
+        private val keystoreCryptoFactory: KeyStoreCrypto.Factory,
+        private val vectorPreferences: VectorPreferences,
+        private val buildVersionSdkIntProvider: BuildVersionSdkIntProvider,
+) {
+
+    /**
+     * If user had biometric auth enabled, ensure system key exists, creating one if needed.
+     */
+    @SuppressLint("NewApi")
+    fun migrate() {
+        if (buildVersionSdkIntProvider.get() >= Build.VERSION_CODES.M && vectorPreferences.useBiometricsToUnlock()) {
+            try {
+                keystoreCryptoFactory.provide(systemKeyAlias, true).ensureKey()
+            } catch (e: KeyPermanentlyInvalidatedException) {
+                Timber.e("Could not automatically create biometric key.", e)
+            }
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/migrations/SystemKeyV1Migrator.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/migrations/SystemKeyV1Migrator.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.pin.lockscreen.crypto.migrations
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import im.vector.app.features.pin.lockscreen.crypto.KeyStoreCrypto
+import im.vector.app.features.pin.lockscreen.di.BiometricKeyAlias
+import java.security.KeyStore
+import javax.inject.Inject
+
+/**
+ * Migrates from the v1 of the biometric/system key to the new format, adding extra security measures to the new key.
+ */
+class SystemKeyV1Migrator @Inject constructor(
+        @BiometricKeyAlias private val systemKeyAlias: String,
+        private val keyStore: KeyStore,
+        private val keystoreCryptoFactory: KeyStoreCrypto.Factory,
+) {
+
+    /**
+     * Removes the old v1 system key and creates a new system key.
+     */
+    @RequiresApi(Build.VERSION_CODES.M)
+    fun migrate() {
+        keyStore.deleteEntry(SYSTEM_KEY_ALIAS_V1)
+        val systemKeyStoreCrypto = keystoreCryptoFactory.provide(systemKeyAlias, keyNeedsUserAuthentication = true)
+        systemKeyStoreCrypto.ensureKey()
+    }
+
+    /**
+     * Checks if an entry with [SYSTEM_KEY_ALIAS_V1] exists in the [keyStore].
+     */
+    fun isMigrationNeeded() = keyStore.containsAlias(SYSTEM_KEY_ALIAS_V1)
+
+    companion object {
+        internal const val SYSTEM_KEY_ALIAS_V1 = "vector.system"
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/pin/lockscreen/di/LockScreenModule.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/lockscreen/di/LockScreenModule.kt
@@ -30,34 +30,31 @@ import im.vector.app.core.di.MavericksViewModelKey
 import im.vector.app.features.pin.PinCodeStore
 import im.vector.app.features.pin.lockscreen.configuration.LockScreenConfiguration
 import im.vector.app.features.pin.lockscreen.configuration.LockScreenMode
-import im.vector.app.features.pin.lockscreen.crypto.KeyStoreCrypto
-import im.vector.app.features.pin.lockscreen.crypto.LockScreenKeyRepository
-import im.vector.app.features.pin.lockscreen.crypto.PinCodeMigrator
+import im.vector.app.features.pin.lockscreen.crypto.migrations.LegacyPinCodeMigrator
 import im.vector.app.features.pin.lockscreen.pincode.EncryptedPinCodeStorage
 import im.vector.app.features.pin.lockscreen.ui.LockScreenViewModel
-import im.vector.app.features.settings.VectorPreferences
 import org.matrix.android.sdk.api.securestorage.SecretStoringUtils
 import org.matrix.android.sdk.api.util.BuildVersionSdkIntProvider
 import org.matrix.android.sdk.api.util.DefaultBuildVersionSdkIntProvider
 import java.security.KeyStore
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object LockScreenModule {
 
     @Provides
+    @PinCodeKeyAlias
+    fun providePinCodeKeyAlias(): String = "vector.pin_code"
+
+    @Provides
+    @BiometricKeyAlias
+    fun provideSystemKeyAlias(): String = "vector.system_v2"
+
+    @Provides
     fun provideKeyStore(): KeyStore = KeyStore.getInstance("AndroidKeyStore").also { it.load(null) }
 
     @Provides
     fun provideBuildVersionSdkIntProvider(): BuildVersionSdkIntProvider = DefaultBuildVersionSdkIntProvider()
-
-    @Provides
-    fun provideSecretStoringUtils(
-            @ApplicationContext context: Context,
-            keyStore: KeyStore,
-            buildVersionSdkIntProvider: BuildVersionSdkIntProvider,
-    ) = SecretStoringUtils(context, keyStore, buildVersionSdkIntProvider)
 
     @Provides
     fun provideLockScreenConfig() = LockScreenConfiguration(
@@ -70,20 +67,22 @@ object LockScreenModule {
     )
 
     @Provides
-    @Singleton
-    fun provideKeyRepository(
-            pinCodeMigrator: PinCodeMigrator,
-            vectorPreferences: VectorPreferences,
-            keyStoreCryptoFactory: KeyStoreCrypto.Factory,
-    ) = LockScreenKeyRepository(
-            baseName = "vector",
-            pinCodeMigrator,
-            vectorPreferences,
-            keyStoreCryptoFactory,
-    )
+    fun provideBiometricManager(@ApplicationContext context: Context) = BiometricManager.from(context)
 
     @Provides
-    fun provideBiometricManager(@ApplicationContext context: Context) = BiometricManager.from(context)
+    fun provideLegacyPinCodeMigrator(
+            @PinCodeKeyAlias pinCodeKeyAlias: String,
+            context: Context,
+            pinCodeStore: PinCodeStore,
+            keyStore: KeyStore,
+            buildVersionSdkIntProvider: BuildVersionSdkIntProvider,
+    ) = LegacyPinCodeMigrator(
+            pinCodeKeyAlias,
+            pinCodeStore,
+            keyStore,
+            SecretStoringUtils(context, keyStore, buildVersionSdkIntProvider),
+            buildVersionSdkIntProvider,
+    )
 }
 
 @Module

--- a/vector/src/main/java/im/vector/app/features/pin/lockscreen/di/LockScreenQualifiers.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/lockscreen/di/LockScreenQualifiers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 The Matrix.org Foundation C.I.C.
+ * Copyright (c) 2022 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,14 @@
  * limitations under the License.
  */
 
-package org.matrix.android.sdk.api.util
+package im.vector.app.features.pin.lockscreen.di
 
-interface BuildVersionSdkIntProvider {
-    /**
-     * Return the current version of the Android SDK.
-     */
-    fun get(): Int
+import javax.inject.Qualifier
 
-    /**
-     * Checks the if the current OS version is equal or greater than [version].
-     * @return A `non-null` result if true, `null` otherwise.
-     */
-    fun <T> whenAtLeast(version: Int, result: () -> T): T? {
-        return if (get() >= version) {
-            result()
-        } else null
-    }
-}
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class PinCodeKeyAlias
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class BiometricKeyAlias

--- a/vector/src/main/java/im/vector/app/features/pin/lockscreen/pincode/PinCodeHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/lockscreen/pincode/PinCodeHelper.kt
@@ -55,11 +55,4 @@ class PinCodeHelper @Inject constructor(
         encryptedStorage.deletePinCode()
         lockScreenKeyRepository.deletePinCodeKey()
     }
-
-    /**
-     * Migrates the PIN code key and encrypted value to use a more secure cipher.
-     */
-    suspend fun migratePinCodeIfNeeded() {
-        lockScreenKeyRepository.migrateKeysIfNeeded()
-    }
 }

--- a/vector/src/main/java/im/vector/app/features/pin/lockscreen/ui/LockScreenViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/lockscreen/ui/LockScreenViewModel.kt
@@ -34,6 +34,7 @@ import im.vector.app.features.pin.lockscreen.biometrics.BiometricHelper
 import im.vector.app.features.pin.lockscreen.configuration.LockScreenConfiguration
 import im.vector.app.features.pin.lockscreen.configuration.LockScreenConfiguratorProvider
 import im.vector.app.features.pin.lockscreen.configuration.LockScreenMode
+import im.vector.app.features.pin.lockscreen.crypto.LockScreenKeysMigrator
 import im.vector.app.features.pin.lockscreen.pincode.PinCodeHelper
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
@@ -47,6 +48,7 @@ class LockScreenViewModel @AssistedInject constructor(
         @Assisted val initialState: LockScreenViewState,
         private val pinCodeHelper: PinCodeHelper,
         private val biometricHelper: BiometricHelper,
+        private val lockScreenKeysMigrator: LockScreenKeysMigrator,
         private val configuratorProvider: LockScreenConfiguratorProvider,
         private val buildVersionSdkIntProvider: BuildVersionSdkIntProvider,
 ) : VectorViewModel<LockScreenViewState, LockScreenAction, LockScreenViewEvent>(initialState) {
@@ -85,7 +87,7 @@ class LockScreenViewModel @AssistedInject constructor(
 
     init {
         // We need this to run synchronously before we start reading the configurations
-        runBlocking { pinCodeHelper.migratePinCodeIfNeeded() }
+        runBlocking { lockScreenKeysMigrator.migrateIfNeeded() }
 
         configuratorProvider.configurationFlow
                 .onEach { updateConfiguration(it) }

--- a/vector/src/test/java/im/vector/app/features/pin/lockscreen/crypto/migrations/LockScreenTestMigratorTests.kt
+++ b/vector/src/test/java/im/vector/app/features/pin/lockscreen/crypto/migrations/LockScreenTestMigratorTests.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.pin.lockscreen.crypto.migrations
+
+import android.os.Build
+import im.vector.app.features.pin.lockscreen.crypto.LockScreenKeysMigrator
+import im.vector.app.test.TestBuildVersionSdkIntProvider
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class LockScreenTestMigratorTests {
+
+    private val legacyPinCodeMigrator = mockk<LegacyPinCodeMigrator>(relaxed = true)
+    private val missingSystemKeyMigrator = mockk<MissingSystemKeyMigrator>(relaxed = true)
+    private val systemKeyV1Migrator = mockk<SystemKeyV1Migrator>(relaxed = true)
+    private val versionProvider = TestBuildVersionSdkIntProvider()
+    private val migrator = LockScreenKeysMigrator(legacyPinCodeMigrator, missingSystemKeyMigrator, systemKeyV1Migrator, versionProvider)
+
+    @Test
+    fun `When legacy pin code migration is needed, both legacyPinCodeMigrator and missingSystemKeyMigrator will be run`() {
+        // When no migration is needed
+        every { legacyPinCodeMigrator.isMigrationNeeded() } returns false
+
+        runBlocking { migrator.migrateIfNeeded() }
+
+        coVerify(exactly = 0) { legacyPinCodeMigrator.migrate() }
+        verify(exactly = 0) { missingSystemKeyMigrator.migrate() }
+
+        // When migration is needed
+        every { legacyPinCodeMigrator.isMigrationNeeded() } returns true
+
+        runBlocking { migrator.migrateIfNeeded() }
+
+        coVerify { legacyPinCodeMigrator.migrate() }
+        verify { missingSystemKeyMigrator.migrate() }
+    }
+
+    @Test
+    fun `System key from v1 migration will not be run for versions that don't support biometrics`() {
+        versionProvider.value = Build.VERSION_CODES.LOLLIPOP
+        every { systemKeyV1Migrator.isMigrationNeeded() } returns true
+
+        runBlocking { migrator.migrateIfNeeded() }
+
+        verify(exactly = 0) { systemKeyV1Migrator.migrate() }
+    }
+
+    @Test
+    fun `When system key from v1 migration is needed it will be run`() {
+        versionProvider.value = Build.VERSION_CODES.M
+        every { systemKeyV1Migrator.isMigrationNeeded() } returns false
+
+        runBlocking { migrator.migrateIfNeeded() }
+
+        verify(exactly = 0) { systemKeyV1Migrator.migrate() }
+
+        every { systemKeyV1Migrator.isMigrationNeeded() } returns true
+
+        runBlocking { migrator.migrateIfNeeded() }
+
+        verify { systemKeyV1Migrator.migrate() }
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/pin/lockscreen/crypto/migrations/MissingSystemKeyMigratorTests.kt
+++ b/vector/src/test/java/im/vector/app/features/pin/lockscreen/crypto/migrations/MissingSystemKeyMigratorTests.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.pin.lockscreen.crypto.migrations
+
+import android.os.Build
+import android.security.keystore.KeyPermanentlyInvalidatedException
+import im.vector.app.features.pin.lockscreen.crypto.KeyStoreCrypto
+import im.vector.app.features.settings.VectorPreferences
+import im.vector.app.test.TestBuildVersionSdkIntProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldNotThrow
+import org.junit.Test
+
+class MissingSystemKeyMigratorTests {
+
+    private val keyStoreCryptoFactory = mockk<KeyStoreCrypto.Factory>()
+    private val vectorPreferences = mockk<VectorPreferences>(relaxed = true)
+    private val versionProvider = TestBuildVersionSdkIntProvider().also { it.value = Build.VERSION_CODES.M }
+    private val missingSystemKeyMigrator = MissingSystemKeyMigrator("vector.system", keyStoreCryptoFactory, vectorPreferences, versionProvider)
+
+    @Test
+    fun migrateEnsuresSystemKeyExistsIfBiometricAuthIsEnabledAndSupported() {
+        val keyStoreCryptoMock = mockk<KeyStoreCrypto> {
+            every { ensureKey() } returns mockk()
+        }
+        every { keyStoreCryptoFactory.provide(any(), any()) } returns keyStoreCryptoMock
+        every { vectorPreferences.useBiometricsToUnlock() } returns true
+
+        missingSystemKeyMigrator.migrate()
+
+        verify { keyStoreCryptoMock.ensureKey() }
+    }
+
+    @Test
+    fun migrateHandlesKeyPermanentlyInvalidatedExceptions() {
+        val keyStoreCryptoMock = mockk<KeyStoreCrypto> {
+            every { ensureKey() } throws KeyPermanentlyInvalidatedException()
+        }
+        every { keyStoreCryptoFactory.provide(any(), any()) } returns keyStoreCryptoMock
+        every { vectorPreferences.useBiometricsToUnlock() } returns true
+
+        invoking { missingSystemKeyMigrator.migrate() } shouldNotThrow KeyPermanentlyInvalidatedException::class
+    }
+
+    @Test
+    fun migrateReturnsEarlyIfBiometricAuthIsDisabled() {
+        val keyStoreCryptoMock = mockk<KeyStoreCrypto> {
+            every { ensureKey() } returns mockk()
+        }
+        every { keyStoreCryptoFactory.provide(any(), any()) } returns keyStoreCryptoMock
+        every { vectorPreferences.useBiometricsToUnlock() } returns false
+
+        missingSystemKeyMigrator.migrate()
+
+        verify(exactly = 0) { keyStoreCryptoMock.ensureKey() }
+    }
+
+    @Test
+    fun migrateReturnsEarlyIfAndroidVersionCantHandleBiometrics() {
+        versionProvider.value = Build.VERSION_CODES.LOLLIPOP
+        val keyStoreCryptoMock = mockk<KeyStoreCrypto> {
+            every { ensureKey() } returns mockk()
+        }
+        every { keyStoreCryptoFactory.provide(any(), any()) } returns keyStoreCryptoMock
+        every { vectorPreferences.useBiometricsToUnlock() } returns false
+
+        missingSystemKeyMigrator.migrate()
+
+        verify(exactly = 0) { keyStoreCryptoMock.ensureKey() }
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/pin/lockscreen/crypto/migrations/SystemKeyV1MigratorTests.kt
+++ b/vector/src/test/java/im/vector/app/features/pin/lockscreen/crypto/migrations/SystemKeyV1MigratorTests.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.pin.lockscreen.crypto.migrations
+
+import im.vector.app.features.pin.lockscreen.crypto.KeyStoreCrypto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.amshove.kluent.shouldBe
+import org.junit.Test
+import java.security.KeyStore
+
+class SystemKeyV1MigratorTests {
+
+    private val keyStoreCryptoFactory = mockk<KeyStoreCrypto.Factory>()
+    private val keyStore = mockk<KeyStore>(relaxed = true)
+    private val systemKeyV1Migrator = SystemKeyV1Migrator("vector.system_new", keyStore, keyStoreCryptoFactory)
+
+    @Test
+    fun isMigrationNeededReturnsTrueIfV1KeyExists() {
+        every { keyStore.containsAlias(SystemKeyV1Migrator.SYSTEM_KEY_ALIAS_V1) } returns true
+        systemKeyV1Migrator.isMigrationNeeded() shouldBe true
+
+        every { keyStore.containsAlias(SystemKeyV1Migrator.SYSTEM_KEY_ALIAS_V1) } returns false
+        systemKeyV1Migrator.isMigrationNeeded() shouldBe false
+    }
+
+    @Test
+    fun migrateDeletesOldEntryAndEnsuresNewKey() {
+        val keyStoreCryptoMock = mockk<KeyStoreCrypto> {
+            every { ensureKey() } returns mockk()
+        }
+        every { keyStoreCryptoFactory.provide("vector.system_new", any()) } returns keyStoreCryptoMock
+
+        systemKeyV1Migrator.migrate()
+
+        verify { keyStore.deleteEntry(SystemKeyV1Migrator.SYSTEM_KEY_ALIAS_V1) }
+        verify { keyStoreCryptoMock.ensureKey() }
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

See #6522 .

## Motivation and context

We want to add additional security measures to the biometric authentication of the lock screen feature: 

1. An extra check to make sure the `Cipher` used is unlocked after authentication.
2. Enabling a setting to only be able to use this `Cipher` while the device is unlocked.

## Tests

<!-- Explain how you tested your development -->

- With your app in `develop` or any other branch, go to Settings -> Security -> Protect access, and create a PIN code and enable biometric authentication. This can be done on the emulator too, but you need to make sure you're on API >= 30).
- Build and launch this branch, make sure you can still use biometric authentication.

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): 12.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
