### PR TITLE
Fix error when building `./gradlew assembleGplayNightly`

### DIFF
--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -280,10 +280,10 @@ android {
         }
 
         nightly {
+            initWith release
             applicationIdSuffix ".nightly"
             versionNameSuffix "-nightly"
 
-            initWith release
             // Just override the background color of the launcher icon for the nightly build.
             resValue "color", "launcher_background", "#07007E"
 


### PR DESCRIPTION
Just reordering lines.

Error was `No matching client found for package name 'im.vector.app'`

Full logs: https://github.com/vector-im/element-android/runs/7402504552?check_suite_focus=true

Let's merge this today and see tomorrow morning for the next try!