### PR TITLE
Reduce boilerplate with some minor sdk improvements

### DIFF
--- a/changelog.d/6799.misc
+++ b/changelog.d/6799.misc
@@ -1,0 +1,1 @@
+[Create Room] Reduce some boilerplate with room state event contents

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomGuestAccessContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomGuestAccessContent.kt
@@ -29,14 +29,12 @@ data class RoomGuestAccessContent(
         // Required. Whether guests can join the room. One of: ["can_join", "forbidden"]
         @Json(name = "guest_access") val guestAccessStr: String? = null
 ) {
-    val guestAccess: GuestAccess? = when (guestAccessStr) {
-        "can_join" -> GuestAccess.CanJoin
-        "forbidden" -> GuestAccess.Forbidden
-        else -> {
-            Timber.w("Invalid value for GuestAccess: `$guestAccessStr`")
-            null
-        }
-    }
+    val guestAccess: GuestAccess? = GuestAccess.values()
+            .find { it.value == guestAccessStr }
+            ?: run {
+                Timber.w("Invalid value for GuestAccess: `$guestAccessStr`")
+                null
+            }
 }
 
 @JsonClass(generateAdapter = false)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomHistoryVisibility.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomHistoryVisibility.kt
@@ -23,30 +23,30 @@ import com.squareup.moshi.JsonClass
  * Ref: https://matrix.org/docs/spec/client_server/latest#room-history-visibility
  */
 @JsonClass(generateAdapter = false)
-enum class RoomHistoryVisibility {
+enum class RoomHistoryVisibility(val value: String) {
     /**
      * All events while this is the m.room.history_visibility value may be shared by any
      * participating homeserver with anyone, regardless of whether they have ever joined the room.
      */
-    @Json(name = "world_readable") WORLD_READABLE,
+    @Json(name = "world_readable") WORLD_READABLE("world_readable"),
 
     /**
      * Previous events are always accessible to newly joined members. All events in the
      * room are accessible, even those sent when the member was not a part of the room.
      */
-    @Json(name = "shared") SHARED,
+    @Json(name = "shared") SHARED("shared"),
 
     /**
      * Events are accessible to newly joined members from the point they were invited onwards.
      * Events stop being accessible when the member's state changes to something other than invite or join.
      */
-    @Json(name = "invited") INVITED,
+    @Json(name = "invited") INVITED("invited"),
 
     /**
      * Events are accessible to newly joined members from the point they joined the room onwards.
      * Events stop being accessible when the member's state changes to something other than join.
      */
-    @Json(name = "joined") JOINED
+    @Json(name = "joined") JOINED("joined")
 }
 
 /**

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomHistoryVisibilityContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/RoomHistoryVisibilityContent.kt
@@ -24,14 +24,10 @@ import timber.log.Timber
 data class RoomHistoryVisibilityContent(
         @Json(name = "history_visibility") val historyVisibilityStr: String? = null
 ) {
-    val historyVisibility: RoomHistoryVisibility? = when (historyVisibilityStr) {
-        "world_readable" -> RoomHistoryVisibility.WORLD_READABLE
-        "shared" -> RoomHistoryVisibility.SHARED
-        "invited" -> RoomHistoryVisibility.INVITED
-        "joined" -> RoomHistoryVisibility.JOINED
-        else -> {
-            Timber.w("Invalid value for RoomHistoryVisibility: `$historyVisibilityStr`")
-            null
-        }
-    }
+    val historyVisibility: RoomHistoryVisibility? = RoomHistoryVisibility.values()
+            .find { it.value == historyVisibilityStr }
+            ?: run {
+                Timber.w("Invalid value for RoomHistoryVisibility: `$historyVisibilityStr`")
+                null
+            }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/create/RoomFeaturePreset.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/create/RoomFeaturePreset.kt
@@ -16,7 +16,6 @@
 
 package org.matrix.android.sdk.api.session.room.model.create
 
-import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilities
@@ -30,7 +29,7 @@ interface RoomFeaturePreset {
 
     fun updateRoomParams(params: CreateRoomParams)
 
-    fun setupInitialStates(): List<Event>?
+    fun setupInitialStates(): List<CreateRoomStateEvent>?
 }
 
 class RestrictedRoomPreset(val homeServerCapabilities: HomeServerCapabilities, val restrictedList: List<RoomJoinRulesAllowEntry>) : RoomFeaturePreset {
@@ -41,9 +40,9 @@ class RestrictedRoomPreset(val homeServerCapabilities: HomeServerCapabilities, v
         params.roomVersion = homeServerCapabilities.versionOverrideForFeature(HomeServerCapabilities.ROOM_CAP_RESTRICTED)
     }
 
-    override fun setupInitialStates(): List<Event>? {
+    override fun setupInitialStates(): List<CreateRoomStateEvent> {
         return listOf(
-                Event(
+                CreateRoomStateEvent(
                         type = EventType.STATE_ROOM_JOIN_RULES,
                         stateKey = "",
                         content = RoomJoinRulesContent(

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomBodyBuilder.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomBodyBuilder.kt
@@ -20,8 +20,13 @@ import org.matrix.android.sdk.api.crypto.MXCRYPTO_ALGORITHM_MEGOLM
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
+import org.matrix.android.sdk.api.session.events.model.content.EncryptionEventContent
+import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.identity.IdentityServiceError
 import org.matrix.android.sdk.api.session.identity.toMedium
+import org.matrix.android.sdk.api.session.room.model.RoomAvatarContent
+import org.matrix.android.sdk.api.session.room.model.RoomGuestAccessContent
+import org.matrix.android.sdk.api.session.room.model.RoomHistoryVisibilityContent
 import org.matrix.android.sdk.api.session.room.model.create.CreateRoomParams
 import org.matrix.android.sdk.api.util.MimeTypes
 import org.matrix.android.sdk.internal.crypto.DeviceListManager
@@ -133,7 +138,7 @@ internal class CreateRoomBodyBuilder @Inject constructor(
             Event(
                     type = EventType.STATE_ROOM_AVATAR,
                     stateKey = "",
-                    content = mapOf("url" to response.contentUri)
+                    content = RoomAvatarContent(response.contentUri).toContent()
             )
         }
     }
@@ -144,7 +149,7 @@ internal class CreateRoomBodyBuilder @Inject constructor(
                     Event(
                             type = EventType.STATE_ROOM_HISTORY_VISIBILITY,
                             stateKey = "",
-                            content = mapOf("history_visibility" to it)
+                            content = RoomHistoryVisibilityContent(it.value).toContent()
                     )
                 }
     }
@@ -155,7 +160,7 @@ internal class CreateRoomBodyBuilder @Inject constructor(
                     Event(
                             type = EventType.STATE_ROOM_GUEST_ACCESS,
                             stateKey = "",
-                            content = mapOf("guest_access" to it.value)
+                            content = RoomGuestAccessContent(it.value).toContent()
                     )
                 }
     }
@@ -177,7 +182,7 @@ internal class CreateRoomBodyBuilder @Inject constructor(
                     Event(
                             type = EventType.STATE_ROOM_ENCRYPTION,
                             stateKey = "",
-                            content = mapOf("algorithm" to it)
+                            content = EncryptionEventContent(it).toContent()
                     )
                 }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomBodyBuilder.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateRoomBodyBuilder.kt
@@ -78,7 +78,7 @@ internal class CreateRoomBodyBuilder @Inject constructor(
                         buildAvatarEvent(params),
                         buildGuestAccess(params)
                 ) +
-                        params.featurePreset?.setupInitialStates().orEmpty() +
+                        buildFeaturePresetInitialStates(params) +
                         buildCustomInitialStates(params)
                 )
                 .takeIf { it.isNotEmpty() }
@@ -97,6 +97,16 @@ internal class CreateRoomBodyBuilder @Inject constructor(
                 powerLevelContentOverride = params.powerLevelContentOverride,
                 roomVersion = params.roomVersion
         )
+    }
+
+    private fun buildFeaturePresetInitialStates(params: CreateRoomParams): List<Event> {
+        return params.featurePreset?.setupInitialStates().orEmpty().map {
+            Event(
+                    type = it.type,
+                    stateKey = it.stateKey,
+                    content = it.content
+            )
+        }
     }
 
     private fun buildCustomInitialStates(params: CreateRoomParams): List<Event> {


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other :

## Content

Improve some sdk stuff:
- Provide JSON keys inside enum fields as a `value` for `GuestAccess` and `RoomHistoryVisibility` (It is already the case for some existing enums) -> It limits the duplication of the keys by having them in a single place
- Replace manual mapping with the related `Content` models in `CreateRoomBodyBuilder` -> it removes some JSON keys duplication and adds clarity to the code
- Replace the return type of `RoomFeaturePreset.setupInitialStates` from a `List<Event>` to a `List<CreateRoomStateEvent>` to be consistent with `CreateRoomParams.initialStates`

## Motivation and context

Further developments related to #5525 

## Tests

By creating rooms in order to trigger the modified code, adding breakpoints and checking that the code was correctly executed.

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
