### PR TITLE
Share location with other apps (PSG-242)

### DIFF
--- a/changelog.d/6567.feature
+++ b/changelog.d/6567.feature
@@ -1,0 +1,1 @@
+Share location with other apps

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapMarkerOptionsDialog.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapMarkerOptionsDialog.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.location.live.map
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.PopupWindow
+import androidx.core.content.ContextCompat
+import im.vector.app.R
+import im.vector.app.databinding.ViewLiveLocationMarkerPopupBinding
+
+class LocationLiveMapMarkerOptionsDialog(
+        context: Context,
+        inflater: LayoutInflater,
+) : PopupWindow() {
+
+    interface Callback {
+        fun onShareLocationClicked()
+    }
+
+    private val views: ViewLiveLocationMarkerPopupBinding
+
+    var callback: Callback? = null
+
+    init {
+        contentView = inflater.inflate(R.layout.view_live_location_marker_popup, null, false)
+
+        views = ViewLiveLocationMarkerPopupBinding.bind(contentView)
+
+        width = ViewGroup.LayoutParams.WRAP_CONTENT
+        height = ViewGroup.LayoutParams.WRAP_CONTENT
+        inputMethodMode = INPUT_METHOD_NOT_NEEDED
+        isFocusable = true
+        isTouchable = true
+        elevation = 8f
+        setBackgroundDrawable(ContextCompat.getDrawable(context, R.drawable.bg_live_location_marker_popup))
+
+        contentView.setOnClickListener {
+            callback?.onShareLocationClicked()
+        }
+    }
+
+    fun show(anchorView: View) {
+        contentView.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
+        showAsDropDown(anchorView, -contentView.measuredWidth / 2, 0)
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapMarkerOptionsDialog.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapMarkerOptionsDialog.kt
@@ -17,17 +17,14 @@
 package im.vector.app.features.location.live.map
 
 import android.content.Context
-import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupWindow
-import androidx.core.content.ContextCompat
 import im.vector.app.R
 import im.vector.app.databinding.ViewLiveLocationMarkerPopupBinding
 
 class LocationLiveMapMarkerOptionsDialog(
         context: Context,
-        inflater: LayoutInflater,
 ) : PopupWindow() {
 
     interface Callback {
@@ -39,7 +36,7 @@ class LocationLiveMapMarkerOptionsDialog(
     var callback: Callback? = null
 
     init {
-        contentView = inflater.inflate(R.layout.view_live_location_marker_popup, null, false)
+        contentView = View.inflate(context, R.layout.view_live_location_marker_popup, null)
 
         views = ViewLiveLocationMarkerPopupBinding.bind(contentView)
 
@@ -48,8 +45,6 @@ class LocationLiveMapMarkerOptionsDialog(
         inputMethodMode = INPUT_METHOD_NOT_NEEDED
         isFocusable = true
         isTouchable = true
-        elevation = 8f
-        setBackgroundDrawable(ContextCompat.getDrawable(context, R.drawable.bg_live_location_marker_popup))
 
         contentView.setOnClickListener {
             callback?.onShareLocationClicked()
@@ -58,6 +53,7 @@ class LocationLiveMapMarkerOptionsDialog(
 
     fun show(anchorView: View) {
         contentView.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
+        // By default the left side of the dialog is aligned with the pin. We need shift it to the left to make it's center aligned with the pin.
         showAsDropDown(anchorView, -contentView.measuredWidth / 2, 0)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapViewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapViewFragment.kt
@@ -143,7 +143,7 @@ class LocationLiveMapViewFragment @Inject constructor() : VectorBaseFragment<Fra
                 y = (screenLocation?.y ?: 0f) - views.liveLocationPopupAnchor.height
             }
 
-            LocationLiveMapMarkerOptionsDialog(requireContext(), layoutInflater)
+            LocationLiveMapMarkerOptionsDialog(requireContext())
                     .apply {
                         callback = object : LocationLiveMapMarkerOptionsDialog.Callback {
                             override fun onShareLocationClicked() {

--- a/vector/src/main/res/drawable/bg_live_location_marker_popup.xml
+++ b/vector/src/main/res/drawable/bg_live_location_marker_popup.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="8dp" />
+    <solid android:color="?android:colorBackground" />
+</shape>

--- a/vector/src/main/res/layout/fragment_location_live_map_view.xml
+++ b/vector/src/main/res/layout/fragment_location_live_map_view.xml
@@ -6,6 +6,11 @@
     android:layout_height="match_parent"
     android:background="@drawable/bg_live_location_users_bottom_sheet">
 
+    <View
+        android:id="@+id/liveLocationPopupAnchor"
+        android:layout_width="40dp"
+        android:layout_height="40dp" />
+
     <FrameLayout
         android:id="@+id/liveLocationMapFragmentContainer"
         android:layout_width="match_parent"

--- a/vector/src/main/res/layout/view_live_location_marker_popup.xml
+++ b/vector/src/main/res/layout/view_live_location_marker_popup.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <ImageView
+        android:id="@+id/shareLocationImageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:importantForAccessibility="no"
+        android:src="@drawable/ic_share_external"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="?vctr_content_tertiary" />
+
+    <TextView
+        style="@style/TextAppearance.Vector.Caption"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:text="@string/live_location_share_location_item_share"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/shareLocationImageView"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/main/res/layout/view_live_location_marker_popup.xml
+++ b/vector/src/main/res/layout/view_live_location_marker_popup.xml
@@ -3,6 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:background="@drawable/bg_live_location_marker_popup"
+    android:elevation="8dp"
     android:padding="8dp">
 
     <ImageView

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3045,6 +3045,7 @@
     <string name="labs_enable_live_location_summary">Temporary implementation: locations persist in room history</string>
     <string name="live_location_bottom_sheet_stop_sharing">Stop sharing</string>
     <string name="live_location_bottom_sheet_last_updated_at">Updated %1$s ago</string>
+    <string name="live_location_share_location_item_share">Share location</string>
 
     <string name="message_bubbles">Show Message bubbles</string>
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Users can now open others' (or their own) live locations with other map applications by tapping the marker of the users. Shared location is the static location at the time users click to share button.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

|Share location|Open with|
|-|-|
|![share_location](https://user-images.githubusercontent.com/1254401/179224377-fee6f39a-3dbc-4256-a1f7-9ae749d0d631.png)|![share_location_2](https://user-images.githubusercontent.com/1254401/179224754-5404d1c6-5159-4e6c-be59-f0e4ae9a2304.png)|

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Share a live location
- Click on timeline item to open maximized map
- Click on user's marker on the map
- You should see the "share" action

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
