### PR TITLE
Feature/bma/fix firebase popup

### DIFF
--- a/vector/src/fdroid/java/im/vector/app/nightly/NightlyProxy.kt
+++ b/vector/src/fdroid/java/im/vector/app/nightly/NightlyProxy.kt
@@ -19,5 +19,5 @@ package im.vector.app.nightly
 import javax.inject.Inject
 
 class NightlyProxy @Inject constructor() {
-    fun updateIfNewReleaseAvailable() = Unit
+    fun mayDisplayFirebasePopup() = Unit
 }

--- a/vector/src/fdroid/java/im/vector/app/nightly/NightlyProxy.kt
+++ b/vector/src/fdroid/java/im/vector/app/nightly/NightlyProxy.kt
@@ -19,5 +19,5 @@ package im.vector.app.nightly
 import javax.inject.Inject
 
 class NightlyProxy @Inject constructor() {
-    fun mayDisplayFirebasePopup() = Unit
+    fun onHomeResumed() = Unit
 }

--- a/vector/src/gplay/java/im/vector/app/nightly/NightlyProxy.kt
+++ b/vector/src/gplay/java/im/vector/app/nightly/NightlyProxy.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.core.content.edit
 import com.google.firebase.appdistribution.FirebaseAppDistribution
 import com.google.firebase.appdistribution.FirebaseAppDistributionException
+import im.vector.app.BuildConfig
 import im.vector.app.core.di.DefaultSharedPreferences
 import im.vector.app.core.time.Clock
 import timber.log.Timber
@@ -54,6 +55,7 @@ class NightlyProxy @Inject constructor(
     }
 
     private fun canDisplayPopup(): Boolean {
+        if (BuildConfig.APPLICATION_ID != "im.vector.app.nightly") return false
         val sharedPreferences = DefaultSharedPreferences.getInstance(context)
         val today = clock.epochMillis() / A_DAY_IN_MILLIS
         val lastDisplayPopupDay = sharedPreferences.getLong(SHARED_PREF_KEY, 0)

--- a/vector/src/gplay/java/im/vector/app/nightly/NightlyProxy.kt
+++ b/vector/src/gplay/java/im/vector/app/nightly/NightlyProxy.kt
@@ -29,7 +29,7 @@ class NightlyProxy @Inject constructor(
         private val clock: Clock,
         private val context: Context,
 ) {
-    fun updateIfNewReleaseAvailable() {
+    fun mayDisplayFirebasePopup() {
         if (!canDisplayPopup()) return
         val firebaseAppDistribution = FirebaseAppDistribution.getInstance()
         firebaseAppDistribution.updateIfNewReleaseAvailable()

--- a/vector/src/gplay/java/im/vector/app/nightly/NightlyProxy.kt
+++ b/vector/src/gplay/java/im/vector/app/nightly/NightlyProxy.kt
@@ -31,7 +31,7 @@ class NightlyProxy @Inject constructor(
         @DefaultPreferences
         private val sharedPreferences: SharedPreferences,
 ) {
-    fun mayDisplayFirebasePopup() {
+    fun onHomeResumed() {
         if (!canDisplayPopup()) return
         val firebaseAppDistribution = FirebaseAppDistribution.getInstance()
         firebaseAppDistribution.updateIfNewReleaseAvailable()

--- a/vector/src/gplay/java/im/vector/app/nightly/NightlyProxy.kt
+++ b/vector/src/gplay/java/im/vector/app/nightly/NightlyProxy.kt
@@ -16,19 +16,20 @@
 
 package im.vector.app.nightly
 
-import android.content.Context
+import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.google.firebase.appdistribution.FirebaseAppDistribution
 import com.google.firebase.appdistribution.FirebaseAppDistributionException
 import im.vector.app.BuildConfig
-import im.vector.app.core.di.DefaultSharedPreferences
+import im.vector.app.core.di.DefaultPreferences
 import im.vector.app.core.time.Clock
 import timber.log.Timber
 import javax.inject.Inject
 
 class NightlyProxy @Inject constructor(
         private val clock: Clock,
-        private val context: Context,
+        @DefaultPreferences
+        private val sharedPreferences: SharedPreferences,
 ) {
     fun mayDisplayFirebasePopup() {
         if (!canDisplayPopup()) return
@@ -56,7 +57,6 @@ class NightlyProxy @Inject constructor(
 
     private fun canDisplayPopup(): Boolean {
         if (BuildConfig.APPLICATION_ID != "im.vector.app.nightly") return false
-        val sharedPreferences = DefaultSharedPreferences.getInstance(context)
         val today = clock.epochMillis() / A_DAY_IN_MILLIS
         val lastDisplayPopupDay = sharedPreferences.getLong(SHARED_PREF_KEY, 0)
         return (today > lastDisplayPopupDay)

--- a/vector/src/gplay/java/im/vector/app/nightly/NightlyProxy.kt
+++ b/vector/src/gplay/java/im/vector/app/nightly/NightlyProxy.kt
@@ -16,13 +16,21 @@
 
 package im.vector.app.nightly
 
+import android.content.Context
+import androidx.core.content.edit
 import com.google.firebase.appdistribution.FirebaseAppDistribution
 import com.google.firebase.appdistribution.FirebaseAppDistributionException
+import im.vector.app.core.di.DefaultSharedPreferences
+import im.vector.app.core.time.Clock
 import timber.log.Timber
 import javax.inject.Inject
 
-class NightlyProxy @Inject constructor() {
+class NightlyProxy @Inject constructor(
+        private val clock: Clock,
+        private val context: Context,
+) {
     fun updateIfNewReleaseAvailable() {
+        if (!canDisplayPopup()) return
         val firebaseAppDistribution = FirebaseAppDistribution.getInstance()
         firebaseAppDistribution.updateIfNewReleaseAvailable()
                 .addOnProgressListener { up ->
@@ -43,5 +51,24 @@ class NightlyProxy @Inject constructor() {
                         Timber.e(e, "FirebaseAppDistribution - other error")
                     }
                 }
+    }
+
+    private fun canDisplayPopup(): Boolean {
+        val sharedPreferences = DefaultSharedPreferences.getInstance(context)
+        val today = clock.epochMillis() / A_DAY_IN_MILLIS
+        val lastDisplayPopupDay = sharedPreferences.getLong(SHARED_PREF_KEY, 0)
+        return (today > lastDisplayPopupDay)
+                .also { canDisplayPopup ->
+                    if (canDisplayPopup) {
+                        sharedPreferences.edit {
+                            putLong(SHARED_PREF_KEY, today)
+                        }
+                    }
+                }
+    }
+
+    companion object {
+        private const val A_DAY_IN_MILLIS = 8_600_000L
+        private const val SHARED_PREF_KEY = "LAST_NIGHTLY_POPUP_DAY"
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -537,7 +537,7 @@ class HomeActivity :
         serverBackupStatusViewModel.refreshRemoteStateIfNeeded()
 
         // Check nightly
-        nightlyProxy.updateIfNewReleaseAvailable()
+        nightlyProxy.mayDisplayFirebasePopup()
     }
 
     override fun getMenuRes() = R.menu.home

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -537,7 +537,7 @@ class HomeActivity :
         serverBackupStatusViewModel.refreshRemoteStateIfNeeded()
 
         // Check nightly
-        nightlyProxy.mayDisplayFirebasePopup()
+        nightlyProxy.onHomeResumed()
     }
 
     override fun getMenuRes() = R.menu.home

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -537,9 +537,7 @@ class HomeActivity :
         serverBackupStatusViewModel.refreshRemoteStateIfNeeded()
 
         // Check nightly
-        if (isFirstCreation()) {
-            nightlyProxy.updateIfNewReleaseAvailable()
-        }
+        nightlyProxy.updateIfNewReleaseAvailable()
     }
 
     override fun getMenuRes() = R.menu.home


### PR DESCRIPTION
Ensure that the Firebase popup is displayed at most once a day.

There is no way to intercept the "Not now" action, this is Firebase internal.

Also the previous fix was not working.

With this implementation, we save the current day in shared pref to ensure that the popup is not displayed twice.