### PR TITLE
Revert "Bump stem-plugin from 2.1.1 to 2.2.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.3.13'
         classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.4.0.2513'
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.5'
-        classpath "com.likethesalad.android:stem-plugin:2.2.0"
+        classpath "com.likethesalad.android:stem-plugin:2.1.1"
         classpath 'org.owasp:dependency-check-gradle:7.1.1'
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.7.10"
         classpath "org.jetbrains.kotlinx:kotlinx-knit:0.4.0"


### PR DESCRIPTION
Reverts vector-im/element-android#6838

Develop is broken.

Dependabot will create again the PR and we will fix any issue there.