### PR TITLE
Cancel infinite animations in TypingMessageDotsView

### DIFF
--- a/changelog.d/6663.bugfix
+++ b/changelog.d/6663.bugfix
@@ -1,0 +1,1 @@
+ObjectAnimators are not canceled in TypingMessageDotsView

--- a/vector/src/main/java/im/vector/app/core/ui/views/TypingMessageDotsView.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/views/TypingMessageDotsView.kt
@@ -42,6 +42,7 @@ class TypingMessageDotsView(context: Context, attrs: AttributeSet) :
     }
 
     private val circles = mutableListOf<View>()
+    private val objectAnimators = mutableListOf<ObjectAnimator>()
 
     init {
         orientation = HORIZONTAL
@@ -76,15 +77,17 @@ class TypingMessageDotsView(context: Context, attrs: AttributeSet) :
     }
 
     private fun animateCircle(index: Int, circle: View) {
-        ObjectAnimator.ofFloat(circle, "alpha", DEFAULT_MAX_ALPHA, DEFAULT_MIN_ALPHA).apply {
+        val objectAnimator = ObjectAnimator.ofFloat(circle, "alpha", DEFAULT_MAX_ALPHA, DEFAULT_MIN_ALPHA).apply {
             duration = DEFAULT_CIRCLE_DURATION
             startDelay = DEFAULT_START_ANIM_CIRCLE_DURATION * index
             repeatCount = ValueAnimator.INFINITE
-        }.start()
+        }
+        objectAnimators.add(objectAnimator)
+        objectAnimator.start()
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        circles.forEach { it.clearAnimation() }
+        objectAnimators.forEach { it.cancel() }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Canceling the infinite animations when the view is destroyed.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6663 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->
Easier to enable LeakCanary to check everything is correct.

- Go to a room where there are threads
- Open a thread timeline
- Press back
- Open again the thread timeline
- Press back
- Check there is no slowness
- If leakcanary is enabled, check there is no leak detected which is related to ObjectAnimator 

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
