### PR TITLE
[Bugfix #5029] disable emoji keyboard not applies to reply

### DIFF
--- a/changelog.d/5029.bugfix
+++ b/changelog.d/5029.bugfix
@@ -1,0 +1,1 @@
+Disable emoji keyboard not applies in reply

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -353,6 +353,8 @@ class TimelineFragment @Inject constructor(
 
     private var lockSendButton = false
     private val currentCallsViewPresenter = CurrentCallsViewPresenter()
+    private val isEmojiKeyboardVisible: Boolean
+        get() = vectorPreferences.showEmojiKeyboard()
 
     private val lazyLoadedViews = RoomDetailLazyLoadedViews()
     private val emojiPopup: EmojiPopup by lifecycleAwareLazy {
@@ -1569,6 +1571,10 @@ class TimelineFragment @Inject constructor(
                     )
                 }
                 attachmentTypeSelector.show(views.composerLayout.views.attachmentButton)
+            }
+
+            override fun onExpandOrCompactChange() {
+                views.composerLayout.views.composerEmojiButton.isVisible = isEmojiKeyboardVisible
             }
 
             override fun onSendMessage(text: CharSequence) {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerView.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerView.kt
@@ -46,6 +46,7 @@ class MessageComposerView @JvmOverloads constructor(
         fun onCloseRelatedMessage()
         fun onSendMessage(text: CharSequence)
         fun onAddAttachment()
+        fun onExpandOrCompactChange()
     }
 
     val views: ComposerLayoutBinding
@@ -96,6 +97,7 @@ class MessageComposerView @JvmOverloads constructor(
         }
         currentConstraintSetId = R.layout.composer_layout_constraint_set_compact
         applyNewConstraintSet(animate, transitionComplete)
+        callback?.onExpandOrCompactChange()
     }
 
     fun expand(animate: Boolean = true, transitionComplete: (() -> Unit)? = null) {
@@ -105,6 +107,7 @@ class MessageComposerView @JvmOverloads constructor(
         }
         currentConstraintSetId = R.layout.composer_layout_constraint_set_expanded
         applyNewConstraintSet(animate, transitionComplete)
+        callback?.onExpandOrCompactChange()
     }
 
     fun setTextIfDifferent(text: CharSequence?): Boolean {

--- a/vector/src/main/res/layout/composer_layout.xml
+++ b/vector/src/main/res/layout/composer_layout.xml
@@ -119,8 +119,10 @@
         android:background="?android:attr/selectableItemBackground"
         android:contentDescription="@string/a11y_open_emoji_picker"
         android:src="@drawable/ic_insert_emoji"
+        android:visibility="invisible"
         app:tint="?vctr_content_tertiary"
-        tools:ignore="MissingConstraints,MissingPrefix" />
+        tools:ignore="MissingConstraints,MissingPrefix"
+        tools:visibility="visible" />
 
     <ImageButton
         android:id="@+id/sendButton"

--- a/vector/src/main/res/layout/composer_layout_constraint_set_compact.xml
+++ b/vector/src/main/res/layout/composer_layout_constraint_set_compact.xml
@@ -155,13 +155,15 @@
         android:background="?android:attr/selectableItemBackground"
         android:contentDescription="@string/a11y_open_emoji_picker"
         android:src="@drawable/ic_insert_emoji"
+        android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="@id/attachmentButton"
         app:layout_constraintEnd_toEndOf="@id/composerEditTextOuterBorder"
         app:layout_constraintStart_toEndOf="@id/composerEditText"
         app:layout_constraintTop_toTopOf="@id/attachmentButton"
         app:layout_goneMarginEnd="8dp"
         app:tint="?vctr_content_quaternary"
-        tools:ignore="MissingPrefix" />
+        tools:ignore="MissingPrefix"
+        tools:visibility="visible" />
 
     <ImageButton
         android:id="@+id/sendButton"

--- a/vector/src/main/res/layout/composer_layout_constraint_set_expanded.xml
+++ b/vector/src/main/res/layout/composer_layout_constraint_set_expanded.xml
@@ -166,6 +166,7 @@
         android:background="?android:attr/selectableItemBackground"
         android:contentDescription="@string/a11y_open_emoji_picker"
         android:src="@drawable/ic_insert_emoji"
+        android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="@id/sendButton"
         app:layout_constraintEnd_toEndOf="@id/composerEditTextOuterBorder"
         app:layout_constraintStart_toEndOf="@id/composerEditText"
@@ -173,7 +174,8 @@
         app:layout_goneMarginBottom="52dp"
         app:layout_goneMarginEnd="8dp"
         app:tint="?vctr_content_quaternary"
-        tools:ignore="MissingPrefix" />
+        tools:ignore="MissingPrefix"
+        tools:visibility="visible" />
 
     <ImageButton
         android:id="@+id/sendButton"


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

When emoji keyboard was disabled in settings, it didn't apply when you replied to a message

## Motivation and context

https://github.com/vector-im/element-android/issues/5029

## Tests

- Disable emoji keyboard
- Open a room
- Reply to a message
- Close reply
- Enable emoji keyboard
- Open a room
- Reply to a message
- Close repoly

## Tested devices

- [x] Physical Pixel 6
- [ ] Emulator
- OS version(s): Android 13 beta

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
