### PR TITLE
Disabling unsupported play store language

### DIFF
--- a/tools/release/pushPlayStoreMetaData.sh
+++ b/tools/release/pushPlayStoreMetaData.sh
@@ -28,6 +28,7 @@ mv ./fastlane/metadata/android/fy  ./fastlane_tmp
 mv ./fastlane/metadata/android/ga  ./fastlane_tmp
 mv ./fastlane/metadata/android/kab ./fastlane_tmp
 mv ./fastlane/metadata/android/nb  ./fastlane_tmp
+mv ./fastlane/metadata/android/gl  ./fastlane_tmp
 
 # Fastlane / PlayStore require longDescription and shortDescription file to be set, so copy the default
 # one for languages where they are missing


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Relase script / Localisation

## Content

Marks the `gl` locale as ignored from the play store upload process as it's unsupported 

```
http_command.rb:236:in `check_status': \e[31m[!] Invalid request\e[0m (Google::Apis::ClientError)

The requested language is not currently supported: gl
```

## Motivation and context

To fix the `tools/release/pushPlayStoreMetaData.sh` release script

## Screenshots / GIFs
No UI changes

## Tests
N/A

## Tested devices
N/A