### PR TITLE
[Devices Management] Header view for sessions lists in new layout (PSG-668)

### DIFF
--- a/changelog.d/6806.wip
+++ b/changelog.d/6806.wip
@@ -1,0 +1,1 @@
+[Devices management] Other sessions section in new layout

--- a/library/ui-styles/src/main/res/values/stylable_devices_list_header_view.xml
+++ b/library/ui-styles/src/main/res/values/stylable_devices_list_header_view.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <declare-styleable name="DevicesListHeaderView">
+        <attr name="devicesListHeaderTitle" format="string" />
+        <attr name="devicesListHeaderDescription" format="string" />
+    </declare-styleable>
+
+</resources>

--- a/library/ui-styles/src/main/res/values/styles_devices_management.xml
+++ b/library/ui-styles/src/main/res/values/styles_devices_management.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="TextAppearance.Vector.Subtitle.Medium.DevicesManagement">
+        <item name="android:textColor">?vctr_content_primary</item>
+    </style>
+
+    <style name="TextAppearance.Vector.Body.DevicesManagement">
+        <item name="android:textColor">?vctr_content_secondary</item>
+    </style>
+
+</resources>

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
@@ -553,7 +553,7 @@ class VectorSettingsSecurityPrivacyFragment @Inject constructor(
         showDeviceListPref.summary = resources.getQuantityString(R.plurals.settings_active_sessions_count, devices.size, devices.size)
 
         showDevicesListV2Pref.isVisible = vectorFeatures.isNewDeviceManagementEnabled()
-        showDevicesListV2Pref.title = getString(R.string.settings_active_sessions_show_all) + " (V2, WIP)"
+        showDevicesListV2Pref.title = getString(R.string.device_manager_settings_active_sessions_show_all)
         showDevicesListV2Pref.summary = resources.getQuantityString(R.plurals.settings_active_sessions_count, devices.size, devices.size)
 
         val userId = session.myUserId

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
@@ -553,7 +553,7 @@ class VectorSettingsSecurityPrivacyFragment @Inject constructor(
         showDeviceListPref.summary = resources.getQuantityString(R.plurals.settings_active_sessions_count, devices.size, devices.size)
 
         showDevicesListV2Pref.isVisible = vectorFeatures.isNewDeviceManagementEnabled()
-        showDevicesListV2Pref.title = showDevicesListV2Pref.title.toString() + " (V2, WIP)"
+        showDevicesListV2Pref.title = getString(R.string.settings_active_sessions_show_all) + " (V2, WIP)"
         showDevicesListV2Pref.summary = resources.getQuantityString(R.plurals.settings_active_sessions_count, devices.size, devices.size)
 
         val userId = session.myUserId

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
@@ -17,8 +17,11 @@
 package im.vector.app.features.settings.devices.v2
 
 import android.content.Context
+import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
@@ -45,5 +48,25 @@ class VectorSettingsDevicesFragment @Inject constructor() : VectorBaseFragment<F
         (activity as? AppCompatActivity)
                 ?.supportActionBar
                 ?.setTitle(R.string.settings_sessions_list)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initLearnMoreButtons()
+    }
+
+    override fun onDestroyView() {
+        cleanUpLearnMoreButtonsListeners()
+        super.onDestroyView()
+    }
+
+    private fun initLearnMoreButtons() {
+        views.devicesListHeaderSectionOther.onLearnMoreClickListener = {
+            Toast.makeText(context, "Learn more other", Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun cleanUpLearnMoreButtonsListeners() {
+        views.devicesListHeaderSectionOther.onLearnMoreClickListener = null
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/DevicesListHeaderView.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/DevicesListHeaderView.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices.v2.list
+
+import android.content.Context
+import android.content.res.TypedArray
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.res.use
+import im.vector.app.R
+import im.vector.app.databinding.ViewDevicesListHeaderBinding
+
+class DevicesListHeaderView @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0
+) : ConstraintLayout(context, attrs, defStyleAttr) {
+
+    private val binding = ViewDevicesListHeaderBinding.inflate(
+            LayoutInflater.from(context),
+            this
+    )
+
+    init {
+        context.obtainStyledAttributes(
+                attrs,
+                R.styleable.DevicesListHeaderView,
+                0,
+                0
+        ).use {
+            setTitle(it)
+            setDescription(it)
+        }
+    }
+
+    private fun setTitle(typedArray: TypedArray) {
+        val title = typedArray.getString(R.styleable.DevicesListHeaderView_devicesListHeaderTitle)
+        binding.devicesListHeaderTitle.text = title
+    }
+
+    private fun setDescription(typedArray: TypedArray) {
+        val description = typedArray.getString(R.styleable.DevicesListHeaderView_devicesListHeaderDescription)
+        binding.devicesListHeaderDescription.text = description
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/DevicesListHeaderView.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/DevicesListHeaderView.kt
@@ -23,6 +23,7 @@ import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.res.use
 import im.vector.app.R
+import im.vector.app.core.extensions.setTextWithColoredPart
 import im.vector.app.databinding.ViewDevicesListHeaderBinding
 
 class DevicesListHeaderView @JvmOverloads constructor(
@@ -35,6 +36,8 @@ class DevicesListHeaderView @JvmOverloads constructor(
             LayoutInflater.from(context),
             this
     )
+
+    var onLearnMoreClickListener: (() -> Unit)? = null
 
     init {
         context.obtainStyledAttributes(
@@ -55,6 +58,18 @@ class DevicesListHeaderView @JvmOverloads constructor(
 
     private fun setDescription(typedArray: TypedArray) {
         val description = typedArray.getString(R.styleable.DevicesListHeaderView_devicesListHeaderDescription)
-        binding.devicesListHeaderDescription.text = description
+        val learnMore = context.getString(R.string.action_learn_more)
+        val stringBuilder = StringBuilder()
+        stringBuilder.append(description)
+        stringBuilder.append(" ")
+        stringBuilder.append(learnMore)
+
+        binding.devicesListHeaderDescription.setTextWithColoredPart(
+                fullText = stringBuilder.toString(),
+                coloredPart = learnMore,
+                underline = false
+        ) {
+            onLearnMoreClickListener?.invoke()
+        }
     }
 }

--- a/vector/src/main/res/layout/fragment_settings_devices.xml
+++ b/vector/src/main/res/layout/fragment_settings_devices.xml
@@ -2,8 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="?android:colorBackground">
+    android:layout_height="match_parent">
 
     <im.vector.app.features.settings.devices.v2.list.DevicesListHeaderView
         android:id="@+id/devices_list_header_section_other"

--- a/vector/src/main/res/layout/fragment_settings_devices.xml
+++ b/vector/src/main/res/layout/fragment_settings_devices.xml
@@ -6,6 +6,7 @@
     android:background="?android:colorBackground">
 
     <im.vector.app.features.settings.devices.v2.list.DevicesListHeaderView
+        android:id="@+id/devices_list_header_section_other"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:devicesListHeaderDescription="@string/settings_sessions_other_description"

--- a/vector/src/main/res/layout/fragment_settings_devices.xml
+++ b/vector/src/main/res/layout/fragment_settings_devices.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?android:colorBackground" />
+    android:background="?android:colorBackground">
+
+    <im.vector.app.features.settings.devices.v2.list.DevicesListHeaderView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:devicesListHeaderDescription="@string/settings_sessions_other_description"
+        app:devicesListHeaderTitle="@string/settings_sessions_other_title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/main/res/layout/view_devices_list_header.xml
+++ b/vector/src/main/res/layout/view_devices_list_header.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
+
+    <TextView
+        android:id="@+id/devices_list_header_title"
+        style="@style/TextAppearance.Vector.Subtitle.Medium.DevicesManagement"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/layout_horizontal_margin"
+        android:layout_marginTop="20dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Other sessions" />
+
+    <TextView
+        android:id="@+id/devices_list_header_description"
+        style="@style/TextAppearance.Vector.Body.DevicesManagement"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="18.5dp"
+        android:layout_marginEnd="40dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/devices_list_header_title"
+        app:layout_constraintTop_toBottomOf="@id/devices_list_header_title"
+        tools:text="For best security, verify your sessions and sign out from any session that you don’t recognize or use anymore. Learn More." />
+</merge>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -2337,6 +2337,8 @@
     <string name="settings_active_sessions_manage">Manage Sessions</string>
     <string name="settings_active_sessions_signout_device">Sign out of this session</string>
     <string name="settings_sessions_list">Sessions</string>
+    <string name="settings_sessions_other_title">Other sessions</string>
+    <string name="settings_sessions_other_description">For best security, verify your sessions and sign out from any session that you don’t recognize or use anymore.</string>
 
     <string name="settings_server_name">Server name</string>
     <string name="settings_server_version">Server version</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -3198,4 +3198,7 @@
     <!-- Element Call Widget -->
     <string name="labs_enable_element_call_permission_shortcuts">Enable Element Call permission shortcuts</string>
     <string name="labs_enable_element_call_permission_shortcuts_summary">Auto-approve Element Call widgets and grant camera / mic access</string>
+
+    <!-- Device Manager -->
+    <string name="device_manager_settings_active_sessions_show_all">Show All Sessions (V2, WIP)</string>
 </resources>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Adding a nex custom view for headers which will be used in sessions lists in the new layout.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
See #6806 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

<img src="https://user-images.githubusercontent.com/46314705/184133507-4935cfc7-e920-41ac-8645-d6efb6a6677a.png" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/184133514-1e522f47-2af0-43ca-bdbb-4aecd2a55440.png" width=300 />

## Tests

<!-- Explain how you tested your development -->

- Enable the new device management feature flag
- Go to "Security & Privacy" settings
- Press the "Show all sessions (V2, WIP)" entry
- Check the header for "Other sessions" section is visible
- Press "Learn more"
- Check there is a toast displayed

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
