### PR TITLE
Start DM on first message when selecting "direct message" from the room member details screen

### DIFF
--- a/changelog.d/5525.wip
+++ b/changelog.d/5525.wip
@@ -1,0 +1,1 @@
+Create DM room only on first message - Trigger the flow when the "Direct Message" action is selected from the room member details screen

--- a/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomViewModel.kt
@@ -132,10 +132,10 @@ class CreateDirectRoomViewModel @AssistedInject constructor(
                 if (vectorFeatures.shouldStartDmOnFirstMessage()) {
                     session.roomService().createLocalRoom(roomParams)
                 } else {
+                    analyticsTracker.capture(CreatedRoom(isDM = roomParams.isDirect.orFalse()))
                     session.roomService().createRoom(roomParams)
                 }
             }
-            analyticsTracker.capture(CreatedRoom(isDM = roomParams.isDirect.orFalse()))
 
             setState {
                 copy(


### PR DESCRIPTION
## Type of change

- [X] WIP Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

When we select the option "Direct Message" on a room member details screen, the start DM flow is now triggered.
This means that the DM room will not be created by selecting the option but only after sending the first message in the local room.

This is almost the same behaviour as creating a DM from the fab button on the home screen, without having to select the users to invite. The local room is directly shown with the related room member.

## Motivation and context

https://github.com/vector-im/element-android/issues/5525#issuecomment-1158963336

## Screenshots / GIFs

![start_dm_room_member](https://user-images.githubusercontent.com/11990514/185193367-dcc50450-fb8c-437a-8203-cf338901b00e.gif)

## Tests

1. Activate the start DM feature flag from the debug menu
2. Open a room with several users
3. Select a user to open the member profile screen
4. Select "Direct Message"

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [X] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
