### PR TITLE
Avoid crashes from unknown exceptions on lockscreen key migration.

### DIFF
--- a/changelog.d/6769.bugfix
+++ b/changelog.d/6769.bugfix
@@ -1,0 +1,1 @@
+Catch all exceptions on lockscreen system key migrations.

--- a/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/LockScreenKeysMigrator.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/LockScreenKeysMigrator.kt
@@ -40,7 +40,7 @@ class LockScreenKeysMigrator @Inject constructor(
     suspend fun migrateIfNeeded() {
         if (legacyPinCodeMigrator.isMigrationNeeded()) {
             legacyPinCodeMigrator.migrate()
-            missingSystemKeyMigrator.migrate()
+            missingSystemKeyMigrator.migrateIfNeeded()
         }
 
         if (systemKeyV1Migrator.isMigrationNeeded() && versionProvider.get() >= Build.VERSION_CODES.M) {

--- a/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/migrations/MissingSystemKeyMigrator.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/lockscreen/crypto/migrations/MissingSystemKeyMigrator.kt
@@ -18,8 +18,6 @@ package im.vector.app.features.pin.lockscreen.crypto.migrations
 
 import android.annotation.SuppressLint
 import android.os.Build
-import android.security.keystore.KeyPermanentlyInvalidatedException
-import android.security.keystore.UserNotAuthenticatedException
 import im.vector.app.features.pin.lockscreen.crypto.KeyStoreCrypto
 import im.vector.app.features.pin.lockscreen.di.BiometricKeyAlias
 import im.vector.app.features.settings.VectorPreferences
@@ -41,14 +39,15 @@ class MissingSystemKeyMigrator @Inject constructor(
      * If user had biometric auth enabled, ensure system key exists, creating one if needed.
      */
     @SuppressLint("NewApi")
-    fun migrate() {
+    fun migrateIfNeeded() {
         if (buildVersionSdkIntProvider.get() >= Build.VERSION_CODES.M && vectorPreferences.useBiometricsToUnlock()) {
-            try {
-                keystoreCryptoFactory.provide(systemKeyAlias, true).ensureKey()
-            } catch (e: KeyPermanentlyInvalidatedException) {
-                Timber.e("Could not automatically create biometric key because it was invalidated.", e)
-            } catch (e: UserNotAuthenticatedException) {
-                Timber.e("Could not automatically create biometric key because there are no enrolled biometric authenticators.", e)
+            val systemKeyStoreCrypto = keystoreCryptoFactory.provide(systemKeyAlias, true)
+            runCatching {
+                systemKeyStoreCrypto.ensureKey()
+            }.onFailure { e ->
+                Timber.e(e, "Could not automatically create biometric key. Biometric authentication will be disabled.")
+                systemKeyStoreCrypto.deleteKey()
+                vectorPreferences.setUseBiometricToUnlock(false)
             }
         }
     }

--- a/vector/src/test/java/im/vector/app/features/pin/lockscreen/crypto/migrations/LockScreenKeysMigratorTests.kt
+++ b/vector/src/test/java/im/vector/app/features/pin/lockscreen/crypto/migrations/LockScreenKeysMigratorTests.kt
@@ -26,7 +26,7 @@ import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
-class LockScreenTestMigratorTests {
+class LockScreenKeysMigratorTests {
 
     private val legacyPinCodeMigrator = mockk<LegacyPinCodeMigrator>(relaxed = true)
     private val missingSystemKeyMigrator = mockk<MissingSystemKeyMigrator>(relaxed = true)
@@ -42,7 +42,7 @@ class LockScreenTestMigratorTests {
         runBlocking { migrator.migrateIfNeeded() }
 
         coVerify(exactly = 0) { legacyPinCodeMigrator.migrate() }
-        verify(exactly = 0) { missingSystemKeyMigrator.migrate() }
+        verify(exactly = 0) { missingSystemKeyMigrator.migrateIfNeeded() }
 
         // When migration is needed
         every { legacyPinCodeMigrator.isMigrationNeeded() } returns true
@@ -50,7 +50,7 @@ class LockScreenTestMigratorTests {
         runBlocking { migrator.migrateIfNeeded() }
 
         coVerify { legacyPinCodeMigrator.migrate() }
-        verify { missingSystemKeyMigrator.migrate() }
+        verify { missingSystemKeyMigrator.migrateIfNeeded() }
     }
 
     @Test

--- a/vector/src/test/java/im/vector/app/features/pin/lockscreen/crypto/migrations/MissingSystemKeyMigratorTests.kt
+++ b/vector/src/test/java/im/vector/app/features/pin/lockscreen/crypto/migrations/MissingSystemKeyMigratorTests.kt
@@ -44,7 +44,7 @@ class MissingSystemKeyMigratorTests {
         every { keyStoreCryptoFactory.provide(any(), any()) } returns keyStoreCryptoMock
         every { vectorPreferences.useBiometricsToUnlock() } returns true
 
-        missingSystemKeyMigrator.migrate()
+        missingSystemKeyMigrator.migrateIfNeeded()
 
         verify { keyStoreCryptoMock.ensureKey() }
     }
@@ -57,7 +57,7 @@ class MissingSystemKeyMigratorTests {
         every { keyStoreCryptoFactory.provide(any(), any()) } returns keyStoreCryptoMock
         every { vectorPreferences.useBiometricsToUnlock() } returns true
 
-        invoking { missingSystemKeyMigrator.migrate() } shouldNotThrow KeyPermanentlyInvalidatedException::class
+        invoking { missingSystemKeyMigrator.migrateIfNeeded() } shouldNotThrow KeyPermanentlyInvalidatedException::class
     }
 
     @Test
@@ -68,7 +68,7 @@ class MissingSystemKeyMigratorTests {
         every { keyStoreCryptoFactory.provide(any(), any()) } returns keyStoreCryptoMock
         every { vectorPreferences.useBiometricsToUnlock() } returns true
 
-        invoking { missingSystemKeyMigrator.migrate() } shouldNotThrow UserNotAuthenticatedException::class
+        invoking { missingSystemKeyMigrator.migrateIfNeeded() } shouldNotThrow UserNotAuthenticatedException::class
     }
 
     @Test
@@ -79,7 +79,7 @@ class MissingSystemKeyMigratorTests {
         every { keyStoreCryptoFactory.provide(any(), any()) } returns keyStoreCryptoMock
         every { vectorPreferences.useBiometricsToUnlock() } returns false
 
-        missingSystemKeyMigrator.migrate()
+        missingSystemKeyMigrator.migrateIfNeeded()
 
         verify(exactly = 0) { keyStoreCryptoMock.ensureKey() }
     }
@@ -93,7 +93,7 @@ class MissingSystemKeyMigratorTests {
         every { keyStoreCryptoFactory.provide(any(), any()) } returns keyStoreCryptoMock
         every { vectorPreferences.useBiometricsToUnlock() } returns false
 
-        missingSystemKeyMigrator.migrate()
+        missingSystemKeyMigrator.migrateIfNeeded()
 
         verify(exactly = 0) { keyStoreCryptoMock.ensureKey() }
     }

--- a/vector/src/test/java/im/vector/app/features/pin/lockscreen/crypto/migrations/SystemKeyV1MigratorTests.kt
+++ b/vector/src/test/java/im/vector/app/features/pin/lockscreen/crypto/migrations/SystemKeyV1MigratorTests.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.pin.lockscreen.crypto.migrations
 
 import android.security.keystore.UserNotAuthenticatedException
 import im.vector.app.features.pin.lockscreen.crypto.KeyStoreCrypto
+import im.vector.app.features.settings.VectorPreferences
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -31,7 +32,8 @@ class SystemKeyV1MigratorTests {
 
     private val keyStoreCryptoFactory = mockk<KeyStoreCrypto.Factory>()
     private val keyStore = mockk<KeyStore>(relaxed = true)
-    private val systemKeyV1Migrator = SystemKeyV1Migrator("vector.system_new", keyStore, keyStoreCryptoFactory)
+    private val vectorPreferences = mockk<VectorPreferences>(relaxed = true)
+    private val systemKeyV1Migrator = SystemKeyV1Migrator("vector.system_new", keyStore, keyStoreCryptoFactory, vectorPreferences)
 
     @Test
     fun isMigrationNeededReturnsTrueIfV1KeyExists() {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes #6769 .

## Motivation and context

During lockscreen biometric key migrations, both `UserNotAuthenticatedException` and `KeyPermanentlyInvalidatedException` were caught, but there are many other possible exceptions that can be thrown. If any exceptions are thrown, we'll catch them, disable biometric authentication, then show pin code authentication.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Install a version < 1.4.31 (1.4.27 maybe?).
- Make sure you have biometric authentication enabled on your device.
- Enable biometric auth in Settings > Security and Privacy > Protect access. You'll need to enable pin code auth, then biometric one.
- Close the app.
- Disable biometric authentication on your *device* (delete all fingerprints, disable face unlock, etc.).
- Upgrade to this version and launch the app.

If the app doesn't crash, everything is fine. Biometric authentication should be disabled in this case too.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 12, 11.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
