### PR TITLE
[Location Share] - Standardise "Stop" texts for live (PSG-622)

### DIFF
--- a/changelog.d/6541.misc
+++ b/changelog.d/6541.misc
@@ -1,0 +1,1 @@
+[Location Share] - Standardise "Stop" texts for live

--- a/library/ui-styles/src/main/res/values/styles_location.xml
+++ b/library/ui-styles/src/main/res/values/styles_location.xml
@@ -5,8 +5,11 @@
         <item name="android:foreground">?selectableItemBackground</item>
         <item name="android:background">@android:color/transparent</item>
         <item name="android:textSize">12sp</item>
-        <item name="android:padding">0dp</item>
         <item name="android:gravity">center</item>
+        <item name="android:padding">0dp</item>
+        <item name="android:minWidth">0dp</item>
+        <item name="android:insetRight">8dp</item>
+        <item name="android:insetLeft">8dp</item>
     </style>
 
     <style name="Widget.Vector.Button.Text.LocationLive">
@@ -14,8 +17,11 @@
         <item name="android:background">@android:color/transparent</item>
         <item name="android:textAppearance">@style/TextAppearance.Vector.Body.Medium</item>
         <item name="android:textColor">?colorError</item>
-        <item name="android:padding">0dp</item>
         <item name="android:gravity">center</item>
+        <item name="android:padding">0dp</item>
+        <item name="android:minWidth">0dp</item>
+        <item name="android:insetRight">12dp</item>
+        <item name="android:insetLeft">12dp</item>
     </style>
 
     <style name="TextAppearance.Vector.Body.BottomSheetDisplayName">
@@ -36,8 +42,11 @@
         <item name="android:background">@android:color/transparent</item>
         <item name="android:textAppearance">@style/TextAppearance.Vector.Body.Medium</item>
         <item name="android:textColor">?colorError</item>
-        <item name="android:padding">0dp</item>
         <item name="android:gravity">center</item>
+        <item name="android:padding">0dp</item>
+        <item name="android:minWidth">0dp</item>
+        <item name="android:insetRight">16dp</item>
+        <item name="android:insetLeft">16dp</item>
     </style>
 
     <style name="Widget.Vector.TextView.Nano.Copyright">

--- a/vector/src/main/res/layout/item_live_location_users_bottom_sheet.xml
+++ b/vector/src/main/res/layout/item_live_location_users_bottom_sheet.xml
@@ -52,8 +52,7 @@
         style="@style/Widget.Vector.Button.Text.BottomSheetStopSharing"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:text="@string/live_location_bottom_sheet_stop_sharing"
+        android:text="@string/location_share_live_stop"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/vector/src/main/res/layout/view_location_live_message_banner.xml
+++ b/vector/src/main/res/layout/view_location_live_message_banner.xml
@@ -37,12 +37,12 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="8dp"
-        tools:text="@string/location_share_live_enabled"
         android:textColor="?colorOnSurface"
         app:layout_constraintBottom_toTopOf="@id/locationLiveMessageBannerSubTitle"
         app:layout_constraintStart_toEndOf="@id/locationLiveMessageBannerIcon"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_chainStyle="packed" />
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="@string/location_share_live_enabled" />
 
     <TextView
         android:id="@+id/locationLiveMessageBannerSubTitle"
@@ -58,10 +58,10 @@
     <Button
         android:id="@+id/locationLiveMessageBannerStop"
         style="@style/Widget.Vector.Button.Text.LocationLive"
-        android:layout_width="45dp"
-        android:layout_height="30dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="@string/location_share_live_stop"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toBottomOf="@id/locationLiveMessageBannerBackground"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/locationLiveMessageBannerBackground" />
 </merge>

--- a/vector/src/main/res/layout/view_location_live_status.xml
+++ b/vector/src/main/res/layout/view_location_live_status.xml
@@ -40,7 +40,7 @@
     <Button
         android:id="@+id/locationLiveStatusStop"
         style="@style/Widget.Vector.Button.Text.OnPrimary.LocationLive"
-        android:layout_width="60dp"
+        android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:text="@string/location_share_live_stop"
         app:layout_constraintBottom_toBottomOf="@id/locationLiveStatusContainer"

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3047,7 +3047,8 @@
     <string name="live_location_sharing_notification_description">Location sharing is in progress</string>
     <string name="labs_enable_live_location">Enable Live Location Sharing</string>
     <string name="labs_enable_live_location_summary">Temporary implementation: locations persist in room history</string>
-    <string name="live_location_bottom_sheet_stop_sharing">Stop sharing</string>
+    <!-- TODO remove key -->
+    <string name="live_location_bottom_sheet_stop_sharing" tools:ignore="UnusedResources">Stop sharing</string>
     <string name="live_location_bottom_sheet_last_updated_at">Updated %1$s ago</string>
 
     <string name="message_bubbles">Show Message bubbles</string>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Enhancement

## Content

<!-- Describe shortly what has been changed -->
Using the same text for stop button in live location share feature.
Fixing some button insets problem on some languages.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6541 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

<img src="https://user-images.githubusercontent.com/46314705/178761743-205a64cd-ff51-4c08-949c-d23d05af72e4.png" width=300/> <img src="https://user-images.githubusercontent.com/46314705/178761734-1239e561-b887-4c7e-9b0f-0a83fa392e5e.png" width=300/>

## Tests

<!-- Explain how you tested your development -->

- Start a live location share in a room
- Check the same text is used for stop buttons in the top status bar in the room and in the tile message
- Check insets are good in your language
- Press the tile message
- Check the correct text is used for the stop button in the bottom sheet list
- Check insets are good in your language

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
