### PR TITLE
FTUE - Focus errors showing on wrong page

### DIFF
--- a/changelog.d/6737.bugfix
+++ b/changelog.d/6737.bugfix
@@ -1,0 +1,1 @@
+Fixes onboarding login/account creation errors showing after navigation

--- a/vector/src/main/java/im/vector/app/core/extensions/TextInputLayout.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/TextInputLayout.kt
@@ -78,10 +78,15 @@ fun TextInputLayout.setOnImeDoneListener(action: () -> Unit) {
     }
 }
 
-fun TextInputLayout.setOnFocusLostListener(action: () -> Unit) {
+/**
+ * Set a listener for when the input has lost focus, such as moving to the another input field.
+ * The listener is only called when the view is in a resumed state to avoid triggers when exiting a screen.
+ */
+fun TextInputLayout.setOnFocusLostListener(lifecycleOwner: LifecycleOwner, action: () -> Unit) {
+    lifecycleOwner.lifecycle
     editText().setOnFocusChangeListener { _, hasFocus ->
         when (hasFocus) {
-            false -> action()
+            false -> lifecycleOwner.lifecycleScope.launchWhenResumed { action() }
             else -> {
                 // do nothing
             }

--- a/vector/src/main/java/im/vector/app/core/extensions/TextInputLayout.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/TextInputLayout.kt
@@ -83,7 +83,6 @@ fun TextInputLayout.setOnImeDoneListener(action: () -> Unit) {
  * The listener is only called when the view is in a resumed state to avoid triggers when exiting a screen.
  */
 fun TextInputLayout.setOnFocusLostListener(lifecycleOwner: LifecycleOwner, action: () -> Unit) {
-    lifecycleOwner.lifecycle
     editText().setOnFocusChangeListener { _, hasFocus ->
         when (hasFocus) {
             false -> lifecycleOwner.lifecycleScope.launchWhenResumed { action() }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedLoginFragment.kt
@@ -63,7 +63,9 @@ class FtueAuthCombinedLoginFragment @Inject constructor(
         views.loginRoot.realignPercentagesToParent()
         views.editServerButton.debouncedClicks { viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.EditServerSelection)) }
         views.loginPasswordInput.setOnImeDoneListener { submit() }
-        views.loginInput.setOnFocusLostListener { viewModel.handle(OnboardingAction.UserNameEnteredAction.Login(views.loginInput.content())) }
+        views.loginInput.setOnFocusLostListener(viewLifecycleOwner) {
+            viewModel.handle(OnboardingAction.UserNameEnteredAction.Login(views.loginInput.content()))
+        }
         views.loginForgotPassword.debouncedClicks { viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnForgetPasswordClicked)) }
     }
 

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedRegisterFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedRegisterFragment.kt
@@ -86,7 +86,7 @@ class FtueAuthCombinedRegisterFragment @Inject constructor() : AbstractSSOFtueAu
             views.createAccountEntryFooter.text = ""
         }
 
-        views.createAccountInput.setOnFocusLostListener {
+        views.createAccountInput.setOnFocusLostListener(viewLifecycleOwner) {
             viewModel.handle(OnboardingAction.UserNameEnteredAction.Registration(views.createAccountInput.content()))
         }
     }

--- a/vector/src/main/res/layout/fragment_ftue_combined_login.xml
+++ b/vector/src/main/res/layout/fragment_ftue_combined_login.xml
@@ -147,6 +147,7 @@
             app:layout_constraintTop_toBottomOf="@id/serverSelectionSpacing">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/loginEditText"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:imeOptions="actionNext"
@@ -176,6 +177,7 @@
             app:layout_constraintTop_toBottomOf="@id/entrySpacing">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/loginPasswordEditText"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:imeOptions="actionDone"

--- a/vector/src/main/res/layout/fragment_ftue_combined_register.xml
+++ b/vector/src/main/res/layout/fragment_ftue_combined_register.xml
@@ -145,6 +145,7 @@
             app:layout_constraintTop_toBottomOf="@id/serverSelectionSpacing">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/createAccountEditText"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:imeOptions="actionNext"
@@ -186,6 +187,7 @@
             app:layout_constraintTop_toBottomOf="@id/entrySpacing">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/createAccountPassword"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:imeOptions="actionDone"


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Ensures we only execute _lost focus_ checks whilst the screen is still in view
- Adds missing view ids to the input field edit text views 

## Motivation and context

Fixes #6737 

When the username field loses focus we're doing a user name availability check, however this check was also being triggered when navigating away from the page (such as pressing EDIT or back) causing the next page to display the availability result.

Fixed by only checking for availability whilst the username field is visible.

## Screenshots / GIFs

| BEFORE | AFTER |
| --- | --- |
![before-empty-user](https://user-images.githubusercontent.com/1848238/182859166-881d8e77-7f46-4137-9e8c-7e05f57ee8ab.gif)|![after-empty-user](https://user-images.githubusercontent.com/1848238/182859173-df52b55f-43f1-49b2-890b-62e41bda7960.gif)
![before-username](https://user-images.githubusercontent.com/1848238/182859158-8cf02efd-9e72-4612-b735-5b9e54b49b54.gif)|![after-username](https://user-images.githubusercontent.com/1848238/182859180-60d659cf-d330-408a-b52d-99e854c92a50.gif)


## Tests

- Select the username field within account creation
- Tap `EDIT`
- Notice an empty user id error

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):


