### PR TITLE
Remove duplicated and unused dependencies.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -49,9 +49,7 @@ ext.libs = [
                 'coroutinesTest'          : "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutines"
         ],
         androidx    : [
-                'annotation'              : "androidx.annotation:annotation:1.4.0",
                 'activity'                : "androidx.activity:activity:1.5.0",
-                'annotations'             : "androidx.annotation:annotation:1.3.0",
                 'appCompat'               : "androidx.appcompat:appcompat:1.4.2",
                 'biometric'               : "androidx.biometric:biometric:1.1.0",
                 'core'                    : "androidx.core:core-ktx:1.8.0",


### PR DESCRIPTION
Probably due to some merge conflicts, and because [it was not added in the alphabetical order at the beginning](https://github.com/vector-im/element-android/commit/6fc278eb2b463388a95e11d86293d6ae118b4249), we end up with duplicated entries here. But actually this is not used, so I just remove them.

If CI is happy, can be merged.