### PR TITLE
Just go back to the timeline if the user is already viewing the DM with the other user.

### DIFF
--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailPendingAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailPendingAction.kt
@@ -17,6 +17,7 @@
 package im.vector.app.features.home.room.detail
 
 sealed class RoomDetailPendingAction {
+    object DoNothing : RoomDetailPendingAction()
     data class JumpToReadReceipt(val userId: String) : RoomDetailPendingAction()
     data class MentionUser(val userId: String) : RoomDetailPendingAction()
     data class OpenRoom(val roomId: String, val closeCurrentRoom: Boolean = false) : RoomDetailPendingAction()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1323,6 +1323,7 @@ class TimelineFragment @Inject constructor(
 
     private fun handlePendingAction(roomDetailPendingAction: RoomDetailPendingAction) {
         when (roomDetailPendingAction) {
+            RoomDetailPendingAction.DoNothing -> Unit
             is RoomDetailPendingAction.JumpToReadReceipt ->
                 timelineViewModel.handle(RoomDetailAction.JumpToReadReceipt(roomDetailPendingAction.userId))
             is RoomDetailPendingAction.MentionUser ->

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
@@ -136,6 +136,7 @@ class RoomMemberProfileFragment @Inject constructor(
                 is RoomMemberProfileViewEvents.OnBanActionSuccess -> Unit
                 is RoomMemberProfileViewEvents.OnIgnoreActionSuccess -> Unit
                 is RoomMemberProfileViewEvents.OnInviteActionSuccess -> Unit
+                RoomMemberProfileViewEvents.GoBack -> handleGoBack()
             }
         }
         setupLongClicks()
@@ -307,6 +308,11 @@ class RoomMemberProfileFragment @Inject constructor(
 
     override fun onOpenDmClicked() {
         viewModel.handle(RoomMemberProfileAction.OpenOrCreateDm(fragmentArgs.userId))
+    }
+
+    private fun handleGoBack() {
+        roomDetailPendingActionStore.data = RoomDetailPendingAction.DoNothing
+        vectorBaseActivity.finish()
     }
 
     override fun onJumpToReadReceiptClicked() {

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewEvents.kt
@@ -40,4 +40,5 @@ sealed class RoomMemberProfileViewEvents : VectorViewEvents {
 
     data class ShareRoomMemberProfile(val permalink: String) : RoomMemberProfileViewEvents()
     data class OpenRoom(val roomId: String) : RoomMemberProfileViewEvents()
+    object GoBack : RoomMemberProfileViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileViewModel.kt
@@ -183,6 +183,9 @@ class RoomMemberProfileViewModel @AssistedInject constructor(
             }
             if (roomId != initialState.roomId) {
                 _viewEvents.post(RoomMemberProfileViewEvents.OpenRoom(roomId = roomId))
+            } else {
+                // Just go back to the previous screen (timeline)
+                _viewEvents.post(RoomMemberProfileViewEvents.GoBack)
             }
         }
     }


### PR DESCRIPTION
Fix #6514

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->


|Before|After|
|-|-|
|![DirectMessageBefore](https://user-images.githubusercontent.com/3940906/178831211-37150f41-416e-4f02-adc0-838476143046.gif)|![DirectMessage](https://user-images.githubusercontent.com/3940906/178831245-200ed6da-8fed-436b-97c1-8d95617be6ba.gif)|


## Tests

<!-- Explain how you tested your development -->

- See #6514

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
