### PR TITLE
Avoid running this workflow twice on PR. #6690

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,8 @@
 name: "Validate Gradle Wrapper"
-on: [push, pull_request]
+on:
+  pull_request: { }
+  push:
+    branches: [ main, develop ]
 
 jobs:
   validation:


### PR DESCRIPTION
Should fix #6690. This workflow should run on every PR, and when pushing on `main` and on `develop` (just in case wrapper is updated outside of a PR, which should not happen). Note that the doc https://github.com/gradle/wrapper-validation-action should probably be udpated too.

See what will happen to this PR.

**EDIT** OK, only one check here:

<img width="475" alt="image" src="https://user-images.githubusercontent.com/3940906/181748600-a59b785a-28ab-48cf-8262-b9b12d4dd4f7.png">
