### PR TITLE
`OnboardingViewModel` tests

### DIFF
--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -867,7 +867,6 @@ class OnboardingViewModelTest {
         viewModel.handle(OnboardingAction.ResetResetPassword)
 
         test
-
                 .assertStatesChanges(
                         initialState,
                         { copy(isLoading = false, resetState = ResetState()) },
@@ -907,7 +906,6 @@ class OnboardingViewModelTest {
                         { copy(selectedAuthenticationState = SelectedAuthenticationState(SSO_REGISTRATION_DESCRIPTION)) }
                 )
                 .finish()
-
     }
 
     private fun viewModelWith(state: OnboardingViewState) {

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -76,6 +76,7 @@ private const val AN_EMAIL = "hello@example.com"
 private const val A_PASSWORD = "a-password"
 private const val A_USERNAME = "hello-world"
 private const val A_MATRIX_ID = "@$A_USERNAME:matrix.org"
+private const val A_LOGIN_TOKEN = "a-login-token"
 
 class OnboardingViewModelTest {
 
@@ -138,6 +139,25 @@ class OnboardingViewModelTest {
                         { copy(isLoading = false) }
                 )
                 .assertEvents(OnboardingViewEvents.OpenCombinedLogin)
+                .finish()
+    }
+
+    @Test
+    fun `given can successfully login in with token, when logging in with token, then emits AccountSignedIn`() = runTest {
+        val test = viewModel.test()
+        fakeAuthenticationService.givenLoginWizard(fakeLoginWizard)
+        fakeLoginWizard.givenLoginWithTokenResult(A_LOGIN_TOKEN, fakeSession)
+        givenInitialisesSession(fakeSession)
+
+        viewModel.handle(OnboardingAction.LoginWithToken(A_LOGIN_TOKEN))
+
+        test
+                .assertStatesChanges(
+                        initialState,
+                        { copy(isLoading = true) },
+                        { copy(isLoading = false) }
+                )
+                .assertEvents(OnboardingViewEvents.OnAccountSignedIn)
                 .finish()
     }
 

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -75,6 +75,7 @@ private val DEFAULT_SELECTED_HOMESERVER_STATE = SELECTED_HOMESERVER_STATE.copy(u
 private const val AN_EMAIL = "hello@example.com"
 private const val A_PASSWORD = "a-password"
 private const val A_USERNAME = "hello-world"
+private const val A_DEVICE_NAME = "a-device-name"
 private const val A_MATRIX_ID = "@$A_USERNAME:matrix.org"
 private const val A_LOGIN_TOKEN = "a-login-token"
 
@@ -150,6 +151,25 @@ class OnboardingViewModelTest {
         givenInitialisesSession(fakeSession)
 
         viewModel.handle(OnboardingAction.LoginWithToken(A_LOGIN_TOKEN))
+
+        test
+                .assertStatesChanges(
+                        initialState,
+                        { copy(isLoading = true) },
+                        { copy(isLoading = false) }
+                )
+                .assertEvents(OnboardingViewEvents.OnAccountSignedIn)
+                .finish()
+    }
+
+    @Test
+    fun `given can login with username and password, when logging in, then emits AccountSignedIn`() = runTest {
+        val test = viewModel.test()
+        fakeAuthenticationService.givenLoginWizard(fakeLoginWizard)
+        fakeLoginWizard.givenLoginSuccess(A_USERNAME, A_PASSWORD, A_DEVICE_NAME, fakeSession)
+        givenInitialisesSession(fakeSession)
+
+        viewModel.handle(OnboardingAction.AuthenticateAction.Login(A_USERNAME, A_PASSWORD, A_DEVICE_NAME))
 
         test
                 .assertStatesChanges(

--- a/vector/src/test/java/im/vector/app/features/onboarding/RegistrationStateFixture.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/RegistrationStateFixture.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.onboarding
+
+object RegistrationStateFixture {
+
+    fun aRegistrationState(
+            email: String? = null,
+            isUserNameAvailable: Boolean = false,
+            selectedMatrixId: String? = null,
+    ) = RegistrationState(email, isUserNameAvailable, selectedMatrixId)
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
@@ -18,6 +18,7 @@ package im.vector.app.test.fakes
 
 import io.mockk.coEvery
 import io.mockk.coJustRun
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import org.matrix.android.sdk.api.auth.AuthenticationService
@@ -67,5 +68,13 @@ class FakeAuthenticationService : AuthenticationService by mockk() {
 
     fun givenDirectAuthenticationThrows(config: HomeServerConnectionConfig, matrixId: String, password: String, deviceName: String, cause: Throwable) {
         coEvery { directAuthentication(config, matrixId, password, deviceName) } throws cause
+    }
+
+    fun verifyReset() {
+        coVerify { reset() }
+    }
+
+    fun verifyCancelsPendingLogin() {
+        coVerify { cancelPendingLoginOrRegistration() }
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeAuthenticationService.kt
@@ -77,4 +77,8 @@ class FakeAuthenticationService : AuthenticationService by mockk() {
     fun verifyCancelsPendingLogin() {
         coVerify { cancelPendingLoginOrRegistration() }
     }
+
+    fun givenSsoUrl(redirectUri: String, deviceId: String, providerId: String, result: String) {
+        coEvery { getSsoUrl(redirectUri, deviceId, providerId) } returns result
+    }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeLoginWizard.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeLoginWizard.kt
@@ -16,15 +16,21 @@
 
 package im.vector.app.test.fakes
 
+import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.mockk
 import org.matrix.android.sdk.api.auth.login.LoginWizard
+import org.matrix.android.sdk.api.session.Session
 
 class FakeLoginWizard : LoginWizard by mockk() {
 
     fun givenResetPasswordSuccess(email: String) {
         coJustRun { resetPassword(email) }
+    }
+
+    fun givenLoginWithTokenResult(token: String, result: Session) {
+        coEvery { loginWithToken(token) } returns result
     }
 
     fun givenConfirmResetPasswordSuccess(password: String) {

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeLoginWizard.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeLoginWizard.kt
@@ -33,6 +33,10 @@ class FakeLoginWizard : LoginWizard by mockk() {
         coEvery { loginWithToken(token) } returns result
     }
 
+    fun givenLoginSuccess(username: String, password: String, deviceName: String, result: Session) {
+        coEvery { login(username, password, deviceName) } returns result
+    }
+
     fun givenConfirmResetPasswordSuccess(password: String) {
         coJustRun { resetPasswordMailConfirmed(password) }
     }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorFeatures.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorFeatures.kt
@@ -35,6 +35,10 @@ class FakeVectorFeatures : VectorFeatures by spyk<DefaultVectorFeatures>() {
         every { isOnboardingCombinedLoginEnabled() } returns true
     }
 
+    fun givenOnboardingUseCaseEnabled() {
+        every { isOnboardingUseCaseEnabled() } returns true
+    }
+
     fun givenCombinedLoginDisabled() {
         every { isOnboardingCombinedLoginEnabled() } returns false
     }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Adds tests around the splash flows, login, reset action and sso url querying.

## Motivation and context

Updates the `onboarding` package to 75% coverage

![2022-07-28T11:48:03,037427480+01:00](https://user-images.githubusercontent.com/1848238/181487914-98f3dad1-a64e-4065-9bb3-4e1672ae2366.png)

## Screenshots / GIFs
No UI changes

## Tests

No production code changes

## Tested devices
N/A