### PR TITLE
[FTUE] Memory leak on FtueAuthSplashCarouselFragment

### DIFF
--- a/changelog.d/6680.misc
+++ b/changelog.d/6680.misc
@@ -1,0 +1,1 @@
+[FTUE] Memory leak on FtueAuthSplashCarouselFragment

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashCarouselFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashCarouselFragment.kt
@@ -51,6 +51,8 @@ class FtueAuthSplashCarouselFragment @Inject constructor(
         private val carouselStateFactory: SplashCarouselStateFactory
 ) : AbstractFtueAuthFragment<FragmentFtueSplashCarouselBinding>() {
 
+    private var tabLayoutMediator: TabLayoutMediator? = null
+
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentFtueSplashCarouselBinding {
         return FragmentFtueSplashCarouselBinding.inflate(inflater, container, false)
     }
@@ -60,10 +62,19 @@ class FtueAuthSplashCarouselFragment @Inject constructor(
         setupViews()
     }
 
+    override fun onDestroyView() {
+        tabLayoutMediator?.detach()
+        tabLayoutMediator = null
+        views.splashCarousel.adapter = null
+        super.onDestroyView()
+    }
+
     private fun setupViews() {
         val carouselAdapter = carouselController.adapter
         views.splashCarousel.adapter = carouselAdapter
-        TabLayoutMediator(views.carouselIndicator, views.splashCarousel) { _, _ -> }.attach()
+        tabLayoutMediator = TabLayoutMediator(views.carouselIndicator, views.splashCarousel) { _, _ -> }
+                .also { it.attach() }
+
         carouselController.setData(carouselStateFactory.create())
 
         val isAlreadyHaveAccountEnabled = vectorFeatures.isOnboardingAlreadyHaveAccountSplashEnabled()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Enhancement

## Content

<!-- Describe shortly what has been changed -->
Clearing references on the `TabLayoutMediator` and `adapter` when `FtueAuthSplashCarouselFragment` is destroyed.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6680 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->
To check, you need to enable LeakCanary. When doing tests, ensure there is no leak detected and related to `FtueAuthSplashCarouselFragment`.

- Start the app from scratch
- Press "I already have an account" or "Create an account" button

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
