### PR TITLE
Add inputType for room name creation and settings

### DIFF
--- a/changelog.d/6645.misc
+++ b/changelog.d/6645.misc
@@ -1,0 +1,1 @@
+Enable auto-capitalization for Room creation Title field

--- a/vector/src/main/java/im/vector/app/features/form/FormEditTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/form/FormEditTextItem.kt
@@ -135,16 +135,9 @@ abstract class FormEditTextItem : VectorEpoxyModel<FormEditTextItem.Holder>(R.la
      */
     private fun configureInputType(holder: Holder) {
         val newInputType =
-                inputType ?: when (singleLine) {
-                    true ->  {
-                        if (autoCapitalize) InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
-                        else InputType.TYPE_CLASS_TEXT
-                    }
-                    false -> {
-                        if (autoCapitalize) InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE or InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
-                        else InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
-                    }
-                }
+                inputType ?: InputType.TYPE_CLASS_TEXT
+                        .let { if (autoCapitalize) it or InputType.TYPE_TEXT_FLAG_CAP_SENTENCES else it }
+                        .let { if (!singleLine) it or InputType.TYPE_TEXT_FLAG_MULTI_LINE else it }
 
         // This is a must in order to avoid extreme lag in some devices, on fast typing
         if (holder.textInputEditText.inputType != newInputType) {

--- a/vector/src/main/java/im/vector/app/features/form/FormEditTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/form/FormEditTextItem.kt
@@ -59,6 +59,9 @@ abstract class FormEditTextItem : VectorEpoxyModel<FormEditTextItem.Holder>(R.la
     var singleLine: Boolean = true
 
     @EpoxyAttribute
+    var autoCapitalize: Boolean = false
+
+    @EpoxyAttribute
     var imeOptions: Int? = null
 
     @EpoxyAttribute
@@ -133,8 +136,14 @@ abstract class FormEditTextItem : VectorEpoxyModel<FormEditTextItem.Holder>(R.la
     private fun configureInputType(holder: Holder) {
         val newInputType =
                 inputType ?: when (singleLine) {
-                    true -> InputType.TYPE_CLASS_TEXT
-                    false -> InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+                    true ->  {
+                        if (autoCapitalize) InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
+                        else InputType.TYPE_CLASS_TEXT
+                    }
+                    false -> {
+                        if (autoCapitalize) InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE or InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
+                        else InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+                    }
                 }
 
         // This is a must in order to avoid extreme lag in some devices, on fast typing

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomController.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.features.roomdirectory.createroom
 
+import android.text.InputType
 import com.airbnb.epoxy.TypedEpoxyController
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
@@ -67,6 +68,7 @@ class CreateRoomController @Inject constructor(
             enabled(enableFormElement)
             value(viewState.roomName)
             hint(host.stringProvider.getString(R.string.create_room_name_hint))
+            inputType(InputType.TYPE_TEXT_FLAG_CAP_SENTENCES)
 
             onTextChange { text ->
                 host.listener?.onNameChange(text)

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomController.kt
@@ -68,7 +68,7 @@ class CreateRoomController @Inject constructor(
             enabled(enableFormElement)
             value(viewState.roomName)
             hint(host.stringProvider.getString(R.string.create_room_name_hint))
-            inputType(InputType.TYPE_TEXT_FLAG_CAP_SENTENCES)
+            autoCapitalize(true)
 
             onTextChange { text ->
                 host.listener?.onNameChange(text)

--- a/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomdirectory/createroom/CreateRoomController.kt
@@ -16,7 +16,6 @@
 
 package im.vector.app.features.roomdirectory.createroom
 
-import android.text.InputType
 import com.airbnb.epoxy.TypedEpoxyController
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsController.kt
@@ -16,7 +16,6 @@
 
 package im.vector.app.features.roomprofile.settings
 
-import android.text.InputType
 import com.airbnb.epoxy.TypedEpoxyController
 import im.vector.app.R
 import im.vector.app.core.epoxy.dividerItem

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsController.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.features.roomprofile.settings
 
+import android.text.InputType
 import com.airbnb.epoxy.TypedEpoxyController
 import im.vector.app.R
 import im.vector.app.core.epoxy.dividerItem
@@ -91,6 +92,7 @@ class RoomSettingsController @Inject constructor(
             enabled(data.actionPermissions.canChangeName)
             value(data.newName ?: roomSummary.displayName)
             hint(host.stringProvider.getString(R.string.room_settings_name_hint))
+            inputType(InputType.TYPE_TEXT_FLAG_CAP_SENTENCES)
 
             onTextChange { text ->
                 host.callback?.onNameChanged(text)

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsController.kt
@@ -92,7 +92,7 @@ class RoomSettingsController @Inject constructor(
             enabled(data.actionPermissions.canChangeName)
             value(data.newName ?: roomSummary.displayName)
             hint(host.stringProvider.getString(R.string.room_settings_name_hint))
-            inputType(InputType.TYPE_TEXT_FLAG_CAP_SENTENCES)
+            autoCapitalize(true)
 
             onTextChange { text ->
                 host.callback?.onNameChanged(text)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [X] Other : Enable auto-capitalization for Room creation Title field and Room settings

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context
#6645 
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [X] Changes has been tested on an Android device or Android emulator with API 21
- [X] UI change has been tested on both light and dark themes
- [] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
