### PR TITLE
Support element call widget (PSG-627)

### DIFF
--- a/changelog.d/6616.feature
+++ b/changelog.d/6616.feature
@@ -1,0 +1,1 @@
+Support element call widget

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/widgets/model/WidgetType.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/widgets/model/WidgetType.kt
@@ -28,7 +28,8 @@ private val DEFINED_TYPES by lazy {
             WidgetType.StickerPicker,
             WidgetType.Grafana,
             WidgetType.Custom,
-            WidgetType.IntegrationManager
+            WidgetType.IntegrationManager,
+            WidgetType.ElementCall
     )
 }
 
@@ -47,6 +48,7 @@ sealed class WidgetType(open val preferred: String, open val legacy: String = pr
     object Grafana : WidgetType("m.grafana")
     object Custom : WidgetType("m.custom")
     object IntegrationManager : WidgetType("m.integration_manager")
+    object ElementCall : WidgetType("io.element.call")
     data class Fallback(override val preferred: String) : WidgetType(preferred)
 
     fun matches(type: String): Boolean {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/widgets/model/WidgetType.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/widgets/model/WidgetType.kt
@@ -29,7 +29,7 @@ private val DEFINED_TYPES by lazy {
             WidgetType.Grafana,
             WidgetType.Custom,
             WidgetType.IntegrationManager,
-            WidgetType.ElementCall
+            WidgetType.ElementCall,
     )
 }
 

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -308,7 +308,8 @@
         <activity android:name=".features.terms.ReviewTermsActivity" />
         <activity
             android:name=".features.widgets.WidgetActivity"
-            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation" />
+            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
+            android:supportsPictureInPicture="true" />
 
         <activity android:name=".features.pin.PinActivity" />
         <activity android:name=".features.analytics.ui.consent.AnalyticsOptInActivity" />

--- a/vector/src/main/java/im/vector/app/core/utils/CheckWebViewPermissionsUseCase.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/CheckWebViewPermissionsUseCase.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.utils
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import android.webkit.PermissionRequest
+import androidx.core.content.ContextCompat
+import javax.inject.Inject
+
+class CheckWebViewPermissionsUseCase @Inject constructor() {
+
+    /**
+     * Checks if required WebView permissions are already granted system level.
+     * @param activity the calling Activity that is requesting the permissions (or fragment parent)
+     * @param request WebView permission request of onPermissionRequest function
+     * @return true if WebView permissions are already granted, false otherwise
+     */
+    fun execute(activity: Activity, request: PermissionRequest): Boolean {
+        return request.resources.all {
+            when (it) {
+                PermissionRequest.RESOURCE_AUDIO_CAPTURE -> {
+                    PERMISSIONS_FOR_AUDIO_IP_CALL.all { permission ->
+                        ContextCompat.checkSelfPermission(activity.applicationContext, permission) == PackageManager.PERMISSION_GRANTED
+                    }
+                }
+                PermissionRequest.RESOURCE_VIDEO_CAPTURE -> {
+                    PERMISSIONS_FOR_VIDEO_IP_CALL.all { permission ->
+                        ContextCompat.checkSelfPermission(activity.applicationContext, permission) == PackageManager.PERMISSION_GRANTED
+                    }
+                }
+                else -> {
+                    false
+                }
+            }
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/core/utils/PermissionsTools.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/PermissionsTools.kt
@@ -19,7 +19,6 @@ package im.vector.app.core.utils
 import android.Manifest
 import android.app.Activity
 import android.content.pm.PackageManager
-import android.webkit.PermissionRequest
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
@@ -135,32 +134,6 @@ fun checkPermissions(
     } else {
         // permissions were granted, start now.
         true
-    }
-}
-
-/**
- * Checks if required WebView permissions are already granted system level.
- * @param activity the calling Activity that is requesting the permissions (or fragment parent)
- * @param request WebView permission request of onPermissionRequest function
- * @return true if WebView permissions are already granted, false otherwise
- */
-fun checkWebViewPermissions(activity: Activity, request: PermissionRequest): Boolean {
-    return request.resources.all {
-        when (it) {
-            PermissionRequest.RESOURCE_AUDIO_CAPTURE -> {
-                PERMISSIONS_FOR_AUDIO_IP_CALL.all { permission ->
-                    ContextCompat.checkSelfPermission(activity.applicationContext, permission) == PackageManager.PERMISSION_GRANTED
-                }
-            }
-            PermissionRequest.RESOURCE_VIDEO_CAPTURE -> {
-                PERMISSIONS_FOR_VIDEO_IP_CALL.all { permission ->
-                    ContextCompat.checkSelfPermission(activity.applicationContext, permission) == PackageManager.PERMISSION_GRANTED
-                }
-            }
-            else -> {
-                false
-            }
-        }
     }
 }
 

--- a/vector/src/main/java/im/vector/app/core/utils/PermissionsTools.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/PermissionsTools.kt
@@ -19,6 +19,7 @@ package im.vector.app.core.utils
 import android.Manifest
 import android.app.Activity
 import android.content.pm.PackageManager
+import android.webkit.PermissionRequest
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
@@ -134,6 +135,32 @@ fun checkPermissions(
     } else {
         // permissions were granted, start now.
         true
+    }
+}
+
+/**
+ * Checks if required WebView permissions are already granted system level.
+ * @param activity the calling Activity that is requesting the permissions (or fragment parent)
+ * @param request WebView permission request of onPermissionRequest function
+ * @return true if WebView permissions are already granted, false otherwise
+ */
+fun checkWebViewPermissions(activity: Activity, request: PermissionRequest): Boolean {
+    return request.resources.all {
+        when (it) {
+            PermissionRequest.RESOURCE_AUDIO_CAPTURE -> {
+                PERMISSIONS_FOR_AUDIO_IP_CALL.all { permission ->
+                    ContextCompat.checkSelfPermission(activity.applicationContext, permission) == PackageManager.PERMISSION_GRANTED
+                }
+            }
+            PermissionRequest.RESOURCE_VIDEO_CAPTURE -> {
+                PERMISSIONS_FOR_VIDEO_IP_CALL.all { permission ->
+                    ContextCompat.checkSelfPermission(activity.applicationContext, permission) == PackageManager.PERMISSION_GRANTED
+                }
+            }
+            else -> {
+                false
+            }
+        }
     }
 }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
@@ -117,4 +117,6 @@ sealed class RoomDetailAction : VectorViewModelAction {
 
     // Live Location
     object StopLiveLocationSharing : RoomDetailAction()
+
+    object OpenElementCallWidget : RoomDetailAction()
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewEvents.kt
@@ -84,4 +84,5 @@ sealed class RoomDetailViewEvents : VectorViewEvents {
     data class StartChatEffect(val type: ChatEffect) : RoomDetailViewEvents()
     object StopChatEffects : RoomDetailViewEvents()
     object RoomReplacementStarted : RoomDetailViewEvents()
+    object OpenElementCallWidget : RoomDetailViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -102,6 +102,8 @@ data class RoomDetailViewState(
     // It can differs for a short period of time on the JitsiState as its computed async.
     fun hasActiveJitsiWidget() = activeRoomWidgets()?.any { it.type == WidgetType.Jitsi && it.isActive }.orFalse()
 
+    fun hasActiveElementCallWidget() = activeRoomWidgets()?.any { it.type == WidgetType.ElementCall && it.isActive }.orFalse()
+
     fun isDm() = asyncRoomSummary()?.isDirect == true
 
     fun isThreadTimeline() = rootThreadEventId != null

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -93,8 +93,7 @@ data class RoomDetailViewState(
         return asyncRoomSummary.invoke()?.isDirect ?: true ||
                 // When there is only one member, a warning will be displayed when the user
                 // clicks on the menu item to start a call
-                asyncRoomSummary.invoke()?.joinedMembersCount == 1 ||
-                hasActiveElementCallWidget()
+                asyncRoomSummary.invoke()?.joinedMembersCount == 1
     }
 
     fun isSearchAvailable() = asyncRoomSummary()?.isEncrypted == false

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailViewState.kt
@@ -93,7 +93,8 @@ data class RoomDetailViewState(
         return asyncRoomSummary.invoke()?.isDirect ?: true ||
                 // When there is only one member, a warning will be displayed when the user
                 // clicks on the menu item to start a call
-                asyncRoomSummary.invoke()?.joinedMembersCount == 1
+                asyncRoomSummary.invoke()?.joinedMembersCount == 1 ||
+                hasActiveElementCallWidget()
     }
 
     fun isSearchAvailable() = asyncRoomSummary()?.isEncrypted == false

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/StartCallActionsHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/StartCallActionsHandler.kt
@@ -47,6 +47,11 @@ class StartCallActionsHandler(
     }
 
     private fun handleCallRequest(isVideoCall: Boolean) = withState(timelineViewModel) { state ->
+        if (state.hasActiveElementCallWidget() && !isVideoCall) {
+            timelineViewModel.handle(RoomDetailAction.OpenElementCallWidget)
+            return@withState
+        }
+
         val roomSummary = state.asyncRoomSummary.invoke() ?: return@withState
         when (roomSummary.joinedMembersCount) {
             1 -> {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1088,12 +1088,11 @@ class TimelineFragment @Inject constructor(
             val hasCallInRoom = callManager.getCallsByRoomId(state.roomId).isNotEmpty() || state.jitsiState.hasJoined
             val callButtonsEnabled = !hasCallInRoom && when (state.asyncRoomSummary.invoke()?.joinedMembersCount) {
                 1 -> false
-                2 -> state.isAllowedToStartWebRTCCall || state.hasActiveElementCallWidget()
-                else -> state.isAllowedToManageWidgets || state.hasActiveElementCallWidget()
+                2 -> state.isAllowedToStartWebRTCCall
+                else -> state.isAllowedToManageWidgets
             }
-            setOf(R.id.voice_call, R.id.video_call).forEach {
-                menu.findItem(it).icon?.alpha = if (callButtonsEnabled) 0xFF else 0x40
-            }
+            menu.findItem(R.id.video_call).icon?.alpha = if (callButtonsEnabled) 0xFF else 0x40
+            menu.findItem(R.id.voice_call).icon?.alpha = if (callButtonsEnabled  || state.hasActiveElementCallWidget()) 0xFF else 0x40
 
             val matrixAppsMenuItem = menu.findItem(R.id.open_matrix_apps)
             val widgetsCount = state.activeRoomWidgets.invoke()?.size ?: 0

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1088,8 +1088,8 @@ class TimelineFragment @Inject constructor(
             val hasCallInRoom = callManager.getCallsByRoomId(state.roomId).isNotEmpty() || state.jitsiState.hasJoined
             val callButtonsEnabled = !hasCallInRoom && when (state.asyncRoomSummary.invoke()?.joinedMembersCount) {
                 1 -> false
-                2 -> state.isAllowedToStartWebRTCCall
-                else -> state.isAllowedToManageWidgets
+                2 -> state.isAllowedToStartWebRTCCall || state.hasActiveElementCallWidget()
+                else -> state.isAllowedToManageWidgets || state.hasActiveElementCallWidget()
             }
             setOf(R.id.voice_call, R.id.video_call).forEach {
                 menu.findItem(it).icon?.alpha = if (callButtonsEnabled) 0xFF else 0x40

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -498,6 +498,7 @@ class TimelineFragment @Inject constructor(
                 RoomDetailViewEvents.StopChatEffects -> handleStopChatEffects()
                 is RoomDetailViewEvents.DisplayAndAcceptCall -> acceptIncomingCall(it)
                 RoomDetailViewEvents.RoomReplacementStarted -> handleRoomReplacement()
+                RoomDetailViewEvents.OpenElementCallWidget -> handleOpenElementCallWidget()
             }
         }
 
@@ -2651,6 +2652,15 @@ class TimelineFragment @Inject constructor(
     private fun onViewWidgetsClicked() {
         RoomWidgetsBottomSheet.newInstance()
                 .show(childFragmentManager, "ROOM_WIDGETS_BOTTOM_SHEET")
+    }
+
+    private fun handleOpenElementCallWidget() = withState(timelineViewModel) { state ->
+        state
+                .activeRoomWidgets()
+                ?.find { it.type == WidgetType.ElementCall }
+                ?.also { widget ->
+                    navigator.openRoomWidget(requireContext(), state.roomId, widget)
+                }
     }
 
     override fun onTapToReturnToCall() {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -752,7 +752,7 @@ class TimelineViewModel @AssistedInject constructor(
                     R.id.timeline_setting -> true
                     R.id.invite -> state.canInvite
                     R.id.open_matrix_apps -> true
-                    R.id.voice_call -> state.isCallOptionAvailable()
+                    R.id.voice_call -> state.isCallOptionAvailable() || state.hasActiveElementCallWidget()
                     R.id.video_call -> state.isCallOptionAvailable() || state.jitsiState.confId == null || state.jitsiState.hasJoined
                     // Show Join conference button only if there is an active conf id not joined. Otherwise fallback to default video disabled. ^
                     R.id.join_conference -> !state.isCallOptionAvailable() && state.jitsiState.confId != null && !state.jitsiState.hasJoined

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -467,6 +467,13 @@ class TimelineViewModel @AssistedInject constructor(
             }
             is RoomDetailAction.EndPoll -> handleEndPoll(action.eventId)
             RoomDetailAction.StopLiveLocationSharing -> handleStopLiveLocationSharing()
+            RoomDetailAction.OpenElementCallWidget -> handleOpenElementCallWidget()
+        }
+    }
+
+    private fun handleOpenElementCallWidget() = withState { state ->
+        if (state.hasActiveElementCallWidget()) {
+            _viewEvents.post(RoomDetailViewEvents.OpenElementCallWidget)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
@@ -465,6 +465,9 @@ class DefaultNavigator @Inject constructor(
                 val enableVideo = options?.get(JitsiCallViewModel.ENABLE_VIDEO_OPTION) == true
                 context.startActivity(VectorJitsiActivity.newIntent(context, roomId = roomId, widgetId = widget.widgetId, enableVideo = enableVideo))
             }
+        } else if (widget.type is WidgetType.ElementCall) {
+            val widgetArgs = widgetArgsBuilder.buildElementCallWidgetArgs(roomId, widget)
+            context.startActivity(WidgetActivity.newIntent(context, widgetArgs))
         } else {
             val widgetArgs = widgetArgsBuilder.buildRoomWidgetArgs(roomId, widget)
             context.startActivity(WidgetActivity.newIntent(context, widgetArgs))

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetAction.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetAction.kt
@@ -26,5 +26,5 @@ sealed class WidgetAction : VectorViewModelAction {
     object DeleteWidget : WidgetAction()
     object RevokeWidget : WidgetAction()
     object OnTermsReviewed : WidgetAction()
-    object HangupElementCall : WidgetAction()
+    object CloseWidget : WidgetAction()
 }

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetAction.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetAction.kt
@@ -26,4 +26,5 @@ sealed class WidgetAction : VectorViewModelAction {
     object DeleteWidget : WidgetAction()
     object RevokeWidget : WidgetAction()
     object OnTermsReviewed : WidgetAction()
+    object HangupElementCall : WidgetAction()
 }

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
@@ -41,6 +41,7 @@ import im.vector.app.databinding.ActivityWidgetBinding
 import im.vector.app.features.widgets.permissions.RoomWidgetPermissionBottomSheet
 import im.vector.app.features.widgets.permissions.RoomWidgetPermissionViewEvents
 import im.vector.app.features.widgets.permissions.RoomWidgetPermissionViewModel
+import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.events.model.Content
 import java.io.Serializable
 
@@ -145,7 +146,7 @@ class WidgetActivity : VectorBaseActivity<ActivityWidgetBinding>() {
     override fun onUserLeaveHint() {
         super.onUserLeaveHint()
         val widgetArgs: WidgetArgs? = intent?.extras?.getParcelable(Mavericks.KEY_ARG)
-        if (widgetArgs?.kind == WidgetKind.ELEMENT_CALL) {
+        if (widgetArgs?.kind?.supportsPictureInPictureMode().orFalse()) {
             enterPictureInPicture()
         }
     }

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
@@ -17,8 +17,11 @@
 package im.vector.app.features.widgets
 
 import android.app.Activity
+import android.app.PictureInPictureParams
 import android.content.Context
 import android.content.Intent
+import android.os.Build
+import android.util.Rational
 import androidx.core.view.isVisible
 import com.airbnb.mvrx.Mavericks
 import com.airbnb.mvrx.viewModel
@@ -116,6 +119,24 @@ class WidgetActivity : VectorBaseActivity<ActivityWidgetBinding>() {
 
         viewModel.onEach(WidgetViewState::canManageWidgets) {
             invalidateOptionsMenu()
+        }
+    }
+
+    override fun onUserLeaveHint() {
+        super.onUserLeaveHint()
+        val widgetArgs: WidgetArgs? = intent?.extras?.getParcelable(Mavericks.KEY_ARG)
+        if (widgetArgs?.kind == WidgetKind.ELEMENT_CALL) {
+            enterPictureInPicture()
+        }
+    }
+
+    private fun enterPictureInPicture() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val aspectRatio = Rational(resources.getDimensionPixelSize(R.dimen.call_pip_width), resources.getDimensionPixelSize(R.dimen.call_pip_height))
+            val params = PictureInPictureParams.Builder()
+                    .setAspectRatio(aspectRatio)
+                    .build()
+            enterPictureInPictureMode(params)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
@@ -24,7 +24,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.content.res.Configuration
 import android.graphics.drawable.Icon
 import android.os.Build
 import android.util.Rational
@@ -34,7 +33,6 @@ import androidx.core.util.Consumer
 import androidx.core.view.isVisible
 import com.airbnb.mvrx.Mavericks
 import com.airbnb.mvrx.viewModel
-import com.airbnb.mvrx.withState
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
 import im.vector.app.core.extensions.addFragment
@@ -184,7 +182,7 @@ class WidgetActivity : VectorBaseActivity<ActivityWidgetBinding>() {
 
     private val pictureInPictureModeChangedInfoConsumer = Consumer<PictureInPictureModeChangedInfo> {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return@Consumer
-        
+
         if (isInPictureInPictureMode) {
             hangupBroadcastReceiver = object : BroadcastReceiver() {
                 override fun onReceive(context: Context?, intent: Intent?) {

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
@@ -17,11 +17,18 @@
 package im.vector.app.features.widgets
 
 import android.app.Activity
+import android.app.PendingIntent
 import android.app.PictureInPictureParams
+import android.app.RemoteAction
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
+import android.content.res.Configuration
+import android.graphics.drawable.Icon
 import android.os.Build
 import android.util.Rational
+import androidx.annotation.RequiresApi
 import androidx.core.view.isVisible
 import com.airbnb.mvrx.Mavericks
 import com.airbnb.mvrx.viewModel
@@ -43,6 +50,10 @@ class WidgetActivity : VectorBaseActivity<ActivityWidgetBinding>() {
         private const val WIDGET_FRAGMENT_TAG = "WIDGET_FRAGMENT_TAG"
         private const val WIDGET_PERMISSION_FRAGMENT_TAG = "WIDGET_PERMISSION_FRAGMENT_TAG"
         private const val EXTRA_RESULT = "EXTRA_RESULT"
+        private const val REQUEST_CODE_HANGUP = 1
+        private const val ACTION_MEDIA_CONTROL = "MEDIA_CONTROL"
+        private const val EXTRA_CONTROL_TYPE = "EXTRA_CONTROL_TYPE"
+        private const val CONTROL_TYPE_HANGUP = 2
 
         fun newIntent(context: Context, args: WidgetArgs): Intent {
             return Intent(context, WidgetActivity::class.java).apply {
@@ -139,11 +150,44 @@ class WidgetActivity : VectorBaseActivity<ActivityWidgetBinding>() {
 
     private fun enterPictureInPicture() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val aspectRatio = Rational(resources.getDimensionPixelSize(R.dimen.call_pip_width), resources.getDimensionPixelSize(R.dimen.call_pip_height))
-            val params = PictureInPictureParams.Builder()
-                    .setAspectRatio(aspectRatio)
-                    .build()
-            enterPictureInPictureMode(params)
+            createElementCallPipParams()?.let {
+                enterPictureInPictureMode(it)
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun createElementCallPipParams(): PictureInPictureParams? {
+        val actions = mutableListOf<RemoteAction>()
+        val intent = Intent(ACTION_MEDIA_CONTROL).putExtra(EXTRA_CONTROL_TYPE, CONTROL_TYPE_HANGUP)
+        val pendingIntent = PendingIntent.getBroadcast(this, REQUEST_CODE_HANGUP, intent, 0)
+        val icon = Icon.createWithResource(this, R.drawable.ic_call_hangup)
+        actions.add(RemoteAction(icon, getString(R.string.call_notification_hangup), getString(R.string.call_notification_hangup), pendingIntent))
+
+        val aspectRatio = Rational(resources.getDimensionPixelSize(R.dimen.call_pip_width), resources.getDimensionPixelSize(R.dimen.call_pip_height))
+        return PictureInPictureParams.Builder()
+                .setAspectRatio(aspectRatio)
+                .setActions(actions)
+                .build()
+    }
+
+    private var hangupBroadcastReceiver: BroadcastReceiver? = null
+    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration?) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+        if (isInPictureInPictureMode) {
+            hangupBroadcastReceiver = object : BroadcastReceiver() {
+                override fun onReceive(context: Context?, intent: Intent?) {
+                    if (intent?.action == ACTION_MEDIA_CONTROL) {
+                        val controlType = intent.getIntExtra(EXTRA_CONTROL_TYPE, 0)
+                        if (controlType == CONTROL_TYPE_HANGUP) {
+                            viewModel.handle(WidgetAction.HangupElementCall)
+                        }
+                    }
+                }
+            }
+            registerReceiver(hangupBroadcastReceiver, IntentFilter(ACTION_MEDIA_CONTROL))
+        } else {
+            unregisterReceiver(hangupBroadcastReceiver)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
@@ -85,29 +85,36 @@ class WidgetActivity : VectorBaseActivity<ActivityWidgetBinding>() {
             }
         }
 
-        permissionViewModel.observeViewEvents {
-            when (it) {
-                is RoomWidgetPermissionViewEvents.Close -> finish()
+        // Trust element call widget by default
+        if (widgetArgs.kind == WidgetKind.ELEMENT_CALL) {
+            if (supportFragmentManager.findFragmentByTag(WIDGET_FRAGMENT_TAG) == null) {
+                addFragment(views.fragmentContainer, WidgetFragment::class.java, widgetArgs, WIDGET_FRAGMENT_TAG)
             }
-        }
+        } else {
+            permissionViewModel.observeViewEvents {
+                when (it) {
+                    is RoomWidgetPermissionViewEvents.Close -> finish()
+                }
+            }
 
-        viewModel.onEach(WidgetViewState::status) { ws ->
-            when (ws) {
-                WidgetStatus.UNKNOWN -> {
-                }
-                WidgetStatus.WIDGET_NOT_ALLOWED -> {
-                    val dFrag = supportFragmentManager.findFragmentByTag(WIDGET_PERMISSION_FRAGMENT_TAG) as? RoomWidgetPermissionBottomSheet
-                    if (dFrag != null && dFrag.dialog?.isShowing == true && !dFrag.isRemoving) {
-                        return@onEach
-                    } else {
-                        RoomWidgetPermissionBottomSheet
-                                .newInstance(widgetArgs)
-                                .show(supportFragmentManager, WIDGET_PERMISSION_FRAGMENT_TAG)
+            viewModel.onEach(WidgetViewState::status) { ws ->
+                when (ws) {
+                    WidgetStatus.UNKNOWN -> {
                     }
-                }
-                WidgetStatus.WIDGET_ALLOWED -> {
-                    if (supportFragmentManager.findFragmentByTag(WIDGET_FRAGMENT_TAG) == null) {
-                        addFragment(views.fragmentContainer, WidgetFragment::class.java, widgetArgs, WIDGET_FRAGMENT_TAG)
+                    WidgetStatus.WIDGET_NOT_ALLOWED -> {
+                        val dFrag = supportFragmentManager.findFragmentByTag(WIDGET_PERMISSION_FRAGMENT_TAG) as? RoomWidgetPermissionBottomSheet
+                        if (dFrag != null && dFrag.dialog?.isShowing == true && !dFrag.isRemoving) {
+                            return@onEach
+                        } else {
+                            RoomWidgetPermissionBottomSheet
+                                    .newInstance(widgetArgs)
+                                    .show(supportFragmentManager, WIDGET_PERMISSION_FRAGMENT_TAG)
+                        }
+                    }
+                    WidgetStatus.WIDGET_ALLOWED -> {
+                        if (supportFragmentManager.findFragmentByTag(WIDGET_FRAGMENT_TAG) == null) {
+                            addFragment(views.fragmentContainer, WidgetFragment::class.java, widgetArgs, WIDGET_FRAGMENT_TAG)
+                        }
                     }
                 }
             }

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
@@ -189,7 +189,7 @@ class WidgetActivity : VectorBaseActivity<ActivityWidgetBinding>() {
                     if (intent?.action == ACTION_MEDIA_CONTROL) {
                         val controlType = intent.getIntExtra(EXTRA_CONTROL_TYPE, 0)
                         if (controlType == CONTROL_TYPE_HANGUP) {
-                            viewModel.handle(WidgetAction.HangupElementCall)
+                            viewModel.handle(WidgetAction.CloseWidget)
                         }
                     }
                 }

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetArgsBuilder.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetArgsBuilder.kt
@@ -78,6 +78,13 @@ class WidgetArgsBuilder @Inject constructor(
         )
     }
 
+    fun buildElementCallWidgetArgs(roomId: String, widget: Widget): WidgetArgs {
+        return buildRoomWidgetArgs(roomId, widget)
+                .copy(
+                        kind = WidgetKind.ELEMENT_CALL
+                )
+    }
+
     @Suppress("UNCHECKED_CAST")
     private fun Map<String, String?>.filterNotNull(): Map<String, String> {
         return filterValues { it != null } as Map<String, String>

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
@@ -131,9 +131,11 @@ class WidgetFragment @Inject constructor(
 
     override fun onPause() {
         super.onPause()
-        views.widgetWebView.let {
-            it.pauseTimers()
-            it.onPause()
+        if (fragmentArgs.kind != WidgetKind.ELEMENT_CALL) {
+            views.widgetWebView.let {
+                it.pauseTimers()
+                it.onPause()
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
@@ -43,6 +43,7 @@ import im.vector.app.core.extensions.registerStartForActivityResult
 import im.vector.app.core.platform.OnBackPressed
 import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.core.platform.VectorMenuProvider
+import im.vector.app.core.utils.CheckWebViewPermissionsUseCase
 import im.vector.app.core.utils.openUrlInExternalBrowser
 import im.vector.app.databinding.FragmentRoomWidgetBinding
 import im.vector.app.features.webview.WebEventListener
@@ -65,7 +66,8 @@ data class WidgetArgs(
 ) : Parcelable
 
 class WidgetFragment @Inject constructor(
-        private val permissionUtils: WebviewPermissionUtils
+        private val permissionUtils: WebviewPermissionUtils,
+        private val checkWebViewPermissionsUseCase: CheckWebViewPermissionsUseCase,
 ) :
         VectorBaseFragment<FragmentRoomWidgetBinding>(),
         WebEventListener,
@@ -81,7 +83,7 @@ class WidgetFragment @Inject constructor(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        views.widgetWebView.setupForWidget(requireActivity(), this)
+        views.widgetWebView.setupForWidget(requireActivity(), checkWebViewPermissionsUseCase, this)
         if (fragmentArgs.kind.isAdmin()) {
             viewModel.getPostAPIMediator().setWebView(views.widgetWebView)
         }

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
@@ -298,7 +298,8 @@ class WidgetFragment @Inject constructor(
                 request = request,
                 context = requireContext(),
                 activity = requireActivity(),
-                activityResultLauncher = permissionResultLauncher
+                activityResultLauncher = permissionResultLauncher,
+                autoApprove = fragmentArgs.kind == WidgetKind.ELEMENT_CALL
         )
     }
 

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
@@ -81,7 +81,7 @@ class WidgetFragment @Inject constructor(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        views.widgetWebView.setupForWidget(this)
+        views.widgetWebView.setupForWidget(requireActivity(), this)
         if (fragmentArgs.kind.isAdmin()) {
             viewModel.getPostAPIMediator().setWebView(views.widgetWebView)
         }

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetViewModel.kt
@@ -147,7 +147,12 @@ class WidgetViewModel @AssistedInject constructor(
             WidgetAction.DeleteWidget -> handleDeleteWidget()
             WidgetAction.RevokeWidget -> handleRevokeWidget()
             WidgetAction.OnTermsReviewed -> loadFormattedUrl(forceFetchToken = false)
+            WidgetAction.HangupElementCall -> handleHangupElementCall()
         }
+    }
+
+    private fun handleHangupElementCall() {
+        _viewEvents.post(WidgetViewEvents.Close())
     }
 
     private fun handleRevokeWidget() {

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetViewModel.kt
@@ -147,11 +147,11 @@ class WidgetViewModel @AssistedInject constructor(
             WidgetAction.DeleteWidget -> handleDeleteWidget()
             WidgetAction.RevokeWidget -> handleRevokeWidget()
             WidgetAction.OnTermsReviewed -> loadFormattedUrl(forceFetchToken = false)
-            WidgetAction.HangupElementCall -> handleHangupElementCall()
+            WidgetAction.CloseWidget -> handleCloseWidget()
         }
     }
 
-    private fun handleHangupElementCall() {
+    private fun handleCloseWidget() {
         _viewEvents.post(WidgetViewEvents.Close())
     }
 

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetViewState.kt
@@ -39,6 +39,10 @@ enum class WidgetKind(@StringRes val nameRes: Int, val screenId: String?) {
     fun isAdmin(): Boolean {
         return this == STICKER_PICKER || this == INTEGRATION_MANAGER
     }
+
+    fun supportsPictureInPictureMode(): Boolean {
+        return this == ELEMENT_CALL
+    }
 }
 
 data class WidgetViewState(

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetViewState.kt
@@ -33,7 +33,8 @@ enum class WidgetStatus {
 enum class WidgetKind(@StringRes val nameRes: Int, val screenId: String?) {
     ROOM(R.string.room_widget_activity_title, null),
     STICKER_PICKER(R.string.title_activity_choose_sticker, WidgetType.StickerPicker.preferred),
-    INTEGRATION_MANAGER(0, null);
+    INTEGRATION_MANAGER(0, null),
+    ELEMENT_CALL(0, null);
 
     fun isAdmin(): Boolean {
         return this == STICKER_PICKER || this == INTEGRATION_MANAGER

--- a/vector/src/main/java/im/vector/app/features/widgets/webview/WidgetWebView.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/webview/WidgetWebView.kt
@@ -17,18 +17,20 @@
 package im.vector.app.features.widgets.webview
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.PermissionRequest
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import im.vector.app.R
+import im.vector.app.core.utils.checkWebViewPermissions
 import im.vector.app.features.themes.ThemeUtils
 import im.vector.app.features.webview.VectorWebViewClient
 import im.vector.app.features.webview.WebEventListener
 
 @SuppressLint("NewApi")
-fun WebView.setupForWidget(eventListener: WebEventListener) {
+fun WebView.setupForWidget(activity: Activity, eventListener: WebEventListener) {
     // xml value seems ignored
     setBackgroundColor(ThemeUtils.getColor(context, R.attr.colorSurface))
 
@@ -59,7 +61,11 @@ fun WebView.setupForWidget(eventListener: WebEventListener) {
     // Permission requests
     webChromeClient = object : WebChromeClient() {
         override fun onPermissionRequest(request: PermissionRequest) {
-            eventListener.onPermissionRequest(request)
+            if (checkWebViewPermissions(activity, request)) {
+                request.grant(request.resources)
+            } else {
+                eventListener.onPermissionRequest(request)
+            }
         }
     }
     webViewClient = VectorWebViewClient(eventListener)

--- a/vector/src/main/java/im/vector/app/features/widgets/webview/WidgetWebView.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/webview/WidgetWebView.kt
@@ -24,13 +24,16 @@ import android.webkit.PermissionRequest
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import im.vector.app.R
-import im.vector.app.core.utils.checkWebViewPermissions
+import im.vector.app.core.utils.CheckWebViewPermissionsUseCase
 import im.vector.app.features.themes.ThemeUtils
 import im.vector.app.features.webview.VectorWebViewClient
 import im.vector.app.features.webview.WebEventListener
 
 @SuppressLint("NewApi")
-fun WebView.setupForWidget(activity: Activity, eventListener: WebEventListener) {
+fun WebView.setupForWidget(activity: Activity,
+                           checkWebViewPermissionsUseCase: CheckWebViewPermissionsUseCase,
+                           eventListener: WebEventListener,
+) {
     // xml value seems ignored
     setBackgroundColor(ThemeUtils.getColor(context, R.attr.colorSurface))
 
@@ -63,7 +66,7 @@ fun WebView.setupForWidget(activity: Activity, eventListener: WebEventListener) 
     // Permission requests
     webChromeClient = object : WebChromeClient() {
         override fun onPermissionRequest(request: PermissionRequest) {
-            if (checkWebViewPermissions(activity, request)) {
+            if (checkWebViewPermissionsUseCase.execute(activity, request)) {
                 request.grant(request.resources)
             } else {
                 eventListener.onPermissionRequest(request)

--- a/vector/src/main/java/im/vector/app/features/widgets/webview/WidgetWebView.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/webview/WidgetWebView.kt
@@ -58,6 +58,8 @@ fun WebView.setupForWidget(activity: Activity, eventListener: WebEventListener) 
 
     settings.displayZoomControls = false
 
+    settings.mediaPlaybackRequiresUserGesture = false
+
     // Permission requests
     webChromeClient = object : WebChromeClient() {
         override fun onPermissionRequest(request: PermissionRequest) {

--- a/vector/src/test/java/im/vector/app/core/utils/CheckWebViewPermissionsUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/core/utils/CheckWebViewPermissionsUseCaseTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.utils
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.webkit.PermissionRequest
+import androidx.core.content.ContextCompat.checkSelfPermission
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.amshove.kluent.shouldBe
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class CheckWebViewPermissionsUseCaseTest {
+
+    private val checkWebViewPermissionsUseCase = CheckWebViewPermissionsUseCase()
+
+    private val activity = mockk<Activity>().apply {
+        every { applicationContext } returns mockk()
+    }
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        mockkStatic("androidx.core.content.ContextCompat")
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic("androidx.core.content.ContextCompat")
+    }
+
+    @Test
+    fun `given an audio permission is granted when the web client requests audio permission then use case returns true`() {
+        val permissionRequest = givenAPermissionRequest(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
+
+        every { checkSelfPermission(activity.applicationContext, any()) } returns PackageManager.PERMISSION_GRANTED
+
+        checkWebViewPermissionsUseCase.execute(activity, permissionRequest) shouldBe true
+    }
+
+    @Test
+    fun `given a camera permission is granted when the web client requests video permission then use case returns true`() {
+        val permissionRequest = givenAPermissionRequest(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
+
+        every { checkSelfPermission(activity.applicationContext, any()) } returns PackageManager.PERMISSION_GRANTED
+
+        checkWebViewPermissionsUseCase.execute(activity, permissionRequest) shouldBe true
+    }
+
+    @Test
+    fun `given an audio and camera permissions are granted when the web client requests audio and video permissions then use case returns true`() {
+        val permissionRequest = givenAPermissionRequest(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE, PermissionRequest.RESOURCE_VIDEO_CAPTURE))
+
+        every { checkSelfPermission(activity.applicationContext, any()) } returns PackageManager.PERMISSION_GRANTED
+
+        checkWebViewPermissionsUseCase.execute(activity, permissionRequest) shouldBe true
+    }
+
+    @Test
+    fun `given an audio permission is granted but camera isn't when the web client requests audio and video permissions then use case returns false`() {
+        val permissionRequest = givenAPermissionRequest(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE, PermissionRequest.RESOURCE_VIDEO_CAPTURE))
+
+        PERMISSIONS_FOR_AUDIO_IP_CALL.forEach {
+            every { checkSelfPermission(activity.applicationContext, it) } returns PackageManager.PERMISSION_GRANTED
+        }
+        PERMISSIONS_FOR_VIDEO_IP_CALL.forEach {
+            every { checkSelfPermission(activity.applicationContext, it) } returns PackageManager.PERMISSION_DENIED
+        }
+
+        checkWebViewPermissionsUseCase.execute(activity, permissionRequest) shouldBe false
+    }
+
+    @Test
+    fun `given an audio and camera permissions are granted when the web client requests another permission then use case returns false`() {
+        val permissionRequest = givenAPermissionRequest(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE, PermissionRequest.RESOURCE_MIDI_SYSEX))
+
+        every { checkSelfPermission(activity.applicationContext, any()) } returns PackageManager.PERMISSION_GRANTED
+
+        checkWebViewPermissionsUseCase.execute(activity, permissionRequest) shouldBe false
+    }
+
+    private fun givenAPermissionRequest(resources: Array<String>): PermissionRequest {
+        return object : PermissionRequest() {
+            override fun getOrigin(): Uri {
+                return mockk()
+            }
+
+            override fun getResources(): Array<String> {
+                return resources
+            }
+
+            override fun grant(resources: Array<out String>?) {
+            }
+
+            override fun deny() {
+            }
+        }
+    }
+}

--- a/vector/src/test/java/im/vector/app/core/utils/CheckWebViewPermissionsUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/core/utils/CheckWebViewPermissionsUseCaseTest.kt
@@ -17,15 +17,16 @@
 package im.vector.app.core.utils
 
 import android.app.Activity
+import android.content.Context
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.webkit.PermissionRequest
 import androidx.core.content.ContextCompat.checkSelfPermission
-import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import io.mockk.verify
 import org.amshove.kluent.shouldBe
 import org.junit.After
 import org.junit.Before
@@ -41,7 +42,6 @@ class CheckWebViewPermissionsUseCaseTest {
 
     @Before
     fun setup() {
-        MockKAnnotations.init(this)
         mockkStatic("androidx.core.content.ContextCompat")
     }
 
@@ -53,34 +53,33 @@ class CheckWebViewPermissionsUseCaseTest {
     @Test
     fun `given an audio permission is granted when the web client requests audio permission then use case returns true`() {
         val permissionRequest = givenAPermissionRequest(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
-
         every { checkSelfPermission(activity.applicationContext, any()) } returns PackageManager.PERMISSION_GRANTED
 
         checkWebViewPermissionsUseCase.execute(activity, permissionRequest) shouldBe true
+        verifyPermissionsChecked(activity.applicationContext, PERMISSIONS_FOR_AUDIO_IP_CALL)
     }
 
     @Test
     fun `given a camera permission is granted when the web client requests video permission then use case returns true`() {
         val permissionRequest = givenAPermissionRequest(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
-
         every { checkSelfPermission(activity.applicationContext, any()) } returns PackageManager.PERMISSION_GRANTED
 
         checkWebViewPermissionsUseCase.execute(activity, permissionRequest) shouldBe true
+        verifyPermissionsChecked(activity.applicationContext, PERMISSIONS_FOR_VIDEO_IP_CALL)
     }
 
     @Test
     fun `given an audio and camera permissions are granted when the web client requests audio and video permissions then use case returns true`() {
         val permissionRequest = givenAPermissionRequest(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE, PermissionRequest.RESOURCE_VIDEO_CAPTURE))
-
         every { checkSelfPermission(activity.applicationContext, any()) } returns PackageManager.PERMISSION_GRANTED
 
         checkWebViewPermissionsUseCase.execute(activity, permissionRequest) shouldBe true
+        verifyPermissionsChecked(activity.applicationContext, PERMISSIONS_FOR_AUDIO_IP_CALL + PERMISSIONS_FOR_VIDEO_IP_CALL)
     }
 
     @Test
     fun `given an audio permission is granted but camera isn't when the web client requests audio and video permissions then use case returns false`() {
         val permissionRequest = givenAPermissionRequest(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE, PermissionRequest.RESOURCE_VIDEO_CAPTURE))
-
         PERMISSIONS_FOR_AUDIO_IP_CALL.forEach {
             every { checkSelfPermission(activity.applicationContext, it) } returns PackageManager.PERMISSION_GRANTED
         }
@@ -89,15 +88,22 @@ class CheckWebViewPermissionsUseCaseTest {
         }
 
         checkWebViewPermissionsUseCase.execute(activity, permissionRequest) shouldBe false
+        verifyPermissionsChecked(activity.applicationContext, PERMISSIONS_FOR_AUDIO_IP_CALL + PERMISSIONS_FOR_VIDEO_IP_CALL.first())
     }
 
     @Test
     fun `given an audio and camera permissions are granted when the web client requests another permission then use case returns false`() {
         val permissionRequest = givenAPermissionRequest(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE, PermissionRequest.RESOURCE_MIDI_SYSEX))
-
         every { checkSelfPermission(activity.applicationContext, any()) } returns PackageManager.PERMISSION_GRANTED
 
         checkWebViewPermissionsUseCase.execute(activity, permissionRequest) shouldBe false
+        verifyPermissionsChecked(activity.applicationContext, PERMISSIONS_FOR_AUDIO_IP_CALL)
+    }
+
+    private fun verifyPermissionsChecked(context: Context, permissions: List<String>) {
+        permissions.forEach {
+            verify { checkSelfPermission(context, it) }
+        }
     }
 
     private fun givenAPermissionRequest(resources: Array<String>): PermissionRequest {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
We implement Element Call as a widget with some extra functionalities.

## Motivation and context
Since this is a call widget we need to make it run in the background, provide a picture-in-picture mode and also preserve the current native WebRTC call implementation for rooms which does not have an active Element Call widget.

This PR is a cherry-pick version of [PR #6464](https://github.com/vector-im/element-android/pull/6464) which additionally implements a Bluetooth connection with push-to-talk devices. Since it is an experimental PR with a hardcoded device name and service address without a good UX, we wanted to create this PR to be able to merge into develop.

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

https://user-images.githubusercontent.com/1254401/180235359-19dcf0c3-05a8-4202-8ce3-7359de96a630.mp4



<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Request an invite (from me?) to the room which has an active Element Call widget
- Click voice call button and this should navigate you to the widget
- Choose a DM room without EC widget and you should be able to make a regular voice call with the same button

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
