### PR TITLE
Fix danger reviewers PR comment

### DIFF
--- a/tools/danger/dangerfile.js
+++ b/tools/danger/dangerfile.js
@@ -102,6 +102,6 @@ if (hasPngs) {
 }
 
 // Check for reviewers
-if (github.requested_reviewers.length == 0 && !pr.draft) {
+if (github.requested_reviewers.users.length == 0 && !pr.draft) {
     warn("Please add a reviewer to your PR.")
 }

--- a/tools/danger/dangerfile.js
+++ b/tools/danger/dangerfile.js
@@ -13,7 +13,7 @@ const github = danger.github
 const user = pr.user.login
 const modified = danger.git.modified_files
 const created = danger.git.created_files
-let editedFiles = [...modified, ...created]
+const editedFiles = [...modified, ...created]
 
 // Check that the PR has a description
 if (pr.body.length == 0) {
@@ -30,10 +30,10 @@ const changelogAllowList = [
     "dependabot[bot]",
 ]
 
-let requiresChangelog = !changelogAllowList.includes(user)
+const requiresChangelog = !changelogAllowList.includes(user)
 
 if (requiresChangelog) {
-    let changelogFiles = editedFiles.filter(file => file.startsWith("changelog.d/"))
+    const changelogFiles = editedFiles.filter(file => file.startsWith("changelog.d/"))
 
     if (changelogFiles.length == 0) {
         warn("Please add a changelog. See instructions [here](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog)")
@@ -77,18 +77,18 @@ const allowList = [
     "yostyle",
 ]
 
-let requiresSignOff = !allowList.includes(user)
+const requiresSignOff = !allowList.includes(user)
 
 if (requiresSignOff) {
-    let hasPRBodySignOff = pr.body.includes(signOff)
-    let hasCommitSignOff = danger.git.commits.every(commit => commit.message.includes(signOff))
+    const hasPRBodySignOff = pr.body.includes(signOff)
+    const hasCommitSignOff = danger.git.commits.every(commit => commit.message.includes(signOff))
     if (!hasPRBodySignOff && !hasCommitSignOff) {
         fail("Please add a sign-off to either the PR description or to the commits themselves.")
     }
 }
 
 // Check for screenshots on view changes
-let hasChangedViews = editedFiles.filter(file => file.includes("/layout")).length > 0
+const hasChangedViews = editedFiles.filter(file => file.includes("/layout")).length > 0
 if (hasChangedViews) {
     if (!pr.body.includes("user-images")) {
         warn("You seem to have made changes to views. Please consider adding screenshots.")
@@ -96,7 +96,7 @@ if (hasChangedViews) {
 }
 
 // Check for pngs on resources
-let hasPngs = editedFiles.filter(file => file.toLowerCase().endsWith(".png")).length > 0
+const hasPngs = editedFiles.filter(file => file.toLowerCase().endsWith(".png")).length > 0
 if (hasPngs) {
     warn("You seem to have made changes to some images. Please consider using an vector drawable.")
 }

--- a/tools/danger/dangerfile.js
+++ b/tools/danger/dangerfile.js
@@ -8,6 +8,7 @@ const {danger, warn} = require('danger')
 // warn(JSON.stringify(danger))
 
 const pr = danger.github.pr
+const github = danger.github
 // User who has created the PR.
 const user = pr.user.login
 const modified = danger.git.modified_files
@@ -101,6 +102,6 @@ if (hasPngs) {
 }
 
 // Check for reviewers
-if (pr.requested_reviewers.length == 0 && !pr.draft) {
+if (github.requested_reviewers.length == 0 && !pr.draft) {
     warn("Please add a reviewer to your PR.")
 }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Reads the `requested_reviewers` from the `github` object as per the [dsl reference](https://danger.systems/js/reference.html#GitHubPRDSL)
- Updates all `let`'s to `const` as the values are not mutated

## Motivation and context

To avoid danger incorrectly warning on PRs

## Screenshots / GIFs
N/A


Running locally against this PR (without a changelog or reviewers set) 

```
## Warnings
Please add a changelog. See instructions [here](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog)
-
Please add a reviewer to your PR.
```

![2022-08-02T12:38:22,528696367+01:00](https://user-images.githubusercontent.com/1848238/182365714-fffb101a-a1e6-4ee9-9a5a-1ad4b0d19f42.png)


## Tests
N/A

## Tested devices
N/A 
