### PR TITLE
[Notification] - Handle creation of notification for live location and poll start (PSG-41)

### DIFF
--- a/changelog.d/6746.feature
+++ b/changelog.d/6746.feature
@@ -1,0 +1,1 @@
+[Notification] - Handle creation of notification for live location and poll start

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/MessageBeaconLocationDataContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/MessageBeaconLocationDataContent.kt
@@ -22,7 +22,7 @@ import org.matrix.android.sdk.api.session.events.model.Content
 import org.matrix.android.sdk.api.session.room.model.relation.RelationDefaultContent
 
 /**
- * Content of the state event of type
+ * Content of the event of type
  * [EventType.BEACON_LOCATION_DATA][org.matrix.android.sdk.api.session.events.model.EventType.BEACON_LOCATION_DATA]
  *
  * It contains location data related to a live location share.

--- a/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
@@ -65,9 +65,10 @@ class NotifiableEventResolver @Inject constructor(
         private val buildMeta: BuildMeta,
 ) {
 
-    // private val eventDisplay = RiotEventDisplay(context)
+    private val nonEncryptedNotifiableEventTypes: List<String> =
+            listOf(EventType.MESSAGE) + EventType.POLL_START + EventType.STATE_ROOM_BEACON_INFO
 
-    suspend fun resolveEvent(event: Event/*, roomState: RoomState?, bingRule: PushRule?*/, session: Session, isNoisy: Boolean): NotifiableEvent? {
+    suspend fun resolveEvent(event: Event, session: Session, isNoisy: Boolean): NotifiableEvent? {
         val roomID = event.roomId ?: return null
         val eventId = event.eventId ?: return null
         if (event.getClearType() == EventType.STATE_ROOM_MEMBER) {
@@ -75,7 +76,7 @@ class NotifiableEventResolver @Inject constructor(
         }
         val timelineEvent = session.getRoom(roomID)?.getTimelineEvent(eventId) ?: return null
         return when (event.getClearType()) {
-            EventType.MESSAGE,
+            in nonEncryptedNotifiableEventTypes,
             EventType.ENCRYPTED -> {
                 resolveMessageEvent(timelineEvent, session, canBeReplaced = false, isNoisy = isNoisy)
             }
@@ -161,9 +162,7 @@ class NotifiableEventResolver @Inject constructor(
             event.attemptToDecryptIfNeeded(session)
             // only convert encrypted messages to NotifiableMessageEvents
             when (event.root.getClearType()) {
-                EventType.MESSAGE,
-                in EventType.POLL_START,
-                in EventType.STATE_ROOM_BEACON_INFO -> {
+                in nonEncryptedNotifiableEventTypes -> {
                     val body = displayableEventFormatter.format(event, isDm = room.roomSummary()?.isDirect.orFalse(), appendAuthor = false).toString()
                     val roomName = room.roomSummary()?.displayName ?: ""
                     val senderDisplayName = event.senderInfo.disambiguatedDisplayName


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Adding support for notification creation when receiving live location or poll start events.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6746 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

This cannot really be tested right now since the default push rules on server side have not been deployed yet (need to validate some MSC first). The only notification we can have now is when starting a poll in an encrypted room.
On my side, I have tested it by adding the corresponding push rules on my test account.

In encrypted room: 
- Start a poll 
- Check you receive a notification on another device
- Start a live location share
- Check you don't receive any notification (note the unread notification counter is not correct due to the lack of push rules)

In non-encrypted room:
- Start a poll 
- Check you don't receive any notification (note the unread notification counter is at 0 due to the lack of push rules)
- Start a live location share
- Check you don't receive any notification (note the unread notification counter is at 0 due to the lack of push rules)

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
