### PR TITLE
Add privacy setting to disable personalized learning by the keyboard

### DIFF
--- a/changelog.d/6633.feature
+++ b/changelog.d/6633.feature
@@ -1,0 +1,1 @@
+Add privacy setting to disable personalized learning by the keyboard

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -2578,6 +2578,9 @@
     <string name="settings_security_prevent_screenshots_title">Prevent screenshots of the application</string>
     <string name="settings_security_prevent_screenshots_summary">Enabling this setting adds the FLAG_SECURE to all Activities. Restart the application for the change to take effect.</string>
 
+    <string name="settings_security_incognito_keyboard_title">Incognito keyboard</string>
+    <string name="settings_security_incognito_keyboard_summary">Request that the keyboard should not update any personalized data such as typing history and dictionary based on what the user typed. Some keyboards may not respect this setting.</string>
+
     <string name="error_saving_media_file">Could not save media file</string>
     <string name="change_password_summary">Set a new account password…</string>
 

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -2579,7 +2579,7 @@
     <string name="settings_security_prevent_screenshots_summary">Enabling this setting adds the FLAG_SECURE to all Activities. Restart the application for the change to take effect.</string>
 
     <string name="settings_security_incognito_keyboard_title">Incognito keyboard</string>
-    <string name="settings_security_incognito_keyboard_summary">Request that the keyboard should not update any personalized data such as typing history and dictionary based on what the user typed. Some keyboards may not respect this setting.</string>
+    <string name="settings_security_incognito_keyboard_summary">"Request that the keyboard should not update any personalized data such as typing history and dictionary based on what you've typed in conversations. Notice that some keyboards may not respect this setting."</string>
 
     <string name="error_saving_media_file">Could not save media file</string>
     <string name="change_password_summary">Set a new account password…</string>

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1537,12 +1537,7 @@ class TimelineFragment :
         observerUserTyping()
 
         composerEditText.setUseIncognitoKeyboard(vectorPreferences.useIncognitoKeyboard())
-
-        if (vectorPreferences.sendMessageWithEnter()) {
-            // imeOptions="actionSend" only works with single line, so we remove multiline inputType
-            composerEditText.inputType = composerEditText.inputType and EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE.inv()
-            composerEditText.imeOptions = EditorInfo.IME_ACTION_SEND
-        }
+        composerEditText.setSendMessageWithEnter(vectorPreferences.sendMessageWithEnter())
 
         composerEditText.setOnEditorActionListener { v, actionId, keyEvent ->
             val imeActionId = actionId and EditorInfo.IME_MASK_ACTION

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1536,6 +1536,8 @@ class TimelineFragment :
 
         observerUserTyping()
 
+        composerEditText.setUseIncognitoKeyboard(vectorPreferences.useIncognitoKeyboard())
+
         if (vectorPreferences.sendMessageWithEnter()) {
             // imeOptions="actionSend" only works with single line, so we remove multiline inputType
             composerEditText.inputType = composerEditText.inputType and EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE.inv()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1536,7 +1536,9 @@ class TimelineFragment :
 
         observerUserTyping()
 
-        composerEditText.setUseIncognitoKeyboard(vectorPreferences.useIncognitoKeyboard())
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            composerEditText.setUseIncognitoKeyboard(vectorPreferences.useIncognitoKeyboard())
+        }
         composerEditText.setSendMessageWithEnter(vectorPreferences.sendMessageWithEnter())
 
         composerEditText.setOnEditorActionListener { v, actionId, keyEvent ->

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/ComposerEditText.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/ComposerEditText.kt
@@ -79,6 +79,11 @@ class ComposerEditText @JvmOverloads constructor(
         return ic
     }
 
+    /** Set whether the keyboard should disable personalized learning. */
+    fun setUseIncognitoKeyboard(useIncognitoKeyboard: Boolean) {
+        imeOptions = if (useIncognitoKeyboard) imeOptions or INCOGNITO_KEYBOARD_IME else imeOptions and INCOGNITO_KEYBOARD_IME.inv()
+    }
+
     init {
         addTextChangedListener(
                 object : SimpleTextWatcher() {
@@ -115,5 +120,9 @@ class ComposerEditText @JvmOverloads constructor(
                     }
                 }
         )
+    }
+
+    companion object {
+        const val INCOGNITO_KEYBOARD_IME = EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/ComposerEditText.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/ComposerEditText.kt
@@ -81,7 +81,22 @@ class ComposerEditText @JvmOverloads constructor(
 
     /** Set whether the keyboard should disable personalized learning. */
     fun setUseIncognitoKeyboard(useIncognitoKeyboard: Boolean) {
-        imeOptions = if (useIncognitoKeyboard) imeOptions or INCOGNITO_KEYBOARD_IME else imeOptions and INCOGNITO_KEYBOARD_IME.inv()
+        imeOptions = if (useIncognitoKeyboard) {
+            imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+        } else {
+            imeOptions and EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING.inv()
+        }
+    }
+
+    /** Set whether enter should send the message or add a new line. */
+    fun setSendMessageWithEnter(sendMessageWithEnter: Boolean) {
+        if (sendMessageWithEnter) {
+            inputType = inputType and EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE.inv()
+            imeOptions = imeOptions or EditorInfo.IME_ACTION_SEND
+        } else {
+            inputType = inputType or EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE
+            imeOptions = imeOptions and EditorInfo.IME_ACTION_SEND.inv()
+        }
     }
 
     init {
@@ -120,9 +135,5 @@ class ComposerEditText @JvmOverloads constructor(
                     }
                 }
         )
-    }
-
-    companion object {
-        const val INCOGNITO_KEYBOARD_IME = EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/ComposerEditText.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/ComposerEditText.kt
@@ -20,10 +20,12 @@ package im.vector.app.features.home.room.detail.composer
 import android.content.ClipData
 import android.content.Context
 import android.net.Uri
+import android.os.Build
 import android.text.Editable
 import android.util.AttributeSet
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
+import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.AppCompatEditText
 import androidx.core.view.OnReceiveContentListener
 import androidx.core.view.ViewCompat
@@ -80,6 +82,7 @@ class ComposerEditText @JvmOverloads constructor(
     }
 
     /** Set whether the keyboard should disable personalized learning. */
+    @RequiresApi(Build.VERSION_CODES.O)
     fun setUseIncognitoKeyboard(useIncognitoKeyboard: Boolean) {
         imeOptions = if (useIncognitoKeyboard) {
             imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -87,6 +87,7 @@ class VectorPreferences @Inject constructor(
         const val SETTINGS_INTEGRATION_MANAGER_UI_URL_KEY = "SETTINGS_INTEGRATION_MANAGER_UI_URL_KEY"
         const val SETTINGS_SECURE_MESSAGE_RECOVERY_PREFERENCE_KEY = "SETTINGS_SECURE_MESSAGE_RECOVERY_PREFERENCE_KEY"
         const val SETTINGS_PERSISTED_SPACE_BACKSTACK = "SETTINGS_PERSISTED_SPACE_BACKSTACK"
+        const val SETTINGS_SECURITY_INCOGNITO_KEYBOARD_PREFERENCE_KEY = "SETTINGS_SECURITY_INCOGNITO_KEYBOARD_PREFERENCE_KEY"
 
         const val SETTINGS_CRYPTOGRAPHY_HS_ADMIN_DISABLED_E2E_DEFAULT = "SETTINGS_CRYPTOGRAPHY_HS_ADMIN_DISABLED_E2E_DEFAULT"
 //        const val SETTINGS_SECURE_BACKUP_RESET_PREFERENCE_KEY = "SETTINGS_SECURE_BACKUP_RESET_PREFERENCE_KEY"
@@ -288,6 +289,7 @@ class VectorPreferences @Inject constructor(
 
                 SETTINGS_USE_RAGE_SHAKE_KEY,
                 SETTINGS_SECURITY_USE_FLAG_SECURE,
+                SETTINGS_SECURITY_INCOGNITO_KEYBOARD_PREFERENCE_KEY,
 
                 ShortcutsHandler.SHARED_PREF_KEY,
         )
@@ -967,6 +969,11 @@ class VectorPreferences @Inject constructor(
      */
     fun useFlagSecure(): Boolean {
         return defaultPrefs.getBoolean(SETTINGS_SECURITY_USE_FLAG_SECURE, false)
+    }
+
+    /** Whether the keyboard should disable personalized learning. */
+    fun useIncognitoKeyboard(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_SECURITY_INCOGNITO_KEYBOARD_PREFERENCE_KEY, false)
     }
 
     /**

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
@@ -20,6 +20,7 @@ package im.vector.app.features.settings
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -160,6 +161,10 @@ class VectorSettingsSecurityPrivacyFragment :
         findPreference<VectorSwitchPreference>("SETTINGS_USER_ANALYTICS_CONSENT_KEY")!!
     }
 
+    private val incognitoKeyboardPref by lazy {
+        findPreference<VectorSwitchPreference>(VectorPreferences.SETTINGS_SECURITY_INCOGNITO_KEYBOARD_PREFERENCE_KEY)!!
+    }
+
     override fun onCreateRecyclerView(inflater: LayoutInflater, parent: ViewGroup, savedInstanceState: Bundle?): RecyclerView {
         return super.onCreateRecyclerView(inflater, parent, savedInstanceState).also {
             // Insert animation are really annoying the first time the list is shown
@@ -275,6 +280,9 @@ class VectorSettingsSecurityPrivacyFragment :
         // Analytics
         setUpAnalytics()
 
+        // Incognito Keyboard
+        setUpIncognitoKeyboard()
+
         // Pin code
         openPinCodeSettingsPref.setOnPreferenceClickListener {
             openPinCodePreferenceScreen()
@@ -335,6 +343,10 @@ class VectorSettingsSecurityPrivacyFragment :
             }
             true
         }
+    }
+
+    private fun setUpIncognitoKeyboard() {
+        incognitoKeyboardPref.isVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
     }
 
     // Todo this should be refactored and use same state as 4S section

--- a/vector/src/main/res/xml/vector_settings_security_privacy.xml
+++ b/vector/src/main/res/xml/vector_settings_security_privacy.xml
@@ -143,6 +143,12 @@
 
         <im.vector.app.core.preference.VectorSwitchPreference
             android:defaultValue="false"
+            android:key="SETTINGS_SECURITY_INCOGNITO_KEYBOARD_PREFERENCE_KEY"
+            android:summary="@string/settings_security_incognito_keyboard_summary"
+            android:title="@string/settings_security_incognito_keyboard_title" />
+
+        <im.vector.app.core.preference.VectorSwitchPreference
+            android:defaultValue="false"
             android:key="SETTINGS_SECURITY_USE_FLAG_SECURE"
             android:summary="@string/settings_security_prevent_screenshots_summary"
             android:title="@string/settings_security_prevent_screenshots_title" />


### PR DESCRIPTION
## Type of change

- [x] Feature

## Content

A new option has been added to the Privacy settings, which requests that the keyboard should not update any personalized data such as typing history and dictionary based on what the user typed.

## Motivation and context

Requesting that the keyboard minimize the amount of data it records about your private communications seems sensible for an encrypted messaging app.

It should disable the keyboard's personalized learning features, like adding your typed words into the personalized dictionary or storing the history of what you type. Some keyboards may not respect this setting. Signal messenger has this feature and missed it here.

## Screenshots

<img src="https://user-images.githubusercontent.com/1648685/180654251-318b4227-a5ae-4bf0-8b4d-7186acbabfd6.png" height="400">

## Tests

- Use a keyboard that supports incognito mode, like Gboard
- In Element, enable "Incognito keyboard" in Settings->Security & Privacy->Other
- Enter a chat, focus the message input field, and the keyboard (in case of Gboard) will show an incognito icon in the top left corner

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 7 (24), Android 12 (31)

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
    - [x] Signed-off-by: Tomáš Beňo <benjiko99@gmail.com>
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
