### PR TITLE
Space Switching: Adds Toolbar Click To Open Space Settings

### DIFF
--- a/changelog.d/6859.wip
+++ b/changelog.d/6859.wip
@@ -1,0 +1,1 @@
+[New Layout] Adds space settings accessible through clicking the toolbar

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
@@ -297,8 +297,17 @@ class NewHomeDetailFragment @Inject constructor(
             }
         }
 
+        views.collapsingToolbar.debouncedClicks(::openSpaceSettings)
+        views.toolbar.debouncedClicks(::openSpaceSettings)
+
         views.avatar.debouncedClicks {
             navigator.openSettings(requireContext())
+        }
+    }
+
+    private fun openSpaceSettings() = withState(viewModel) { viewState ->
+        viewState.selectedSpace?.let {
+            sharedActionViewModel.post(HomeActivitySharedAction.ShowSpaceSettings(it.roomId))
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Adds a click action to the toolbar in the new app layout to open space settings

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/6859

This functionality is present in the old app layout but wasn't yet present in the new layout.

We need to add the click listener on both the collapsing toolbar and the toolbar to have an effective click area of the whole toolbar. Adding a click listener on AppBarLayout doesn't work.

## Screenshots / GIFs

<img width="200" alt="image" src="https://user-images.githubusercontent.com/20701752/185236274-f401e834-2913-436e-bfa3-d49a41f0c5dc.png">

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
