### PR TITLE
FTUE - Crash fixes

### DIFF
--- a/changelog.d/6855.bugfix
+++ b/changelog.d/6855.bugfix
@@ -1,0 +1,1 @@
+Fixes onboarding captcha crashing when no WebView is available by showing an error with information instead

--- a/changelog.d/6860.bugfix
+++ b/changelog.d/6860.bugfix
@@ -1,0 +1,1 @@
+Removes ability to continue registration after the app has been destroyed, fixes the next steps crashing due to missing information from the previous steps

--- a/changelog.d/6861.bugfix
+++ b/changelog.d/6861.bugfix
@@ -1,0 +1,1 @@
+Fixes crash when exiting the login or registration entry screens whilst they're loading

--- a/vector/src/main/java/im/vector/app/core/extensions/Throwable.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/Throwable.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.extensions
+
+/**
+ * Recursive through the throwable and its causes for the given predicate
+ *
+ * @return true when the predicate finds a match
+ */
+tailrec fun Throwable?.crawlCausesFor(predicate: (Throwable) -> Boolean): Boolean {
+    return when {
+        this == null -> false
+        else -> {
+            when (predicate(this)) {
+                true -> true
+                else -> this.cause.crawlCausesFor(predicate)
+            }
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/core/extensions/Throwable.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/Throwable.kt
@@ -17,9 +17,9 @@
 package im.vector.app.core.extensions
 
 /**
- * Recursive through the throwable and its causes for the given predicate
+ * Recursive through the throwable and its causes for the given predicate.
  *
- * @return true when the predicate finds a match
+ * @return true when the predicate finds a match.
  */
 tailrec fun Throwable?.crawlCausesFor(predicate: (Throwable) -> Boolean): Boolean {
     return when {

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -71,7 +71,7 @@ import java.util.concurrent.CancellationException
  *
  */
 class OnboardingViewModel @AssistedInject constructor(
-        @Assisted initialState: OnboardingViewState,
+        @Assisted private val initialState: OnboardingViewState,
         private val applicationContext: Context,
         private val authenticationService: AuthenticationService,
         private val activeSessionHolder: ActiveSessionHolder,
@@ -122,9 +122,6 @@ class OnboardingViewModel @AssistedInject constructor(
 
     private val registrationWizard: RegistrationWizard
         get() = authenticationService.getRegistrationWizard()
-
-    val currentThreePid: String?
-        get() = registrationWizard.getCurrentThreePid()
 
     // True when login and password has been sent with success to the homeserver
     val isRegistrationStarted: Boolean
@@ -492,17 +489,6 @@ class OnboardingViewModel @AssistedInject constructor(
 
     private fun handleInitWith(action: OnboardingAction.InitWith) {
         loginConfig = action.loginConfig
-        // If there is a pending email validation continue on this step
-        try {
-            if (registrationWizard.isRegistrationStarted()) {
-                currentThreePid?.let {
-                    handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.OnSendEmailSuccess(it, isRestoredSession = true)))
-                }
-            }
-        } catch (e: Throwable) {
-            // NOOP. API is designed to use wizards in a login/registration flow,
-            // but we need to check the state anyway.
-        }
     }
 
     private fun handleResetPassword(action: OnboardingAction.ResetPassword) {

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -71,7 +71,7 @@ import java.util.concurrent.CancellationException
  *
  */
 class OnboardingViewModel @AssistedInject constructor(
-        @Assisted private val initialState: OnboardingViewState,
+        @Assisted initialState: OnboardingViewState,
         private val applicationContext: Context,
         private val authenticationService: AuthenticationService,
         private val activeSessionHolder: ActiveSessionHolder,

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCaptchaFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCaptchaFragment.kt
@@ -25,6 +25,7 @@ import android.view.ViewStub
 import com.airbnb.mvrx.args
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import im.vector.app.R
+import im.vector.app.core.extensions.crawlCausesFor
 import im.vector.app.databinding.FragmentFtueLoginCaptchaBinding
 import im.vector.app.databinding.ViewStubWebviewBinding
 import im.vector.app.features.onboarding.OnboardingAction
@@ -98,18 +99,6 @@ private fun ViewStub.inflateWebView(onError: (Throwable) -> Unit) {
             onError(MissingWebViewException(e))
         } else {
             onError(e)
-        }
-    }
-}
-
-private fun Throwable?.crawlCausesFor(predicate: (Throwable) -> Boolean): Boolean {
-    return when {
-        this == null -> false
-        else -> {
-            when (predicate(this)) {
-                true -> true
-                else -> this.cause.crawlCausesFor(predicate)
-            }
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCaptchaFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCaptchaFragment.kt
@@ -16,15 +16,22 @@
 
 package im.vector.app.features.onboarding.ftueauth
 
+import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
+import android.view.ViewStub
 import com.airbnb.mvrx.args
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import im.vector.app.R
 import im.vector.app.databinding.FragmentFtueLoginCaptchaBinding
+import im.vector.app.databinding.ViewStubWebviewBinding
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewState
 import im.vector.app.features.onboarding.RegisterAction
 import kotlinx.parcelize.Parcelize
+import org.matrix.android.sdk.api.extensions.orFalse
 import javax.inject.Inject
 
 @Parcelize
@@ -40,10 +47,32 @@ class FtueAuthCaptchaFragment @Inject constructor(
 ) : AbstractFtueAuthFragment<FragmentFtueLoginCaptchaBinding>() {
 
     private val params: FtueAuthCaptchaFragmentArgument by args()
+    private var webViewBinding: ViewStubWebviewBinding? = null
     private var isWebViewLoaded = false
 
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentFtueLoginCaptchaBinding {
-        return FragmentFtueLoginCaptchaBinding.inflate(inflater, container, false)
+        return FragmentFtueLoginCaptchaBinding.inflate(inflater, container, false).also {
+            it.loginCaptchaWebViewStub.setOnInflateListener { _, inflated ->
+                webViewBinding = ViewStubWebviewBinding.bind(inflated)
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        inflateWebViewOrShowError()
+    }
+
+    private fun inflateWebViewOrShowError() {
+        views.loginCaptchaWebViewStub.inflateWebView(onError = {
+            MaterialAlertDialogBuilder(requireActivity())
+                    .setTitle(R.string.dialog_title_error)
+                    .setMessage(it.localizedMessage)
+                    .setPositiveButton(R.string.ok) { _, _ ->
+                        requireActivity().recreate()
+                    }
+                    .show()
+        })
     }
 
     override fun resetViewModel() {
@@ -51,11 +80,38 @@ class FtueAuthCaptchaFragment @Inject constructor(
     }
 
     override fun updateWithState(state: OnboardingViewState) {
-        if (!isWebViewLoaded) {
-            captchaWebview.setupWebView(this, views.loginCaptchaWevView, views.loginCaptchaProgress, params.siteKey, state) {
+        if (!isWebViewLoaded && webViewBinding != null) {
+            captchaWebview.setupWebView(this, webViewBinding!!.root, views.loginCaptchaProgress, params.siteKey, state) {
                 viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.CaptchaDone(it)))
             }
             isWebViewLoaded = true
         }
     }
 }
+
+private fun ViewStub.inflateWebView(onError: (Throwable) -> Unit) {
+    try {
+        inflate()
+    } catch (e: Exception) {
+        val isMissingWebView = e.crawlCausesFor { it.message?.contains("MissingWebViewPackageException").orFalse() }
+        if (isMissingWebView) {
+            onError(MissingWebViewException(e))
+        } else {
+            onError(e)
+        }
+    }
+}
+
+private fun Throwable?.crawlCausesFor(predicate: (Throwable) -> Boolean): Boolean {
+    return when {
+        this == null -> false
+        else -> {
+            when (predicate(this)) {
+                true -> true
+                else -> this.cause.crawlCausesFor(predicate)
+            }
+        }
+    }
+}
+
+private class MissingWebViewException(cause: Throwable) : IllegalStateException("Failed to load WebView provider: No WebView installed", cause)

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -264,7 +264,7 @@ class FtueAuthVariant(
     }
 
     private fun openStartCombinedRegister() {
-        addRegistrationStageFragmentToBackstack(FtueAuthCombinedRegisterFragment::class.java)
+        addRegistrationStageFragmentToBackstack(FtueAuthCombinedRegisterFragment::class.java, allowStateLoss = true)
     }
 
     private fun displayFallbackWebDialog() {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -260,7 +260,7 @@ class FtueAuthVariant(
     }
 
     private fun onStartCombinedLogin() {
-        addRegistrationStageFragmentToBackstack(FtueAuthCombinedLoginFragment::class.java)
+        addRegistrationStageFragmentToBackstack(FtueAuthCombinedLoginFragment::class.java, allowStateLoss = true)
     }
 
     private fun openStartCombinedRegister() {
@@ -519,13 +519,14 @@ class FtueAuthVariant(
         )
     }
 
-    private fun addRegistrationStageFragmentToBackstack(fragmentClass: Class<out Fragment>, params: Parcelable? = null) {
+    private fun addRegistrationStageFragmentToBackstack(fragmentClass: Class<out Fragment>, params: Parcelable? = null, allowStateLoss: Boolean = false) {
         activity.addFragmentToBackstack(
                 views.loginFragmentContainer,
                 fragmentClass,
                 params,
                 tag = FRAGMENT_REGISTRATION_STAGE_TAG,
-                option = commonOption
+                option = commonOption,
+                allowStateLoss = allowStateLoss,
         )
     }
 

--- a/vector/src/main/res/layout/fragment_ftue_login_captcha.xml
+++ b/vector/src/main/res/layout/fragment_ftue_login_captcha.xml
@@ -64,15 +64,27 @@
         android:id="@+id/titleContentSpacing"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@id/loginCaptchaWevView"
+        app:layout_constraintBottom_toTopOf="@id/loginWebViewBarrier"
         app:layout_constraintHeight_percent="0.03"
         app:layout_constraintTop_toBottomOf="@id/captchaHeaderTitle" />
 
-    <WebView
-        android:id="@+id/loginCaptchaWevView"
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/loginWebViewBarrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:constraint_referenced_ids="loginCaptchaWebViewStub,loginCaptchaWebView"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/captchaGutterEnd"
+        app:layout_constraintStart_toStartOf="@id/captchaGutterStart"
+        app:layout_constraintTop_toBottomOf="@id/titleContentSpacing"/>
+
+    <ViewStub
+        android:id="@+id/loginCaptchaWebViewStub"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/login_a11y_captcha_container"
+        android:layout="@layout/view_stub_webview"
+        android:inflatedId="@+id/loginCaptchaWebView"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@id/captchaGutterEnd"
         app:layout_constraintStart_toStartOf="@id/captchaGutterStart"

--- a/vector/src/main/res/layout/view_stub_webview.xml
+++ b/vector/src/main/res/layout/view_stub_webview.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WebView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -192,21 +192,6 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given registration started with currentThreePid, when handling InitWith, then emits restored session OnSendEmailSuccess`() = runTest {
-        val test = viewModel.test()
-        fakeAuthenticationService.givenRegistrationWizard(FakeRegistrationWizard().also {
-            it.givenRegistrationStarted(hasStarted = true)
-            it.givenCurrentThreePid(AN_EMAIL)
-        })
-
-        viewModel.handle(OnboardingAction.InitWith(LoginConfig(A_HOMESERVER_URL, identityServerUrl = null)))
-
-        test
-                .assertEvents(OnboardingViewEvents.OnSendEmailSuccess(AN_EMAIL, isRestoredSession = true))
-                .finish()
-    }
-
-    @Test
     fun `given registration not started, when handling InitWith, then does nothing`() = runTest {
         val test = viewModel.test()
         fakeAuthenticationService.givenRegistrationWizard(FakeRegistrationWizard().also { it.givenRegistrationStarted(hasStarted = false) })


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Removes the ability to continue the account creation process after the app has been destroyed. This was not taking into account the missing data from the previous onboarding steps, causing the `OnboardingViewState` to be in an invalid empty state. Fixes #6860
- Replaces the captcha `WebView` xml declaration with a `ViewStub` which try/catches the inflation. Allows us to catch the missing webview crash and provide an error dialog with information about the error. Fixes #6855 
- Allows the initial login and registration fragment transactions to have _state loss_, as these fragments are the entry points the UX damage is minimal and will simply require the user pressing the `already have an account` or `use case selection` buttons again. Fixes #6861

## Motivation and context

- #6860 Crash when attempting to continue account registration after the app has been killed/force stopped
- #6855 Crash when attempting to show the captcha webview on a device that no webview installed
- #6861 Crash when leaving the app whilst loading the login or registration page

## Screenshots / GIFs

#### WebView disabled
*animations are disabled

|Before|After|
|-|-|
|![before-webview-disabled](https://user-images.githubusercontent.com/1848238/185152146-d80bbd18-a0e1-4868-9c13-5a243b7b0a07.gif)|![disable-webview](https://user-images.githubusercontent.com/1848238/185152172-56f40de4-8c98-4d02-825f-9f7b32a5d13d.gif)|

## Tests

- See issue https://github.com/vector-im/element-android/issues/6860

----

- #6861 Unable to reproduce locally

----

- #6855
- Disable the system webview and chrome (or other browsers) via the system application settings
- Attempt to create an account
- Notice the app crashes when showing the captcha step.


## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): 28, 31
