### PR TITLE
fix olm session proliferation

### DIFF
--- a/changelog.d/6534.bugfix
+++ b/changelog.d/6534.bugfix
@@ -1,0 +1,1 @@
+Unwedging could cause the SDK to force creating a new olm session every hour

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/UnwedgingTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/UnwedgingTest.kt
@@ -21,7 +21,6 @@ import org.amshove.kluent.shouldBe
 import org.junit.Assert
 import org.junit.Before
 import org.junit.FixMethodOrder
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.MethodSorters

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/UnwedgingTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/UnwedgingTest.kt
@@ -60,7 +60,6 @@ import kotlin.coroutines.resume
  */
 @RunWith(AndroidJUnit4::class)
 @FixMethodOrder(MethodSorters.JVM)
-@Ignore
 class UnwedgingTest : InstrumentedTest {
 
     private lateinit var messagesReceivedByBob: List<TimelineEvent>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Bugfix

## Content

When a to_device olm message cannot be decrypted (BAD_ENCRYPTED_MESSAGE), the sending devices was marked as wedged (ratchet got desync). 
In order to fix it, the SDK will automatically try to refresh the session with this device by creating a new session and sending a new dummy prekey message.
This unwedging mechanism can only be done once per hour.

The issue is that when a device was marked as wedged it was never removed later. Meaning that if the app stayed on for long, a new olm session will be created every hour. This could explain the proliferation of olm sessions noticed in some logs:
Fixes #6534

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->
Can be tested by commenting out persisting olm sessions in the code, then force discard session and send messages. Kill/Restart the sending device will then restore an old ratchet version causing a desync.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] Pull request is based on the develop branch
- [x] You've made a self review of your PR
