### PR TITLE
Realm migration bg

### DIFF
--- a/changelog.d/6548.feature
+++ b/changelog.d/6548.feature
@@ -1,0 +1,1 @@
+Move initialization of the Session to a background thread. MainActivity is restoring the session now, instead of VectorApplication. Useful when for instance a long migration of a database is required.

--- a/vector/src/debug/java/im/vector/app/features/MainViewModel.kt
+++ b/vector/src/debug/java/im/vector/app/features/MainViewModel.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features
+
+import com.airbnb.mvrx.MavericksViewModelFactory
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import im.vector.app.core.di.ActiveSessionSetter
+import im.vector.app.core.di.MavericksAssistedViewModelFactory
+import im.vector.app.core.di.hiltMavericksViewModelFactory
+import im.vector.app.core.platform.VectorDummyViewState
+import im.vector.app.core.platform.VectorViewEvents
+import im.vector.app.core.platform.VectorViewModel
+import im.vector.app.core.platform.VectorViewModelAction
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+sealed interface MainViewAction : VectorViewModelAction {
+    object StartApp : MainViewAction
+}
+
+sealed interface MainViewEvent : VectorViewEvents {
+    object AppStarted : MainViewEvent
+}
+
+class MainViewModel @AssistedInject constructor(
+        @Assisted val initialState: VectorDummyViewState,
+        private val activeSessionSetter: ActiveSessionSetter,
+) : VectorViewModel<VectorDummyViewState, MainViewAction, MainViewEvent>(initialState) {
+
+    @AssistedFactory
+    interface Factory : MavericksAssistedViewModelFactory<MainViewModel, VectorDummyViewState> {
+        override fun create(initialState: VectorDummyViewState): MainViewModel
+    }
+
+    companion object : MavericksViewModelFactory<MainViewModel, VectorDummyViewState> by hiltMavericksViewModelFactory()
+
+    override fun handle(action: MainViewAction) {
+        when (action) {
+            MainViewAction.StartApp -> handleStartApp()
+        }
+    }
+
+    private fun handleStartApp() {
+        viewModelScope.launch(Dispatchers.IO) {
+            // This can take time because of DB migration(s), so do it in a background task.
+            activeSessionSetter.tryToSetActiveSession(startSync = true)
+            _viewEvents.post(MainViewEvent.AppStarted)
+        }
+    }
+}

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -381,6 +381,11 @@
             android:foregroundServiceType="location" />
 
         <service
+            android:name=".features.start.StartAppAndroidService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+
+        <service
             android:name=".features.call.webrtc.ScreenCaptureAndroidService"
             android:exported="false"
             android:foregroundServiceType="mediaProjection"

--- a/vector/src/main/java/im/vector/app/VectorApplication.kt
+++ b/vector/src/main/java/im/vector/app/VectorApplication.kt
@@ -41,8 +41,6 @@ import com.vanniktech.emoji.EmojiManager
 import com.vanniktech.emoji.google.GoogleEmojiProvider
 import dagger.hilt.android.HiltAndroidApp
 import im.vector.app.core.di.ActiveSessionHolder
-import im.vector.app.core.extensions.configureAndStart
-import im.vector.app.core.extensions.startSyncing
 import im.vector.app.features.analytics.VectorAnalytics
 import im.vector.app.features.call.webrtc.WebRtcCallManager
 import im.vector.app.features.configuration.VectorConfiguration
@@ -165,14 +163,6 @@ class VectorApplication :
             doNotShowDisclaimerDialog(this)
         }
 
-        if (authenticationService.hasAuthenticatedSessions() && !activeSessionHolder.hasActiveSession()) {
-            val lastAuthenticatedSession = authenticationService.getLastAuthenticatedSession()!!
-            activeSessionHolder.setActiveSession(lastAuthenticatedSession)
-            lastAuthenticatedSession.configureAndStart(applicationContext, startSyncing = false)
-        }
-
-        ProcessLifecycleOwner.get().lifecycle.addObserver(startSyncOnFirstStart)
-
         ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
             override fun onResume(owner: LifecycleOwner) {
                 Timber.i("App entered foreground")
@@ -203,14 +193,6 @@ class VectorApplication :
 
         // Initialize Mapbox before inflating mapViews
         Mapbox.getInstance(this)
-    }
-
-    private val startSyncOnFirstStart = object : DefaultLifecycleObserver {
-        override fun onStart(owner: LifecycleOwner) {
-            Timber.i("App process started")
-            authenticationService.getLastAuthenticatedSession()?.startSyncing(appContext)
-            ProcessLifecycleOwner.get().lifecycle.removeObserver(this)
-        }
     }
 
     private fun enableStrictModeIfNeeded() {

--- a/vector/src/main/java/im/vector/app/core/di/ActiveSessionSetter.kt
+++ b/vector/src/main/java/im/vector/app/core/di/ActiveSessionSetter.kt
@@ -26,12 +26,15 @@ class ActiveSessionSetter @Inject constructor(
         private val authenticationService: AuthenticationService,
         private val applicationContext: Context,
 ) {
+    fun shouldSetActionSession(): Boolean {
+        return authenticationService.hasAuthenticatedSessions() && !activeSessionHolder.hasActiveSession()
+    }
+
     fun tryToSetActiveSession(startSync: Boolean) {
-        if (authenticationService.hasAuthenticatedSessions() && !activeSessionHolder.hasActiveSession()) {
+        if (shouldSetActionSession()) {
             val lastAuthenticatedSession = authenticationService.getLastAuthenticatedSession()!!
             activeSessionHolder.setActiveSession(lastAuthenticatedSession)
             lastAuthenticatedSession.configureAndStart(applicationContext, startSyncing = startSync)
-            activeSessionHolder.setActiveSession(lastAuthenticatedSession)
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/core/di/ActiveSessionSetter.kt
+++ b/vector/src/main/java/im/vector/app/core/di/ActiveSessionSetter.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.di
+
+import android.content.Context
+import im.vector.app.core.extensions.configureAndStart
+import org.matrix.android.sdk.api.auth.AuthenticationService
+import javax.inject.Inject
+
+class ActiveSessionSetter @Inject constructor(
+        private val activeSessionHolder: ActiveSessionHolder,
+        private val authenticationService: AuthenticationService,
+        private val applicationContext: Context,
+) {
+    fun tryToSetActiveSession(startSync: Boolean) {
+        if (authenticationService.hasAuthenticatedSessions() && !activeSessionHolder.hasActiveSession()) {
+            val lastAuthenticatedSession = authenticationService.getLastAuthenticatedSession()!!
+            activeSessionHolder.setActiveSession(lastAuthenticatedSession)
+            lastAuthenticatedSession.configureAndStart(applicationContext, startSyncing = startSync)
+            activeSessionHolder.setActiveSession(lastAuthenticatedSession)
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/core/di/MavericksViewModelModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/MavericksViewModelModule.kt
@@ -20,7 +20,6 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.multibindings.IntoMap
-import im.vector.app.features.MainViewModel
 import im.vector.app.features.analytics.accountdata.AnalyticsAccountDataViewModel
 import im.vector.app.features.analytics.ui.consent.AnalyticsConsentViewModel
 import im.vector.app.features.auth.ReAuthViewModel
@@ -112,6 +111,7 @@ import im.vector.app.features.spaces.manage.SpaceManageSharedViewModel
 import im.vector.app.features.spaces.people.SpacePeopleViewModel
 import im.vector.app.features.spaces.preview.SpacePreviewViewModel
 import im.vector.app.features.spaces.share.ShareSpaceViewModel
+import im.vector.app.features.start.StartAppViewModel
 import im.vector.app.features.terms.ReviewTermsViewModel
 import im.vector.app.features.usercode.UserCodeSharedViewModel
 import im.vector.app.features.userdirectory.UserListViewModel
@@ -486,8 +486,8 @@ interface MavericksViewModelModule {
 
     @Binds
     @IntoMap
-    @MavericksViewModelKey(MainViewModel::class)
-    fun mainViewModelFactory(factory: MainViewModel.Factory): MavericksAssistedViewModelFactory<*, *>
+    @MavericksViewModelKey(StartAppViewModel::class)
+    fun startAppViewModelFactory(factory: StartAppViewModel.Factory): MavericksAssistedViewModelFactory<*, *>
 
     @Binds
     @IntoMap

--- a/vector/src/main/java/im/vector/app/core/di/MavericksViewModelModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/MavericksViewModelModule.kt
@@ -20,6 +20,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.multibindings.IntoMap
+import im.vector.app.features.MainViewModel
 import im.vector.app.features.analytics.accountdata.AnalyticsAccountDataViewModel
 import im.vector.app.features.analytics.ui.consent.AnalyticsConsentViewModel
 import im.vector.app.features.auth.ReAuthViewModel
@@ -482,6 +483,11 @@ interface MavericksViewModelModule {
     @IntoMap
     @MavericksViewModelKey(AnalyticsAccountDataViewModel::class)
     fun analyticsAccountDataViewModelFactory(factory: AnalyticsAccountDataViewModel.Factory): MavericksAssistedViewModelFactory<*, *>
+
+    @Binds
+    @IntoMap
+    @MavericksViewModelKey(MainViewModel::class)
+    fun mainViewModelFactory(factory: MainViewModel.Factory): MavericksAssistedViewModelFactory<*, *>
 
     @Binds
     @IntoMap

--- a/vector/src/main/java/im/vector/app/core/pushers/VectorMessagingReceiver.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/VectorMessagingReceiver.kt
@@ -27,6 +27,7 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.BuildConfig
 import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.core.di.ActiveSessionSetter
 import im.vector.app.core.network.WifiDetector
 import im.vector.app.core.pushers.model.PushData
 import im.vector.app.core.services.GuardServiceStarter
@@ -59,6 +60,7 @@ class VectorMessagingReceiver : MessagingReceiver() {
     @Inject lateinit var notificationDrawerManager: NotificationDrawerManager
     @Inject lateinit var notifiableEventResolver: NotifiableEventResolver
     @Inject lateinit var pushersManager: PushersManager
+    @Inject lateinit var activeSessionSetter: ActiveSessionSetter
     @Inject lateinit var activeSessionHolder: ActiveSessionHolder
     @Inject lateinit var vectorPreferences: VectorPreferences
     @Inject lateinit var vectorDataStore: VectorDataStore
@@ -177,6 +179,11 @@ class VectorMessagingReceiver : MessagingReceiver() {
             }
 
             val session = activeSessionHolder.getSafeActiveSession()
+                    ?: run {
+                        // Active session may not exist yet, if MainActivity has not been launched
+                        activeSessionSetter.tryToSetActiveSession(startSync = false)
+                        activeSessionHolder.getSafeActiveSession()
+                    }
 
             if (session == null) {
                 Timber.tag(loggerTag.value).w("## Can't sync from push, no current session")

--- a/vector/src/main/java/im/vector/app/features/MainActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/MainActivity.kt
@@ -22,6 +22,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import com.airbnb.mvrx.viewModel
 import com.bumptech.glide.Glide
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
@@ -47,6 +48,8 @@ import im.vector.app.features.signout.hard.SignedOutActivity
 import im.vector.app.features.themes.ActivityOtherThemes
 import im.vector.app.features.ui.UiStateRepository
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
@@ -84,6 +87,8 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
         }
     }
 
+    private val mainViewModel: MainViewModel by viewModel()
+
     override fun getBinding() = ActivityMainBinding.inflate(layoutInflater)
 
     override fun getOtherThemes() = ActivityOtherThemes.Launcher
@@ -103,6 +108,21 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        mainViewModel.viewEvents.stream()
+                .onEach(::handleViewEvents)
+                .launchIn(lifecycleScope)
+
+        mainViewModel.handle(MainViewAction.StartApp)
+    }
+
+    private fun handleViewEvents(event: MainViewEvent) {
+        when (event) {
+            MainViewEvent.AppStarted -> handleAppStarted()
+        }
+    }
+
+    private fun handleAppStarted() {
         args = parseArgs()
         if (args.clearCredentials || args.isUserLoggedOut || args.clearCache) {
             clearNotifications()

--- a/vector/src/main/java/im/vector/app/features/MainActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/MainActivity.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -48,6 +49,7 @@ import im.vector.app.features.session.VectorSessionStore
 import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.signout.hard.SignedOutActivity
 import im.vector.app.features.start.StartAppAction
+import im.vector.app.features.start.StartAppAndroidService
 import im.vector.app.features.start.StartAppViewEvent
 import im.vector.app.features.start.StartAppViewModel
 import im.vector.app.features.start.StartAppViewState
@@ -144,6 +146,11 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
             views.status.setText(R.string.updating_your_data)
         }
         views.status.isVisible = state.duration > 0
+        if (state.duration == 1L && startAppViewModel.shouldStartApp()) {
+            // Start foreground service, because the operation may take a while
+            val intent = Intent(this, StartAppAndroidService::class.java)
+            ContextCompat.startForegroundService(this, intent)
+        }
     }
 
     private fun handleViewEvents(event: StartAppViewEvent) {

--- a/vector/src/main/java/im/vector/app/features/MainActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/MainActivity.kt
@@ -17,6 +17,7 @@
 package im.vector.app.features
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
@@ -76,6 +77,7 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
 
     companion object {
         private const val EXTRA_ARGS = "EXTRA_ARGS"
+        private const val EXTRA_NEXT_INTENT = "EXTRA_NEXT_INTENT"
 
         // Special action to clear cache and/or clear credentials
         fun restartApp(activity: Activity, args: MainActivityArgs) {
@@ -84,6 +86,12 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
 
             intent.putExtra(EXTRA_ARGS, args)
             activity.startActivity(intent)
+        }
+
+        fun getIntentWithNextIntent(context: Context, nextIntent: Intent): Intent {
+            val intent = Intent(context, MainActivity::class.java)
+            intent.putExtra(EXTRA_NEXT_INTENT, nextIntent)
+            return intent
         }
     }
 
@@ -123,15 +131,21 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
     }
 
     private fun handleAppStarted() {
-        args = parseArgs()
-        if (args.clearCredentials || args.isUserLoggedOut || args.clearCache) {
-            clearNotifications()
-        }
-        // Handle some wanted cleanup
-        if (args.clearCache || args.clearCredentials) {
-            doCleanUp()
+        if (intent.hasExtra(EXTRA_NEXT_INTENT)) {
+            // Start the next Activity
+            val nextIntent = intent.getParcelableExtra<Intent>(EXTRA_NEXT_INTENT)
+            startIntentAndFinish(nextIntent)
         } else {
-            startNextActivityAndFinish()
+            args = parseArgs()
+            if (args.clearCredentials || args.isUserLoggedOut || args.clearCache) {
+                clearNotifications()
+            }
+            // Handle some wanted cleanup
+            if (args.clearCache || args.clearCredentials) {
+                doCleanUp()
+            } else {
+                startNextActivityAndFinish()
+            }
         }
     }
 
@@ -273,6 +287,10 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
                 null
             }
         }
+        startIntentAndFinish(intent)
+    }
+
+    private fun startIntentAndFinish(intent: Intent?) {
         intent?.let { startActivity(it) }
         finish()
     }

--- a/vector/src/main/java/im/vector/app/features/MainActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/MainActivity.kt
@@ -300,7 +300,7 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
                 // We have a session.
                 // Check it can be opened
                 if (sessionHolder.getActiveSession().isOpenable) {
-                    HomeActivity.newIntent(this, existingSession = true)
+                    HomeActivity.newIntent(this, firstStartMainActivity = false, existingSession = true)
                 } else {
                     // The token is still invalid
                     navigator.softLogout(this)

--- a/vector/src/main/java/im/vector/app/features/MainActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/MainActivity.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
+import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import com.airbnb.mvrx.viewModel
@@ -49,6 +50,7 @@ import im.vector.app.features.signout.hard.SignedOutActivity
 import im.vector.app.features.start.StartAppAction
 import im.vector.app.features.start.StartAppViewEvent
 import im.vector.app.features.start.StartAppViewModel
+import im.vector.app.features.start.StartAppViewState
 import im.vector.app.features.themes.ActivityOtherThemes
 import im.vector.app.features.ui.UiStateRepository
 import kotlinx.coroutines.Dispatchers
@@ -127,11 +129,21 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        startAppViewModel.onEach {
+            renderState(it)
+        }
         startAppViewModel.viewEvents.stream()
                 .onEach(::handleViewEvents)
                 .launchIn(lifecycleScope)
 
         startAppViewModel.handle(StartAppAction.StartApp)
+    }
+
+    private fun renderState(state: StartAppViewState) {
+        if (state.duration > 0) {
+            views.status.setText(R.string.updating_your_data)
+        }
+        views.status.isVisible = state.duration > 0
     }
 
     private fun handleViewEvents(event: StartAppViewEvent) {

--- a/vector/src/main/java/im/vector/app/features/MainActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/MainActivity.kt
@@ -142,20 +142,24 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
     }
 
     private fun renderState(state: StartAppViewState) {
-        if (state.duration > 0) {
+        if (state.mayBeLongToProcess) {
             views.status.setText(R.string.updating_your_data)
         }
-        views.status.isVisible = state.duration > 0
-        if (state.duration == 1L && startAppViewModel.shouldStartApp()) {
-            // Start foreground service, because the operation may take a while
-            val intent = Intent(this, StartAppAndroidService::class.java)
-            ContextCompat.startForegroundService(this, intent)
-        }
+        views.status.isVisible = state.mayBeLongToProcess
     }
 
     private fun handleViewEvents(event: StartAppViewEvent) {
         when (event) {
+            StartAppViewEvent.StartForegroundService -> handleStartForegroundService()
             StartAppViewEvent.AppStarted -> handleAppStarted()
+        }
+    }
+
+    private fun handleStartForegroundService() {
+        if (startAppViewModel.shouldStartApp()) {
+            // Start foreground service, because the operation may take a while
+            val intent = Intent(this, StartAppAndroidService::class.java)
+            ContextCompat.startForegroundService(this, intent)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
@@ -604,7 +604,7 @@ class VectorCallActivity :
     private fun returnToChat() {
         val roomId = withState(callViewModel) { it.roomId }
         val args = TimelineArgs(roomId)
-        val intent = RoomDetailActivity.newIntent(this, args).apply {
+        val intent = RoomDetailActivity.newIntent(this, args, false).apply {
             flags = FLAG_ACTIVITY_CLEAR_TOP
         }
         startActivity(intent)

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -611,6 +611,7 @@ class HomeActivity :
     companion object {
         fun newIntent(
                 context: Context,
+                firstStartMainActivity: Boolean,
                 clearNotification: Boolean = false,
                 authenticationDescription: AuthenticationDescription? = null,
                 existingSession: Boolean = false,
@@ -628,7 +629,11 @@ class HomeActivity :
                         putExtra(Mavericks.KEY_ARG, args)
                     }
 
-            return MainActivity.getIntentWithNextIntent(context, intent)
+            return if (firstStartMainActivity) {
+                MainActivity.getIntentWithNextIntent(context, intent)
+            } else {
+                intent
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -623,10 +623,12 @@ class HomeActivity :
                     inviteNotificationRoomId = inviteNotificationRoomId
             )
 
-            return Intent(context, HomeActivity::class.java)
+            val intent = Intent(context, HomeActivity::class.java)
                     .apply {
                         putExtra(Mavericks.KEY_ARG, args)
                     }
+
+            return MainActivity.getIntentWithNextIntent(context, intent)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailActivity.kt
@@ -35,6 +35,7 @@ import im.vector.app.core.extensions.keepScreenOn
 import im.vector.app.core.extensions.replaceFragment
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.databinding.ActivityRoomDetailBinding
+import im.vector.app.features.MainActivity
 import im.vector.app.features.analytics.plan.MobileScreen
 import im.vector.app.features.analytics.plan.ViewRoom
 import im.vector.app.features.home.room.breadcrumbs.BreadcrumbsFragment
@@ -191,9 +192,14 @@ class RoomDetailActivity :
         const val EXTRA_ROOM_ID = "EXTRA_ROOM_ID"
         const val ACTION_ROOM_DETAILS_FROM_SHORTCUT = "ROOM_DETAILS_FROM_SHORTCUT"
 
-        fun newIntent(context: Context, timelineArgs: TimelineArgs): Intent {
-            return Intent(context, RoomDetailActivity::class.java).apply {
+        fun newIntent(context: Context, timelineArgs: TimelineArgs, firstStartMainActivity: Boolean): Intent {
+            val intent = Intent(context, RoomDetailActivity::class.java).apply {
                 putExtra(EXTRA_ROOM_DETAIL_ARGS, timelineArgs)
+            }
+            return if (firstStartMainActivity) {
+                MainActivity.getIntentWithNextIntent(context, intent)
+            } else {
+                intent
             }
         }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1206,9 +1206,9 @@ class TimelineFragment @Inject constructor(
         getRootThreadEventId()?.let {
             val newRoom = timelineArgs.copy(threadTimelineArgs = null, eventId = it)
             context?.let { con ->
-                val int = RoomDetailActivity.newIntent(con, newRoom)
-                int.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
-                con.startActivity(int)
+                val intent = RoomDetailActivity.newIntent(con, newRoom, false)
+                intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+                con.startActivity(intent)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/link/LinkHandlerActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/link/LinkHandlerActivity.kt
@@ -18,18 +18,23 @@ package im.vector.app.features.link
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
 import androidx.lifecycle.lifecycleScope
+import com.airbnb.mvrx.viewModel
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.error.ErrorFormatter
+import im.vector.app.core.extensions.registerStartForActivityResult
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.core.utils.toast
 import im.vector.app.databinding.ActivityProgressBinding
+import im.vector.app.features.MainActivity
 import im.vector.app.features.home.HomeActivity
 import im.vector.app.features.login.LoginConfig
 import im.vector.app.features.permalink.PermalinkHandler
+import im.vector.app.features.start.StartAppViewModel
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService
 import timber.log.Timber
@@ -45,10 +50,31 @@ class LinkHandlerActivity : VectorBaseActivity<ActivityProgressBinding>() {
     @Inject lateinit var errorFormatter: ErrorFormatter
     @Inject lateinit var permalinkHandler: PermalinkHandler
 
+    private val startAppViewModel: StartAppViewModel by viewModel()
+
     override fun getBinding() = ActivityProgressBinding.inflate(layoutInflater)
 
     override fun initUiAndData() {
         handleIntent()
+    }
+
+    private val launcher = registerStartForActivityResult {
+        if (it.resultCode == RESULT_OK) {
+            handleIntent()
+        } else {
+            // User has pressed back on the MainActivity, so finish also this one.
+            finish()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (startAppViewModel.shouldStartApp()) {
+            launcher.launch(MainActivity.getIntentToInitSession(this))
+        } else {
+            handleIntent()
+        }
     }
 
     override fun onNewIntent(intent: Intent?) {

--- a/vector/src/main/java/im/vector/app/features/login/LoginActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginActivity.kt
@@ -221,7 +221,7 @@ open class LoginActivity : VectorBaseActivity<ActivityLoginBinding>(), UnlockedA
                 analyticsScreenName = MobileScreen.ScreenName.Register
             }
             val authDescription = inferAuthDescription(loginViewState)
-            val intent = HomeActivity.newIntent(this, authenticationDescription = authDescription)
+            val intent = HomeActivity.newIntent(this, firstStartMainActivity = false, authenticationDescription = authDescription)
             startActivity(intent)
             finish()
             return

--- a/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
@@ -173,7 +173,7 @@ class DefaultNavigator @Inject constructor(
         }
 
         val args = TimelineArgs(roomId = roomId, eventId = eventId, isInviteAlreadyAccepted = isInviteAlreadyAccepted)
-        val intent = RoomDetailActivity.newIntent(context, args)
+        val intent = RoomDetailActivity.newIntent(context, args, false)
         startActivity(context, intent, buildTask)
     }
 
@@ -203,7 +203,7 @@ class DefaultNavigator @Inject constructor(
                         eventId = null,
                         openShareSpaceForId = spaceId.takeIf { postSwitchSpaceAction.showShareSheet }
                 )
-                val intent = RoomDetailActivity.newIntent(context, args)
+                val intent = RoomDetailActivity.newIntent(context, args, false)
                 startActivity(context, intent, false)
             }
         }
@@ -290,7 +290,7 @@ class DefaultNavigator @Inject constructor(
 
     override fun openRoomForSharingAndFinish(activity: Activity, roomId: String, sharedData: SharedData) {
         val args = TimelineArgs(roomId, null, sharedData)
-        val intent = RoomDetailActivity.newIntent(activity, args)
+        val intent = RoomDetailActivity.newIntent(activity, args, false)
         activity.startActivity(intent)
         activity.finish()
     }

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
@@ -240,7 +240,7 @@ class NotificationUtils @Inject constructor(
     @SuppressLint("NewApi")
     fun buildForegroundServiceNotification(@StringRes subTitleResId: Int, withProgress: Boolean = true): Notification {
         // build the pending intent go to the home screen if this is clicked.
-        val i = HomeActivity.newIntent(context)
+        val i = HomeActivity.newIntent(context, firstStartMainActivity = false)
         i.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
         val mainIntent = MainActivity.getIntentWithNextIntent(context, i)
         val pi = PendingIntent.getActivity(context, 0, mainIntent, PendingIntentCompat.FLAG_IMMUTABLE)
@@ -346,7 +346,7 @@ class NotificationUtils @Inject constructor(
         )
 
         val answerCallPendingIntent = TaskStackBuilder.create(context)
-                .addNextIntentWithParentStack(HomeActivity.newIntent(context))
+                .addNextIntentWithParentStack(HomeActivity.newIntent(context, firstStartMainActivity = false))
                 .addNextIntent(
                         VectorCallActivity.newIntent(
                                 context = context,
@@ -470,7 +470,7 @@ class NotificationUtils @Inject constructor(
         )
 
         val contentPendingIntent = TaskStackBuilder.create(context)
-                .addNextIntentWithParentStack(HomeActivity.newIntent(context))
+                .addNextIntentWithParentStack(HomeActivity.newIntent(context, firstStartMainActivity = false))
                 .addNextIntent(VectorCallActivity.newIntent(context, call, null))
                 .getPendingIntent(clock.epochMillis().toInt(), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntentCompat.FLAG_IMMUTABLE)
 
@@ -532,7 +532,7 @@ class NotificationUtils @Inject constructor(
                 .setCategory(NotificationCompat.CATEGORY_CALL)
 
         val contentPendingIntent = TaskStackBuilder.create(context)
-                .addNextIntentWithParentStack(HomeActivity.newIntent(context))
+                .addNextIntentWithParentStack(HomeActivity.newIntent(context, firstStartMainActivity = false))
                 .addNextIntent(RoomDetailActivity.newIntent(context, TimelineArgs(callInformation.nativeRoomId), true))
                 .getPendingIntent(clock.epochMillis().toInt(), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntentCompat.FLAG_IMMUTABLE)
 
@@ -767,7 +767,11 @@ class NotificationUtils @Inject constructor(
                             joinIntentPendingIntent
                     )
 
-                    val contentIntent = HomeActivity.newIntent(context, inviteNotificationRoomId = inviteNotifiableEvent.roomId)
+                    val contentIntent = HomeActivity.newIntent(
+                            context,
+                            firstStartMainActivity = true,
+                            inviteNotificationRoomId = inviteNotifiableEvent.roomId
+                    )
                     contentIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
                     // pending intent get reused by system, this will mess up the extra params, so put unique info to avoid that
                     contentIntent.data = createIgnoredUri(inviteNotifiableEvent.eventId)
@@ -808,7 +812,7 @@ class NotificationUtils @Inject constructor(
                 .setColor(accentColor)
                 .setAutoCancel(true)
                 .apply {
-                    val contentIntent = HomeActivity.newIntent(context)
+                    val contentIntent = HomeActivity.newIntent(context, firstStartMainActivity = true)
                     contentIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
                     // pending intent get reused by system, this will mess up the extra params, so put unique info to avoid that
                     contentIntent.data = createIgnoredUri(simpleNotifiableEvent.eventId)
@@ -837,7 +841,7 @@ class NotificationUtils @Inject constructor(
 
         // Recreate the back stack
         return TaskStackBuilder.create(context)
-                .addNextIntentWithParentStack(HomeActivity.newIntent(context))
+                .addNextIntentWithParentStack(HomeActivity.newIntent(context, firstStartMainActivity = false))
                 .addNextIntent(roomIntentTap)
                 .getPendingIntent(
                         clock.epochMillis().toInt(),
@@ -846,7 +850,7 @@ class NotificationUtils @Inject constructor(
     }
 
     private fun buildOpenHomePendingIntentForSummary(): PendingIntent {
-        val intent = HomeActivity.newIntent(context, clearNotification = true)
+        val intent = HomeActivity.newIntent(context, firstStartMainActivity = false, clearNotification = true)
         intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
         intent.data = createIgnoredUri("tapSummary")
         val mainIntent = MainActivity.getIntentWithNextIntent(context, intent)

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
@@ -53,6 +53,7 @@ import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.services.CallAndroidService
 import im.vector.app.core.time.Clock
 import im.vector.app.core.utils.startNotificationChannelSettingsIntent
+import im.vector.app.features.MainActivity
 import im.vector.app.features.call.VectorCallActivity
 import im.vector.app.features.call.service.CallHeadsUpActionReceiver
 import im.vector.app.features.call.webrtc.WebRtcCall
@@ -241,7 +242,8 @@ class NotificationUtils @Inject constructor(
         // build the pending intent go to the home screen if this is clicked.
         val i = HomeActivity.newIntent(context)
         i.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-        val pi = PendingIntent.getActivity(context, 0, i, PendingIntentCompat.FLAG_IMMUTABLE)
+        val mainIntent = MainActivity.getIntentWithNextIntent(context, i)
+        val pi = PendingIntent.getActivity(context, 0, mainIntent, PendingIntentCompat.FLAG_IMMUTABLE)
 
         val accentColor = ContextCompat.getColor(context, R.color.notification_accent_color)
 
@@ -531,7 +533,7 @@ class NotificationUtils @Inject constructor(
 
         val contentPendingIntent = TaskStackBuilder.create(context)
                 .addNextIntentWithParentStack(HomeActivity.newIntent(context))
-                .addNextIntent(RoomDetailActivity.newIntent(context, TimelineArgs(callInformation.nativeRoomId)))
+                .addNextIntent(RoomDetailActivity.newIntent(context, TimelineArgs(callInformation.nativeRoomId), true))
                 .getPendingIntent(clock.epochMillis().toInt(), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntentCompat.FLAG_IMMUTABLE)
 
         builder.setContentIntent(contentPendingIntent)
@@ -828,7 +830,7 @@ class NotificationUtils @Inject constructor(
     }
 
     private fun buildOpenRoomIntent(roomId: String): PendingIntent? {
-        val roomIntentTap = RoomDetailActivity.newIntent(context, TimelineArgs(roomId = roomId, switchToParentSpace = true))
+        val roomIntentTap = RoomDetailActivity.newIntent(context, TimelineArgs(roomId = roomId, switchToParentSpace = true), true)
         roomIntentTap.action = TAP_TO_VIEW_ACTION
         // pending intent get reused by system, this will mess up the extra params, so put unique info to avoid that
         roomIntentTap.data = createIgnoredUri("openRoom?$roomId")
@@ -847,10 +849,11 @@ class NotificationUtils @Inject constructor(
         val intent = HomeActivity.newIntent(context, clearNotification = true)
         intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
         intent.data = createIgnoredUri("tapSummary")
+        val mainIntent = MainActivity.getIntentWithNextIntent(context, intent)
         return PendingIntent.getActivity(
                 context,
                 Random.nextInt(1000),
-                intent,
+                mainIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntentCompat.FLAG_IMMUTABLE
         )
     }

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
@@ -568,6 +568,19 @@ class NotificationUtils @Inject constructor(
                 .build()
     }
 
+    /**
+     * Creates a notification that indicates the application is initializing.
+     */
+    fun buildStartAppNotification(): Notification {
+        return NotificationCompat.Builder(context, LISTENING_FOR_EVENTS_NOTIFICATION_CHANNEL_ID)
+                .setContentTitle(stringProvider.getString(R.string.updating_your_data))
+                .setSmallIcon(R.drawable.sync)
+                .setColor(ThemeUtils.getColor(context, android.R.attr.colorPrimary))
+                .setCategory(NotificationCompat.CATEGORY_SERVICE)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .build()
+    }
+
     fun buildDownloadFileNotification(uri: Uri, fileName: String, mimeType: String): Notification {
         return NotificationCompat.Builder(context, SILENT_NOTIFICATION_CHANNEL_ID)
                 .setGroup(stringProvider.getString(R.string.app_name))

--- a/vector/src/main/java/im/vector/app/features/onboarding/Login2Variant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/Login2Variant.kt
@@ -302,7 +302,8 @@ class Login2Variant(
 
     private fun terminate() {
         val intent = HomeActivity.newIntent(
-                activity
+                activity,
+                firstStartMainActivity = false,
         )
         activity.startActivity(intent)
         activity.finish()

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -482,7 +482,11 @@ class FtueAuthVariant(
 
     private fun navigateToHome() {
         withState(onboardingViewModel) {
-            val intent = HomeActivity.newIntent(activity, authenticationDescription = it.selectedAuthenticationState.description)
+            val intent = HomeActivity.newIntent(
+                    activity,
+                    firstStartMainActivity = false,
+                    authenticationDescription = it.selectedAuthenticationState.description
+            )
             activity.startActivity(intent)
             activity.finish()
         }

--- a/vector/src/main/java/im/vector/app/features/share/IncomingShareAction.kt
+++ b/vector/src/main/java/im/vector/app/features/share/IncomingShareAction.kt
@@ -22,7 +22,7 @@ import org.matrix.android.sdk.api.session.room.model.RoomSummary
 sealed class IncomingShareAction : VectorViewModelAction {
     data class SelectRoom(val roomSummary: RoomSummary, val enableMultiSelect: Boolean) : IncomingShareAction()
     object ShareToSelectedRooms : IncomingShareAction()
-    data class ShareToRoom(val roomSummary: RoomSummary) : IncomingShareAction()
+    data class ShareToRoom(val roomId: String) : IncomingShareAction()
     data class ShareMedia(val keepOriginalSize: Boolean) : IncomingShareAction()
     data class FilterWith(val filter: String) : IncomingShareAction()
     data class UpdateSharedData(val sharedData: SharedData) : IncomingShareAction()

--- a/vector/src/main/java/im/vector/app/features/share/IncomingShareActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/share/IncomingShareActivity.kt
@@ -16,21 +16,66 @@
 
 package im.vector.app.features.share
 
+import android.content.Intent
+import android.os.Bundle
+import com.airbnb.mvrx.viewModel
 import dagger.hilt.android.AndroidEntryPoint
+import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.extensions.addFragment
+import im.vector.app.core.extensions.registerStartForActivityResult
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.databinding.ActivitySimpleBinding
+import im.vector.app.features.MainActivity
+import im.vector.app.features.start.StartAppViewModel
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class IncomingShareActivity : VectorBaseActivity<ActivitySimpleBinding>() {
+
+    private val startAppViewModel: StartAppViewModel by viewModel()
+
+    @Inject lateinit var activeSessionHolder: ActiveSessionHolder
+
+    private val launcher = registerStartForActivityResult {
+        if (it.resultCode == RESULT_OK) {
+            handleAppStarted()
+        } else {
+            // User has pressed back on the MainActivity, so finish also this one.
+            finish()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (startAppViewModel.shouldStartApp()) {
+            launcher.launch(MainActivity.getIntentToInitSession(this))
+        } else {
+            handleAppStarted()
+        }
+    }
 
     override fun getBinding() = ActivitySimpleBinding.inflate(layoutInflater)
 
     override fun getCoordinatorLayout() = views.coordinatorLayout
 
-    override fun initUiAndData() {
-        if (isFirstCreation()) {
-            addFragment(views.simpleFragmentContainer, IncomingShareFragment::class.java)
+    private fun handleAppStarted() {
+        // If we are not logged in, stop the sharing process and open login screen.
+        // In the future, we might want to relaunch the sharing process after login.
+        if (!activeSessionHolder.hasActiveSession()) {
+            startLoginActivity()
+        } else {
+            if (isFirstCreation()) {
+                addFragment(views.simpleFragmentContainer, IncomingShareFragment::class.java)
+            }
         }
+    }
+
+    private fun startLoginActivity() {
+        navigator.openLogin(
+                context = this,
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+        )
+        finish()
     }
 }

--- a/vector/src/main/java/im/vector/app/features/share/IncomingShareViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/share/IncomingShareViewModel.kt
@@ -35,6 +35,7 @@ import org.matrix.android.sdk.api.query.QueryStringValue
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.content.ContentAttachmentData
 import org.matrix.android.sdk.api.session.getRoom
+import org.matrix.android.sdk.api.session.getRoomSummary
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.roomSummaryQueryParams
 import org.matrix.android.sdk.flow.flow
@@ -134,7 +135,8 @@ class IncomingShareViewModel @AssistedInject constructor(
 
     private fun handleShareToRoom(action: IncomingShareAction.ShareToRoom) = withState { state ->
         val sharedData = state.sharedData ?: return@withState
-        _viewEvents.post(IncomingShareViewEvents.ShareToRoom(action.roomSummary, sharedData, showAlert = false))
+        val roomSummary = session.getRoomSummary(action.roomId) ?: return@withState
+        _viewEvents.post(IncomingShareViewEvents.ShareToRoom(roomSummary, sharedData, showAlert = false))
     }
 
     private fun handleShareMediaToSelectedRooms(action: IncomingShareAction.ShareMedia) = withState { state ->

--- a/vector/src/main/java/im/vector/app/features/start/StartAppAction.kt
+++ b/vector/src/main/java/im/vector/app/features/start/StartAppAction.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.start
+
+import im.vector.app.core.platform.VectorViewModelAction
+
+sealed interface StartAppAction : VectorViewModelAction {
+    object StartApp : StartAppAction
+}

--- a/vector/src/main/java/im/vector/app/features/start/StartAppAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/features/start/StartAppAndroidService.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.start
+
+import android.content.Intent
+import dagger.hilt.android.AndroidEntryPoint
+import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.core.di.NamedGlobalScope
+import im.vector.app.core.services.VectorAndroidService
+import im.vector.app.features.notifications.NotificationUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * A simple foreground service that let the app (and the SDK) time to initialize.
+ * Will self stop itself once the active session is set.
+ */
+@AndroidEntryPoint
+class StartAppAndroidService : VectorAndroidService() {
+
+    @NamedGlobalScope @Inject lateinit var globalScope: CoroutineScope
+    @Inject lateinit var notificationUtils: NotificationUtils
+    @Inject lateinit var activeSessionHolder: ActiveSessionHolder
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        showStickyNotification()
+        startPollingActiveSession()
+        return START_STICKY
+    }
+
+    private fun startPollingActiveSession() {
+        globalScope.launch {
+            do {
+                delay(1.seconds.inWholeMilliseconds)
+            } while (activeSessionHolder.hasActiveSession().not())
+            myStopSelf()
+        }
+    }
+
+    private fun showStickyNotification() {
+        val notificationId = Random.nextInt()
+        val notification = notificationUtils.buildStartAppNotification()
+        startForeground(notificationId, notification)
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/start/StartAppViewEvent.kt
+++ b/vector/src/main/java/im/vector/app/features/start/StartAppViewEvent.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.start
+
+import im.vector.app.core.platform.VectorViewEvents
+
+sealed interface StartAppViewEvent : VectorViewEvents {
+    object AppStarted : StartAppViewEvent
+}

--- a/vector/src/main/java/im/vector/app/features/start/StartAppViewEvent.kt
+++ b/vector/src/main/java/im/vector/app/features/start/StartAppViewEvent.kt
@@ -19,5 +19,13 @@ package im.vector.app.features.start
 import im.vector.app.core.platform.VectorViewEvents
 
 sealed interface StartAppViewEvent : VectorViewEvents {
+    /**
+     * Will be sent if the process is taking more than 1 second.
+     */
+    object StartForegroundService : StartAppViewEvent
+
+    /**
+     * Will be sent when the current Session has been set.
+     */
     object AppStarted : StartAppViewEvent
 }

--- a/vector/src/main/java/im/vector/app/features/start/StartAppViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/start/StartAppViewModel.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features
+package im.vector.app.features.start
 
 import com.airbnb.mvrx.MavericksViewModelFactory
 import dagger.assisted.Assisted
@@ -23,36 +23,29 @@ import dagger.assisted.AssistedInject
 import im.vector.app.core.di.ActiveSessionSetter
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
-import im.vector.app.core.platform.VectorDummyViewState
-import im.vector.app.core.platform.VectorViewEvents
 import im.vector.app.core.platform.VectorViewModel
-import im.vector.app.core.platform.VectorViewModelAction
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-sealed interface MainViewAction : VectorViewModelAction {
-    object StartApp : MainViewAction
-}
-
-sealed interface MainViewEvent : VectorViewEvents {
-    object AppStarted : MainViewEvent
-}
-
-class MainViewModel @AssistedInject constructor(
-        @Assisted val initialState: VectorDummyViewState,
+class StartAppViewModel @AssistedInject constructor(
+        @Assisted val initialState: StartAppViewState,
         private val activeSessionSetter: ActiveSessionSetter,
-) : VectorViewModel<VectorDummyViewState, MainViewAction, MainViewEvent>(initialState) {
+) : VectorViewModel<StartAppViewState, StartAppAction, StartAppViewEvent>(initialState) {
 
     @AssistedFactory
-    interface Factory : MavericksAssistedViewModelFactory<MainViewModel, VectorDummyViewState> {
-        override fun create(initialState: VectorDummyViewState): MainViewModel
+    interface Factory : MavericksAssistedViewModelFactory<StartAppViewModel, StartAppViewState> {
+        override fun create(initialState: StartAppViewState): StartAppViewModel
     }
 
-    companion object : MavericksViewModelFactory<MainViewModel, VectorDummyViewState> by hiltMavericksViewModelFactory()
+    companion object : MavericksViewModelFactory<StartAppViewModel, StartAppViewState> by hiltMavericksViewModelFactory()
 
-    override fun handle(action: MainViewAction) {
+    fun shouldStartApp(): Boolean {
+        return activeSessionSetter.shouldSetActionSession()
+    }
+
+    override fun handle(action: StartAppAction) {
         when (action) {
-            MainViewAction.StartApp -> handleStartApp()
+            StartAppAction.StartApp -> handleStartApp()
         }
     }
 
@@ -60,7 +53,7 @@ class MainViewModel @AssistedInject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             // This can take time because of DB migration(s), so do it in a background task.
             activeSessionSetter.tryToSetActiveSession(startSync = true)
-            _viewEvents.post(MainViewEvent.AppStarted)
+            _viewEvents.post(StartAppViewEvent.AppStarted)
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/start/StartAppViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/start/StartAppViewState.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.start
+
+import com.airbnb.mvrx.MavericksState
+
+data class StartAppViewState(
+        val duration: Long = 0
+) : MavericksState

--- a/vector/src/main/java/im/vector/app/features/start/StartAppViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/start/StartAppViewState.kt
@@ -19,5 +19,5 @@ package im.vector.app.features.start
 import com.airbnb.mvrx.MavericksState
 
 data class StartAppViewState(
-        val duration: Long = 0
+        val mayBeLongToProcess: Boolean = false
 ) : MavericksState

--- a/vector/src/main/res/layout/activity_main.xml
+++ b/vector/src/main/res/layout/activity_main.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- The background of this Activity is in the theme (so just added as tools here, for preview),
+<?xml version="1.0" encoding="utf-8"?><!-- The background of this Activity is in the theme (so just added as tools here, for preview),
  so we just add a ProgressBar here -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -21,5 +20,21 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/status"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/layout_horizontal_margin"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="@dimen/layout_horizontal_margin"
+        android:gravity="center"
+        android:textColor="@color/palette_white"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/progressBar"
+        tools:text="@string/updating_your_data"
+        tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1625,6 +1625,7 @@
     <string name="error_no_network">No network. Please check your Internet connection.</string>
     <string name="change_room_directory_network">"Change network"</string>
     <string name="please_wait">"Please wait…"</string>
+    <string name="updating_your_data">Updating your data…</string>
     <!--TODO: delete-->
     <string name="group_all_communities" tools:ignore="UnusedResources">"All Communities"</string>
 


### PR DESCRIPTION
This PR tries to move the Realm migration DB into background.

The first commit ensure there is always a migration to do and the migration will last 5 minutes. To be dropped of course.

|Before - migration in `VectorApplication.onCreate()`|After - migration in `MainActivity` view model|
|-|-|
|![DbMigrationInFg](https://user-images.githubusercontent.com/3940906/178817395-90a76b18-d0f9-4fce-a8fb-062b9e368bdd.gif)|![DbMigrationInBg](https://user-images.githubusercontent.com/3940906/178817199-bc2c64d2-e169-40a0-baf2-2e652cceb245.gif)|

New design with a wording (will iterate with @ganfra ):

<img width="293" alt="image" src="https://user-images.githubusercontent.com/3940906/179472073-a30f759a-5aab-484a-94b2-19431d8efeda.png">

Before we can have ANR if the migration takes time. After this should not happen anymore.

I create the PR to make this work public.

There are still some limitations:
- [ ] the code is quite dirty.
- [ ] we should consider using a mono Activity pattern to avoid some UI side effect when opening the app from a notification, after the app has been killed.
- [x] deep links management are not handled yet
- [x] ShareActivity management
- [x] Notification intent management  
- [x] Handle the todo : `TODO This will not work, handle this case.`
- [ ] probably some remaining crashes...