### PR TITLE
[Location sharing] Invisible text on map symbol

### DIFF
--- a/changelog.d/6687.bugfix
+++ b/changelog.d/6687.bugfix
@@ -1,0 +1,1 @@
+[Location sharing] Invisible text on map symbol

--- a/vector/src/main/java/im/vector/app/features/location/MapTilerMapView.kt
+++ b/vector/src/main/java/im/vector/app/features/location/MapTilerMapView.kt
@@ -23,6 +23,7 @@ import android.view.Gravity
 import android.widget.ImageView
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.use
+import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.marginBottom
 import androidx.core.view.marginTop
 import androidx.core.view.updateLayoutParams
@@ -162,7 +163,7 @@ class MapTilerMapView @JvmOverloads constructor(
         pinDrawable?.let { drawable ->
             if (!safeMapRefs.style.isFullyLoaded ||
                     safeMapRefs.style.getImage(state.pinId) == null) {
-                safeMapRefs.style.addImage(state.pinId, drawable)
+                safeMapRefs.style.addImage(state.pinId, drawable.toBitmap())
             }
         }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Convert the map symbol drawable to bitmap to be able to see text on it.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6687 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|<img src="https://user-images.githubusercontent.com/46314705/182378222-f2f9009c-d15b-44cb-a90e-bc0cd0be0a1e.png" width=300/>|<img src="https://user-images.githubusercontent.com/46314705/182378230-222597a3-633c-4fda-9e1c-351e94ec9ba3.png" width=300/>|

## Tests

<!-- Explain how you tested your development -->

- Share you current location in a room with a user without picture
- Open the new message
- Check the shortname of the user is displayed on the map pin

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
