### PR TITLE
Fix broken unit test on emoji search

### DIFF
--- a/vector/src/androidTest/java/im/vector/app/features/reactions/data/EmojiDataSourceTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/reactions/data/EmojiDataSourceTest.kt
@@ -76,7 +76,7 @@ class EmojiDataSourceTest : InstrumentedTest {
     fun searchTestOneResult() {
         val emojiDataSource = createEmojiDataSource()
         val result = runBlocking {
-            emojiDataSource.filterWith("france")
+            emojiDataSource.filterWith("flag-france")
         }
         assertEquals("Should have 1 result", 1, result.size)
     }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [X] Other :

## Content

Fix the unit test which was broken since the emoji filter on "france" does not return the expected result anymore. Replaced the filter with "flag-france" which returns a single result and should not change in the long term.

## Motivation and context

FIx the broken CI on develop

## Screenshots / GIFs

N/A

## Tests

- Run `EmojiDataSourceTest.searchTestOneResult()`

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
