### PR TITLE
Live Location Sharing - Reset zoom level while focusing a user (PSG-624)

### DIFF
--- a/changelog.d/6609.misc
+++ b/changelog.d/6609.misc
@@ -1,0 +1,1 @@
+Live Location Sharing - Reset zoom level while focusing a user

--- a/vector/src/main/java/im/vector/app/features/location/MapBoxMapExt.kt
+++ b/vector/src/main/java/im/vector/app/features/location/MapBoxMapExt.kt
@@ -28,10 +28,12 @@ fun MapboxMap?.zoomToLocation(locationData: LocationData, preserveCurrentZoomLev
     } else {
         INITIAL_MAP_ZOOM_IN_PREVIEW
     }
-    this?.cameraPosition = CameraPosition.Builder()
-            .target(LatLng(locationData.latitude, locationData.longitude))
-            .zoom(zoomLevel)
-            .build()
+    this?.easeCamera {
+        CameraPosition.Builder()
+                .target(LatLng(locationData.latitude, locationData.longitude))
+                .zoom(zoomLevel)
+                .build()
+    }
 }
 
 fun MapboxMap?.zoomToBounds(latLngBounds: LatLngBounds) {

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapViewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapViewFragment.kt
@@ -273,7 +273,7 @@ class LocationLiveMapViewFragment @Inject constructor() : VectorBaseFragment<Fra
                 .find { it.matrixItem.id == userId }
                 ?.locationData
                 ?.let { locationData ->
-                    mapboxMap?.get()?.zoomToLocation(locationData, preserveCurrentZoomLevel = true)
+                    mapboxMap?.get()?.zoomToLocation(locationData, preserveCurrentZoomLevel = false)
                 }
     }
 

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapViewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapViewFragment.kt
@@ -45,6 +45,7 @@ import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.core.utils.DimensionConverter
 import im.vector.app.core.utils.openLocation
 import im.vector.app.databinding.FragmentLocationLiveMapViewBinding
+import im.vector.app.features.location.LocationData
 import im.vector.app.features.location.UrlMapProvider
 import im.vector.app.features.location.zoomToBounds
 import im.vector.app.features.location.zoomToLocation
@@ -137,11 +138,9 @@ class LocationLiveMapViewFragment @Inject constructor() : VectorBaseFragment<Fra
 
     private fun onSymbolClicked(symbol: Symbol?) {
         symbol?.let {
-            val screenLocation = mapboxMap?.get()?.projection?.toScreenLocation(it.latLng)
-            views.liveLocationPopupAnchor.apply {
-                x = screenLocation?.x ?: 0f
-                y = (screenLocation?.y ?: 0f) - views.liveLocationPopupAnchor.height
-            }
+            mapboxMap
+                    ?.get()
+                    ?.zoomToLocation(LocationData(it.latLng.latitude, it.latLng.longitude, null), preserveCurrentZoomLevel = false)
 
             LocationLiveMapMarkerOptionsDialog(requireContext())
                     .apply {

--- a/vector/src/main/res/layout/fragment_location_live_map_view.xml
+++ b/vector/src/main/res/layout/fragment_location_live_map_view.xml
@@ -8,8 +8,9 @@
 
     <View
         android:id="@+id/liveLocationPopupAnchor"
-        android:layout_width="40dp"
-        android:layout_height="40dp" />
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_gravity="center"/>
 
     <FrameLayout
         android:id="@+id/liveLocationMapFragmentContainer"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

When a user is selected on bottom sheet of maximized live location map view, we shouldn't preserve the current zoom level. Changing zoom level to a meaningful value will improve UX.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

https://user-images.githubusercontent.com/1254401/179989271-83b390a8-2b7a-46c1-ad6e-9624855a5295.mp4


<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Share a live location
- Tap on the live location message in the timeline
- On maximized map screen tap on user to focus

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
