### PR TITLE
FTUE - Enable onboarding FTUE flows

### DIFF
--- a/changelog.d/2585.feature
+++ b/changelog.d/2585.feature
@@ -1,0 +1,1 @@
+FTUE - Enable improved login and register onboarding flows

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
@@ -182,13 +182,8 @@ class ElementRobot {
             val activity = EspressoHelper.getCurrentActivity()!!
             val popup = activity.findViewById<View>(com.tapadoo.alerter.R.id.llAlertBackground)!!
             activity.runOnUiThread { popup.performClick() }
-
             waitUntilViewVisible(withId(R.id.bottomSheetFragmentContainer))
-            waitUntilViewVisible(ViewMatchers.withText(R.string.action_skip))
-            clickOn(R.string.action_skip)
-            assertDisplayed(R.string.are_you_sure)
-            clickOn(R.string.action_skip)
-            waitUntilViewVisible(withId(R.id.bottomSheetFragmentContainer))
+            pressBack()
         }.onFailure { Timber.w(it, "Verification popup missing") }
     }
 

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/OnboardingRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/OnboardingRobot.kt
@@ -34,31 +34,46 @@ import im.vector.app.waitForView
 
 class OnboardingRobot {
 
+    private val defaultVectorFeatures = DefaultVectorFeatures()
+
     fun crawl() {
         waitUntilViewVisible(withId(R.id.loginSplashSubmit))
-        crawlGetStarted()
+        crawlCreateAccount()
         crawlAlreadyHaveAccount()
     }
 
-    private fun crawlGetStarted() {
-        clickOn(R.id.loginSplashSubmit)
-        assertDisplayed(R.id.useCaseHeaderTitle, R.string.ftue_auth_use_case_title)
-        clickOn(R.id.useCaseOptionOne)
-        OnboardingServersRobot().crawlSignUp()
-        pressBack()
-        pressBack()
+    private fun crawlCreateAccount() {
+        if (defaultVectorFeatures.isOnboardingCombinedRegisterEnabled()) {
+            // TODO
+        } else {
+            clickOn(R.id.loginSplashSubmit)
+            assertDisplayed(R.id.useCaseHeaderTitle, R.string.ftue_auth_use_case_title)
+            clickOn(R.id.useCaseOptionOne)
+            OnboardingServersRobot().crawlSignUp()
+            pressBack()
+            pressBack()
+        }
     }
 
     private fun crawlAlreadyHaveAccount() {
-        clickOn(R.id.loginSplashAlreadyHaveAccount)
-        OnboardingServersRobot().crawlSignIn()
-        pressBack()
+        if (defaultVectorFeatures.isOnboardingCombinedLoginEnabled()) {
+            // TODO
+        } else {
+            clickOn(R.id.loginSplashAlreadyHaveAccount)
+            OnboardingServersRobot().crawlSignIn()
+            pressBack()
+        }
     }
 
     fun createAccount(userId: String, password: String = "password", homeServerUrl: String = "http://10.0.2.2:8080") {
-        initSession(true, userId, password, homeServerUrl)
+        if (defaultVectorFeatures.isOnboardingCombinedRegisterEnabled()) {
+            createAccountViaCombinedRegister(homeServerUrl, userId, password)
+        } else {
+            initSession(true, userId, password, homeServerUrl)
+        }
+
         waitUntilViewVisible(withText(R.string.ftue_account_created_congratulations_title))
-        if (DefaultVectorFeatures().isOnboardingPersonalizeEnabled()) {
+        if (defaultVectorFeatures.isOnboardingPersonalizeEnabled()) {
             clickOn(R.string.ftue_account_created_personalize)
 
             waitUntilViewVisible(withText(R.string.ftue_display_name_title))
@@ -75,8 +90,47 @@ class OnboardingRobot {
         }
     }
 
+    private fun createAccountViaCombinedRegister(homeServerUrl: String, userId: String, password: String) {
+        waitUntilViewVisible(withId(R.id.loginSplashSubmit))
+        assertDisplayed(R.id.loginSplashSubmit, R.string.login_splash_create_account)
+        clickOn(R.id.loginSplashSubmit)
+        clickOn(R.id.useCaseOptionOne)
+
+        waitUntilViewVisible(withId(R.id.createAccountRoot))
+        clickOn(R.id.editServerButton)
+        writeTo(R.id.chooseServerInput, homeServerUrl)
+        closeSoftKeyboard()
+        clickOn(R.id.chooseServerSubmit)
+        waitUntilViewVisible(withId(R.id.createAccountRoot))
+
+        writeTo(R.id.createAccountInput, userId)
+        writeTo(R.id.createAccountPasswordInput, password)
+        clickOn(R.id.createAccountSubmit)
+    }
+
     fun login(userId: String, password: String = "password", homeServerUrl: String = "http://10.0.2.2:8080") {
-        initSession(false, userId, password, homeServerUrl)
+        if (defaultVectorFeatures.isOnboardingCombinedLoginEnabled()) {
+            loginViaCombinedLogin(homeServerUrl, userId, password)
+        } else {
+            initSession(false, userId, password, homeServerUrl)
+        }
+    }
+
+    private fun loginViaCombinedLogin(homeServerUrl: String, userId: String, password: String) {
+        waitUntilViewVisible(withId(R.id.loginSplashSubmit))
+        assertDisplayed(R.id.loginSplashSubmit, R.string.login_splash_create_account)
+        clickOn(R.id.loginSplashAlreadyHaveAccount)
+
+        waitUntilViewVisible(withId(R.id.loginRoot))
+        clickOn(R.id.editServerButton)
+        writeTo(R.id.chooseServerInput, homeServerUrl)
+        closeSoftKeyboard()
+        clickOn(R.id.chooseServerSubmit)
+        waitUntilViewVisible(withId(R.id.loginRoot))
+
+        writeTo(R.id.loginInput, userId)
+        writeTo(R.id.loginPasswordInput, password)
+        clickOn(R.id.loginSubmit)
     }
 
     private fun initSession(

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/settings/SettingsPreferencesRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/settings/SettingsPreferencesRobot.kt
@@ -17,6 +17,7 @@
 package im.vector.app.ui.robot.settings
 
 import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.adevinta.android.barista.interaction.BaristaDialogInteractions.clickDialogNegativeButton
@@ -34,8 +35,7 @@ class SettingsPreferencesRobot {
         clickOn(R.string.settings_theme)
         clickDialogNegativeButton()
         clickOn(R.string.font_size)
-        waitUntilActivityVisible<FontScaleSettingActivity> {
-            pressBack()
-        }
+        waitUntilViewVisible(withId(R.id.fons_scale_recycler))
+        pressBack()
     }
 }

--- a/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
+++ b/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
@@ -46,9 +46,9 @@ class DefaultVectorFeatures : VectorFeatures {
     override fun isOnboardingAlreadyHaveAccountSplashEnabled() = true
     override fun isOnboardingSplashCarouselEnabled() = true
     override fun isOnboardingUseCaseEnabled() = true
-    override fun isOnboardingPersonalizeEnabled() = false
-    override fun isOnboardingCombinedRegisterEnabled() = false
-    override fun isOnboardingCombinedLoginEnabled() = false
+    override fun isOnboardingPersonalizeEnabled() = true
+    override fun isOnboardingCombinedRegisterEnabled() = true
+    override fun isOnboardingCombinedLoginEnabled() = true
     override fun allowExternalUnifiedPushDistributors(): Boolean = Config.ALLOW_EXTERNAL_UNIFIED_PUSH_DISTRIBUTORS
     override fun isScreenSharingEnabled(): Boolean = true
     override fun forceUsageOfOpusEncoder(): Boolean = false


### PR DESCRIPTION
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Enables the FTUE flags

- Updates the sanity test to take into account changes around the font scaling page and verification bottomsheet
- Updates the sanity test onboarding flow to support the combined register and login flows (AKA FTUE)

## Motivation and context

To enable FTUE by default for all users (https://github.com/vector-im/element-android/pulls?q=is%3Apr+label%3AZ-FTUE+)

## Tests

- Create a new account or Sign in to an existing account

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 31
