### PR TITLE
Fixes crash when entering non ascii username during account creation

### DIFF
--- a/changelog.d/6735.bugfix
+++ b/changelog.d/6735.bugfix
@@ -1,0 +1,1 @@
+Fixes crash when entering non ascii characters during account creation

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
@@ -62,7 +62,10 @@ fun Throwable.isUsernameInUse() = this is Failure.ServerError &&
         error.code == MatrixError.M_USER_IN_USE
 
 fun Throwable.isInvalidUsername() = this is Failure.ServerError &&
-        error.code == MatrixError.M_INVALID_USERNAME
+        (error.code == MatrixError.M_INVALID_USERNAME || usernameContainsNonAsciiCharacters())
+
+private fun Failure.ServerError.usernameContainsNonAsciiCharacters() = error.code == MatrixError.M_UNKNOWN &&
+        error.message == "Query parameter \'username\' must be ascii"
 
 fun Throwable.isInvalidPassword() = this is Failure.ServerError &&
         error.code == MatrixError.M_FORBIDDEN &&

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -391,6 +391,20 @@ class OnboardingViewModelTest {
     }
 
     @Test
+    fun `given available username throws, when a register username is entered, then emits error`() = runTest {
+        viewModelWith(initialRegistrationState(A_HOMESERVER_URL))
+        fakeAuthenticationService.givenRegistrationWizard(FakeRegistrationWizard().also { it.givenUserNameIsAvailableThrows(A_USERNAME, AN_ERROR) })
+        val test = viewModel.test()
+
+        viewModel.handle(OnboardingAction.UserNameEnteredAction.Registration(A_USERNAME))
+
+        test
+                .assertStates(initialState)
+                .assertEvents(OnboardingViewEvents.Failure(AN_ERROR))
+                .finish()
+    }
+
+    @Test
     fun `given available username, when a register username is entered, then emits available registration state`() = runTest {
         viewModelWith(initialRegistrationState(A_HOMESERVER_URL))
         val onlyUsername = "a-username"

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeRegistrationWizard.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeRegistrationWizard.kt
@@ -57,6 +57,10 @@ class FakeRegistrationWizard : RegistrationWizard by mockk(relaxed = false) {
         coEvery { registrationAvailable(userName) } returns RegistrationAvailability.Available
     }
 
+    fun givenUserNameIsAvailableThrows(userName: String, cause: Throwable) {
+        coEvery { registrationAvailable(userName) } throws cause
+    }
+
     fun givenUserNameIsUnavailable(userName: String, failure: Failure.ServerError) {
         coEvery { registrationAvailable(userName) } returns RegistrationAvailability.NotAvailable(failure)
     }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Handles the exception throwing of the username availability check 

## Motivation and context

To avoid a crash when non ascii characters are used in the username during account creation

## Screenshots / GIFs

|Before|After|
|-|-|
|![before-non-ascii-account](https://user-images.githubusercontent.com/1848238/182831158-3469f5fc-5e1b-419d-b9d7-a58146d1faee.gif)|![after-ascii](https://user-images.githubusercontent.com/1848238/182831463-f060da44-5b5a-44dc-9332-a7719915a3e7.gif)|


## Tests

- In the account creation screen
- Enter non ascii characters in the username field


## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28