### PR TITLE
`Home` always showing all rooms

### DIFF
--- a/changelog.d/6665.bugfix
+++ b/changelog.d/6665.bugfix
@@ -1,0 +1,1 @@
+Fixes the room list not taking into account the Show all rooms in Home preference

--- a/changelog.d/6666.sdk
+++ b/changelog.d/6666.sdk
@@ -1,0 +1,1 @@
+SDK - The SpaceFilter is query parameter is no longer nullable, use SpaceFilter.NoFilter instead

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/query/SpaceFilter.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/query/SpaceFilter.kt
@@ -35,9 +35,19 @@ sealed interface SpaceFilter {
      * Used to get all the rooms that do not have the provided space in their parent hierarchy.
      */
     data class ExcludeSpace(val spaceId: String) : SpaceFilter
+
+    /**
+     * Used to apply no filtering to the space.
+     */
+    object NoFilter : SpaceFilter
 }
 
 /**
  * Return a [SpaceFilter.ActiveSpace] if the String is not null, or [SpaceFilter.OrphanRooms].
  */
 fun String?.toActiveSpaceOrOrphanRooms(): SpaceFilter = this?.let { SpaceFilter.ActiveSpace(it) } ?: SpaceFilter.OrphanRooms
+
+/**
+ * Return a [SpaceFilter.ActiveSpace] if the String is not null, or [SpaceFilter.NoFilter].
+ */
+fun String?.toActiveSpaceOrNoFilter(): SpaceFilter = this?.let { SpaceFilter.ActiveSpace(it) } ?: SpaceFilter.NoFilter

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomSummaryQueryParams.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomSummaryQueryParams.kt
@@ -86,7 +86,7 @@ data class RoomSummaryQueryParams(
         /**
          * Used to filter room using the current space.
          */
-        val spaceFilter: SpaceFilter?,
+        val spaceFilter: SpaceFilter,
 ) {
 
     /**
@@ -101,7 +101,7 @@ data class RoomSummaryQueryParams(
         var roomTagQueryFilter: RoomTagQueryFilter? = null
         var excludeType: List<String?>? = listOf(RoomType.SPACE)
         var includeType: List<String?>? = null
-        var spaceFilter: SpaceFilter? = null
+        var spaceFilter: SpaceFilter = SpaceFilter.NoFilter
 
         fun build() = RoomSummaryQueryParams(
                 displayName = displayName,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryDataSource.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryDataSource.kt
@@ -317,7 +317,7 @@ internal class RoomSummaryDataSource @Inject constructor(
             is SpaceFilter.ExcludeSpace -> {
                 query.not().contains(RoomSummaryEntityFields.FLATTEN_PARENT_IDS, queryParams.spaceFilter.spaceId)
             }
-            null -> Unit // nop
+            SpaceFilter.NoFilter -> Unit // nop
         }
 
         return query

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
@@ -45,7 +45,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.query.RoomCategoryFilter
-import org.matrix.android.sdk.api.query.SpaceFilter
 import org.matrix.android.sdk.api.query.toActiveSpaceOrNoFilter
 import org.matrix.android.sdk.api.query.toActiveSpaceOrOrphanRooms
 import org.matrix.android.sdk.api.session.Session

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailViewModel.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.query.RoomCategoryFilter
 import org.matrix.android.sdk.api.query.SpaceFilter
+import org.matrix.android.sdk.api.query.toActiveSpaceOrNoFilter
 import org.matrix.android.sdk.api.query.toActiveSpaceOrOrphanRooms
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.crypto.NewSessionListener
@@ -235,7 +236,7 @@ class HomeDetailViewModel @AssistedInject constructor(
                                 roomSummaryQueryParams {
                                     memberships = listOf(Membership.INVITE)
                                     roomCategoryFilter = RoomCategoryFilter.ONLY_DM
-                                    spaceFilter = activeSpaceRoomId?.let { SpaceFilter.ActiveSpace(it) }
+                                    spaceFilter = activeSpaceRoomId.toActiveSpaceOrNoFilter()
                                 }
                         ).size
 
@@ -252,7 +253,7 @@ class HomeDetailViewModel @AssistedInject constructor(
                             roomSummaryQueryParams {
                                 memberships = listOf(Membership.JOIN)
                                 roomCategoryFilter = RoomCategoryFilter.ONLY_DM
-                                spaceFilter = activeSpaceRoomId?.let { SpaceFilter.ActiveSpace(it) }
+                                spaceFilter = activeSpaceRoomId.toActiveSpaceOrNoFilter()
                             }
                     )
 

--- a/vector/src/main/java/im/vector/app/features/home/UnreadMessagesSharedViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/UnreadMessagesSharedViewModel.kt
@@ -142,9 +142,10 @@ class UnreadMessagesSharedViewModel @AssistedInject constructor(
             val totalCount = roomService.getNotificationCountForRooms(
                     roomSummaryQueryParams {
                         this.memberships = listOf(Membership.JOIN)
-                        this.spaceFilter = SpaceFilter.OrphanRooms.takeIf {
-                            !vectorPreferences.prefSpacesShowAllRoomInHome()
-                        } ?: SpaceFilter.NoFilter
+                        this.spaceFilter = when {
+                            vectorPreferences.prefSpacesShowAllRoomInHome() -> SpaceFilter.NoFilter
+                            else -> SpaceFilter.OrphanRooms
+                        }
                     }
             )
 

--- a/vector/src/main/java/im/vector/app/features/home/UnreadMessagesSharedViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/UnreadMessagesSharedViewModel.kt
@@ -144,7 +144,7 @@ class UnreadMessagesSharedViewModel @AssistedInject constructor(
                         this.memberships = listOf(Membership.JOIN)
                         this.spaceFilter = SpaceFilter.OrphanRooms.takeIf {
                             !vectorPreferences.prefSpacesShowAllRoomInHome()
-                        }
+                        } ?: SpaceFilter.NoFilter
                     }
             )
 

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListSectionBuilder.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListSectionBuilder.kt
@@ -378,7 +378,7 @@ class RoomListSectionBuilder(
                     activeSpaceUpdaters.add(object : RoomListViewModel.ActiveSpaceQueryUpdater {
                         override fun updateForSpaceId(roomId: String?) {
                             filteredPagedRoomSummariesLive.queryParams = roomQueryParams.copy(
-                                    spaceFilter = roomId?.toActiveSpaceOrOrphanRooms()
+                                    spaceFilter = roomId.toActiveSpaceOrOrphanRooms()
                             )
                             liveQueryParams.update { filteredPagedRoomSummariesLive.queryParams }
                         }
@@ -444,7 +444,7 @@ class RoomListSectionBuilder(
         return when (spaceFilter) {
             RoomListViewModel.SpaceFilterStrategy.ORPHANS_IF_SPACE_NULL -> {
                 copy(
-                        spaceFilter = currentSpace?.toActiveSpaceOrOrphanRooms()
+                        spaceFilter = currentSpace.toActiveSpaceOrOrphanRooms()
                 )
             }
             RoomListViewModel.SpaceFilterStrategy.ALL_IF_SPACE_NULL -> {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListSectionBuilder.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListSectionBuilder.kt
@@ -45,6 +45,7 @@ import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.query.RoomCategoryFilter
 import org.matrix.android.sdk.api.query.RoomTagQueryFilter
 import org.matrix.android.sdk.api.query.SpaceFilter
+import org.matrix.android.sdk.api.query.toActiveSpaceOrNoFilter
 import org.matrix.android.sdk.api.query.toActiveSpaceOrOrphanRooms
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.getRoomSummary
@@ -393,7 +394,7 @@ class RoomListSectionBuilder(
                                 )
                             } else {
                                 filteredPagedRoomSummariesLive.queryParams = roomQueryParams.copy(
-                                        spaceFilter = null
+                                        spaceFilter = SpaceFilter.NoFilter
                                 )
                             }
                             liveQueryParams.update { filteredPagedRoomSummariesLive.queryParams }
@@ -449,7 +450,7 @@ class RoomListSectionBuilder(
             }
             RoomListViewModel.SpaceFilterStrategy.ALL_IF_SPACE_NULL -> {
                 copy(
-                        spaceFilter = currentSpace?.let { SpaceFilter.ActiveSpace(it) }
+                        spaceFilter = currentSpace.toActiveSpaceOrNoFilter()
                 )
             }
             RoomListViewModel.SpaceFilterStrategy.NONE -> this

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewModel.kt
@@ -124,7 +124,7 @@ class HomeRoomListViewModel @AssistedInject constructor(
     private fun getSpaceFilter(selectedSpaceId: String?, strategy: RoomListViewModel.SpaceFilterStrategy): SpaceFilter? {
         return when (strategy) {
             RoomListViewModel.SpaceFilterStrategy.ORPHANS_IF_SPACE_NULL -> {
-                selectedSpaceId?.toActiveSpaceOrOrphanRooms()
+                selectedSpaceId.toActiveSpaceOrOrphanRooms()
             }
             RoomListViewModel.SpaceFilterStrategy.ALL_IF_SPACE_NULL -> {
                 selectedSpaceId?.let { SpaceFilter.ActiveSpace(it) }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewModel.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.query.SpaceFilter
+import org.matrix.android.sdk.api.query.toActiveSpaceOrNoFilter
 import org.matrix.android.sdk.api.query.toActiveSpaceOrOrphanRooms
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.getRoom
@@ -121,15 +122,15 @@ class HomeRoomListViewModel @AssistedInject constructor(
         )
     }
 
-    private fun getSpaceFilter(selectedSpaceId: String?, strategy: RoomListViewModel.SpaceFilterStrategy): SpaceFilter? {
+    private fun getSpaceFilter(selectedSpaceId: String?, strategy: RoomListViewModel.SpaceFilterStrategy): SpaceFilter {
         return when (strategy) {
             RoomListViewModel.SpaceFilterStrategy.ORPHANS_IF_SPACE_NULL -> {
                 selectedSpaceId.toActiveSpaceOrOrphanRooms()
             }
             RoomListViewModel.SpaceFilterStrategy.ALL_IF_SPACE_NULL -> {
-                selectedSpaceId?.let { SpaceFilter.ActiveSpace(it) }
+                selectedSpaceId.toActiveSpaceOrNoFilter()
             }
-            RoomListViewModel.SpaceFilterStrategy.NONE -> null
+            RoomListViewModel.SpaceFilterStrategy.NONE -> SpaceFilter.NoFilter
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewModel.kt
@@ -27,7 +27,6 @@ import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.StateView
 import im.vector.app.core.platform.VectorViewModel
-import im.vector.app.features.home.room.list.RoomListViewModel
 import im.vector.app.features.settings.VectorPreferences
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -107,13 +106,8 @@ class HomeRoomListViewModel @AssistedInject constructor(
                 }
                 .onEach { selectedSpaceOption ->
                     val selectedSpace = selectedSpaceOption.orNull()
-                    val strategy = if (!vectorPreferences.prefSpacesShowAllRoomInHome()) {
-                        RoomListViewModel.SpaceFilterStrategy.ALL_IF_SPACE_NULL
-                    } else {
-                        RoomListViewModel.SpaceFilterStrategy.ORPHANS_IF_SPACE_NULL
-                    }
                     filteredPagedRoomSummariesLive.queryParams = filteredPagedRoomSummariesLive.queryParams.copy(
-                            spaceFilter = getSpaceFilter(selectedSpaceId = selectedSpace?.roomId, strategy)
+                            spaceFilter = getSpaceFilter(selectedSpaceId = selectedSpace?.roomId)
                     )
                 }.launchIn(viewModelScope)
 
@@ -122,15 +116,10 @@ class HomeRoomListViewModel @AssistedInject constructor(
         )
     }
 
-    private fun getSpaceFilter(selectedSpaceId: String?, strategy: RoomListViewModel.SpaceFilterStrategy): SpaceFilter {
-        return when (strategy) {
-            RoomListViewModel.SpaceFilterStrategy.ORPHANS_IF_SPACE_NULL -> {
-                selectedSpaceId.toActiveSpaceOrOrphanRooms()
-            }
-            RoomListViewModel.SpaceFilterStrategy.ALL_IF_SPACE_NULL -> {
-                selectedSpaceId.toActiveSpaceOrNoFilter()
-            }
-            RoomListViewModel.SpaceFilterStrategy.NONE -> SpaceFilter.NoFilter
+    private fun getSpaceFilter(selectedSpaceId: String?): SpaceFilter {
+        return when {
+            vectorPreferences.prefSpacesShowAllRoomInHome() -> selectedSpaceId.toActiveSpaceOrNoFilter()
+            else -> selectedSpaceId.toActiveSpaceOrOrphanRooms()
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceListViewModel.kt
@@ -98,9 +98,7 @@ class SpaceListViewModel @AssistedInject constructor(
         session.roomService().getPagedRoomSummariesLive(
                 roomSummaryQueryParams {
                     this.memberships = listOf(Membership.JOIN)
-                    this.spaceFilter = SpaceFilter.OrphanRooms.takeIf {
-                        !vectorPreferences.prefSpacesShowAllRoomInHome()
-                    } ?: SpaceFilter.NoFilter
+                    this.spaceFilter = roomsInSpaceFilter()
                 }, sortOrder = RoomSortOrder.NONE
         ).asFlow()
                 .sample(300)
@@ -115,9 +113,7 @@ class SpaceListViewModel @AssistedInject constructor(
                     val totalCount = session.roomService().getNotificationCountForRooms(
                             roomSummaryQueryParams {
                                 this.memberships = listOf(Membership.JOIN)
-                                this.spaceFilter = SpaceFilter.OrphanRooms.takeIf {
-                                    !vectorPreferences.prefSpacesShowAllRoomInHome()
-                                } ?: SpaceFilter.NoFilter
+                                this.spaceFilter = roomsInSpaceFilter()
                             }
                     )
                     val counts = RoomAggregateNotificationCount(
@@ -132,6 +128,11 @@ class SpaceListViewModel @AssistedInject constructor(
                 }
                 .flowOn(Dispatchers.Default)
                 .launchIn(viewModelScope)
+    }
+
+    private fun roomsInSpaceFilter() = when {
+        vectorPreferences.prefSpacesShowAllRoomInHome() -> SpaceFilter.NoFilter
+        else -> SpaceFilter.OrphanRooms
     }
 
     override fun handle(action: SpaceListAction) {

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceListViewModel.kt
@@ -100,7 +100,7 @@ class SpaceListViewModel @AssistedInject constructor(
                     this.memberships = listOf(Membership.JOIN)
                     this.spaceFilter = SpaceFilter.OrphanRooms.takeIf {
                         !vectorPreferences.prefSpacesShowAllRoomInHome()
-                    }
+                    } ?: SpaceFilter.NoFilter
                 }, sortOrder = RoomSortOrder.NONE
         ).asFlow()
                 .sample(300)
@@ -117,7 +117,7 @@ class SpaceListViewModel @AssistedInject constructor(
                                 this.memberships = listOf(Membership.JOIN)
                                 this.spaceFilter = SpaceFilter.OrphanRooms.takeIf {
                                     !vectorPreferences.prefSpacesShowAllRoomInHome()
-                                }
+                                } ?: SpaceFilter.NoFilter
                             }
                     )
                     val counts = RoomAggregateNotificationCount(


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Updates the `toActiveSpaceOrOrphanRooms` usages to avoid the nullsafe fallback, the extension already handles the null case for us (this is the fix!)
- Replaces the nullable `SpaceFilter` in favour of a dedicated `NoFilter` type, should help address the ambiguity of the different states 

## Motivation and context

Fixes #6665 

## Screenshots / GIFs

| BEFORE | AFTER | 
| --- | --- | 
|![before-show-rooms](https://user-images.githubusercontent.com/1848238/181473554-20be90d2-0cfa-40d3-8d57-afa0241c1346.gif)|![after-rooms-in-home](https://user-images.githubusercontent.com/1848238/181473565-bb15a375-33f2-4cd6-a929-fad4db06f208.gif)

## Tests

- Have rooms across spaces
- Notice Home is always showing all rooms
- Notice the `Show all rooms in Home` preference has no effect

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28

