### PR TITLE
FTUE - Fix trusting certificates during edit server flow

### DIFF
--- a/changelog.d/6864.bugfix
+++ b/changelog.d/6864.bugfix
@@ -1,0 +1,1 @@
+Fixes server selection being unable to trust certificates

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
@@ -93,6 +93,8 @@ fun Throwable.isMissingEmailVerification() = this is Failure.ServerError &&
         error.code == MatrixError.M_UNAUTHORIZED &&
         error.message == "Unable to get validated threepid"
 
+fun Throwable.isUnrecognisedCertificate() = this is Failure.UnrecognizedCertificateFailure
+
 /**
  * Try to convert to a RegistrationFlowResponse. Return null in the cases it's not possible
  */

--- a/vector/src/main/java/im/vector/app/features/login/HomeServerConnectionConfigFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/login/HomeServerConnectionConfigFactory.kt
@@ -17,12 +17,13 @@
 package im.vector.app.features.login
 
 import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
+import org.matrix.android.sdk.api.network.ssl.Fingerprint
 import timber.log.Timber
 import javax.inject.Inject
 
 class HomeServerConnectionConfigFactory @Inject constructor() {
 
-    fun create(url: String?): HomeServerConnectionConfig? {
+    fun create(url: String?, fingerprint: Fingerprint? = null): HomeServerConnectionConfig? {
         if (url == null) {
             return null
         }
@@ -30,6 +31,13 @@ class HomeServerConnectionConfigFactory @Inject constructor() {
         return try {
             HomeServerConnectionConfig.Builder()
                     .withHomeServerUri(url)
+                    .run {
+                        if (fingerprint == null) {
+                            this
+                        } else {
+                            withAllowedFingerPrints(listOf(fingerprint))
+                        }
+                    }
                     .build()
         } catch (t: Throwable) {
             Timber.e(t)

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingAction.kt
@@ -82,7 +82,7 @@ sealed interface OnboardingAction : VectorViewModelAction {
 
     data class PostViewEvent(val viewEvent: OnboardingViewEvents) : OnboardingAction
 
-    data class UserAcceptCertificate(val fingerprint: Fingerprint) : OnboardingAction
+    data class UserAcceptCertificate(val fingerprint: Fingerprint, val retryAction: OnboardingAction) : OnboardingAction
 
     object PersonalizeProfile : OnboardingAction
     data class UpdateDisplayName(val displayName: String) : OnboardingAction

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewEvents.kt
@@ -21,6 +21,7 @@ import im.vector.app.core.platform.VectorViewEvents
 import im.vector.app.features.login.ServerType
 import im.vector.app.features.login.SignMode
 import org.matrix.android.sdk.api.auth.registration.Stage
+import org.matrix.android.sdk.api.failure.Failure as SdkFailure
 
 /**
  * Transient events for Login.
@@ -29,6 +30,7 @@ sealed class OnboardingViewEvents : VectorViewEvents {
     data class Loading(val message: CharSequence? = null) : OnboardingViewEvents()
     data class Failure(val throwable: Throwable) : OnboardingViewEvents()
     data class DeeplinkAuthenticationFailure(val retryAction: OnboardingAction) : OnboardingViewEvents()
+    data class UnrecognisedCertificateFailure(val retryAction: OnboardingAction, val cause: SdkFailure.UnrecognizedCertificateFailure) : OnboardingViewEvents()
 
     object DisplayRegistrationFallback : OnboardingViewEvents()
     data class DisplayRegistrationStage(val stage: Stage) : OnboardingViewEvents()

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -280,11 +280,8 @@ class OnboardingViewModel @AssistedInject constructor(
             is AuthenticateAction.LoginDirect ->
                 handleDirectLogin(
                         action.retryAction,
-                        HomeServerConnectionConfig.Builder()
-                                // Will be replaced by the task
-                                .withHomeServerUri("https://dummy.org")
-                                .withAllowedFingerPrints(listOf(action.fingerprint))
-                                .build()
+                        // Will be replaced by the task
+                        homeServerConnectionConfigFactory.create("https://dummy.org", action.fingerprint)
                 )
             else -> Unit
         }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -202,6 +202,7 @@ class FtueAuthVariant(
                 openMsisdnConfirmation(viewEvents.msisdn)
             }
             is OnboardingViewEvents.Failure,
+            is OnboardingViewEvents.UnrecognisedCertificateFailure,
             is OnboardingViewEvents.Loading ->
                 // This is handled by the Fragments
                 Unit

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeHomeServerConnectionConfigFactory.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeHomeServerConnectionConfigFactory.kt
@@ -20,11 +20,12 @@ import im.vector.app.features.login.HomeServerConnectionConfigFactory
 import io.mockk.every
 import io.mockk.mockk
 import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
+import org.matrix.android.sdk.api.network.ssl.Fingerprint
 
 class FakeHomeServerConnectionConfigFactory {
     val instance: HomeServerConnectionConfigFactory = mockk()
 
-    fun givenConfigFor(url: String, config: HomeServerConnectionConfig) {
-        every { instance.create(url) } returns config
+    fun givenConfigFor(url: String, fingerprint: Fingerprint? = null, config: HomeServerConnectionConfig) {
+        every { instance.create(url, fingerprint) } returns config
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeStartAuthenticationFlowUseCase.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeStartAuthenticationFlowUseCase.kt
@@ -31,6 +31,10 @@ class FakeStartAuthenticationFlowUseCase {
         coEvery { instance.execute(config) } returns result
     }
 
+    fun givenErrors(config: HomeServerConnectionConfig, error: Throwable) {
+        coEvery { instance.execute(config) } throws  error
+    }
+
     fun givenHomeserverUnavailable(config: HomeServerConnectionConfig) {
         coEvery { instance.execute(config) } throws aHomeserverUnavailableError()
     }

--- a/vector/src/test/java/im/vector/app/test/fixtures/FailureFixture.kt
+++ b/vector/src/test/java/im/vector/app/test/fixtures/FailureFixture.kt
@@ -18,6 +18,7 @@ package im.vector.app.test.fixtures
 
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.failure.MatrixError
+import org.matrix.android.sdk.api.network.ssl.Fingerprint
 import java.net.UnknownHostException
 import javax.net.ssl.HttpsURLConnection
 
@@ -38,3 +39,5 @@ fun aLoginEmailUnknownError() = Failure.ServerError(
 )
 
 fun aHomeserverUnavailableError() = Failure.NetworkConnection(UnknownHostException())
+
+fun anUnrecognisedCertificateError() = Failure.UnrecognizedCertificateFailure("a-url", Fingerprint(ByteArray(1), Fingerprint.HashType.SHA1))


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Includes the `EditHomeserver` flow when handling certificate trusting
- Removes the mutable `HomeserverConfig` state in favour of recreating when needed (when trusting the certificate) which massively simplifies the unit testing setup
- Supplies a `retryAction` when creating the `CertificateError`, avoids needing _non persisted_ mutable state in the view model and reduces unit test setup 

## Motivation and context

Fixes #6864  - Certificate trusting during the edit homeserver flow doing nothing

## Screenshots / GIFs

|Before|After|
|-|-|
|![before-trust-server-ca](https://user-images.githubusercontent.com/1848238/185374004-948cdce6-83b3-4f1d-9269-904506c6bec2.gif)|![after-allow-trusting-ca-during-edits](https://user-images.githubusercontent.com/1848238/185374030-57a7e162-8d48-41cb-93d9-058e42c62c52.gif)|


## Tests

- Set your device time to the past (to cause the certificate to become invalid)
- Whilst signed out, enter the `I already have an account` flow
- Tap `EDIT`
- Tap `next` with `matrix.org` selected
- Notice the certificate trust dialog, tap next and nothing happens

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 31
