### PR TITLE
Fixing flaky `CantVerifyTest`

### DIFF
--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -598,4 +598,5 @@ dependencies {
     androidTestImplementation libs.mockk.mockkAndroid
     androidTestUtil libs.androidx.orchestrator
     debugImplementation libs.androidx.fragmentTesting
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-reflect:1.7.10"
 }

--- a/vector/src/androidTest/java/im/vector/app/CantVerifyTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/CantVerifyTest.kt
@@ -27,6 +27,7 @@ import im.vector.app.features.MainActivity
 import im.vector.app.ui.robot.ElementRobot
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import java.util.UUID
 
@@ -35,7 +36,9 @@ import java.util.UUID
 class CantVerifyTest : VerificationTestBase() {
 
     @get:Rule
-    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+    val testRule = RuleChain
+            .outerRule(ActivityScenarioRule(MainActivity::class.java))
+            .around(ClearCurrentSessionRule())
 
     private val elementRobot = ElementRobot()
     var userName: String = "loginTest_${UUID.randomUUID()}"

--- a/vector/src/androidTest/java/im/vector/app/ClearCurrentSessionRule.kt
+++ b/vector/src/androidTest/java/im/vector/app/ClearCurrentSessionRule.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app
+
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class ClearCurrentSessionRule : TestWatcher() {
+    override fun apply(base: Statement, description: Description): Statement {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        runBlocking {
+            runCatching {
+                val holder = (context.applicationContext as VectorApplication).activeSessionHolder
+                holder.getSafeActiveSession()?.signOutService()?.signOut(true)
+                context.preferencesDataStoreFile(name = "vector_analytics").delete()
+                (context.applicationContext as VectorApplication).vectorPreferences.clearPreferences()
+                holder.clearActiveSession()
+            }
+        }
+        return super.apply(base, description)
+    }
+}

--- a/vector/src/androidTest/java/im/vector/app/ClearCurrentSessionRule.kt
+++ b/vector/src/androidTest/java/im/vector/app/ClearCurrentSessionRule.kt
@@ -28,6 +28,11 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import kotlin.reflect.KClass
 
+/**
+ * A TestRule to reset and clear the current Session.
+ * If a Session is active it will be signed out and cleared from the ActiveSessionHolder.
+ * The VectorPreferences and AnalyticsDatastore are also cleared in an attempt to recreate a fresh base.
+ */
 class ClearCurrentSessionRule : TestWatcher() {
     override fun apply(base: Statement, description: Description): Statement {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -46,6 +51,10 @@ class ClearCurrentSessionRule : TestWatcher() {
 
 private fun KClass<*>.asTopLevel() = Class.forName("${qualifiedName}Kt")
 
+/**
+ * Fetches the top level, private [Context.dataStore] extension property from [im.vector.app.features.analytics.store.AnalyticsStore]
+ * via reflection to avoid exposing property to all callers.
+ */
 @Suppress("UNCHECKED_CAST")
 private fun reflectAnalyticDatastore(context: Context): DataStore<Preferences> {
     val klass = AnalyticsStore::class.asTopLevel()

--- a/vector/src/main/java/im/vector/app/features/analytics/store/AnalyticsStore.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/store/AnalyticsStore.kt
@@ -29,6 +29,9 @@ import kotlinx.coroutines.flow.map
 import org.matrix.android.sdk.api.extensions.orFalse
 import javax.inject.Inject
 
+/**
+ * Also accessed via reflection by the instrumentation tests @see [im.vector.app.ClearCurrentSessionRule].
+ */
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "vector_analytics")
 
 /**


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Adds a test rule to reset an active session in order to force the app to go through the authentication flow

## Motivation and context

- Fixes the `CantVerifyTest` failing if the test is executed after a session has been cached. The test can sometimes be triggered with a cached `Session` which means the app is already logged in. 

## Screenshots / GIFs
No production changes

## Tests

<!-- Explain how you tested your development -->

- Run the `CantVerifyTest` multiple times without clearing data between tests

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 31