### PR TITLE
Try to fix Danger job

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -16,3 +16,5 @@ jobs:
           args: "--dangerfile tools/danger/dangerfile.js"
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          # Fallback for forks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -71,6 +71,8 @@ jobs:
           args: "--dangerfile tools/danger/dangerfile-lint.js"
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          # Fallback for forks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Gradle dependency analysis using https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin
   dependency-analysis:

--- a/docs/danger.md
+++ b/docs/danger.md
@@ -85,6 +85,8 @@ To let Danger check all the PRs, including PRs form forks, a GitHub account have
 - password: Stored on Passbolt
 - GitHub token: A token with limited access has been created and added to the repository https://github.com/vector-im/element-android as secret DANGER_GITHUB_API_TOKEN. This token is not saved anywhere else. In case of problem, just delete it and create a new one, then update the secret.
 
+PRs from forks do not always have access to the secret `secrets.DANGER_GITHUB_API_TOKEN`, so `secrets.GITHUB_TOKEN` is also provided to the job environment. If `secrets.DANGER_GITHUB_API_TOKEN` is available, it will be used, so user `ElementBot` will comment the PR. Else `secrets.GITHUB_TOKEN` will be used, and bot `github-actions` will comment the PR.
+
 ## Useful links
 
 - https://danger.systems/


### PR DESCRIPTION
Copied from the doc in this PR:

> PRs from forks do not always have access to the secret `secrets.DANGER_GITHUB_API_TOKEN`, so `secrets.GITHUB_TOKEN` is also provided to the job environment. If `secrets.DANGER_GITHUB_API_TOKEN` is available, it will be used, so user `ElementBot` will comment the PR. Else `secrets.GITHUB_TOKEN` will be used, and bot `github-actions` will comment the PR.

Doing some test, it seems fine for internal and external PR.

Let see with this solution how it will behave.

No changelog required, but happy to see that @ElementBot is commenting correctly this PR!