### PR TITLE
Shortcuts must first start MainActivity to ensure the session is restored.

### DIFF
--- a/vector/src/main/java/im/vector/app/features/MainActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/MainActivity.kt
@@ -86,6 +86,8 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
         private const val EXTRA_ARGS = "EXTRA_ARGS"
         private const val EXTRA_NEXT_INTENT = "EXTRA_NEXT_INTENT"
         private const val EXTRA_INIT_SESSION = "EXTRA_INIT_SESSION"
+        private const val EXTRA_ROOM_ID = "EXTRA_ROOM_ID"
+        private const val ACTION_ROOM_DETAILS_FROM_SHORTCUT = "ROOM_DETAILS_FROM_SHORTCUT"
 
         // Special action to clear cache and/or clear credentials
         fun restartApp(activity: Activity, args: MainActivityArgs) {
@@ -106,6 +108,14 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
             val intent = Intent(context, MainActivity::class.java)
             intent.putExtra(EXTRA_NEXT_INTENT, nextIntent)
             return intent
+        }
+
+        // Shortcuts can't have intents with parcelables
+        fun shortcutIntent(context: Context, roomId: String): Intent {
+            return Intent(context, MainActivity::class.java).apply {
+                action = ACTION_ROOM_DETAILS_FROM_SHORTCUT
+                putExtra(EXTRA_ROOM_ID, roomId)
+            }
         }
     }
 
@@ -170,6 +180,13 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
             startIntentAndFinish(nextIntent)
         } else if (intent.hasExtra(EXTRA_INIT_SESSION)) {
             setResult(RESULT_OK)
+            finish()
+        } else if (intent.action == ACTION_ROOM_DETAILS_FROM_SHORTCUT) {
+            val roomId = intent.getStringExtra(EXTRA_ROOM_ID)
+            if (roomId?.isNotEmpty() == true) {
+                // TODO Add a trigger Shortcut to the analytics.
+                navigator.openRoom(this, roomId)
+            }
             finish()
         } else {
             args = parseArgs()

--- a/vector/src/main/java/im/vector/app/features/MainActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/MainActivity.kt
@@ -141,6 +141,8 @@ class MainActivity : VectorBaseActivity<ActivityMainBinding>(), UnlockedActivity
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        shortcutsHandler.updateShortcutsWithPreviousIntent()
+
         startAppViewModel.onEach {
             renderState(it)
         }

--- a/vector/src/main/java/im/vector/app/features/home/ShortcutCreator.kt
+++ b/vector/src/main/java/im/vector/app/features/home/ShortcutCreator.kt
@@ -27,7 +27,7 @@ import androidx.core.graphics.drawable.IconCompat
 import im.vector.app.BuildConfig
 import im.vector.app.core.glide.GlideApp
 import im.vector.app.core.utils.DimensionConverter
-import im.vector.app.features.home.room.detail.RoomDetailActivity
+import im.vector.app.features.MainActivity
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 import org.matrix.android.sdk.api.util.toMatrixItem
 import javax.inject.Inject
@@ -58,7 +58,7 @@ class ShortcutCreator @Inject constructor(
 
     @WorkerThread
     fun create(roomSummary: RoomSummary, rank: Int = 1): ShortcutInfoCompat {
-        val intent = RoomDetailActivity.shortcutIntent(context, roomSummary.roomId)
+        val intent = MainActivity.shortcutIntent(context, roomSummary.roomId)
         val bitmap = try {
             val glideRequests = GlideApp.with(context)
             val matrixItem = roomSummary.toMatrixItem()

--- a/vector/src/main/java/im/vector/app/features/home/ShortcutsHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/home/ShortcutsHandler.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.features.home
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.pm.ShortcutManager
@@ -96,7 +97,9 @@ class ShortcutsHandler @Inject constructor(
                 .launchIn(coroutineScope)
     }
 
+    @SuppressLint("RestrictedApi")
     fun updateShortcutsWithPreviousIntent() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1) return
         // Check if it's been already done
         if (sharedPreferences.getBoolean(SHARED_PREF_KEY, false)) return
         ShortcutManagerCompat.getShortcuts(context, ShortcutManagerCompat.FLAG_MATCH_PINNED)

--- a/vector/src/main/java/im/vector/app/features/home/ShortcutsHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/home/ShortcutsHandler.kt
@@ -17,14 +17,20 @@
 package im.vector.app.features.home
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.content.pm.ShortcutManager
 import android.os.Build
+import androidx.core.content.edit
 import androidx.core.content.getSystemService
+import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.core.di.DefaultPreferences
 import im.vector.app.core.dispatchers.CoroutineDispatchers
 import im.vector.app.core.resources.StringProvider
+import im.vector.app.features.MainActivity
+import im.vector.app.features.home.room.detail.RoomDetailActivity
 import im.vector.app.features.pin.PinCodeStore
 import im.vector.app.features.pin.PinCodeStoreListener
 import kotlinx.coroutines.CoroutineScope
@@ -35,6 +41,7 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.room.RoomSortOrder
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
@@ -50,7 +57,9 @@ class ShortcutsHandler @Inject constructor(
         private val appDispatchers: CoroutineDispatchers,
         private val shortcutCreator: ShortcutCreator,
         private val activeSessionHolder: ActiveSessionHolder,
-        private val pinCodeStore: PinCodeStore
+        private val pinCodeStore: PinCodeStore,
+        @DefaultPreferences
+        private val sharedPreferences: SharedPreferences,
 ) : PinCodeStoreListener {
 
     private val isRequestPinShortcutSupported = ShortcutManagerCompat.isRequestPinShortcutSupported(context)
@@ -85,6 +94,25 @@ class ShortcutsHandler @Inject constructor(
                 }
                 .flowOn(appDispatchers.computation)
                 .launchIn(coroutineScope)
+    }
+
+    fun updateShortcutsWithPreviousIntent() {
+        // Check if it's been already done
+        if (sharedPreferences.getBoolean(SHARED_PREF_KEY, false)) return
+        ShortcutManagerCompat.getShortcuts(context, ShortcutManagerCompat.FLAG_MATCH_PINNED)
+                .filter { it.intent.component?.className == RoomDetailActivity::class.qualifiedName }
+                .mapNotNull {
+                    it.intent.getStringExtra("EXTRA_ROOM_ID")?.let { roomId ->
+                        ShortcutInfoCompat.Builder(context, it.toShortcutInfo())
+                                .setIntent(MainActivity.shortcutIntent(context, roomId))
+                                .build()
+                    }
+                }
+                .takeIf { it.isNotEmpty() }
+                ?.also { Timber.d("Update ${it.size} shortcut(s)") }
+                ?.let { tryOrNull("Error") { ShortcutManagerCompat.updateShortcuts(context, it) } }
+                ?.also { Timber.d("Update shortcuts with success: $it") }
+        sharedPreferences.edit { putBoolean(SHARED_PREF_KEY, true) }
     }
 
     private fun removeDeadShortcuts(roomIds: List<String>) {
@@ -162,5 +190,9 @@ class ShortcutsHandler @Inject constructor(
         }
         // Else shortcut will be created next time any room summary is updated, or
         // next time the app is started which is acceptable
+    }
+
+    companion object {
+        const val SHARED_PREF_KEY = "ROOM_DETAIL_ACTIVITY_SHORTCUT_UPDATED"
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailActivity.kt
@@ -99,12 +99,7 @@ class RoomDetailActivity :
         super.onCreate(savedInstanceState)
         supportFragmentManager.registerFragmentLifecycleCallbacks(fragmentLifecycleCallbacks, false)
         waitingView = views.waitingView.waitingView
-        val timelineArgs: TimelineArgs? = if (intent?.action == ACTION_ROOM_DETAILS_FROM_SHORTCUT) {
-            TimelineArgs(roomId = intent?.extras?.getString(EXTRA_ROOM_ID)!!)
-        } else {
-            intent?.extras?.getParcelable(EXTRA_ROOM_DETAIL_ARGS)
-        }
-        if (timelineArgs == null) return
+        val timelineArgs: TimelineArgs = intent?.extras?.getParcelable(EXTRA_ROOM_DETAIL_ARGS) ?: return
         intent.putExtra(Mavericks.KEY_ARG, timelineArgs)
         currentRoomId = timelineArgs.roomId
 
@@ -187,10 +182,7 @@ class RoomDetailActivity :
     }
 
     companion object {
-
         const val EXTRA_ROOM_DETAIL_ARGS = "EXTRA_ROOM_DETAIL_ARGS"
-        const val EXTRA_ROOM_ID = "EXTRA_ROOM_ID"
-        const val ACTION_ROOM_DETAILS_FROM_SHORTCUT = "ROOM_DETAILS_FROM_SHORTCUT"
 
         fun newIntent(context: Context, timelineArgs: TimelineArgs, firstStartMainActivity: Boolean): Intent {
             val intent = Intent(context, RoomDetailActivity::class.java).apply {
@@ -200,14 +192,6 @@ class RoomDetailActivity :
                 MainActivity.getIntentWithNextIntent(context, intent)
             } else {
                 intent
-            }
-        }
-
-        // Shortcuts can't have intents with parcelables
-        fun shortcutIntent(context: Context, roomId: String): Intent {
-            return Intent(context, RoomDetailActivity::class.java).apply {
-                action = ACTION_ROOM_DETAILS_FROM_SHORTCUT
-                putExtra(EXTRA_ROOM_ID, roomId)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -28,6 +28,7 @@ import im.vector.app.R
 import im.vector.app.core.di.DefaultSharedPreferences
 import im.vector.app.core.time.Clock
 import im.vector.app.features.disclaimer.SHARED_PREF_KEY
+import im.vector.app.features.home.ShortcutsHandler
 import im.vector.app.features.homeserver.ServerUrlsRepository
 import im.vector.app.features.themes.ThemeUtils
 import org.matrix.android.sdk.api.extensions.tryOrNull
@@ -268,7 +269,9 @@ class VectorPreferences @Inject constructor(
                 SETTINGS_DEVELOPER_MODE_FAIL_FAST_PREFERENCE_KEY,
 
                 SETTINGS_USE_RAGE_SHAKE_KEY,
-                SETTINGS_SECURITY_USE_FLAG_SECURE
+                SETTINGS_SECURITY_USE_FLAG_SECURE,
+
+                ShortcutsHandler.SHARED_PREF_KEY,
         )
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix (not in prod)
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

Closes #6672 

Fix tested OK on my side, using the two ways to have a shortcut.

Will double check what we can do for existing shortcuts on home screen, but I think there is nothing we can do except try to remove / disable them.

**EDIT** Ok, pinned shortcut can be updated, tested OK on my device.

No changelog since it's not released code.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- See #6672 

Also:
- create a shortcut with the previous version
- click on the shortcut: the app crash
- install the app with this PR
- the existing shortcuts are migrated
- clicking on the same shortcut open the app without crashing

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
