### PR TITLE
warn on cross signing reset

### DIFF
--- a/changelog.d/6702.bugfix
+++ b/changelog.d/6702.bugfix
@@ -1,0 +1,1 @@
+Add Warning shield when a user previously verified rotated his cross signing keys

--- a/changelog.d/6702.bugfix
+++ b/changelog.d/6702.bugfix
@@ -1,1 +1,1 @@
-Add Warning shield when a user previously verified rotated his cross signing keys
+Add Warning shield when a user previously verified rotated their cross signing keys

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -167,7 +167,8 @@ ext.libs = [
         tests       : [
                 'kluent'                 : "org.amshove.kluent:kluent-android:1.68",
                 'timberJunitRule'        : "net.lachlanmckee:timber-junit-rule:1.0.1",
-                'junit'                  : "junit:junit:4.13.2"
+                'junit'                  : "junit:junit:4.13.2",
+                'robolectric'            : "org.robolectric:robolectric:4.8",
         ]
 ]
 

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/CryptoTestHelper.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/CryptoTestHelper.kt
@@ -365,7 +365,7 @@ class CryptoTestHelper(val testHelper: CommonTestHelper) {
         }
 
         testHelper.retryPeriodically {
-            alice.cryptoService().crossSigningService().isUserTrusted(bob.myUserId)
+            bob.cryptoService().crossSigningService().isUserTrusted(alice.myUserId)
         }
     }
 

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/crosssigning/XSigningTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/internal/crypto/crosssigning/XSigningTest.kt
@@ -18,6 +18,7 @@ package org.matrix.android.sdk.internal.crypto.crosssigning
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -257,6 +258,11 @@ class XSigningTest : InstrumentedTest {
             assertTrue(it is UserTrustResult.Success)
         }
 
+        // Ensure also that bob device is trusted
+        aliceSession.cryptoService().getUserDevices(bobSession.myUserId).first().let { bobDeviceAlicePoc ->
+            bobDeviceAlicePoc.trustLevel!!.crossSigningVerified shouldBeEqualTo true
+        }
+
         val currentBobMSK = aliceSession.cryptoService().crossSigningService()
                 .getUserCrossSigningKeys(bobSession.myUserId)!!
                 .masterKey()!!.unpaddedBase64PublicKey!!
@@ -308,6 +314,11 @@ class XSigningTest : InstrumentedTest {
             testHelper.retryPeriodicallyWithLatch(it) {
                 !aliceSession.cryptoService().crossSigningService().isUserTrusted(bobSession.myUserId)
             }
+        }
+
+        // Ensure also that bob device are not trusted
+        aliceSession.cryptoService().getUserDevices(bobSession.myUserId).first().let { bobDeviceAlicePoc ->
+            bobDeviceAlicePoc.trustLevel!!.crossSigningVerified shouldBeEqualTo false
         }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/crosssigning/MXCrossSigningInfo.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/crosssigning/MXCrossSigningInfo.kt
@@ -18,7 +18,8 @@ package org.matrix.android.sdk.api.session.crypto.crosssigning
 
 data class MXCrossSigningInfo(
         val userId: String,
-        val crossSigningKeys: List<CryptoCrossSigningKey>
+        val crossSigningKeys: List<CryptoCrossSigningKey>,
+        val wasTrustedOnce: Boolean
 ) {
 
     fun isTrusted(): Boolean = masterKey()?.trustLevel?.isVerified() == true &&

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/model/UserVerificationLevel.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/model/UserVerificationLevel.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.api.session.crypto.model
+
+enum class UserVerificationLevel {
+
+    VERIFIED_ALL_DEVICES_TRUSTED,
+
+    VERIFIED_WITH_DEVICES_UNTRUSTED,
+
+    UNVERIFIED_BUT_WAS_PREVIOUSLY,
+
+    WAS_NEVER_VERIFIED,
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/DefaultCrossSigningService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/DefaultCrossSigningService.kt
@@ -167,7 +167,11 @@ internal class DefaultCrossSigningService @Inject constructor(
                 }
 
                 override fun onSuccess(data: InitializeCrossSigningTask.Result) {
-                    val crossSigningInfo = MXCrossSigningInfo(userId, listOf(data.masterKeyInfo, data.userKeyInfo, data.selfSignedKeyInfo))
+                    val crossSigningInfo = MXCrossSigningInfo(
+                            userId,
+                            listOf(data.masterKeyInfo, data.userKeyInfo, data.selfSignedKeyInfo),
+                            true
+                    )
                     cryptoStore.setMyCrossSigningInfo(crossSigningInfo)
                     setUserKeysAsTrusted(userId, true)
                     cryptoStore.storePrivateKeysInfo(data.masterKeyPK, data.userKeyPK, data.selfSigningKeyPK)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/UpdateTrustWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/UpdateTrustWorker.kt
@@ -259,21 +259,27 @@ internal class UpdateTrustWorker(context: Context, params: WorkerParameters, ses
         cryptoRealm.where(CrossSigningInfoEntity::class.java)
                 .equalTo(CrossSigningInfoEntityFields.USER_ID, userId)
                 .findFirst()
-                ?.crossSigningKeys
-                ?.forEach { info ->
-                    // optimization to avoid trigger updates when there is no change..
-                    if (info.trustLevelEntity?.isVerified() != verified) {
-                        Timber.d("## CrossSigning - Trust change for $userId : $verified")
-                        val level = info.trustLevelEntity
-                        if (level == null) {
-                            info.trustLevelEntity = cryptoRealm.createObject(TrustLevelEntity::class.java).also {
-                                it.locallyVerified = verified
-                                it.crossSignedVerified = verified
+                ?.let { userKeyInfo ->
+                    userKeyInfo
+                            .crossSigningKeys
+                            .forEach { key ->
+                                // optimization to avoid trigger updates when there is no change..
+                                if (key.trustLevelEntity?.isVerified() != verified) {
+                                    Timber.d("## CrossSigning - Trust change for $userId : $verified")
+                                    val level = key.trustLevelEntity
+                                    if (level == null) {
+                                        key.trustLevelEntity = cryptoRealm.createObject(TrustLevelEntity::class.java).also {
+                                            it.locallyVerified = verified
+                                            it.crossSignedVerified = verified
+                                        }
+                                    } else {
+                                        level.locallyVerified = verified
+                                        level.crossSignedVerified = verified
+                                    }
+                                }
                             }
-                        } else {
-                            level.locallyVerified = verified
-                            level.crossSignedVerified = verified
-                        }
+                    if (verified) {
+                        userKeyInfo.wasUserVerifiedOnce = true
                     }
                 }
     }
@@ -299,8 +305,18 @@ internal class UpdateTrustWorker(context: Context, params: WorkerParameters, ses
                     getCrossSigningInfo(cryptoRealm, userId)?.isTrusted() == true
                 }
 
+        val resetTrust = listToCheck
+                .filter { userId ->
+                    val crossSigningInfo = getCrossSigningInfo(cryptoRealm, userId)
+                    crossSigningInfo?.isTrusted() != true && crossSigningInfo?.wasTrustedOnce == true
+                }
+
         return if (allTrustedUserIds.isEmpty()) {
-            RoomEncryptionTrustLevel.Default
+            if (resetTrust.isEmpty()) {
+                RoomEncryptionTrustLevel.Default
+            } else {
+                RoomEncryptionTrustLevel.Warning
+            }
         } else {
             // If one of the verified user as an untrusted device -> warning
             // If all devices of all verified users are trusted -> green
@@ -327,11 +343,15 @@ internal class UpdateTrustWorker(context: Context, params: WorkerParameters, ses
                         if (hasWarning) {
                             RoomEncryptionTrustLevel.Warning
                         } else {
-                            if (listToCheck.size == allTrustedUserIds.size) {
-                                // all users are trusted and all devices are verified
-                                RoomEncryptionTrustLevel.Trusted
+                            if (resetTrust.isEmpty()) {
+                                if (listToCheck.size == allTrustedUserIds.size) {
+                                    // all users are trusted and all devices are verified
+                                    RoomEncryptionTrustLevel.Trusted
+                                } else {
+                                    RoomEncryptionTrustLevel.Default
+                                }
                             } else {
-                                RoomEncryptionTrustLevel.Default
+                                RoomEncryptionTrustLevel.Warning
                             }
                         }
                     }
@@ -344,7 +364,8 @@ internal class UpdateTrustWorker(context: Context, params: WorkerParameters, ses
                 userId = userId,
                 crossSigningKeys = xsignInfo.crossSigningKeys.mapNotNull {
                     crossSigningKeysMapper.map(userId, it)
-                }
+                },
+                wasTrustedOnce = xsignInfo.wasUserVerifiedOnce
         )
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/UpdateTrustWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/UpdateTrustWorker.kt
@@ -161,6 +161,7 @@ internal class UpdateTrustWorker(context: Context, params: WorkerParameters, ses
             // i have all the new trusts, update DB
             trusts.forEach {
                 val verified = it.value?.isVerified() == true
+                Timber.v("[$myUserId] ## CrossSigning - Updating user trust: ${it.key} to $verified")
                 updateCrossSigningKeysTrust(cryptoRealm, it.key, verified)
             }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -1611,7 +1611,8 @@ internal class RealmCryptoStore @Inject constructor(
                 userId = userId,
                 crossSigningKeys = xsignInfo.crossSigningKeys.mapNotNull {
                     crossSigningKeysMapper.map(userId, it)
-                }
+                },
+                wasTrustedOnce = xsignInfo.wasUserVerifiedOnce
         )
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStoreMigration.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStoreMigration.kt
@@ -35,6 +35,7 @@ import org.matrix.android.sdk.internal.crypto.store.db.migration.MigrateCryptoTo
 import org.matrix.android.sdk.internal.crypto.store.db.migration.MigrateCryptoTo016
 import org.matrix.android.sdk.internal.crypto.store.db.migration.MigrateCryptoTo017
 import org.matrix.android.sdk.internal.crypto.store.db.migration.MigrateCryptoTo018
+import org.matrix.android.sdk.internal.crypto.store.db.migration.MigrateCryptoTo019
 import org.matrix.android.sdk.internal.util.database.MatrixRealmMigration
 import org.matrix.android.sdk.internal.util.time.Clock
 import javax.inject.Inject
@@ -49,7 +50,7 @@ internal class RealmCryptoStoreMigration @Inject constructor(
         private val clock: Clock,
 ) : MatrixRealmMigration(
         dbName = "Crypto",
-        schemaVersion = 18L,
+        schemaVersion = 19L,
 ) {
     /**
      * Forces all RealmCryptoStoreMigration instances to be equal.
@@ -77,5 +78,6 @@ internal class RealmCryptoStoreMigration @Inject constructor(
         if (oldVersion < 16) MigrateCryptoTo016(realm).perform()
         if (oldVersion < 17) MigrateCryptoTo017(realm).perform()
         if (oldVersion < 18) MigrateCryptoTo018(realm).perform()
+        if (oldVersion < 19) MigrateCryptoTo019(realm).perform()
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/migration/MigrateCryptoTo019.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/migration/MigrateCryptoTo019.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.crypto.store.db.migration
+
+import io.realm.DynamicRealm
+import io.realm.DynamicRealmObject
+import org.matrix.android.sdk.api.session.crypto.crosssigning.KeyUsage
+import org.matrix.android.sdk.internal.crypto.store.db.model.CrossSigningInfoEntityFields
+import org.matrix.android.sdk.internal.crypto.store.db.model.KeyInfoEntityFields
+import org.matrix.android.sdk.internal.crypto.store.db.model.TrustLevelEntityFields
+import org.matrix.android.sdk.internal.util.database.RealmMigrator
+
+/**
+ * This migration is adding support for trusted flags on megolm sessions.
+ * We can't really assert the trust of existing keys, so for the sake of simplicity we are going to
+ * mark existing keys as safe.
+ * This migration can take long depending on the account
+ */
+internal class MigrateCryptoTo019(realm: DynamicRealm) : RealmMigrator(realm, 18) {
+
+    override fun doMigrate(realm: DynamicRealm) {
+        realm.schema.get("CrossSigningInfoEntity")
+                ?.addField(CrossSigningInfoEntityFields.WAS_USER_VERIFIED_ONCE, Boolean::class.java)
+                ?.transform { dynamicObject ->
+
+                    val knowKeys = dynamicObject.getList(CrossSigningInfoEntityFields.CROSS_SIGNING_KEYS.`$`)
+                    val msk = knowKeys.firstOrNull {
+                        it.getList(KeyInfoEntityFields.USAGES.`$`, String::class.java).orEmpty().contains(KeyUsage.MASTER.value)
+                    }
+                    val ssk = knowKeys.firstOrNull {
+                        it.getList(KeyInfoEntityFields.USAGES.`$`, String::class.java).orEmpty().contains(KeyUsage.SELF_SIGNING.value)
+                    }
+                    val isTrusted = isDynamicKeyInfoTrusted(msk?.get<DynamicRealmObject>(KeyInfoEntityFields.TRUST_LEVEL_ENTITY.`$`)) &&
+                            isDynamicKeyInfoTrusted(ssk?.get<DynamicRealmObject>(KeyInfoEntityFields.TRUST_LEVEL_ENTITY.`$`))
+
+                    dynamicObject.setBoolean(CrossSigningInfoEntityFields.WAS_USER_VERIFIED_ONCE, isTrusted)
+                }
+    }
+
+    private fun isDynamicKeyInfoTrusted(keyInfo: DynamicRealmObject?): Boolean {
+        if (keyInfo == null) return false
+        return !keyInfo.isNull(TrustLevelEntityFields.CROSS_SIGNED_VERIFIED) && keyInfo.getBoolean(TrustLevelEntityFields.CROSS_SIGNED_VERIFIED) &&
+                !keyInfo.isNull(TrustLevelEntityFields.LOCALLY_VERIFIED) && keyInfo.getBoolean(TrustLevelEntityFields.LOCALLY_VERIFIED)
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/CrossSigningInfoEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/CrossSigningInfoEntity.kt
@@ -25,6 +25,7 @@ import org.matrix.android.sdk.internal.extensions.clearWith
 internal open class CrossSigningInfoEntity(
         @PrimaryKey
         var userId: String? = null,
+        var wasUserVerifiedOnce: Boolean = false,
         var crossSigningKeys: RealmList<KeyInfoEntity> = RealmList()
 ) : RealmObject() {
 

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -290,6 +290,7 @@ dependencies {
     testImplementation libs.tests.kluent
     testImplementation libs.mockk.mockk
     testImplementation libs.androidx.coreTesting
+    testImplementation libs.tests.robolectric
     // Plant Timber tree for test
     testImplementation libs.tests.timberJunitRule
     testImplementation libs.airbnb.mavericksTesting

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -289,6 +289,7 @@ dependencies {
     testImplementation libs.tests.junit
     testImplementation libs.tests.kluent
     testImplementation libs.mockk.mockk
+    testImplementation libs.androidx.coreTesting
     // Plant Timber tree for test
     testImplementation libs.tests.timberJunitRule
     testImplementation libs.airbnb.mavericksTesting

--- a/vector/src/main/java/im/vector/app/core/epoxy/profiles/BaseProfileMatrixItem.kt
+++ b/vector/src/main/java/im/vector/app/core/epoxy/profiles/BaseProfileMatrixItem.kt
@@ -26,7 +26,7 @@ import im.vector.app.core.epoxy.onClick
 import im.vector.app.core.extensions.setTextOrHide
 import im.vector.app.features.displayname.getBestName
 import im.vector.app.features.home.AvatarRenderer
-import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel
+import org.matrix.android.sdk.api.session.crypto.model.UserVerificationLevel
 import org.matrix.android.sdk.api.util.MatrixItem
 
 abstract class BaseProfileMatrixItem<T : ProfileMatrixItem.Holder>(@LayoutRes layoutId: Int) : VectorEpoxyModel<T>(layoutId) {
@@ -35,7 +35,7 @@ abstract class BaseProfileMatrixItem<T : ProfileMatrixItem.Holder>(@LayoutRes la
     @EpoxyAttribute var editable: Boolean = true
 
     @EpoxyAttribute
-    var userEncryptionTrustLevel: RoomEncryptionTrustLevel? = null
+    var userVerificationLevel: UserVerificationLevel? = null
 
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
     var clickListener: ClickListener? = null
@@ -53,6 +53,6 @@ abstract class BaseProfileMatrixItem<T : ProfileMatrixItem.Holder>(@LayoutRes la
         holder.subtitleView.setTextOrHide(matrixId)
         holder.editableView.isVisible = editable
         avatarRenderer.render(matrixItem, holder.avatarImageView)
-        holder.avatarDecorationImageView.render(userEncryptionTrustLevel)
+        holder.avatarDecorationImageView.renderUser(userVerificationLevel)
     }
 }

--- a/vector/src/main/java/im/vector/app/core/ui/views/ShieldImageView.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/views/ShieldImageView.kt
@@ -24,6 +24,7 @@ import androidx.core.view.isVisible
 import im.vector.app.R
 import im.vector.app.features.home.room.detail.timeline.item.E2EDecoration
 import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel
+import org.matrix.android.sdk.api.session.crypto.model.UserVerificationLevel
 
 class ShieldImageView @JvmOverloads constructor(
         context: Context,
@@ -100,6 +101,35 @@ class ShieldImageView @JvmOverloads constructor(
                 contentDescription = null
                 isVisible = false
             }
+        }
+    }
+
+    fun renderUser(userVerificationLevel: UserVerificationLevel?, borderLess: Boolean = false) {
+        isVisible = userVerificationLevel != null
+        when (userVerificationLevel) {
+            UserVerificationLevel.VERIFIED_ALL_DEVICES_TRUSTED -> {
+                contentDescription = context.getString(R.string.a11y_trust_level_trusted)
+                setImageResource(
+                        if (borderLess) R.drawable.ic_shield_trusted_no_border
+                        else R.drawable.ic_shield_trusted
+                )
+            }
+            UserVerificationLevel.UNVERIFIED_BUT_WAS_PREVIOUSLY,
+            UserVerificationLevel.VERIFIED_WITH_DEVICES_UNTRUSTED -> {
+                contentDescription = context.getString(R.string.a11y_trust_level_warning)
+                setImageResource(
+                        if (borderLess) R.drawable.ic_shield_warning_no_border
+                        else R.drawable.ic_shield_warning
+                )
+            }
+            UserVerificationLevel.WAS_NEVER_VERIFIED -> {
+                contentDescription = context.getString(R.string.a11y_trust_level_default)
+                setImageResource(
+                        if (borderLess) R.drawable.ic_shield_black_no_border
+                        else R.drawable.ic_shield_black
+                )
+            }
+            null -> Unit
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/RoomMemberProfileFragment.kt
@@ -59,7 +59,7 @@ import im.vector.app.features.home.room.detail.timeline.helper.MatrixItemColorPr
 import im.vector.app.features.roommemberprofile.devices.DeviceListBottomSheet
 import im.vector.app.features.roommemberprofile.powerlevel.EditPowerLevelDialogs
 import kotlinx.parcelize.Parcelize
-import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel
+import org.matrix.android.sdk.api.session.crypto.model.UserVerificationLevel
 import org.matrix.android.sdk.api.session.room.powerlevels.Role
 import org.matrix.android.sdk.api.util.MatrixItem
 import javax.inject.Inject
@@ -235,23 +235,27 @@ class RoomMemberProfileFragment :
                         if (state.userMXCrossSigningInfo.isTrusted()) {
                             // User is trusted
                             if (state.allDevicesAreCrossSignedTrusted) {
-                                RoomEncryptionTrustLevel.Trusted
+                                UserVerificationLevel.VERIFIED_ALL_DEVICES_TRUSTED
                             } else {
-                                RoomEncryptionTrustLevel.Warning
+                                UserVerificationLevel.VERIFIED_WITH_DEVICES_UNTRUSTED
                             }
                         } else {
-                            RoomEncryptionTrustLevel.Default
+                            if (state.userMXCrossSigningInfo.wasTrustedOnce) {
+                                UserVerificationLevel.UNVERIFIED_BUT_WAS_PREVIOUSLY
+                            } else {
+                                UserVerificationLevel.WAS_NEVER_VERIFIED
+                            }
                         }
                     } else {
                         // Legacy
                         if (state.allDevicesAreTrusted) {
-                            RoomEncryptionTrustLevel.Trusted
+                            UserVerificationLevel.VERIFIED_ALL_DEVICES_TRUSTED
                         } else {
-                            RoomEncryptionTrustLevel.Warning
+                            UserVerificationLevel.VERIFIED_WITH_DEVICES_UNTRUSTED
                         }
                     }
-                    headerViews.memberProfileDecorationImageView.render(trustLevel)
-                    views.matrixProfileDecorationToolbarAvatarImageView.render(trustLevel)
+                    headerViews.memberProfileDecorationImageView.renderUser(trustLevel)
+                    views.matrixProfileDecorationToolbarAvatarImageView.renderUser(trustLevel)
                 } else {
                     headerViews.memberProfileDecorationImageView.isVisible = false
                 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/members/RoomMemberListController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/members/RoomMemberListController.kt
@@ -129,7 +129,7 @@ class RoomMemberListController @Inject constructor(
             id(roomMember.userId)
             matrixItem(roomMember.toMatrixItem())
             avatarRenderer(host.avatarRenderer)
-            userEncryptionTrustLevel(data.trustLevelMap.invoke()?.get(roomMember.userId))
+            userVerificationLevel(data.trustLevelMap.invoke()?.get(roomMember.userId))
             clickListener {
                 host.callback?.onRoomMemberClicked(roomMember)
             }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/members/RoomMemberListViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/members/RoomMemberListViewState.kt
@@ -23,7 +23,7 @@ import com.airbnb.mvrx.Uninitialized
 import im.vector.app.R
 import im.vector.app.core.platform.GenericIdArgs
 import im.vector.app.features.roomprofile.RoomProfileArgs
-import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel
+import org.matrix.android.sdk.api.session.crypto.model.UserVerificationLevel
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.room.model.RoomMemberSummary
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
@@ -36,7 +36,7 @@ data class RoomMemberListViewState(
         val ignoredUserIds: List<String> = emptyList(),
         val filter: String = "",
         val threePidInvites: Async<List<Event>> = Uninitialized,
-        val trustLevelMap: Async<Map<String, RoomEncryptionTrustLevel?>> = Uninitialized,
+        val trustLevelMap: Async<Map<String, UserVerificationLevel>> = Uninitialized,
         val actionsPermissions: ActionPermissions = ActionPermissions()
 ) : MavericksState {
 

--- a/vector/src/main/java/im/vector/app/features/spaces/people/SpacePeopleListController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/people/SpacePeopleListController.kt
@@ -77,7 +77,7 @@ class SpacePeopleListController @Inject constructor(
                                     id(roomMember.userId)
                                     matrixItem(roomMember.toMatrixItem())
                                     avatarRenderer(host.avatarRenderer)
-                                    userEncryptionTrustLevel(data.trustLevelMap.invoke()?.get(roomMember.userId))
+                                    userVerificationLevel(data.trustLevelMap.invoke()?.get(roomMember.userId))
                                             .apply {
                                                 val pl = host.toPowerLevelLabel(memberEntry.first)
                                                 if (memberEntry.first == RoomMemberListCategories.INVITE) {

--- a/vector/src/test/java/im/vector/app/features/MemberListViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/MemberListViewModelTest.kt
@@ -263,8 +263,8 @@ class MemberListViewModelTest {
         val viewModel = createViewModel()
         viewModel
                 .test()
-                .assertPredicateLatestState {
-                    val trustMap = it.trustLevelMap.invoke() ?: return@assertPredicateLatestState false
+                .assertLatestState {
+                    val trustMap = it.trustLevelMap.invoke() ?: return@assertLatestState false
                     trustMap[aliceMxid] == UserVerificationLevel.VERIFIED_WITH_DEVICES_UNTRUSTED &&
                             trustMap[bobMxid] == UserVerificationLevel.VERIFIED_ALL_DEVICES_TRUSTED &&
                             trustMap[marcMxid] == UserVerificationLevel.UNVERIFIED_BUT_WAS_PREVIOUSLY

--- a/vector/src/test/java/im/vector/app/features/MemberListViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/MemberListViewModelTest.kt
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import com.airbnb.mvrx.test.MvRxTestRule
+import im.vector.app.features.roomprofile.RoomProfileArgs
+import im.vector.app.features.roomprofile.members.RoomMemberListViewModel
+import im.vector.app.features.roomprofile.members.RoomMemberListViewState
+import im.vector.app.features.roomprofile.members.RoomMemberSummaryComparator
+import im.vector.app.test.test
+import im.vector.app.test.testCoroutineDispatchers
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Rule
+import org.junit.Test
+import org.matrix.android.sdk.api.session.Session
+import org.matrix.android.sdk.api.session.crypto.CryptoService
+import org.matrix.android.sdk.api.session.crypto.crosssigning.CrossSigningService
+import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigningKey
+import org.matrix.android.sdk.api.session.crypto.crosssigning.DeviceTrustLevel
+import org.matrix.android.sdk.api.session.crypto.crosssigning.MXCrossSigningInfo
+import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
+import org.matrix.android.sdk.api.session.crypto.model.UserVerificationLevel
+import org.matrix.android.sdk.api.session.room.Room
+import org.matrix.android.sdk.api.session.room.RoomService
+import org.matrix.android.sdk.api.session.room.crypto.RoomCryptoService
+import org.matrix.android.sdk.api.session.room.members.MembershipService
+import org.matrix.android.sdk.api.session.room.model.Membership
+import org.matrix.android.sdk.api.session.room.model.RoomMemberSummary
+import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import org.matrix.android.sdk.api.session.room.state.StateService
+import org.matrix.android.sdk.api.session.user.UserService
+import org.matrix.android.sdk.api.util.Optional
+
+class MemberListViewModelTest {
+
+    @get:Rule
+    val mvrxTestRule = MvRxTestRule()
+
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    private val fakeRoomId = "!roomId"
+    private val args = RoomProfileArgs(fakeRoomId)
+
+    private val aliceMxid = "@alice:example.com"
+    private val bobMxid = "@bob:example.com"
+    private val marcMxid = "@marc:example.com"
+
+    private val aliceDevice1 = CryptoDeviceInfo(
+            deviceId = "ALICE_1",
+            userId = aliceMxid,
+            trustLevel = DeviceTrustLevel(true, true)
+    )
+
+    private val aliceDevice2 = CryptoDeviceInfo(
+            deviceId = "ALICE_2",
+            userId = aliceMxid,
+            trustLevel = DeviceTrustLevel(false, false)
+    )
+
+    private val bobDevice1 = CryptoDeviceInfo(
+            deviceId = "BOB_1",
+            userId = bobMxid,
+            trustLevel = DeviceTrustLevel(true, true)
+    )
+
+    private val bobDevice2 = CryptoDeviceInfo(
+            deviceId = "BOB_2",
+            userId = bobMxid,
+            trustLevel = DeviceTrustLevel(true, true)
+    )
+
+    private val markDevice = CryptoDeviceInfo(
+            deviceId = "MARK_1",
+            userId = marcMxid,
+            trustLevel = DeviceTrustLevel(false, true)
+    )
+
+    private val fakeMembershipservice: MembershipService = mockk {
+
+        val memberList = mutableListOf<RoomMemberSummary>(
+                RoomMemberSummary(Membership.JOIN, aliceMxid, displayName = "Alice"),
+                RoomMemberSummary(Membership.JOIN, bobMxid, displayName = "Bob"),
+                RoomMemberSummary(Membership.JOIN, marcMxid, displayName = "marc")
+        )
+
+        every { getRoomMembers(any()) } returns memberList
+
+        every { getRoomMembersLive(any()) } returns MutableLiveData(memberList)
+
+        every { areAllMembersLoadedLive() } returns MutableLiveData(true)
+
+        coEvery { areAllMembersLoaded() } returns true
+    }
+
+    private val fakeRoomCryptoService: RoomCryptoService = mockk {
+        every { isEncrypted() } returns true
+    }
+    private val fakeRoom: Room = mockk {
+
+        val fakeStateService: StateService = mockk {
+            every { getStateEventLive(any(), any()) } returns MutableLiveData()
+            every { getStateEventsLive(any(), any()) } returns MutableLiveData()
+            every { getStateEvent(any(), any()) } returns null
+        }
+
+        every { stateService() } returns fakeStateService
+
+        every { coroutineDispatchers } returns testCoroutineDispatchers
+
+        every { getRoomSummaryLive() } returns MutableLiveData<Optional<RoomSummary>>(Optional(fakeRoomSummary))
+
+        every { membershipService() } returns fakeMembershipservice
+
+        every { roomCryptoService() } returns fakeRoomCryptoService
+
+        every { roomSummary() } returns fakeRoomSummary
+    }
+
+    private val fakeUserService: UserService = mockk {
+        every { getIgnoredUsersLive() } returns MutableLiveData()
+    }
+
+    val fakeSession: Session = mockk {
+
+        val fakeCrossSigningService: CrossSigningService = mockk {
+            every { isUserTrusted(aliceMxid) } returns true
+            every { isUserTrusted(bobMxid) } returns true
+            every { isUserTrusted(marcMxid) } returns false
+
+            every { getUserCrossSigningKeys(aliceMxid) } returns MXCrossSigningInfo(
+                    aliceMxid,
+                    crossSigningKeys = listOf(
+                            CryptoCrossSigningKey(
+                                    aliceMxid,
+                                    usages = listOf("master"),
+                                    keys = emptyMap(),
+                                    trustLevel = DeviceTrustLevel(true, true),
+                                    signatures = emptyMap()
+                            ),
+                            CryptoCrossSigningKey(
+                                    aliceMxid,
+                                    usages = listOf("self_signing"),
+                                    keys = emptyMap(),
+                                    trustLevel = DeviceTrustLevel(true, true),
+                                    signatures = emptyMap()
+                            ),
+                            CryptoCrossSigningKey(
+                                    aliceMxid,
+                                    usages = listOf("user_signing"),
+                                    keys = emptyMap(),
+                                    trustLevel = DeviceTrustLevel(true, true),
+                                    signatures = emptyMap()
+                            )
+                    ),
+                    true
+            )
+            every { getUserCrossSigningKeys(bobMxid) } returns MXCrossSigningInfo(
+                    aliceMxid,
+                    crossSigningKeys = listOf(
+                            CryptoCrossSigningKey(
+                                    bobMxid,
+                                    usages = listOf("master"),
+                                    keys = emptyMap(),
+                                    trustLevel = DeviceTrustLevel(true, true),
+                                    signatures = emptyMap()
+                            ),
+                            CryptoCrossSigningKey(
+                                    bobMxid,
+                                    usages = listOf("self_signing"),
+                                    keys = emptyMap(),
+                                    trustLevel = DeviceTrustLevel(true, true),
+                                    signatures = emptyMap()
+                            ),
+                            CryptoCrossSigningKey(
+                                    bobMxid,
+                                    usages = listOf("user_signing"),
+                                    keys = emptyMap(),
+                                    trustLevel = DeviceTrustLevel(true, true),
+                                    signatures = emptyMap()
+                            )
+                    ),
+                    true
+            )
+            every { getUserCrossSigningKeys(marcMxid) } returns MXCrossSigningInfo(
+                    aliceMxid,
+                    crossSigningKeys = listOf(
+                            CryptoCrossSigningKey(
+                                    marcMxid,
+                                    usages = listOf("master"),
+                                    keys = emptyMap(),
+                                    trustLevel = DeviceTrustLevel(false, false),
+                                    signatures = emptyMap()
+                            ),
+                            CryptoCrossSigningKey(
+                                    marcMxid,
+                                    usages = listOf("self_signing"),
+                                    keys = emptyMap(),
+                                    trustLevel = DeviceTrustLevel(false, false),
+                                    signatures = emptyMap()
+                            ),
+                            CryptoCrossSigningKey(
+                                    marcMxid,
+                                    usages = listOf("user_signing"),
+                                    keys = emptyMap(),
+                                    trustLevel = DeviceTrustLevel(false, false),
+                                    signatures = emptyMap()
+                            )
+                    ),
+                    true
+            )
+        }
+
+        val fakeCryptoService: CryptoService = mockk {
+            every { crossSigningService() } returns fakeCrossSigningService
+
+            every {
+                getLiveCryptoDeviceInfo(listOf(aliceMxid, bobMxid, marcMxid))
+            } returns MutableLiveData(
+                    listOf(
+                            aliceDevice1, aliceDevice2, bobDevice1, bobDevice2, markDevice
+                    )
+            )
+        }
+
+        val fakeRoomService: RoomService = mockk {
+            every { getRoom(any()) } returns fakeRoom
+        }
+        every { roomService() } returns fakeRoomService
+        every { userService() } returns fakeUserService
+        every { cryptoService() } returns fakeCryptoService
+    }
+
+    private val fakeRoomSummary = RoomSummary(
+            roomId = fakeRoomId,
+            displayName = "Fake Room",
+            topic = "A topic",
+            isEncrypted = true,
+            encryptionEventTs = 0,
+            typingUsers = emptyList(),
+    )
+
+    @Test
+    fun testBasicUserVerificationLevels() {
+        val viewModel = createViewModel()
+        viewModel
+                .test()
+                .assertPredicateLatestState {
+                    val trustMap = it.trustLevelMap.invoke() ?: return@assertPredicateLatestState false
+                    trustMap[aliceMxid] == UserVerificationLevel.VERIFIED_WITH_DEVICES_UNTRUSTED &&
+                            trustMap[bobMxid] == UserVerificationLevel.VERIFIED_ALL_DEVICES_TRUSTED &&
+                            trustMap[marcMxid] == UserVerificationLevel.UNVERIFIED_BUT_WAS_PREVIOUSLY
+                }
+                .finish()
+    }
+
+    private fun createViewModel(): RoomMemberListViewModel {
+        return RoomMemberListViewModel(
+                RoomMemberListViewState(args),
+                RoomMemberSummaryComparator(),
+                fakeSession,
+        )
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/RoomMemberListControllerTest.kt
+++ b/vector/src/test/java/im/vector/app/features/RoomMemberListControllerTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.airbnb.mvrx.Success
+import com.airbnb.mvrx.test.MvRxTestRule
+import im.vector.app.core.epoxy.profiles.ProfileMatrixItemWithPowerLevelWithPresence
+import im.vector.app.features.roomprofile.members.RoomMemberListCategories
+import im.vector.app.features.roomprofile.members.RoomMemberListController
+import im.vector.app.features.roomprofile.members.RoomMemberListViewState
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.matrix.android.sdk.api.session.crypto.model.UserVerificationLevel
+import org.matrix.android.sdk.api.session.room.model.Membership
+import org.matrix.android.sdk.api.session.room.model.RoomMemberSummary
+import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RoomMemberListControllerTest {
+
+    @get:Rule
+    val mvrxTestRule = MvRxTestRule()
+
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    @Test
+    fun testControllerUserVerificationLevel() {
+        val roomListController = RoomMemberListController(
+                avatarRenderer = mockk {
+                },
+                stringProvider = mockk {
+                    every { getString(any()) } answers {
+                        this.args[0].toString()
+                    }
+                },
+                colorProvider = mockk {
+                    every { getColorFromAttribute(any()) } returns 0x0
+                },
+                roomMemberSummaryFilter = mockk(relaxed = true) {
+                    every { test(any()) } returns true
+                }
+        )
+
+        val fakeRoomSummary = RoomSummary(
+                roomId = "!roomId",
+                displayName = "Fake Room",
+                topic = "A topic",
+                isEncrypted = true,
+                encryptionEventTs = 0,
+                typingUsers = emptyList(),
+        )
+
+        val state = RoomMemberListViewState(
+                roomId = "!roomId",
+                roomSummary = Success(fakeRoomSummary),
+                areAllMembersLoaded = true,
+                roomMemberSummaries = Success(
+                        listOf(
+                                RoomMemberListCategories.USER to listOf(
+                                        RoomMemberSummary(
+                                                membership = Membership.JOIN,
+                                                userId = "@alice:example.com"
+                                        ),
+                                        RoomMemberSummary(
+                                                membership = Membership.JOIN,
+                                                userId = "@bob:example.com"
+                                        ),
+                                        RoomMemberSummary(
+                                                membership = Membership.JOIN,
+                                                userId = "@carl:example.com"
+                                        ),
+                                        RoomMemberSummary(
+                                                membership = Membership.JOIN,
+                                                userId = "@massy:example.com"
+                                        )
+                                )
+                        )
+                ),
+                trustLevelMap = Success(
+                        mapOf(
+                                "@alice:example.com" to UserVerificationLevel.UNVERIFIED_BUT_WAS_PREVIOUSLY,
+                                "@bob:example.com" to UserVerificationLevel.VERIFIED_ALL_DEVICES_TRUSTED,
+                                "@carl:example.com" to UserVerificationLevel.WAS_NEVER_VERIFIED,
+                                "@massy:example.com" to UserVerificationLevel.VERIFIED_WITH_DEVICES_UNTRUSTED,
+                        )
+                )
+        )
+
+        roomListController.setData(state)
+
+        val models = roomListController.adapter.copyOfModels
+
+        val profileItems = models.filterIsInstance<ProfileMatrixItemWithPowerLevelWithPresence>()
+
+        profileItems.firstOrNull {
+            it.matrixItem.id == "@alice:example.com"
+        }!!.userVerificationLevel shouldBeEqualTo UserVerificationLevel.UNVERIFIED_BUT_WAS_PREVIOUSLY
+
+        profileItems.firstOrNull {
+            it.matrixItem.id == "@bob:example.com"
+        }!!.userVerificationLevel shouldBeEqualTo UserVerificationLevel.VERIFIED_ALL_DEVICES_TRUSTED
+
+        profileItems.firstOrNull {
+            it.matrixItem.id == "@carl:example.com"
+        }!!.userVerificationLevel shouldBeEqualTo UserVerificationLevel.WAS_NEVER_VERIFIED
+
+        profileItems.firstOrNull {
+            it.matrixItem.id == "@massy:example.com"
+        }!!.userVerificationLevel shouldBeEqualTo UserVerificationLevel.VERIFIED_WITH_DEVICES_UNTRUSTED
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Bugfix

## Content

Fixes #6702 
Parity with web. Show a warning when a previously verified user rotated his cross signing keys.

<!-- Describe shortly what has been changed -->

We now remember locally when a user was verified once.
When/If that user rotate his cross signing keys he will be marked with a red shield instead of black shield.

- Requires a database migration to remember that the user was verfied once
- Refactoring: The shield state of users was using the same enum as rooms `RoomEncryptionTrustLevel`, now I introduced a new enum for users `UserVerificationLevel` that is used in UI to decorate avatars.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
