### PR TITLE
[Location sharing] - OnTap on the top live status bar, display the expanded map view (PSG-614)

### DIFF
--- a/changelog.d/6625.misc
+++ b/changelog.d/6625.misc
@@ -1,0 +1,1 @@
+[Location sharing] - OnTap on the top live status bar, display the expanded map view

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -859,6 +859,9 @@ class TimelineFragment @Inject constructor(
         views.locationLiveStatusIndicator.stopButton.debouncedClicks {
             timelineViewModel.handle(RoomDetailAction.StopLiveLocationSharing)
         }
+        views.locationLiveStatusIndicator.root.debouncedClicks {
+            navigateToLocationLiveMap()
+        }
     }
 
     private fun joinJitsiRoom(jitsiWidget: Widget, enableVideo: Boolean) {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -859,7 +859,7 @@ class TimelineFragment @Inject constructor(
         views.locationLiveStatusIndicator.stopButton.debouncedClicks {
             timelineViewModel.handle(RoomDetailAction.StopLiveLocationSharing)
         }
-        views.locationLiveStatusIndicator.root.debouncedClicks {
+        views.locationLiveStatusIndicator.debouncedClicks {
             navigateToLocationLiveMap()
         }
     }

--- a/vector/src/main/java/im/vector/app/features/location/live/LocationLiveStatusView.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/LocationLiveStatusView.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.location.live
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import android.view.View
 import android.widget.Button
 import androidx.constraintlayout.widget.ConstraintLayout
 import im.vector.app.databinding.ViewLocationLiveStatusBinding
@@ -33,6 +34,9 @@ class LocationLiveStatusView @JvmOverloads constructor(
             LayoutInflater.from(context),
             this
     )
+
+    val root: View
+        get() = binding.root
 
     val stopButton: Button
         get() = binding.locationLiveStatusStop

--- a/vector/src/main/java/im/vector/app/features/location/live/LocationLiveStatusView.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/LocationLiveStatusView.kt
@@ -19,7 +19,6 @@ package im.vector.app.features.location.live
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.view.View
 import android.widget.Button
 import androidx.constraintlayout.widget.ConstraintLayout
 import im.vector.app.databinding.ViewLocationLiveStatusBinding
@@ -34,9 +33,6 @@ class LocationLiveStatusView @JvmOverloads constructor(
             LayoutInflater.from(context),
             this
     )
-
-    val root: View
-        get() = binding.root
 
     val stopButton: Button
         get() = binding.locationLiveStatusStop


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : UX improvement

## Content

<!-- Describe shortly what has been changed -->
Navigating to expanded map view when tapping on the status bar which indicates a live is active.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6625 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Go to a room
- Start a live location share
- Press on the top status bar
- Check it navigates to the expanded map view
- Go back to timeline
- Press the stop button on the top status bar
- Check the live is ended

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
