### PR TITLE
FTUE - Allow editing email during email verification 

### DIFF
--- a/changelog.d/6622.feature
+++ b/changelog.d/6622.feature
@@ -1,0 +1,1 @@
+FTUE - Allows the email address to be changed during the verification process

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewEvents.kt
@@ -53,7 +53,7 @@ sealed class OnboardingViewEvents : VectorViewEvents {
     object OnResetPasswordBreakerConfirmed : OnboardingViewEvents()
     object OnResetPasswordComplete : OnboardingViewEvents()
 
-    data class OnSendEmailSuccess(val email: String) : OnboardingViewEvents()
+    data class OnSendEmailSuccess(val email: String, val isRestoredSession: Boolean) : OnboardingViewEvents()
     data class OnSendMsisdnSuccess(val msisdn: String) : OnboardingViewEvents()
 
     data class OnWebLoginError(val errorCode: Int, val description: String, val failingUrl: String) : OnboardingViewEvents()

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -348,9 +348,10 @@ class OnboardingViewModel @AssistedInject constructor(
                             overrideNextStage?.invoke() ?: _viewEvents.post(OnboardingViewEvents.DisplayStartRegistration)
                         }
                         RegistrationActionHandler.Result.UnsupportedStage -> _viewEvents.post(OnboardingViewEvents.DisplayRegistrationFallback)
-                        is RegistrationActionHandler.Result.SendEmailSuccess -> _viewEvents.post(
-                                OnboardingViewEvents.OnSendEmailSuccess(it.email, isRestoredSession = false)
-                        )
+                        is RegistrationActionHandler.Result.SendEmailSuccess -> {
+                            _viewEvents.post(OnboardingViewEvents.OnSendEmailSuccess(it.email, isRestoredSession = false))
+                            setState { copy(registrationState = registrationState.copy(email = it.email)) }
+                        }
                         is RegistrationActionHandler.Result.SendMsisdnSuccess -> _viewEvents.post(OnboardingViewEvents.OnSendMsisdnSuccess(it.msisdn.msisdn))
                         is RegistrationActionHandler.Result.Error -> _viewEvents.post(OnboardingViewEvents.Failure(it.cause))
                         RegistrationActionHandler.Result.MissingNextStage -> {

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -348,7 +348,9 @@ class OnboardingViewModel @AssistedInject constructor(
                             overrideNextStage?.invoke() ?: _viewEvents.post(OnboardingViewEvents.DisplayStartRegistration)
                         }
                         RegistrationActionHandler.Result.UnsupportedStage -> _viewEvents.post(OnboardingViewEvents.DisplayRegistrationFallback)
-                        is RegistrationActionHandler.Result.SendEmailSuccess -> _viewEvents.post(OnboardingViewEvents.OnSendEmailSuccess(it.email))
+                        is RegistrationActionHandler.Result.SendEmailSuccess -> _viewEvents.post(
+                                OnboardingViewEvents.OnSendEmailSuccess(it.email, isRestoredSession = false)
+                        )
                         is RegistrationActionHandler.Result.SendMsisdnSuccess -> _viewEvents.post(OnboardingViewEvents.OnSendMsisdnSuccess(it.msisdn.msisdn))
                         is RegistrationActionHandler.Result.Error -> _viewEvents.post(OnboardingViewEvents.Failure(it.cause))
                         RegistrationActionHandler.Result.MissingNextStage -> {
@@ -412,8 +414,8 @@ class OnboardingViewModel @AssistedInject constructor(
                     authenticationService.cancelPendingLoginOrRegistration()
                     setState {
                         copy(
-                            isLoading = false,
-                            registrationState = RegistrationState(),
+                                isLoading = false,
+                                registrationState = RegistrationState(),
                         )
                     }
                 }
@@ -486,7 +488,7 @@ class OnboardingViewModel @AssistedInject constructor(
         try {
             if (registrationWizard.isRegistrationStarted()) {
                 currentThreePid?.let {
-                    handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnSendEmailSuccess(it)))
+                    handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnSendEmailSuccess(it, isRestoredSession = true)))
                 }
             }
         } catch (e: Throwable) {

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewState.kt
@@ -101,6 +101,7 @@ data class SelectedAuthenticationState(
 
 @Parcelize
 data class RegistrationState(
+        val email: String? = null,
         val isUserNameAvailable: Boolean = false,
         val selectedMatrixId: String? = null,
 ) : Parcelable

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/AbstractFtueAuthFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/AbstractFtueAuthFragment.kt
@@ -46,6 +46,7 @@ abstract class AbstractFtueAuthFragment<VB : ViewBinding> : VectorBaseFragment<V
 
     // Due to async, we keep a boolean to avoid displaying twice the cancellation dialog
     private var displayCancelDialog = true
+    protected open fun backIsHardExit() = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -115,7 +116,7 @@ abstract class AbstractFtueAuthFragment<VB : ViewBinding> : VectorBaseFragment<V
 
     override fun onBackPressed(toolbarButton: Boolean): Boolean {
         return when {
-            displayCancelDialog && viewModel.isRegistrationStarted -> {
+            displayCancelDialog && viewModel.isRegistrationStarted && backIsHardExit() -> {
                 // Ask for confirmation before cancelling the registration
                 MaterialAlertDialogBuilder(requireActivity())
                         .setTitle(R.string.login_signup_cancel_confirmation_title)

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthEmailEntryFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthEmailEntryFragment.kt
@@ -25,6 +25,8 @@ import im.vector.app.core.extensions.associateContentStateWith
 import im.vector.app.core.extensions.autofillEmail
 import im.vector.app.core.extensions.clearErrorOnChange
 import im.vector.app.core.extensions.content
+import im.vector.app.core.extensions.editText
+import im.vector.app.core.extensions.hasContent
 import im.vector.app.core.extensions.isEmail
 import im.vector.app.core.extensions.setOnImeDoneListener
 import im.vector.app.core.extensions.toReducedUrl
@@ -61,6 +63,10 @@ class FtueAuthEmailEntryFragment @Inject constructor() : AbstractFtueAuthFragmen
 
     override fun updateWithState(state: OnboardingViewState) {
         views.emailEntryHeaderSubtitle.text = getString(R.string.ftue_auth_email_subtitle, state.selectedHomeserver.userFacingUrl.toReducedUrl())
+
+        if (!views.emailEntryInput.hasContent()) {
+            views.emailEntryInput.editText().setText(state.registrationState.email)
+        }
     }
 
     override fun onError(throwable: Throwable) {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -414,16 +414,18 @@ class FtueAuthVariant(
     }
 
     private fun openWaitForEmailVerification(email: String, isRestoredSession: Boolean) {
-        supportFragmentManager.popBackStack(FRAGMENT_REGISTRATION_STAGE_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE)
         when {
             vectorFeatures.isOnboardingCombinedRegisterEnabled() -> addRegistrationStageFragmentToBackstack(
                     FtueAuthWaitForEmailFragment::class.java,
                     FtueAuthWaitForEmailFragmentArgument(email, isRestoredSession),
             )
-            else -> addRegistrationStageFragmentToBackstack(
-                    FtueAuthLegacyWaitForEmailFragment::class.java,
-                    FtueAuthWaitForEmailFragmentArgument(email, isRestoredSession),
-            )
+            else -> {
+                supportFragmentManager.popBackStack(FRAGMENT_REGISTRATION_STAGE_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                addRegistrationStageFragmentToBackstack(
+                        FtueAuthLegacyWaitForEmailFragment::class.java,
+                        FtueAuthWaitForEmailFragmentArgument(email, isRestoredSession),
+                )
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -196,7 +196,7 @@ class FtueAuthVariant(
                 activity.popBackstack()
             }
             is OnboardingViewEvents.OnSendEmailSuccess -> {
-                openWaitForEmailVerification(viewEvents.email)
+                openWaitForEmailVerification(viewEvents.email, viewEvents.isRestoredSession)
             }
             is OnboardingViewEvents.OnSendMsisdnSuccess -> {
                 openMsisdnConfirmation(viewEvents.msisdn)
@@ -413,16 +413,16 @@ class FtueAuthVariant(
         }
     }
 
-    private fun openWaitForEmailVerification(email: String) {
+    private fun openWaitForEmailVerification(email: String, isRestoredSession: Boolean) {
         supportFragmentManager.popBackStack(FRAGMENT_REGISTRATION_STAGE_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE)
         when {
             vectorFeatures.isOnboardingCombinedRegisterEnabled() -> addRegistrationStageFragmentToBackstack(
                     FtueAuthWaitForEmailFragment::class.java,
-                    FtueAuthWaitForEmailFragmentArgument(email),
+                    FtueAuthWaitForEmailFragmentArgument(email, isRestoredSession),
             )
             else -> addRegistrationStageFragmentToBackstack(
                     FtueAuthLegacyWaitForEmailFragment::class.java,
-                    FtueAuthWaitForEmailFragmentArgument(email),
+                    FtueAuthWaitForEmailFragmentArgument(email, isRestoredSession),
             )
         }
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthWaitForEmailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthWaitForEmailFragment.kt
@@ -35,7 +35,8 @@ import javax.inject.Inject
 
 @Parcelize
 data class FtueAuthWaitForEmailFragmentArgument(
-        val email: String
+        val email: String,
+        val isRestoredSession: Boolean,
 ) : Parcelable
 
 /**

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthWaitForEmailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthWaitForEmailFragment.kt
@@ -49,6 +49,8 @@ class FtueAuthWaitForEmailFragment @Inject constructor(
     private val params: FtueAuthWaitForEmailFragmentArgument by args()
     private var inferHasLeftAndReturnedToScreen = false
 
+    override fun backIsHardExit() = params.isRestoredSession
+
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentFtueWaitForEmailVerificationBinding {
         return FragmentFtueWaitForEmailVerificationBinding.inflate(inflater, container, false)
     }
@@ -89,6 +91,11 @@ class FtueAuthWaitForEmailFragment @Inject constructor(
     }
 
     override fun resetViewModel() {
-        viewModel.handle(OnboardingAction.ResetAuthenticationAttempt)
+        when {
+            backIsHardExit() -> viewModel.handle(OnboardingAction.ResetAuthenticationAttempt)
+            else -> {
+                // delegate to the previous step
+            }
+        }
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeRegistrationWizard.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeRegistrationWizard.kt
@@ -45,6 +45,14 @@ class FakeRegistrationWizard : RegistrationWizard by mockk(relaxed = false) {
         }
     }
 
+    fun givenRegistrationStarted(hasStarted: Boolean) {
+        coEvery { isRegistrationStarted() } returns hasStarted
+    }
+
+    fun givenCurrentThreePid(threePid: String?) {
+        coEvery { getCurrentThreePid() } returns threePid
+    }
+
     fun givenUserNameIsAvailable(userName: String) {
         coEvery { registrationAvailable(userName) } returns RegistrationAvailability.Available
     }


### PR DESCRIPTION
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Avoids marking the "Waiting for email verification" as a hard exit, which allows the user to go back and edit the entered email address.

- When restoring the session (eg killing the app whilst within the waiting for verification) the back action will force the user to start the flow again from scratch.

## Motivation and context

#6622 Allow editing email during the verification steps

## Screenshots / GIFs

| BEFORE | AFTER | 
| --- | --- | 
|![before-change-email](https://user-images.githubusercontent.com/1848238/181026288-31700142-e38f-4405-824e-d1ab3f5b6919.gif)|![after-change-email](https://user-images.githubusercontent.com/1848238/181017183-e6971302-c445-4f36-932b-c009b9a1e25a.gif)|

## Tests

- With the FTUE flags enabled
- Start the account creation process on a homeserver with email verification (eg matrix.org)
- type an incorrect email and press next
- attempt to go back to edit the email

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28


