### PR TITLE
Put EC permission shortcuts behind labs flag (PSG-630)

### DIFF
--- a/changelog.d/6634.bugfix
+++ b/changelog.d/6634.bugfix
@@ -1,0 +1,1 @@
+Put EC permission shortcuts behind labs flag (PSG-630)

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -206,6 +206,8 @@ class VectorPreferences @Inject constructor(
 
         private const val SETTINGS_LABS_ENABLE_LIVE_LOCATION = "SETTINGS_LABS_ENABLE_LIVE_LOCATION"
 
+        private const val SETTINGS_LABS_ENABLE_ELEMENT_CALL_PERMISSION_SHORTCUTS = "SETTINGS_LABS_ENABLE_ELEMENT_CALL_PERMISSION_SHORTCUTS"
+
         // This key will be used to identify clients with the old thread support enabled io.element.thread
         const val SETTINGS_LABS_ENABLE_THREAD_MESSAGES_OLD_CLIENTS = "SETTINGS_LABS_ENABLE_THREAD_MESSAGES"
 
@@ -1048,6 +1050,10 @@ class VectorPreferences @Inject constructor(
         defaultPrefs.edit {
             putBoolean(SETTINGS_LABS_ENABLE_LIVE_LOCATION, isEnabled)
         }
+    }
+
+    fun labsEnableElementCallPermissionShortcuts(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_LABS_ENABLE_ELEMENT_CALL_PERMISSION_SHORTCUTS, false)
     }
 
     /**

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.widgets
 
 import android.app.Activity
 import android.app.PendingIntent
+import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.PictureInPictureParams
 import android.app.RemoteAction
 import android.content.BroadcastReceiver
@@ -172,7 +173,7 @@ class WidgetActivity : VectorBaseActivity<ActivityWidgetBinding>() {
     private fun createElementCallPipParams(): PictureInPictureParams? {
         val actions = mutableListOf<RemoteAction>()
         val intent = Intent(ACTION_MEDIA_CONTROL).putExtra(EXTRA_CONTROL_TYPE, CONTROL_TYPE_HANGUP)
-        val pendingIntent = PendingIntent.getBroadcast(this, REQUEST_CODE_HANGUP, intent, 0)
+        val pendingIntent = PendingIntent.getBroadcast(this, REQUEST_CODE_HANGUP, intent, FLAG_IMMUTABLE)
         val icon = Icon.createWithResource(this, R.drawable.ic_call_hangup)
         actions.add(RemoteAction(icon, getString(R.string.call_notification_hangup), getString(R.string.call_notification_hangup), pendingIntent))
 

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
@@ -38,12 +38,14 @@ import im.vector.app.R
 import im.vector.app.core.extensions.addFragment
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.databinding.ActivityWidgetBinding
+import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.widgets.permissions.RoomWidgetPermissionBottomSheet
 import im.vector.app.features.widgets.permissions.RoomWidgetPermissionViewEvents
 import im.vector.app.features.widgets.permissions.RoomWidgetPermissionViewModel
 import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.events.model.Content
 import java.io.Serializable
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class WidgetActivity : VectorBaseActivity<ActivityWidgetBinding>() {
@@ -78,6 +80,8 @@ class WidgetActivity : VectorBaseActivity<ActivityWidgetBinding>() {
     private val viewModel: WidgetViewModel by viewModel()
     private val permissionViewModel: RoomWidgetPermissionViewModel by viewModel()
 
+    @Inject lateinit var vectorPreferences: VectorPreferences
+
     override fun getBinding() = ActivityWidgetBinding.inflate(layoutInflater)
 
     override fun getTitleRes() = R.string.room_widget_activity_title
@@ -99,7 +103,7 @@ class WidgetActivity : VectorBaseActivity<ActivityWidgetBinding>() {
         }
 
         // Trust element call widget by default
-        if (widgetArgs.kind == WidgetKind.ELEMENT_CALL) {
+        if (widgetArgs.kind == WidgetKind.ELEMENT_CALL && vectorPreferences.labsEnableElementCallPermissionShortcuts()) {
             if (supportFragmentManager.findFragmentByTag(WIDGET_FRAGMENT_TAG) == null) {
                 addOnPictureInPictureModeChangedListener(pictureInPictureModeChangedInfoConsumer)
                 addFragment(views.fragmentContainer, WidgetFragment::class.java, widgetArgs, WIDGET_FRAGMENT_TAG)

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
@@ -46,6 +46,7 @@ import im.vector.app.core.platform.VectorMenuProvider
 import im.vector.app.core.utils.CheckWebViewPermissionsUseCase
 import im.vector.app.core.utils.openUrlInExternalBrowser
 import im.vector.app.databinding.FragmentRoomWidgetBinding
+import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.webview.WebEventListener
 import im.vector.app.features.widgets.webview.WebviewPermissionUtils
 import im.vector.app.features.widgets.webview.clearAfterWidget
@@ -68,6 +69,7 @@ data class WidgetArgs(
 class WidgetFragment @Inject constructor(
         private val permissionUtils: WebviewPermissionUtils,
         private val checkWebViewPermissionsUseCase: CheckWebViewPermissionsUseCase,
+        private val vectorPreferences: VectorPreferences,
 ) :
         VectorBaseFragment<FragmentRoomWidgetBinding>(),
         WebEventListener,
@@ -303,7 +305,7 @@ class WidgetFragment @Inject constructor(
                 context = requireContext(),
                 activity = requireActivity(),
                 activityResultLauncher = permissionResultLauncher,
-                autoApprove = fragmentArgs.kind == WidgetKind.ELEMENT_CALL
+                autoApprove = fragmentArgs.kind == WidgetKind.ELEMENT_CALL && vectorPreferences.labsEnableElementCallPermissionShortcuts()
         )
     }
 

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3179,4 +3179,8 @@
         <item quantity="one">%d message removed</item>
         <item quantity="other">%d messages removed</item>
     </plurals>
+
+    <!-- Element Call Widget -->
+    <string name="labs_enable_element_call_permission_shortcuts">Enable Element Call permission shortcuts</string>
+    <string name="labs_enable_element_call_permission_shortcuts_summary">Auto-approve Element Call widgets and grant camera / mic access</string>
 </resources>

--- a/vector/src/main/res/xml/vector_settings_labs.xml
+++ b/vector/src/main/res/xml/vector_settings_labs.xml
@@ -77,4 +77,10 @@
         android:summary="@string/labs_enable_live_location_summary"
         android:title="@string/labs_enable_live_location" />
 
+    <im.vector.app.core.preference.VectorSwitchPreference
+        android:defaultValue="false"
+        android:key="SETTINGS_LABS_ENABLE_ELEMENT_CALL_PERMISSION_SHORTCUTS"
+        android:summary="@string/labs_enable_element_call_permission_shortcuts_summary"
+        android:title="@string/labs_enable_element_call_permission_shortcuts" />
+
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Signed-off-by: Johannes Marbach <johannesm@element.io>
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

This is a follow-up on https://github.com/vector-im/element-android/pull/6616 that puts the Element Call permission shortcuts behind a labs flag. Anyone can create a false widget of type `io.element.call` and silently acquire permissions so we don't want to enable this behavior by default.

## Tests

Can be tested e.g. in #ecwidgettest:matrix.org

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

CC @onurays 