### PR TITLE
[Location Share] Open maximized map on tapping on live sharing notification (PSG-616)

### DIFF
--- a/changelog.d/6642.misc
+++ b/changelog.d/6642.misc
@@ -1,0 +1,1 @@
+[Location Share] Open maximized map on tapping on live sharing notification

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -377,7 +377,7 @@
         </service>
 
         <service
-            android:name=".features.location.LocationSharingAndroidService"
+            android:name=".features.location.live.tracking.LocationSharingAndroidService"
             android:exported="false"
             android:foregroundServiceType="location" />
 

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
@@ -42,6 +42,7 @@ import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.detail.timeline.helper.MatrixItemColorProvider
 import im.vector.app.features.location.live.LiveLocationLabsFlagPromotionBottomSheet
 import im.vector.app.features.location.live.duration.ChooseLiveDurationBottomSheet
+import im.vector.app.features.location.live.tracking.LocationSharingAndroidService
 import im.vector.app.features.location.option.LocationSharingOption
 import im.vector.app.features.settings.VectorPreferences
 import org.matrix.android.sdk.api.util.MatrixItem

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingServiceConnection.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingServiceConnection.kt
@@ -22,6 +22,7 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.os.IBinder
 import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.features.location.live.tracking.LocationSharingAndroidService
 import im.vector.app.features.session.coroutineScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapViewActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LocationLiveMapViewActivity.kt
@@ -24,6 +24,7 @@ import im.vector.app.R
 import im.vector.app.core.extensions.addFragment
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.databinding.ActivityLocationSharingBinding
+import im.vector.app.features.MainActivity
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -59,9 +60,14 @@ class LocationLiveMapViewActivity : VectorBaseActivity<ActivityLocationSharingBi
 
         private const val EXTRA_LOCATION_LIVE_MAP_VIEW_ARGS = "EXTRA_LOCATION_LIVE_MAP_VIEW_ARGS"
 
-        fun getIntent(context: Context, locationLiveMapViewArgs: LocationLiveMapViewArgs): Intent {
-            return Intent(context, LocationLiveMapViewActivity::class.java).apply {
+        fun getIntent(context: Context, locationLiveMapViewArgs: LocationLiveMapViewArgs, firstStartMainActivity: Boolean = false): Intent {
+            val intent = Intent(context, LocationLiveMapViewActivity::class.java).apply {
                 putExtra(EXTRA_LOCATION_LIVE_MAP_VIEW_ARGS, locationLiveMapViewArgs)
+            }
+            return if (firstStartMainActivity) {
+                MainActivity.getIntentWithNextIntent(context, intent)
+            } else {
+                intent
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/location/live/tracking/LiveLocationNotificationBuilder.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/tracking/LiveLocationNotificationBuilder.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.location.live.tracking
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import androidx.core.app.TaskStackBuilder
+import im.vector.app.R
+import im.vector.app.core.extensions.createIgnoredUri
+import im.vector.app.core.platform.PendingIntentCompat
+import im.vector.app.core.resources.StringProvider
+import im.vector.app.core.time.Clock
+import im.vector.app.features.home.HomeActivity
+import im.vector.app.features.home.room.detail.RoomDetailActivity
+import im.vector.app.features.home.room.detail.arguments.TimelineArgs
+import im.vector.app.features.location.live.map.LocationLiveMapViewActivity
+import im.vector.app.features.location.live.map.LocationLiveMapViewArgs
+import im.vector.app.features.notifications.NotificationUtils
+import im.vector.app.features.themes.ThemeUtils
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LiveLocationNotificationBuilder @Inject constructor(
+        private val context: Context,
+        private val stringProvider: StringProvider,
+        private val clock: Clock,
+) {
+
+    /**
+     * Creates a notification that indicates the application is retrieving location even if it is in background or killed.
+     * @param roomId the id of the room where a live location is shared
+     */
+    fun buildLiveLocationSharingNotification(roomId: String): Notification {
+        return NotificationCompat.Builder(context, NotificationUtils.SILENT_NOTIFICATION_CHANNEL_ID)
+                .setContentTitle(stringProvider.getString(R.string.live_location_sharing_notification_title))
+                .setContentText(stringProvider.getString(R.string.live_location_sharing_notification_description))
+                .setSmallIcon(R.drawable.ic_attachment_location_live_white)
+                .setColor(ThemeUtils.getColor(context, android.R.attr.colorPrimary))
+                .setCategory(NotificationCompat.CATEGORY_LOCATION_SHARING)
+                .setContentIntent(buildOpenLiveLocationMapIntent(roomId))
+                .build()
+    }
+
+    private fun buildOpenLiveLocationMapIntent(roomId: String): PendingIntent? {
+        val homeIntent = HomeActivity.newIntent(context, firstStartMainActivity = false)
+        val roomIntent = RoomDetailActivity.newIntent(context, TimelineArgs(roomId = roomId, switchToParentSpace = true), firstStartMainActivity = false)
+        val mapIntent = LocationLiveMapViewActivity.getIntent(
+                context = context,
+                locationLiveMapViewArgs = LocationLiveMapViewArgs(roomId = roomId),
+                firstStartMainActivity = true
+        )
+        mapIntent.action = NotificationUtils.TAP_TO_VIEW_ACTION
+        // pending intent get reused by system, this will mess up the extra params, so put unique info to avoid that
+        mapIntent.data = createIgnoredUri("openLiveLocationMap?$roomId")
+
+        // Recreate the back stack
+        return TaskStackBuilder.create(context)
+                .addNextIntentWithParentStack(homeIntent)
+                .addNextIntent(roomIntent)
+                .addNextIntent(mapIntent)
+                .getPendingIntent(
+                        clock.epochMillis().toInt(),
+                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntentCompat.FLAG_IMMUTABLE
+                )
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/location/live/tracking/LocationSharingAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/tracking/LocationSharingAndroidService.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.location
+package im.vector.app.features.location.live.tracking
 
 import android.content.Intent
 import android.os.Binder
@@ -24,8 +24,9 @@ import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.services.VectorAndroidService
+import im.vector.app.features.location.LocationData
+import im.vector.app.features.location.LocationTracker
 import im.vector.app.features.location.live.GetLiveLocationShareSummaryUseCase
-import im.vector.app.features.notifications.NotificationUtils
 import im.vector.app.features.redaction.CheckIfEventIsRedactedUseCase
 import im.vector.app.features.session.coroutineScope
 import kotlinx.coroutines.CoroutineScope
@@ -54,7 +55,7 @@ class LocationSharingAndroidService : VectorAndroidService(), LocationTracker.Ca
             val durationMillis: Long
     ) : Parcelable
 
-    @Inject lateinit var notificationUtils: NotificationUtils
+    @Inject lateinit var liveLocationNotificationBuilder: LiveLocationNotificationBuilder
     @Inject lateinit var locationTracker: LocationTracker
     @Inject lateinit var activeSessionHolder: ActiveSessionHolder
     @Inject lateinit var getLiveLocationShareSummaryUseCase: GetLiveLocationShareSummaryUseCase
@@ -102,7 +103,7 @@ class LocationSharingAndroidService : VectorAndroidService(), LocationTracker.Ca
 
         if (roomArgs != null) {
             // Show a sticky notification
-            val notification = notificationUtils.buildLiveLocationSharingNotification()
+            val notification = liveLocationNotificationBuilder.buildLiveLocationSharingNotification(roomArgs.roomId)
             startForeground(roomArgs.roomId.hashCode(), notification)
 
             // Send beacon info state event

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
@@ -105,7 +105,7 @@ class NotificationUtils @Inject constructor(
         const val SMART_REPLY_ACTION = "${BuildConfig.APPLICATION_ID}.NotificationActions.SMART_REPLY_ACTION"
         const val DISMISS_SUMMARY_ACTION = "${BuildConfig.APPLICATION_ID}.NotificationActions.DISMISS_SUMMARY_ACTION"
         const val DISMISS_ROOM_NOTIF_ACTION = "${BuildConfig.APPLICATION_ID}.NotificationActions.DISMISS_ROOM_NOTIF_ACTION"
-        private const val TAP_TO_VIEW_ACTION = "${BuildConfig.APPLICATION_ID}.NotificationActions.TAP_TO_VIEW_ACTION"
+        const val TAP_TO_VIEW_ACTION = "${BuildConfig.APPLICATION_ID}.NotificationActions.TAP_TO_VIEW_ACTION"
         const val DIAGNOSTIC_ACTION = "${BuildConfig.APPLICATION_ID}.NotificationActions.DIAGNOSTIC"
         const val PUSH_ACTION = "${BuildConfig.APPLICATION_ID}.PUSH"
 
@@ -118,7 +118,7 @@ class NotificationUtils @Inject constructor(
 
         private const val NOISY_NOTIFICATION_CHANNEL_ID = "DEFAULT_NOISY_NOTIFICATION_CHANNEL_ID"
 
-        private const val SILENT_NOTIFICATION_CHANNEL_ID = "DEFAULT_SILENT_NOTIFICATION_CHANNEL_ID_V2"
+        const val SILENT_NOTIFICATION_CHANNEL_ID = "DEFAULT_SILENT_NOTIFICATION_CHANNEL_ID_V2"
         private const val CALL_NOTIFICATION_CHANNEL_ID = "CALL_NOTIFICATION_CHANNEL_ID_V2"
 
         fun supportNotificationChannels() = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
@@ -538,20 +538,6 @@ class NotificationUtils @Inject constructor(
 
         builder.setContentIntent(contentPendingIntent)
         return builder.build()
-    }
-
-    /**
-     * Creates a notification that indicates the application is retrieving location even if it is in background or killed.
-     */
-    fun buildLiveLocationSharingNotification(): Notification {
-        return NotificationCompat.Builder(context, SILENT_NOTIFICATION_CHANNEL_ID)
-                .setContentTitle(stringProvider.getString(R.string.live_location_sharing_notification_title))
-                .setContentText(stringProvider.getString(R.string.live_location_sharing_notification_description))
-                .setSmallIcon(R.drawable.ic_attachment_location_live_white)
-                .setColor(ThemeUtils.getColor(context, android.R.attr.colorPrimary))
-                .setCategory(NotificationCompat.CATEGORY_LOCATION_SHARING)
-                .setContentIntent(buildOpenHomePendingIntentForSummary())
-                .build()
     }
 
     /**


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Enhancement

## Content

<!-- Describe shortly what has been changed -->
Modifying the notification of the foreground service so that it forwards to the live location map of the last room where a live has been started by the user.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6642 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Start a live in a room
- Put the app in background
- Press the service notification
- Check the map associated to the room where the live has been started is displayed
- Press back
- Check the timeline of the room is displayed
- Press back
- Check the home is displayed
- Start another live in another room
- Press the service notification
- Check the map associated to the last room where the live has been started is displayed

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
