### PR TITLE
replace android:gravity for backward compatibility

### DIFF
--- a/vector/src/main/res/drawable/poll_option_checked.xml
+++ b/vector/src/main/res/drawable/poll_option_checked.xml
@@ -10,5 +10,9 @@
     </item>
     <item
         android:drawable="@drawable/ic_check_on_white"
-        android:gravity="center" />
+        android:top="2dp"
+        android:bottom="2dp"
+        android:left="2dp"
+        android:right="2dp"
+        />
 </layer-list>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Hello,

I found an issue induced by ``android:gravity`` in https://github.com/vector-im/element-android/blob/81897a179e4cbd836c97f86a207d14c84ff85151/vector/src/main/res/drawable/poll_option_checked.xml#L13

This attribute can only be used in layer-list starting from API Level 23. Therefore the padding of the icon is wrong.

This issue can be reproduced when I participate a vote in the chat. You can see the tick is full of the icon at API Level 22.

API Level 31
![2651659840659_ pic](https://user-images.githubusercontent.com/109571086/183273487-ca659d11-56c7-405b-9b48-6dad33ea6843.jpg)

API Level 22
![2661659842281_ pic](https://user-images.githubusercontent.com/109571086/183273508-0b92c891-2363-407d-8884-b66d479ef3aa.jpg)

To fix this issue, I use ``android:top``, ``android:bottom``, ``android:left`` and ``android:right``. 2dp is set by considering the 16dp width and height of tick mark and 20dp width and height of the whole icon. The issue have gone on my side.

Hope the above information is useful 

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x ] Changes has been tested on an Android device or Android emulator with API 21
- [x ] UI change has been tested on both light and dark themes
- [x ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x ] Pull request is based on the develop branch
- [x ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x ] Pull request includes screenshots or videos if containing UI changes
- [x ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x ] You've made a self review of your PR
- [x ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
Signed-off-by: Rudmannn conffix@proton.me