### PR TITLE
Add in-app alert to let user know if a new version is available.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -15,6 +15,7 @@ def gradle = "7.1.3"
 def kotlin = "1.6.21"
 def kotlinCoroutines = "1.6.4"
 def dagger = "2.42"
+def appDistribution = "16.0.0-beta03"
 def retrofit = "2.9.0"
 def arrow = "0.8.2"
 def markwon = "4.6.2"
@@ -83,7 +84,9 @@ ext.libs = [
                 'transition'              : "androidx.transition:transition:1.2.0",
         ],
         google      : [
-                'material'                : "com.google.android.material:material:1.6.1"
+                'material'                : "com.google.android.material:material:1.6.1",
+                'appdistributionApi'      : "com.google.firebase:firebase-appdistribution-api-ktx:$appDistribution",
+                'appdistribution'         : "com.google.firebase:firebase-appdistribution:$appDistribution",
         ],
         dagger      : [
                 'dagger'                  : "com.google.dagger:dagger:$dagger",

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -449,6 +449,12 @@ dependencies {
     implementation libs.airbnb.epoxyPaging
     implementation libs.airbnb.mavericks
 
+    // Nightly
+    // API-only library
+    gplayImplementation libs.google.appdistributionApi
+    // Full SDK implementation
+    gplayImplementation libs.google.appdistribution
+
     // Work
     implementation libs.androidx.work
 

--- a/vector/src/fdroid/java/im/vector/app/nightly/NightlyProxy.kt
+++ b/vector/src/fdroid/java/im/vector/app/nightly/NightlyProxy.kt
@@ -19,7 +19,5 @@ package im.vector.app.nightly
 import javax.inject.Inject
 
 class NightlyProxy @Inject constructor() {
-    fun updateIfNewReleaseAvailable() {
-        // No op
-    }
+    fun updateIfNewReleaseAvailable() = Unit
 }

--- a/vector/src/fdroid/java/im/vector/app/nightly/NightlyProxy.kt
+++ b/vector/src/fdroid/java/im/vector/app/nightly/NightlyProxy.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.nightly
+
+import javax.inject.Inject
+
+class NightlyProxy @Inject constructor() {
+    fun updateIfNewReleaseAvailable() {
+        // No op
+    }
+}

--- a/vector/src/gplay/java/im/vector/app/nightly/NightlyProxy.kt
+++ b/vector/src/gplay/java/im/vector/app/nightly/NightlyProxy.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.nightly
+
+import com.google.firebase.appdistribution.FirebaseAppDistribution
+import com.google.firebase.appdistribution.FirebaseAppDistributionException
+import timber.log.Timber
+import javax.inject.Inject
+
+class NightlyProxy @Inject constructor() {
+    fun updateIfNewReleaseAvailable() {
+        val firebaseAppDistribution = FirebaseAppDistribution.getInstance()
+        firebaseAppDistribution.updateIfNewReleaseAvailable()
+                .addOnProgressListener { up ->
+                    Timber.d("FirebaseAppDistribution progress: ${up.updateStatus}. ${up.apkBytesDownloaded}/${up.apkFileTotalBytes}")
+                }
+                .addOnFailureListener { e ->
+                    if (e is FirebaseAppDistributionException) {
+                        when (e.errorCode) {
+                            FirebaseAppDistributionException.Status.NOT_IMPLEMENTED -> {
+                                // SDK did nothing. This is expected when building for Play.
+                            }
+                            else -> {
+                                // Handle other errors.
+                                Timber.e(e, "FirebaseAppDistribution error, status: ${e.errorCode}")
+                            }
+                        }
+                    } else {
+                        Timber.e(e, "FirebaseAppDistribution - other error")
+                    }
+                }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -78,6 +78,7 @@ import im.vector.app.features.spaces.invite.SpaceInviteBottomSheet
 import im.vector.app.features.spaces.share.ShareSpaceBottomSheet
 import im.vector.app.features.themes.ThemeUtils
 import im.vector.app.features.workers.signout.ServerBackupStatusViewModel
+import im.vector.app.nightly.NightlyProxy
 import im.vector.app.push.fcm.FcmHelper
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -132,6 +133,7 @@ class HomeActivity :
     @Inject lateinit var appStateHandler: AppStateHandler
     @Inject lateinit var unifiedPushHelper: UnifiedPushHelper
     @Inject lateinit var fcmHelper: FcmHelper
+    @Inject lateinit var nightlyProxy: NightlyProxy
 
     private val createSpaceResultLauncher = registerStartForActivityResult { activityResult ->
         if (activityResult.resultCode == Activity.RESULT_OK) {
@@ -533,6 +535,9 @@ class HomeActivity :
 
         // Force remote backup state update to update the banner if needed
         serverBackupStatusViewModel.refreshRemoteStateIfNeeded()
+
+        // Check nightly
+        nightlyProxy.updateIfNewReleaseAvailable()
     }
 
     override fun getMenuRes() = R.menu.home


### PR DESCRIPTION
Add in app new version alert on nightly build version of the app, following this recipe: https://firebase.google.com/docs/app-distribution/set-up-alerts?platform=android, step 1, step 2 and step 4.

<img width="404" alt="Screenshot 2022-07-22 at 15 33 51" src="https://user-images.githubusercontent.com/3940906/180474232-e8811696-8024-42fb-b24d-aaa4abfddc50.png">

Still not working on my device with my account.

I have got this error when sign in to my Google Account:

<img width="341" alt="image" src="https://user-images.githubusercontent.com/3940906/180475690-9b5bd90d-eb5d-472f-9a69-76316450b934.png">

The step 4 suggest that the app have to be installed from Firebase to test the implementation. Let's merge this PR, wait for the next nightly build and get the app from Firebase to see if it's working?