### PR TITLE
Improve tests for lockscreen

### DIFF
--- a/vector/src/main/java/im/vector/app/features/pin/lockscreen/ui/LockScreenViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/pin/lockscreen/ui/LockScreenViewState.kt
@@ -27,11 +27,11 @@ data class LockScreenViewState(
         val isBiometricKeyInvalidated: Boolean,
 ) : MavericksState {
     constructor(lockScreenConfiguration: LockScreenConfiguration) : this(
-            lockScreenConfiguration, false, false, PinCodeState.Idle, false
+            lockScreenConfiguration, false, false, PinCodeState.Idle, false,
     )
 }
 
 sealed class PinCodeState {
     object Idle : PinCodeState()
-    object FirstCodeEntered : PinCodeState()
+    data class FirstCodeEntered(val pinCode: String) : PinCodeState()
 }

--- a/vector/src/test/java/im/vector/app/features/pin/lockscreen/fragment/LockScreenViewModelTests.kt
+++ b/vector/src/test/java/im/vector/app/features/pin/lockscreen/fragment/LockScreenViewModelTests.kt
@@ -276,13 +276,12 @@ class LockScreenViewModelTests {
 
         exception.isAuthDisabledError.shouldBeTrue()
         events.assertValues(LockScreenViewEvent.AuthError(AuthMethod.BIOMETRICS, exception))
-        viewModel.test().states.assertLatestValue { !it.canUseBiometricAuth }
+        viewModel.test().assertLatestState { !it.canUseBiometricAuth }
     }
 
     @Test
     fun `when OnUIReady action is received and showBiometricPromptAutomatically is true it shows prompt`() = runTest {
-        // To force showBiometricPromptAutomatically to be true
-        every { biometricHelper.isSystemAuthEnabledAndValid } returns true
+        givenShowBiometricPromptAutomatically()
         val viewModel = LockScreenViewModel(createViewState(), pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
         val events = viewModel.test().viewEvents
         viewModel.handle(LockScreenAction.OnUIReady)
@@ -291,9 +290,7 @@ class LockScreenViewModelTests {
 
     @Test
     fun `when OnUIReady action is received and isBiometricKeyInvalidated is true it shows prompt`() = runTest {
-        // To force isBiometricKeyInvalidated to be true
-        every { biometricHelper.hasSystemKey } returns true
-        every { biometricHelper.isSystemKeyValid } returns false
+        givenBiometricKeyIsInvalidated()
         val viewModel = LockScreenViewModel(createViewState(), pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
         val events = viewModel.test().viewEvents
         viewModel.handle(LockScreenAction.OnUIReady)
@@ -326,4 +323,13 @@ class LockScreenViewModelTests {
             isDeviceCredentialUnlockEnabled,
             needsNewCodeValidation
     ).let(otherChanges)
+
+    private fun givenBiometricKeyIsInvalidated() {
+        every { biometricHelper.hasSystemKey } returns true
+        every { biometricHelper.isSystemKeyValid } returns false
+    }
+
+    private fun givenShowBiometricPromptAutomatically() {
+        every { biometricHelper.isSystemAuthEnabledAndValid } returns true
+    }
 }

--- a/vector/src/test/java/im/vector/app/features/pin/lockscreen/fragment/LockScreenViewModelTests.kt
+++ b/vector/src/test/java/im/vector/app/features/pin/lockscreen/fragment/LockScreenViewModelTests.kt
@@ -121,7 +121,7 @@ class LockScreenViewModelTests {
     }
 
     @Test
-    fun `when onPinCodeEntered is called in VERIFY mode and verification is successful, the code is verified and the result is emitted as a ViewEvent`() = runTest {
+    fun `when onPinCodeEntered is called in VERIFY mode and verification is successful, code is verified and result is emitted as a ViewEvent`() = runTest {
         // given
         val initialState = createViewState()
         val viewModel = LockScreenViewModel(initialState, pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)

--- a/vector/src/test/java/im/vector/app/features/pin/lockscreen/fragment/LockScreenViewModelTests.kt
+++ b/vector/src/test/java/im/vector/app/features/pin/lockscreen/fragment/LockScreenViewModelTests.kt
@@ -44,10 +44,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeEqualTo
 import org.junit.Before
@@ -79,138 +76,141 @@ class LockScreenViewModelTests {
 
     @Test
     fun `init migrates old keys to new ones if needed`() {
+        // given
         val initialState = createViewState()
+        // when
         LockScreenViewModel(initialState, pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
-
+        // then
         coVerify { keysMigrator.migrateIfNeeded() }
     }
 
     @Test
     fun `init updates the initial state with biometric info`() = runTest {
+        // given
         every { biometricHelper.isSystemAuthEnabledAndValid } returns true
         val initialState = createViewState()
+        // when
         val viewModel = LockScreenViewModel(initialState, pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
-        advanceUntilIdle()
-        val newState = viewModel.awaitState()
+        // then
+        val newState = viewModel.awaitState() // Can't use viewModel.test() here since we want to record events emitted on init
         newState shouldNotBeEqualTo initialState
     }
 
     @Test
     fun `Updating the initial state with biometric info waits until device is unlocked on Android 12+`() = runTest {
+        // given
         val initialState = createViewState()
         versionProvider.value = Build.VERSION_CODES.S
+        // when
         LockScreenViewModel(initialState, pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
-        advanceUntilIdle()
+        // then
         verify { keyguardManager.isDeviceLocked }
     }
 
     @Test
     fun `when ViewModel is instantiated initialState is updated with biometric info`() {
+        // given
+        givenShowBiometricPromptAutomatically()
         val initialState = createViewState()
-        // This should set canUseBiometricAuth to true
-        every { biometricHelper.isSystemAuthEnabledAndValid } returns true
+        // when
         val viewModel = LockScreenViewModel(initialState, pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
-        val newState = withState(viewModel) { it }
-        initialState shouldNotBeEqualTo newState
+        // then
+        withState(viewModel) { newState ->
+            initialState shouldNotBeEqualTo newState
+        }
     }
 
     @Test
-    fun `when onPinCodeEntered is called in VERIFY mode, the code is verified and the result is emitted as a ViewEvent`() = runTest {
+    fun `when onPinCodeEntered is called in VERIFY mode and verification is successful, the code is verified and the result is emitted as a ViewEvent`() = runTest {
+        // given
         val initialState = createViewState()
         val viewModel = LockScreenViewModel(initialState, pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
         coEvery { pinCodeHelper.verifyPinCode(any()) } returns true
-
-        val events = viewModel.test().viewEvents
-        events.assertNoValues()
-
-        val stateBefore = viewModel.awaitState()
-
+        val test = viewModel.test()
+        // when
         viewModel.handle(LockScreenAction.PinCodeEntered("1234"))
+        // then
         coVerify { pinCodeHelper.verifyPinCode(any()) }
-        events.assertValues(LockScreenViewEvent.AuthSuccessful(AuthMethod.PIN_CODE))
+        test.assertEvents(LockScreenViewEvent.AuthSuccessful(AuthMethod.PIN_CODE))
+        test.assertStates(initialState)
+    }
 
+    @Test
+    fun `when onPinCodeEntered is called in VERIFY mode and verification fails, the error result is emitted as a ViewEvent`() = runTest {
+        // given
+        val initialState = createViewState()
+        val viewModel = LockScreenViewModel(initialState, pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
         coEvery { pinCodeHelper.verifyPinCode(any()) } returns false
+        val test = viewModel.test()
+        // when
         viewModel.handle(LockScreenAction.PinCodeEntered("1234"))
-        events.assertValues(LockScreenViewEvent.AuthSuccessful(AuthMethod.PIN_CODE), LockScreenViewEvent.AuthFailure(AuthMethod.PIN_CODE))
-
-        val stateAfter = viewModel.awaitState()
-        stateBefore shouldBeEqualTo stateAfter
+        // then
+        coVerify { pinCodeHelper.verifyPinCode(any()) }
+        test.assertEvents(LockScreenViewEvent.AuthFailure(AuthMethod.PIN_CODE))
+        test.assertStates(initialState)
     }
 
     @Test
     fun `when onPinCodeEntered is called in CREATE mode with no confirmation needed it creates the pin code`() = runTest {
+        // given
         val configuration = createDefaultConfiguration(mode = LockScreenMode.CREATE, needsNewCodeValidation = false)
         val initialState = createViewState(lockScreenConfiguration = configuration)
         val viewModel = LockScreenViewModel(initialState, pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
-
-        val events = viewModel.test().viewEvents
-        events.assertNoValues()
-
+        val test = viewModel.test()
+        // when
         viewModel.handle(LockScreenAction.PinCodeEntered("1234"))
+        // then
         coVerify { pinCodeHelper.createPinCode(any()) }
-
-        events.assertValues(LockScreenViewEvent.CodeCreationComplete)
+        test.assertEvents(LockScreenViewEvent.CodeCreationComplete)
     }
 
     @Test
     fun `when onPinCodeEntered is called twice in CREATE mode with confirmation needed it verifies and creates the pin code`() = runTest {
+        // given
+        val pinCode = "1234"
         val configuration = createDefaultConfiguration(mode = LockScreenMode.CREATE, needsNewCodeValidation = true)
-        val initialState = createViewState(lockScreenConfiguration = configuration)
+        val initialState = createViewState(lockScreenConfiguration = configuration, pinCodeState = PinCodeState.FirstCodeEntered(pinCode))
         val viewModel = LockScreenViewModel(initialState, pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
-
-        val events = viewModel.test().viewEvents
-        events.assertNoValues()
-
-        viewModel.handle(LockScreenAction.PinCodeEntered("1234"))
-
-        events.assertValues(LockScreenViewEvent.ClearPinCode(false))
-        val pinCodeState = viewModel.awaitState().pinCodeState
-        pinCodeState shouldBeEqualTo PinCodeState.FirstCodeEntered
-
-        viewModel.handle(LockScreenAction.PinCodeEntered("1234"))
-        events.assertValues(LockScreenViewEvent.ClearPinCode(false), LockScreenViewEvent.CodeCreationComplete)
+        val test = viewModel.test()
+        // when
+        viewModel.handle(LockScreenAction.PinCodeEntered(pinCode))
+        // then
+        test.assertEvents(LockScreenViewEvent.CodeCreationComplete)
+                .assertLatestState { (it.pinCodeState as? PinCodeState.FirstCodeEntered)?.pinCode == pinCode }
     }
 
     @Test
     fun `when onPinCodeEntered is called in CREATE mode with incorrect confirmation it clears the pin code`() = runTest {
+        // given
         val configuration = createDefaultConfiguration(mode = LockScreenMode.CREATE, needsNewCodeValidation = true)
-        val initialState = createViewState(lockScreenConfiguration = configuration)
+        val initialState = createViewState(lockScreenConfiguration = configuration, pinCodeState = PinCodeState.FirstCodeEntered("1234"))
         val viewModel = LockScreenViewModel(initialState, pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
-
-        val events = viewModel.test().viewEvents
-        events.assertNoValues()
-
-        viewModel.handle(LockScreenAction.PinCodeEntered("1234"))
-
-        events.assertValues(LockScreenViewEvent.ClearPinCode(false))
-        val pinCodeState = viewModel.awaitState().pinCodeState
-        pinCodeState shouldBeEqualTo PinCodeState.FirstCodeEntered
-
+        val test = viewModel.test()
+        // when
         viewModel.handle(LockScreenAction.PinCodeEntered("4321"))
-        events.assertValues(LockScreenViewEvent.ClearPinCode(false), LockScreenViewEvent.ClearPinCode(true))
-        val newPinCodeState = viewModel.awaitState().pinCodeState
-        newPinCodeState shouldBeEqualTo PinCodeState.Idle
+        // then
+        test.assertEvents(LockScreenViewEvent.ClearPinCode(true))
+                .assertLatestState(initialState.copy(pinCodeState = PinCodeState.Idle))
     }
 
     @Test
     fun `onPinCodeEntered handles exceptions`() = runTest {
+        // given
         val initialState = createViewState()
         val viewModel = LockScreenViewModel(initialState, pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
         val exception = IllegalStateException("Something went wrong")
         coEvery { pinCodeHelper.verifyPinCode(any()) } throws exception
-
-        val events = viewModel.test().viewEvents
-        events.assertNoValues()
-
+        val test = viewModel.test()
+        // when
         viewModel.handle(LockScreenAction.PinCodeEntered("1234"))
-
-        events.assertValues(LockScreenViewEvent.AuthError(AuthMethod.PIN_CODE, exception))
+        // then
+        test.assertEvents(LockScreenViewEvent.AuthError(AuthMethod.PIN_CODE, exception))
     }
 
     @Test
     fun `when showBiometricPrompt catches a KeyPermanentlyInvalidatedException it disables biometric authentication`() = runTest {
+        // given
         versionProvider.value = Build.VERSION_CODES.M
-
         every { biometricHelper.isSystemKeyValid } returns false
         val exception = KeyPermanentlyInvalidatedException()
         coEvery { biometricHelper.authenticate(any<FragmentActivity>()) } throws exception
@@ -221,80 +221,78 @@ class LockScreenViewModelTests {
                 lockScreenConfiguration = configuration
         )
         val viewModel = LockScreenViewModel(initialState, pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
-
-        val events = viewModel.test().viewEvents
-        events.assertNoValues()
-
+        val test = viewModel.test()
+        // when
         viewModel.handle(LockScreenAction.ShowBiometricPrompt(mockk()))
-
-        events.assertValues(LockScreenViewEvent.ShowBiometricKeyInvalidatedMessage)
+        // then
+        test.assertEvents(LockScreenViewEvent.ShowBiometricKeyInvalidatedMessage)
+                // Biometric key is invalidated so biometric auth is disabled
+                .assertLatestState { !it.canUseBiometricAuth }
         verify { biometricHelper.disableAuthentication() }
-
-        // System key was deleted, biometric auth should be disabled
-        every { biometricHelper.isSystemAuthEnabledAndValid } returns false
-        val newState = viewModel.awaitState()
-        newState.canUseBiometricAuth.shouldBeFalse()
     }
 
     @Test
     fun `when showBiometricPrompt receives an event it propagates it as a ViewEvent`() = runTest {
+        // given
         val viewModel = LockScreenViewModel(createViewState(), pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
         coEvery { biometricHelper.authenticate(any<FragmentActivity>()) } returns flowOf(false, true)
-
-        val events = viewModel.test().viewEvents
-        events.assertNoValues()
-
+        val test = viewModel.test()
+        // when
         viewModel.handle(LockScreenAction.ShowBiometricPrompt(mockk()))
-
-        events.assertValues(LockScreenViewEvent.AuthFailure(AuthMethod.BIOMETRICS), LockScreenViewEvent.AuthSuccessful(AuthMethod.BIOMETRICS))
+        // then
+        test.assertEvents(LockScreenViewEvent.AuthFailure(AuthMethod.BIOMETRICS), LockScreenViewEvent.AuthSuccessful(AuthMethod.BIOMETRICS))
     }
 
     @Test
     fun `showBiometricPrompt handles exceptions`() = runTest {
+        // given
         val viewModel = LockScreenViewModel(createViewState(), pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
         val exception = IllegalStateException("Something went wrong")
         coEvery { biometricHelper.authenticate(any<FragmentActivity>()) } throws exception
-
-        val events = viewModel.test().viewEvents
-        events.assertNoValues()
-
+        val test = viewModel.test()
+        // when
         viewModel.handle(LockScreenAction.ShowBiometricPrompt(mockk()))
-
-        events.assertValues(LockScreenViewEvent.AuthError(AuthMethod.BIOMETRICS, exception))
+        // then
+        test.assertEvents(LockScreenViewEvent.AuthError(AuthMethod.BIOMETRICS, exception))
     }
 
     @Test
     fun `when showBiometricPrompt handles isAuthDisabledError, canUseBiometricAuth becomes false`() = runTest {
+        // given
         val viewModel = LockScreenViewModel(createViewState(), pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
         val exception = BiometricAuthError(BiometricPrompt.ERROR_LOCKOUT_PERMANENT, "Permanent lockout")
         coEvery { biometricHelper.authenticate(any<FragmentActivity>()) } throws exception
-
-        val events = viewModel.test().viewEvents
-        events.assertNoValues()
-
+        val test = viewModel.test()
+        // when
         viewModel.handle(LockScreenAction.ShowBiometricPrompt(mockk()))
-
+        // then
         exception.isAuthDisabledError.shouldBeTrue()
-        events.assertValues(LockScreenViewEvent.AuthError(AuthMethod.BIOMETRICS, exception))
-        viewModel.test().assertLatestState { !it.canUseBiometricAuth }
+        test.assertEvents(LockScreenViewEvent.AuthError(AuthMethod.BIOMETRICS, exception))
+                .assertLatestState { !it.canUseBiometricAuth }
     }
 
     @Test
     fun `when OnUIReady action is received and showBiometricPromptAutomatically is true it shows prompt`() = runTest {
+        // given
         givenShowBiometricPromptAutomatically()
         val viewModel = LockScreenViewModel(createViewState(), pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
-        val events = viewModel.test().viewEvents
+        val test = viewModel.test()
+        // when
         viewModel.handle(LockScreenAction.OnUIReady)
-        events.assertLatestValue(LockScreenViewEvent.ShowBiometricPromptAutomatically)
+        // then
+        test.assertEvents(LockScreenViewEvent.ShowBiometricPromptAutomatically)
     }
 
     @Test
     fun `when OnUIReady action is received and isBiometricKeyInvalidated is true it shows prompt`() = runTest {
+        // given
         givenBiometricKeyIsInvalidated()
         val viewModel = LockScreenViewModel(createViewState(), pinCodeHelper, biometricHelperFactory, keysMigrator, versionProvider, keyguardManager)
-        val events = viewModel.test().viewEvents
+        val test = viewModel.test()
+        // when
         viewModel.handle(LockScreenAction.OnUIReady)
-        events.assertLatestValue(LockScreenViewEvent.ShowBiometricKeyInvalidatedMessage)
+        // then
+        test.assertEvents(LockScreenViewEvent.ShowBiometricKeyInvalidatedMessage)
     }
 
         private fun createViewState(

--- a/vector/src/test/java/im/vector/app/test/Extensions.kt
+++ b/vector/src/test/java/im/vector/app/test/Extensions.kt
@@ -22,6 +22,7 @@ import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.core.platform.VectorViewModelAction
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import org.junit.Assert
 
 fun String.trimIndentOneLine() = trimIndent().replace("\n", "")
 
@@ -88,6 +89,11 @@ class ViewModelTest<S, VE>(
 
     fun assertLatestState(expected: S): ViewModelTest<S, VE> {
         states.assertLatestValue(expected)
+        return this
+    }
+
+    fun assertLatestState(predicate: (S) -> Boolean): ViewModelTest<S, VE> {
+        states.assertLatestValue(predicate)
         return this
     }
 

--- a/vector/src/test/java/im/vector/app/test/Extensions.kt
+++ b/vector/src/test/java/im/vector/app/test/Extensions.kt
@@ -22,7 +22,6 @@ import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.core.platform.VectorViewModelAction
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import org.junit.Assert
 
 fun String.trimIndentOneLine() = trimIndent().replace("\n", "")
 

--- a/vector/src/test/java/im/vector/app/test/FlowTestObserver.kt
+++ b/vector/src/test/java/im/vector/app/test/FlowTestObserver.kt
@@ -47,6 +47,11 @@ class FlowTestObserver<T>(
         return this
     }
 
+    fun assertLatestValue(predicate: (T) -> Boolean): FlowTestObserver<T> {
+        assertTrue(predicate(values.last()))
+        return this
+    }
+
     fun assertLatestValue(value: T) {
         assertTrue(values.last() == value)
     }

--- a/vector/src/test/java/im/vector/app/test/FlowTestObserver.kt
+++ b/vector/src/test/java/im/vector/app/test/FlowTestObserver.kt
@@ -52,8 +52,9 @@ class FlowTestObserver<T>(
         return this
     }
 
-    fun assertLatestValue(value: T) {
-        assertTrue(values.last() == value)
+    fun assertLatestValue(value: T): FlowTestObserver<T> {
+        assertEquals(value, values.last())
+        return this
     }
 
     fun assertValues(values: List<T>): FlowTestObserver<T> {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

A few new tests for lockscreen.

## Motivation and context

Improving coverage and making sure we won't break the feature with new changes in the future

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

- Run unit tests.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
