### PR TITLE
[Call] Memory leak after a call

### DIFF
--- a/changelog.d/6808.misc
+++ b/changelog.d/6808.misc
@@ -1,0 +1,1 @@
+[Call] Memory leak after a call

--- a/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/call/VectorCallActivity.kt
@@ -241,6 +241,7 @@ class VectorCallActivity :
         detachRenderersIfNeeded()
         turnScreenOffAndKeyguardOn()
         removeOnPictureInPictureModeChangedListener(pictureInPictureModeChangedInfoConsumer)
+        screenCaptureServiceConnection.unbind()
         super.onDestroy()
     }
 

--- a/vector/src/main/java/im/vector/app/features/call/webrtc/ScreenCaptureServiceConnection.kt
+++ b/vector/src/main/java/im/vector/app/features/call/webrtc/ScreenCaptureServiceConnection.kt
@@ -47,6 +47,10 @@ class ScreenCaptureServiceConnection @Inject constructor(
         }
     }
 
+    fun unbind() {
+        callback = null
+    }
+
     fun stopScreenCapturing() {
         screenCaptureAndroidService?.stopService()
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Fixing memory leak

## Content

<!-- Describe shortly what has been changed -->
Setting the callback to `null` in `ScreenCaptureServiceConnection` when `VectorCallActivity` is destroyed.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6808 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Enable the developer mode
- Enable the memory leak analysis in the debug settings
- Start a call in a room
- End the call
- Check there is no leak detected by LeakCanary

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
