### PR TITLE
Add polling option to gplay variant

### DIFF
--- a/changelog.d/6878.feature
+++ b/changelog.d/6878.feature
@@ -1,0 +1,1 @@
+Add polling option to gplay variant.

--- a/vector/src/fdroid/java/im/vector/app/push/fcm/FdroidFcmHelper.kt
+++ b/vector/src/fdroid/java/im/vector/app/push/fcm/FdroidFcmHelper.kt
@@ -31,7 +31,6 @@ import javax.inject.Inject
  */
 class FdroidFcmHelper @Inject constructor(
         private val context: Context,
-        private val backgroundSyncStarter: BackgroundSyncStarter,
 ) : FcmHelper {
 
     override fun isFirebaseAvailable(): Boolean = false
@@ -54,7 +53,7 @@ class FdroidFcmHelper @Inject constructor(
         AlarmSyncBroadcastReceiver.cancelAlarm(context)
     }
 
-    override fun onEnterBackground(activeSessionHolder: ActiveSessionHolder) {
+    override fun onEnterBackground(activeSessionHolder: ActiveSessionHolder, backgroundSyncStarter: BackgroundSyncStarter) {
         backgroundSyncStarter.start(activeSessionHolder)
     }
 }

--- a/vector/src/gplay/AndroidManifest.xml
+++ b/vector/src/gplay/AndroidManifest.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="im.vector.app">
+
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!--
+    Required for long polling account synchronisation in background.
+    If not present ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS intent action won't work
+    -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <application>
 
@@ -20,6 +30,40 @@
             </intent-filter>
 
         </receiver>
+
+        <!--Components for polling-->
+        <receiver
+            android:name=".gplay.receiver.OnApplicationUpgradeOrRebootReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".gplay.receiver.AlarmSyncBroadcastReceiver"
+            android:enabled="true"
+            android:exported="false" />
+
+        <receiver
+            android:name=".gplay.receiver.KeepInternalDistributor"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <!--
+                This action is checked to track installed and uninstalled distributors.
+                We declare it to keep the background sync as an internal
+                unifiedpush distributor.
+                -->
+                <action android:name="org.unifiedpush.android.distributor.REGISTER" />
+            </intent-filter>
+        </receiver>
+
+        <service
+            android:name=".gplay.service.GuardAndroidService"
+            android:exported="false"
+            tools:ignore="Instantiatable" />
 
     </application>
 

--- a/vector/src/gplay/java/im/vector/app/di/FlavorModule.kt
+++ b/vector/src/gplay/java/im/vector/app/di/FlavorModule.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.di
 
+import android.content.Context
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -25,7 +26,9 @@ import im.vector.app.GoogleFlavorLegals
 import im.vector.app.core.pushers.FcmHelper
 import im.vector.app.core.services.GuardServiceStarter
 import im.vector.app.features.home.NightlyProxy
+import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.settings.legals.FlavorLegals
+import im.vector.app.gplay.service.PollingGuardServiceStarter
 import im.vector.app.nightly.FirebaseNightlyProxy
 import im.vector.app.push.fcm.GoogleFcmHelper
 
@@ -35,8 +38,8 @@ abstract class FlavorModule {
 
     companion object {
         @Provides
-        fun provideGuardServiceStarter(): GuardServiceStarter {
-            return object : GuardServiceStarter {}
+        fun provideGuardServiceStarter(preferences: VectorPreferences, appContext: Context): GuardServiceStarter {
+            return PollingGuardServiceStarter(preferences, appContext)
         }
     }
 

--- a/vector/src/gplay/java/im/vector/app/gplay/BackgroundSyncStarter.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/BackgroundSyncStarter.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.gplay
+
+import android.content.Context
+import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.core.time.Clock
+import im.vector.app.gplay.receiver.AlarmSyncBroadcastReceiver
+import im.vector.app.features.settings.BackgroundSyncMode
+import im.vector.app.features.settings.VectorPreferences
+import timber.log.Timber
+import javax.inject.Inject
+
+class BackgroundSyncStarter @Inject constructor(
+        private val context: Context,
+        private val vectorPreferences: VectorPreferences,
+        private val clock: Clock
+) {
+    fun start(activeSessionHolder: ActiveSessionHolder) {
+        if (vectorPreferences.areNotificationEnabledForDevice()) {
+            val activeSession = activeSessionHolder.getSafeActiveSession() ?: return
+            when (vectorPreferences.getSyncBackgroundMode()) {
+                BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_BATTERY -> {
+                    // we rely on periodic worker
+                    Timber.i("## Sync: Work scheduled to periodically sync in ${vectorPreferences.backgroundSyncDelay()}s")
+                    activeSession.syncService().startAutomaticBackgroundSync(
+                            vectorPreferences.backgroundSyncTimeOut().toLong(),
+                            vectorPreferences.backgroundSyncDelay().toLong()
+                    )
+                }
+                BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_REALTIME -> {
+                    // We need to use alarm in this mode
+                    AlarmSyncBroadcastReceiver.scheduleAlarm(
+                            context,
+                            activeSession.sessionId,
+                            vectorPreferences.backgroundSyncDelay(),
+                            clock
+                    )
+                    Timber.i("## Sync: Alarm scheduled to start syncing")
+                }
+                BackgroundSyncMode.BACKGROUND_SYNC_MODE_DISABLED -> {
+                    // we do nothing
+                    Timber.i("## Sync: background sync is disabled")
+                }
+            }
+        }
+    }
+}

--- a/vector/src/gplay/java/im/vector/app/gplay/receiver/AlarmSyncBroadcastReceiver.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/receiver/AlarmSyncBroadcastReceiver.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.gplay.receiver
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.content.ContextCompat
+import androidx.core.content.getSystemService
+import im.vector.app.core.extensions.singletonEntryPoint
+import im.vector.app.core.platform.PendingIntentCompat
+import im.vector.app.core.services.VectorSyncAndroidService
+import im.vector.app.core.time.Clock
+import org.matrix.android.sdk.api.session.sync.job.SyncAndroidService
+import timber.log.Timber
+
+class AlarmSyncBroadcastReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        Timber.d("## Sync: AlarmSyncBroadcastReceiver received intent")
+        val singletonEntryPoint = context.singletonEntryPoint()
+        if (singletonEntryPoint.activeSessionHolder().getSafeActiveSession() == null) {
+            Timber.v("No active session, so don't launch sync service.")
+            return
+        }
+        val vectorPreferences = singletonEntryPoint.vectorPreferences()
+        val clock = singletonEntryPoint.clock()
+
+        val sessionId = intent.getStringExtra(SyncAndroidService.EXTRA_SESSION_ID) ?: return
+        VectorSyncAndroidService.newPeriodicIntent(
+                context = context,
+                sessionId = sessionId,
+                syncTimeoutSeconds = vectorPreferences.backgroundSyncTimeOut(),
+                syncDelaySeconds = vectorPreferences.backgroundSyncDelay(),
+                isNetworkBack = false
+        )
+                .let {
+                    try {
+                        ContextCompat.startForegroundService(context, it)
+                    } catch (ex: Throwable) {
+                        Timber.i("## Sync: Failed to start service, Alarm scheduled to restart service")
+                        scheduleAlarm(context, sessionId, vectorPreferences.backgroundSyncDelay(), clock)
+                        Timber.e(ex)
+                    }
+                }
+    }
+
+    companion object {
+        private const val REQUEST_CODE = 0
+
+        fun scheduleAlarm(context: Context, sessionId: String, delayInSeconds: Int, clock: Clock) {
+            // Reschedule
+            Timber.v("## Sync: Scheduling alarm for background sync in $delayInSeconds seconds")
+            val intent = Intent(context, AlarmSyncBroadcastReceiver::class.java).apply {
+                putExtra(SyncAndroidService.EXTRA_SESSION_ID, sessionId)
+                putExtra(SyncAndroidService.EXTRA_PERIODIC, true)
+            }
+            val pIntent = PendingIntent.getBroadcast(
+                    context,
+                    REQUEST_CODE,
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntentCompat.FLAG_IMMUTABLE
+            )
+            val firstMillis = clock.epochMillis() + delayInSeconds * 1000L
+            val alarmMgr = context.getSystemService<AlarmManager>()!!
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmMgr.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, firstMillis, pIntent)
+            } else {
+                alarmMgr.set(AlarmManager.RTC_WAKEUP, firstMillis, pIntent)
+            }
+        }
+
+        fun cancelAlarm(context: Context) {
+            Timber.v("## Sync: Cancel alarm for background sync")
+            val intent = Intent(context, AlarmSyncBroadcastReceiver::class.java)
+            val pIntent = PendingIntent.getBroadcast(
+                    context,
+                    REQUEST_CODE,
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntentCompat.FLAG_IMMUTABLE
+            )
+            val alarmMgr = context.getSystemService<AlarmManager>()!!
+            alarmMgr.cancel(pIntent)
+
+            // Stop current service to restart
+            VectorSyncAndroidService.stopIntent(context).let {
+                try {
+                    ContextCompat.startForegroundService(context, it)
+                } catch (ex: Throwable) {
+                    Timber.i("## Sync: Cancel sync")
+                }
+            }
+        }
+    }
+}

--- a/vector/src/gplay/java/im/vector/app/gplay/receiver/KeepInternalDistributor.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/receiver/KeepInternalDistributor.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.gplay.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+/**
+ * UnifiedPush lib tracks an action to check installed and uninstalled distributors.
+ * We declare it to keep the background sync as an internal unifiedpush distributor.
+ * This class is used to declare this action.
+ */
+class KeepInternalDistributor : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {}
+}

--- a/vector/src/gplay/java/im/vector/app/gplay/receiver/OnApplicationUpgradeOrRebootReceiver.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/receiver/OnApplicationUpgradeOrRebootReceiver.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 New Vector Ltd
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.gplay.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.AndroidEntryPoint
+import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.gplay.BackgroundSyncStarter
+import timber.log.Timber
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class OnApplicationUpgradeOrRebootReceiver : BroadcastReceiver() {
+
+    @Inject lateinit var activeSessionHolder: ActiveSessionHolder
+    @Inject lateinit var backgroundSyncStarter: BackgroundSyncStarter
+
+    override fun onReceive(context: Context, intent: Intent) {
+        Timber.v("## onReceive() ${intent.action}")
+        backgroundSyncStarter.start(activeSessionHolder)
+    }
+}

--- a/vector/src/gplay/java/im/vector/app/gplay/service/GuardAndroidService.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/service/GuardAndroidService.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package im.vector.app.gplay.service
+
+import android.content.Intent
+import dagger.hilt.android.AndroidEntryPoint
+import im.vector.app.R
+import im.vector.app.core.services.VectorAndroidService
+import im.vector.app.features.notifications.NotificationUtils
+import javax.inject.Inject
+
+/**
+ * This no-op foreground service acts as a deterrent to the system eagerly killing the app process.
+ *
+ * Keeping the app process alive avoids some OEMs ignoring scheduled WorkManager and AlarmManager tasks
+ * when the app is not in the foreground.
+ */
+@AndroidEntryPoint
+class GuardAndroidService : VectorAndroidService() {
+
+    @Inject lateinit var notificationUtils: NotificationUtils
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val notificationSubtitleRes = R.string.notification_listening_for_notifications
+        val notification = notificationUtils.buildForegroundServiceNotification(notificationSubtitleRes, false)
+        startForeground(NotificationUtils.NOTIFICATION_ID_FOREGROUND_SERVICE, notification)
+        return START_STICKY
+    }
+}

--- a/vector/src/gplay/java/im/vector/app/gplay/service/PollingGuardServiceStarter.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/service/PollingGuardServiceStarter.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.gplay.service
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+import im.vector.app.core.services.GuardServiceStarter
+import im.vector.app.features.settings.VectorPreferences
+import timber.log.Timber
+import javax.inject.Inject
+
+class PollingGuardServiceStarter @Inject constructor(
+        private val preferences: VectorPreferences,
+        private val appContext: Context
+) : GuardServiceStarter {
+
+    override fun start() {
+        if (preferences.isBackgroundSyncEnabled()) {
+            try {
+                Timber.i("## Sync: starting GuardService")
+                val intent = Intent(appContext, GuardAndroidService::class.java)
+                ContextCompat.startForegroundService(appContext, intent)
+            } catch (ex: Throwable) {
+                Timber.e("## Sync: ERROR starting GuardService")
+            }
+        }
+    }
+
+    override fun stop() {
+        val intent = Intent(appContext, GuardAndroidService::class.java)
+        appContext.stopService(intent)
+    }
+}

--- a/vector/src/gplay/java/im/vector/app/push/fcm/GoogleFcmHelper.kt
+++ b/vector/src/gplay/java/im/vector/app/push/fcm/GoogleFcmHelper.kt
@@ -27,6 +27,8 @@ import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.di.DefaultSharedPreferences
 import im.vector.app.core.pushers.FcmHelper
 import im.vector.app.core.pushers.PushersManager
+import im.vector.app.gplay.BackgroundSyncStarter
+import im.vector.app.gplay.receiver.AlarmSyncBroadcastReceiver
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -35,7 +37,7 @@ import javax.inject.Inject
  * It has an alter ego in the fdroid variant.
  */
 class GoogleFcmHelper @Inject constructor(
-        context: Context,
+        private val context: Context,
 ) : FcmHelper {
     companion object {
         private const val PREFS_KEY_FCM_TOKEN = "FCM_TOKEN"
@@ -92,10 +94,12 @@ class GoogleFcmHelper @Inject constructor(
     }
 
     override fun onEnterForeground(activeSessionHolder: ActiveSessionHolder) {
-        // No op
+        // try to stop all regardless of background mode
+        activeSessionHolder.getSafeActiveSession()?.syncService()?.stopAnyBackgroundSync()
+        AlarmSyncBroadcastReceiver.cancelAlarm(context)
     }
 
-    override fun onEnterBackground(activeSessionHolder: ActiveSessionHolder) {
-        // No op
+    override fun onEnterBackground(activeSessionHolder: ActiveSessionHolder, backgroundSyncStarter: BackgroundSyncStarter) {
+        backgroundSyncStarter.start(activeSessionHolder)
     }
 }

--- a/vector/src/main/java/im/vector/app/VectorApplication.kt
+++ b/vector/src/main/java/im/vector/app/VectorApplication.kt
@@ -66,6 +66,7 @@ import im.vector.app.features.settings.VectorLocale
 import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.themes.ThemeUtils
 import im.vector.app.features.version.VersionProvider
+import im.vector.app.gplay.BackgroundSyncStarter
 import org.jitsi.meet.sdk.log.JitsiMeetDefaultLogHandler
 import org.matrix.android.sdk.api.Matrix
 import org.matrix.android.sdk.api.auth.AuthenticationService
@@ -108,6 +109,8 @@ class VectorApplication :
     @Inject lateinit var fcmHelper: FcmHelper
     @Inject lateinit var buildMeta: BuildMeta
     @Inject lateinit var leakDetector: LeakDetector
+    @Inject lateinit var backgroundSyncStarter: BackgroundSyncStarter
+
 
     // font thread handler
     private var fontThreadHandler: Handler? = null
@@ -184,7 +187,7 @@ class VectorApplication :
 
             override fun onPause(owner: LifecycleOwner) {
                 Timber.i("App entered background")
-                fcmHelper.onEnterBackground(activeSessionHolder)
+                fcmHelper.onEnterBackground(activeSessionHolder, backgroundSyncStarter)
             }
         })
         ProcessLifecycleOwner.get().lifecycle.addObserver(spaceStateHandler)

--- a/vector/src/main/java/im/vector/app/core/pushers/FcmHelper.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/FcmHelper.kt
@@ -18,6 +18,7 @@ package im.vector.app.core.pushers
 
 import android.app.Activity
 import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.gplay.BackgroundSyncStarter
 
 interface FcmHelper {
     fun isFirebaseAvailable(): Boolean
@@ -47,5 +48,5 @@ interface FcmHelper {
 
     fun onEnterForeground(activeSessionHolder: ActiveSessionHolder)
 
-    fun onEnterBackground(activeSessionHolder: ActiveSessionHolder)
+    fun onEnterBackground(activeSessionHolder: ActiveSessionHolder, backgroundSyncStarter: BackgroundSyncStarter)
 }

--- a/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
@@ -170,8 +170,8 @@ class UnifiedPushHelper @Inject constructor(
     }
 
     suspend fun unregister(pushersManager: PushersManager? = null) {
-        val mode = BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_REALTIME
-        vectorPreferences.setFdroidSyncBackgroundMode(mode)
+        val mode = BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_REALTIME
+        vectorPreferences.setSyncBackgroundMode(mode)
         try {
             pushersManager?.unregisterPusher(unifiedPushStore.getEndpointOrToken().orEmpty())
         } catch (e: Exception) {
@@ -246,7 +246,7 @@ class UnifiedPushHelper @Inject constructor(
     }
 
     fun isBackgroundSync(): Boolean {
-        return UnifiedPush.getDistributor(context) == context.packageName && !fcmHelper.isFirebaseAvailable()
+        return true
     }
 
     fun getPrivacyFriendlyUpEndpoint(): String? {

--- a/vector/src/main/java/im/vector/app/core/pushers/VectorMessagingReceiver.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/VectorMessagingReceiver.kt
@@ -140,22 +140,22 @@ class VectorMessagingReceiver : MessagingReceiver() {
                 Timber.tag(loggerTag.value).i("onNewEndpoint: skipped")
             }
         }
-        val mode = BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_DISABLED
-        vectorPreferences.setFdroidSyncBackgroundMode(mode)
+        val mode = BackgroundSyncMode.BACKGROUND_SYNC_MODE_DISABLED
+        vectorPreferences.setSyncBackgroundMode(mode)
         guardServiceStarter.stop()
     }
 
     override fun onRegistrationFailed(context: Context, instance: String) {
         Toast.makeText(context, "Push service registration failed", Toast.LENGTH_SHORT).show()
-        val mode = BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_REALTIME
-        vectorPreferences.setFdroidSyncBackgroundMode(mode)
+        val mode = BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_REALTIME
+        vectorPreferences.setSyncBackgroundMode(mode)
         guardServiceStarter.start()
     }
 
     override fun onUnregistered(context: Context, instance: String) {
         Timber.tag(loggerTag.value).d("Unifiedpush: Unregistered")
-        val mode = BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_REALTIME
-        vectorPreferences.setFdroidSyncBackgroundMode(mode)
+        val mode = BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_REALTIME
+        vectorPreferences.setSyncBackgroundMode(mode)
         guardServiceStarter.start()
         runBlocking {
             try {

--- a/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCallManager.kt
+++ b/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCallManager.kt
@@ -32,6 +32,7 @@ import im.vector.app.features.call.lookup.CallUserMapper
 import im.vector.app.features.call.utils.EglUtils
 import im.vector.app.features.call.vectorCallService
 import im.vector.app.features.session.coroutineScope
+import im.vector.app.features.settings.VectorPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import org.matrix.android.sdk.api.extensions.orFalse
@@ -74,7 +75,8 @@ class WebRtcCallManager @Inject constructor(
         private val analyticsTracker: AnalyticsTracker,
         private val unifiedPushHelper: UnifiedPushHelper,
         private val voipConfig: VoipConfig,
-) : CallListener,
+        private val vectorPreferences: VectorPreferences,
+        ) : CallListener,
         DefaultLifecycleObserver {
 
     private val currentSession: Session?
@@ -273,7 +275,7 @@ class WebRtcCallManager @Inject constructor(
             audioManager.setMode(CallAudioManager.Mode.DEFAULT)
             // did we start background sync? so we should stop it
             if (isInBackground) {
-                if (!unifiedPushHelper.isBackgroundSync()) {
+                if (!unifiedPushHelper.isBackgroundSync() && !vectorPreferences.isBackgroundSyncEnabled()) {
                     currentSession?.syncService()?.stopAnyBackgroundSync()
                 } else {
                     // for fdroid we should not stop, it should continue syncing
@@ -379,11 +381,11 @@ class WebRtcCallManager @Inject constructor(
         // and thus won't be able to received events. For example if the call is
         // accepted on an other session this device will continue ringing
         if (isInBackground) {
-            if (!unifiedPushHelper.isBackgroundSync()) {
+            if (!unifiedPushHelper.isBackgroundSync() && !vectorPreferences.isBackgroundSyncEnabled()) {
                 // only for push version as fdroid version is already doing it?
                 currentSession?.syncService()?.startAutomaticBackgroundSync(30, 0)
             } else {
-                // Maybe increase sync freq? but how to set back to default values?
+                // Maybe increase sync freq? but how to set back to default values? Why not in DefaultPreferences?
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/settings/BackgroundSyncMode.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/BackgroundSyncMode.kt
@@ -17,7 +17,7 @@
 package im.vector.app.features.settings
 
 /**
- * Different strategies for Background sync, only applicable to F-Droid version of the app.
+ * Different strategies for Background sync.
  */
 enum class BackgroundSyncMode {
     /**
@@ -25,24 +25,24 @@ enum class BackgroundSyncMode {
      * of syncs when battery is low or when the phone is idle (sync will occur in allowed maintenance windows). After completion
      * the sync work will schedule another one.
      */
-    FDROID_BACKGROUND_SYNC_MODE_FOR_BATTERY,
+    BACKGROUND_SYNC_MODE_FOR_BATTERY,
 
     /**
      * This mode requires the app to be exempted from battery optimization. Alarms will be launched and will wake up the app
      * in order to perform the background sync as a foreground service. After completion the service will schedule another alarm
      */
-    FDROID_BACKGROUND_SYNC_MODE_FOR_REALTIME,
+    BACKGROUND_SYNC_MODE_FOR_REALTIME,
 
     /**
      * The app won't sync in background.
      */
-    FDROID_BACKGROUND_SYNC_MODE_DISABLED;
+    BACKGROUND_SYNC_MODE_DISABLED;
 
     companion object {
         const val DEFAULT_SYNC_DELAY_SECONDS = 60
         const val DEFAULT_SYNC_TIMEOUT_SECONDS = 6
 
         fun fromString(value: String?): BackgroundSyncMode = values().firstOrNull { it.name == value }
-                ?: FDROID_BACKGROUND_SYNC_MODE_DISABLED
+                ?: BACKGROUND_SYNC_MODE_DISABLED
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/BackgroundSyncModeChooserDialog.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/BackgroundSyncModeChooserDialog.kt
@@ -33,27 +33,27 @@ class BackgroundSyncModeChooserDialog : DialogFragment() {
         val view = requireActivity().layoutInflater.inflate(R.layout.dialog_background_sync_mode, null)
         val views = DialogBackgroundSyncModeBinding.bind(view)
         val dialog = MaterialAlertDialogBuilder(requireActivity())
-                .setTitle(R.string.settings_background_fdroid_sync_mode)
+                .setTitle(R.string.settings_background_sync_mode)
                 .setView(view)
                 .setPositiveButton(R.string.action_cancel, null)
                 .create()
 
         views.backgroundSyncModeBattery.setOnClickListener {
             interactionListener
-                    ?.takeIf { initialMode != BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_BATTERY }
-                    ?.onOptionSelected(BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_BATTERY)
+                    ?.takeIf { initialMode != BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_BATTERY }
+                    ?.onOptionSelected(BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_BATTERY)
             dialog.dismiss()
         }
         views.backgroundSyncModeReal.setOnClickListener {
             interactionListener
-                    ?.takeIf { initialMode != BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_REALTIME }
-                    ?.onOptionSelected(BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_REALTIME)
+                    ?.takeIf { initialMode != BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_REALTIME }
+                    ?.onOptionSelected(BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_REALTIME)
             dialog.dismiss()
         }
         views.backgroundSyncModeOff.setOnClickListener {
             interactionListener
-                    ?.takeIf { initialMode != BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_DISABLED }
-                    ?.onOptionSelected(BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_DISABLED)
+                    ?.takeIf { initialMode != BackgroundSyncMode.BACKGROUND_SYNC_MODE_DISABLED }
+                    ?.onOptionSelected(BackgroundSyncMode.BACKGROUND_SYNC_MODE_DISABLED)
             dialog.dismiss()
         }
         return dialog

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -1031,7 +1031,11 @@ class VectorPreferences @Inject constructor(
     }
 
     fun getSyncBackgroundMode(): BackgroundSyncMode {
-        val defValue = if (fcmHelper.isFirebaseAvailable()) BackgroundSyncMode.BACKGROUND_SYNC_MODE_DISABLED else BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_BATTERY
+        val defValue = if (fcmHelper.isFirebaseAvailable()){
+            BackgroundSyncMode.BACKGROUND_SYNC_MODE_DISABLED
+        } else {
+            BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_BATTERY
+        }
         return try {
             val strPref = defaultPrefs
                     .getString(SETTINGS_BACKGROUND_SYNC_MODE, defValue.name)

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -25,6 +25,7 @@ import androidx.core.content.edit
 import com.squareup.seismic.ShakeDetector
 import im.vector.app.R
 import im.vector.app.core.di.DefaultSharedPreferences
+import im.vector.app.core.pushers.FcmHelper
 import im.vector.app.core.resources.BuildMeta
 import im.vector.app.core.time.Clock
 import im.vector.app.features.disclaimer.SHARED_PREF_KEY
@@ -39,7 +40,8 @@ class VectorPreferences @Inject constructor(
         private val context: Context,
         private val clock: Clock,
         private val buildMeta: BuildMeta,
-) {
+        private val fcmHelper: FcmHelper,
+        ) {
 
     companion object {
         const val SETTINGS_HELP_PREFERENCE_KEY = "SETTINGS_HELP_PREFERENCE_KEY"
@@ -59,7 +61,7 @@ class VectorPreferences @Inject constructor(
         const val SETTINGS_CONTACT_PREFERENCE_KEYS = "SETTINGS_CONTACT_PREFERENCE_KEYS"
         const val SETTINGS_NOTIFICATIONS_TARGETS_PREFERENCE_KEY = "SETTINGS_NOTIFICATIONS_TARGETS_PREFERENCE_KEY"
         const val SETTINGS_NOTIFICATIONS_TARGET_DIVIDER_PREFERENCE_KEY = "SETTINGS_NOTIFICATIONS_TARGET_DIVIDER_PREFERENCE_KEY"
-        const val SETTINGS_FDROID_BACKGROUND_SYNC_MODE = "SETTINGS_FDROID_BACKGROUND_SYNC_MODE"
+        const val SETTINGS_BACKGROUND_SYNC_MODE = "SETTINGS_BACKGROUND_SYNC_MODE"
         const val SETTINGS_BACKGROUND_SYNC_PREFERENCE_KEY = "SETTINGS_BACKGROUND_SYNC_PREFERENCE_KEY"
         const val SETTINGS_BACKGROUND_SYNC_DIVIDER_PREFERENCE_KEY = "SETTINGS_BACKGROUND_SYNC_DIVIDER_PREFERENCE_KEY"
         const val SETTINGS_LABS_PREFERENCE_KEY = "SETTINGS_LABS_PREFERENCE_KEY"
@@ -1018,23 +1020,24 @@ class VectorPreferences @Inject constructor(
     }
 
     fun isBackgroundSyncEnabled(): Boolean {
-        return getFdroidSyncBackgroundMode() != BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_DISABLED
+        return getSyncBackgroundMode() != BackgroundSyncMode.BACKGROUND_SYNC_MODE_DISABLED
     }
 
-    fun setFdroidSyncBackgroundMode(mode: BackgroundSyncMode) {
+    fun setSyncBackgroundMode(mode: BackgroundSyncMode) {
         defaultPrefs
                 .edit()
-                .putString(SETTINGS_FDROID_BACKGROUND_SYNC_MODE, mode.name)
+                .putString(SETTINGS_BACKGROUND_SYNC_MODE, mode.name)
                 .apply()
     }
 
-    fun getFdroidSyncBackgroundMode(): BackgroundSyncMode {
+    fun getSyncBackgroundMode(): BackgroundSyncMode {
+        val defValue = if (fcmHelper.isFirebaseAvailable()) BackgroundSyncMode.BACKGROUND_SYNC_MODE_DISABLED else BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_BATTERY
         return try {
             val strPref = defaultPrefs
-                    .getString(SETTINGS_FDROID_BACKGROUND_SYNC_MODE, BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_BATTERY.name)
-            BackgroundSyncMode.values().firstOrNull { it.name == strPref } ?: BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_BATTERY
+                    .getString(SETTINGS_BACKGROUND_SYNC_MODE, defValue.name)
+            BackgroundSyncMode.values().firstOrNull { it.name == strPref } ?: defValue
         } catch (e: Throwable) {
-            BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_BATTERY
+            defValue
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/VectorSettingsNotificationPreferenceFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/VectorSettingsNotificationPreferenceFragment.kt
@@ -113,9 +113,9 @@ class VectorSettingsNotificationPreferenceFragment @Inject constructor(
             }
         }
 
-        findPreference<VectorPreference>(VectorPreferences.SETTINGS_FDROID_BACKGROUND_SYNC_MODE)?.let {
+        findPreference<VectorPreference>(VectorPreferences.SETTINGS_BACKGROUND_SYNC_MODE)?.let {
             it.onPreferenceClickListener = Preference.OnPreferenceClickListener {
-                val initialMode = vectorPreferences.getFdroidSyncBackgroundMode()
+                val initialMode = vectorPreferences.getSyncBackgroundMode()
                 val dialogFragment = BackgroundSyncModeChooserDialog.newInstance(initialMode)
                 dialogFragment.interactionListener = this
                 activity?.supportFragmentManager?.let { fm ->
@@ -219,7 +219,7 @@ class VectorSettingsNotificationPreferenceFragment @Inject constructor(
     // BackgroundSyncModeChooserDialog.InteractionListener
     override fun onOptionSelected(mode: BackgroundSyncMode) {
         // option has change, need to act
-        if (mode == BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_REALTIME) {
+        if (mode == BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_REALTIME) {
             // Important, Battery optim white listing is needed in this mode;
             // Even if using foreground service with foreground notif, it stops to work
             // in doze mode for certain devices :/
@@ -227,21 +227,17 @@ class VectorSettingsNotificationPreferenceFragment @Inject constructor(
                 requestDisablingBatteryOptimization(requireActivity(), batteryStartForActivityResult)
             }
         }
-        vectorPreferences.setFdroidSyncBackgroundMode(mode)
+        vectorPreferences.setSyncBackgroundMode(mode)
         refreshBackgroundSyncPrefs()
     }
 
     private fun refreshBackgroundSyncPrefs() {
-        findPreference<VectorPreference>(VectorPreferences.SETTINGS_FDROID_BACKGROUND_SYNC_MODE)?.let {
-            it.summary = when (vectorPreferences.getFdroidSyncBackgroundMode()) {
-                BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_BATTERY -> getString(R.string.settings_background_fdroid_sync_mode_battery)
-                BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_FOR_REALTIME -> getString(R.string.settings_background_fdroid_sync_mode_real_time)
-                BackgroundSyncMode.FDROID_BACKGROUND_SYNC_MODE_DISABLED -> getString(R.string.settings_background_fdroid_sync_mode_disabled)
+        findPreference<VectorPreference>(VectorPreferences.SETTINGS_BACKGROUND_SYNC_MODE)?.let {
+            it.summary = when (vectorPreferences.getSyncBackgroundMode()) {
+                BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_BATTERY -> getString(R.string.settings_background_sync_mode_battery)
+                BackgroundSyncMode.BACKGROUND_SYNC_MODE_FOR_REALTIME -> getString(R.string.settings_background_sync_mode_real_time)
+                BackgroundSyncMode.BACKGROUND_SYNC_MODE_DISABLED -> getString(R.string.settings_background_sync_mode_disabled)
             }
-        }
-
-        findPreference<VectorPreferenceCategory>(VectorPreferences.SETTINGS_BACKGROUND_SYNC_PREFERENCE_KEY)?.let {
-            it.isVisible = unifiedPushHelper.isBackgroundSync()
         }
 
         val backgroundSyncEnabled = vectorPreferences.isBackgroundSyncEnabled()

--- a/vector/src/main/res/layout/dialog_background_sync_mode.xml
+++ b/vector/src/main/res/layout/dialog_background_sync_mode.xml
@@ -20,7 +20,7 @@
                 style="@style/Widget.Vector.TextView.Body"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/settings_background_fdroid_sync_mode_battery"
+                android:text="@string/settings_background_sync_mode_battery"
                 android:textColor="?vctr_content_primary"
                 android:textStyle="bold" />
 
@@ -46,7 +46,7 @@
                 style="@style/Widget.Vector.TextView.Body"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/settings_background_fdroid_sync_mode_real_time"
+                android:text="@string/settings_background_sync_mode_real_time"
                 android:textColor="?vctr_content_primary"
                 android:textStyle="bold" />
 
@@ -72,7 +72,7 @@
                 style="@style/Widget.Vector.TextView.Body"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/settings_background_fdroid_sync_mode_disabled"
+                android:text="@string/settings_background_sync_mode_disabled"
                 android:textColor="?vctr_content_primary"
                 android:textStyle="bold" />
 
@@ -81,7 +81,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="16dp"
-                android:text="@string/settings_background_fdroid_sync_mode_disabled_description"
+                android:text="@string/settings_background_sync_mode_disabled_description"
                 android:textColor="?vctr_content_secondary" />
 
         </LinearLayout>

--- a/vector/src/main/res/values-ar/strings.xml
+++ b/vector/src/main/res/values-ar/strings.xml
@@ -1077,7 +1077,7 @@
     <string name="action_enable">فعّل</string>
     <string name="cannot_call_yourself_with_invite">لا يمكنك إجراء مكالمة مع نفسك، انتظر قبول منتسبين لطلب</string>
     <string name="notice_end_to_end_unknown_algorithm_by_you">شغّلتّ التعمية بين الطرفيات (خورزمية مجهولة %1$s).</string>
-    <string name="settings_background_fdroid_sync_mode">وضع المزامنة في الخلفية</string>
+    <string name="settings_background_sync_mode">وضع المزامنة في الخلفية</string>
     <string name="settings_mentions_and_keywords_encryption_notice">على الهاتف لن تتلق إخطارات عند ذكرك أو ذكر كلمة مفتاحية في الغرف المعماة.</string>
     <string name="settings_room_upgrades">ترقيات الغرف</string>
     <string name="settings_messages_by_bot">رسائل آلي (Bot)</string>
@@ -1148,9 +1148,9 @@
     <string name="location_share_option_pinned">شارك هذا الموقع</string>
     <string name="location_timeline_failed_to_load_map">فَشِلَ تحميل الخريطة</string>
     <string name="user_directory_search_hint_2">ابحث باسم المستخدم، أو الهوية (ID) أو البريد</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">لا توجد مزامنة في الخلفية</string>
+    <string name="settings_background_sync_mode_disabled">لا توجد مزامنة في الخلفية</string>
     <string name="settings_room_invitations">دعوات الغُرف</string>
-    <string name="settings_background_fdroid_sync_mode_battery">الأمثل للبطارية</string>
+    <string name="settings_background_sync_mode_battery">الأمثل للبطارية</string>
     <string name="settings_messages_at_room">الرسائل التي تحتوي على @room</string>
     <string name="room_unsupported_e2e_algorithm_as_admin">هُيِئَتْ التَعْمِيَةُ بشَكَلٍ خَاطِئ لِذَا لا تَسْتَطِيعُ إرْسَال الرَسَائِل. اُنْقُرْ لِفَتْحِ الإعدَادَات.</string>
     <string name="login_error_homeserver_from_url_not_found_enter_manual">اِخْتَرْ خَادِمًا رَّئِيسِيًا</string>

--- a/vector/src/main/res/values-b+sr+Latn/strings.xml
+++ b/vector/src/main/res/values-b+sr+Latn/strings.xml
@@ -137,8 +137,8 @@
     <string name="settings_messages_sent_by_bot">Poruke koje je poslao bot</string>
 
     <string name="settings_background_sync">Sinhronizacija u pozadini</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimizovano za potrošnju baterije</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Bez sinhronizacije u pozadini</string>
+    <string name="settings_background_sync_mode_battery">Optimizovano za potrošnju baterije</string>
+    <string name="settings_background_sync_mode_disabled">Bez sinhronizacije u pozadini</string>
 
     <string name="settings_version">Verzija</string>
     <string name="settings_olm_version">olm verzija</string>

--- a/vector/src/main/res/values-bg/strings.xml
+++ b/vector/src/main/res/values-bg/strings.xml
@@ -898,15 +898,15 @@
     <string name="action_revoke">Оттегли</string>
     <string name="action_disconnect">Прекъсни</string>
     <string name="login_error_homeserver_not_found">Неуспешна връзка със сървъра на този адрес, моля проверете</string>
-    <string name="settings_background_fdroid_sync_mode">Режим на фонова синхронизация</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Пестящ батерия</string>
+    <string name="settings_background_sync_mode">Режим на фонова синхронизация</string>
+    <string name="settings_background_sync_mode_battery">Пестящ батерия</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} ще синхронизира във фонов режим по начин, който пести ограничените ресурси на устройството (батерия).
 \nВ зависимост от състоянието на ресурсите, синхронизацията може да бъде отложена от операционната система.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Целящ висока интерактивност</string>
+    <string name="settings_background_sync_mode_real_time">Целящ висока интерактивност</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} ще синхронизира във фонов режим на определен интервал (конфигурируемо).
 \nТова ще повлияе на използването на антената и батерията. Ще се показва перманентна нотификация, че ${app_name} слуша за събития.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Без фонова синхронизация</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Няма да бъдете уведомени за входящи съобщения, когато приложението е във фонов режим.</string>
+    <string name="settings_background_sync_mode_disabled">Без фонова синхронизация</string>
+    <string name="settings_background_sync_mode_disabled_description">Няма да бъдете уведомени за входящи съобщения, когато приложението е във фонов режим.</string>
     <string name="settings_discovery_category">Откриване</string>
     <string name="settings_discovery_manage">Управлявайте настройките на откриваемостта.</string>
     <string name="identity_server_not_defined">Не използвате сървър за самоличност</string>

--- a/vector/src/main/res/values-bn-rBD/strings.xml
+++ b/vector/src/main/res/values-bn-rBD/strings.xml
@@ -201,7 +201,7 @@
         <item quantity="one">১ টি রুম</item>
         <item quantity="other">%d টি রুম</item>
     </plurals>
-    <string name="settings_background_fdroid_sync_mode">পটভূমি সিঙ্ক মোড (পরীক্ষামূলক)</string>
+    <string name="settings_background_sync_mode">পটভূমি সিঙ্ক মোড (পরীক্ষামূলক)</string>
     <string name="settings_background_sync">পটভূমি সিঙ্ক্রোনাইজেশন</string>
     <string name="settings_messages_sent_by_bot">বোট দ্বারা পাঠানো বার্তাগুলি</string>
     <string name="settings_call_invitations">কল এর আমন্ত্রণগুলি</string>
@@ -572,14 +572,14 @@
 
     <string name="settings_set_sync_timeout">সিঙ্ক অনুরোধ সময়সীমার</string>
     <string name="settings_start_on_boot">বুট করার সময় শুরু</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">অ্যাপটি ব্যাকগ্রাউন্ডে থাকা অবস্থায় আপনাকে আগত বার্তাগুলি সম্পর্কে অবহিত করা হবে না।</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">কোনও পটভূমি সিঙ্ক না</string>
+    <string name="settings_background_sync_mode_disabled_description">অ্যাপটি ব্যাকগ্রাউন্ডে থাকা অবস্থায় আপনাকে আগত বার্তাগুলি সম্পর্কে অবহিত করা হবে না।</string>
+    <string name="settings_background_sync_mode_disabled">কোনও পটভূমি সিঙ্ক না</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">রায়ট নির্দিষ্ট সময়ে সময়ে পটভূমিতে সিঙ্ক হবে (কনফিগারযোগ্য)।
 \nএটি রেডিও এবং ব্যাটারির ব্যবহারকে প্রভাবিত করবে, রায়ট ইভেন্টগুলি শুনছে বলে জানিয়ে একটি স্থায়ী বিজ্ঞপ্তি প্রদর্শিত হবে।</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">রিয়েল টাইম জন্য অনুকূলিত</string>
+    <string name="settings_background_sync_mode_real_time">রিয়েল টাইম জন্য অনুকূলিত</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">রায়ট এমনভাবে পটভূমিতে সিঙ্ক হবে যা ডিভাইসের সীমিত সংস্থান (ব্যাটারি) সংরক্ষণ করে।
 \nআপনার ডিভাইস রিসোর্স স্থিতির উপর নির্ভর করে সিঙ্কটি অপারেটিং সিস্টেম দ্বারা পিছিয়ে যেতে পারে।</string>
-    <string name="settings_background_fdroid_sync_mode_battery">ব্যাটারির জন্য অনুকূলিত</string>
+    <string name="settings_background_sync_mode_battery">ব্যাটারির জন্য অনুকূলিত</string>
     <string name="action_skip">বাদ</string>
     <string name="action_accept">স্বীকার</string>
     <string name="action_invite">আমন্ত্রণ</string>

--- a/vector/src/main/res/values-bn-rIN/strings.xml
+++ b/vector/src/main/res/values-bn-rIN/strings.xml
@@ -825,15 +825,15 @@
     <string name="login_error_homeserver_not_found">এই ইউআরএলে কোনও হোম সার্ভারে পৌঁছানো যায় না, দয়া করে এটি পরীক্ষা করে দেখুন</string>
 
 
-    <string name="settings_background_fdroid_sync_mode">পটভূমি সিঙ্ক মোড (পরীক্ষামূলক)</string>
-    <string name="settings_background_fdroid_sync_mode_battery">ব্যাটারির জন্য অনুকূলিত</string>
+    <string name="settings_background_sync_mode">পটভূমি সিঙ্ক মোড (পরীক্ষামূলক)</string>
+    <string name="settings_background_sync_mode_battery">ব্যাটারির জন্য অনুকূলিত</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">রায়ট এমনভাবে পটভূমিতে সিঙ্ক হবে যা ডিভাইসের সীমিত সংস্থান (ব্যাটারি) সংরক্ষণ করে।
 \nআপনার ডিভাইস রিসোর্স স্থিতির উপর নির্ভর করে সিঙ্কটি অপারেটিং সিস্টেম দ্বারা পিছিয়ে যেতে পারে।</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">রিয়েল টাইম জন্য অনুকূলিত</string>
+    <string name="settings_background_sync_mode_real_time">রিয়েল টাইম জন্য অনুকূলিত</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">রায়ট নির্দিষ্ট সময়ে সময়ে পটভূমিতে সিঙ্ক হবে (কনফিগারযোগ্য)।
 \nএটি রেডিও এবং ব্যাটারির ব্যবহারকে প্রভাবিত করবে, রায়ট ইভেন্টগুলি শুনছে বলে জানিয়ে একটি স্থায়ী বিজ্ঞপ্তি প্রদর্শিত হবে।</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">কোনও পটভূমি সিঙ্ক না</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">অ্যাপটি ব্যাকগ্রাউন্ডে থাকা অবস্থায় আপনাকে আগত বার্তাগুলি সম্পর্কে অবহিত করা হবে না।</string>
+    <string name="settings_background_sync_mode_disabled">কোনও পটভূমি সিঙ্ক না</string>
+    <string name="settings_background_sync_mode_disabled_description">অ্যাপটি ব্যাকগ্রাউন্ডে থাকা অবস্থায় আপনাকে আগত বার্তাগুলি সম্পর্কে অবহিত করা হবে না।</string>
 
 
 

--- a/vector/src/main/res/values-ca/strings.xml
+++ b/vector/src/main/res/values-ca/strings.xml
@@ -1131,15 +1131,15 @@
         <item quantity="one">%d segon</item>
         <item quantity="other">%d segons</item>
     </plurals>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">No se\'t notificarà de missatges entrants quan l\'aplicació es trobi en segon pla.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Sense sincronització en segon pla</string>
+    <string name="settings_background_sync_mode_disabled_description">No se\'t notificarà de missatges entrants quan l\'aplicació es trobi en segon pla.</string>
+    <string name="settings_background_sync_mode_disabled">Sense sincronització en segon pla</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} farà la sincronització en segon pla periòdicament en instants de temps precisos (configurable).
 \nAixò tindrà un impacte en l\'ús de la ràdio i la bateria, es mostrarà una notificació permanent informant de que ${app_name} està a l\'espera d\'esdeveniments.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimitzat per a temps real</string>
+    <string name="settings_background_sync_mode_real_time">Optimitzat per a temps real</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} farà la sincronització en segon pla de manera que es preservin els recursos limitats del dispositiu (bateria).
 \nEn funció de l\'estat dels recursos del dispositiu, pot ser que el sistema operatiu endarrereixi la sincronització.</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimitzat per a la bateria</string>
-    <string name="settings_background_fdroid_sync_mode">Mode de sincronització en segon pla</string>
+    <string name="settings_background_sync_mode_battery">Optimitzat per a la bateria</string>
+    <string name="settings_background_sync_mode">Mode de sincronització en segon pla</string>
     <string name="settings_troubleshoot_test_notification_notification_clicked">La notificació ha estat clicada!</string>
     <string name="settings_troubleshoot_test_notification_notice">Fes clic a la notificació. Si no veus la notificació, revisa la configuració del sistema.</string>
     <string name="room_settings_permissions_subtitle">Revisa i actualitza els rols necessaris per canviar diferents parts de la sala.</string>

--- a/vector/src/main/res/values-cs/strings.xml
+++ b/vector/src/main/res/values-cs/strings.xml
@@ -523,15 +523,15 @@
     <string name="settings_call_invitations">Pozvání k hovoru</string>
     <string name="settings_messages_sent_by_bot">Zprávy poslané botem</string>
     <string name="settings_background_sync">Synchronizace na pozadí</string>
-    <string name="settings_background_fdroid_sync_mode">Režim synchronizace na pozadí</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimalizován pro baterii</string>
+    <string name="settings_background_sync_mode">Režim synchronizace na pozadí</string>
+    <string name="settings_background_sync_mode_battery">Optimalizován pro baterii</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} bude synchronizovat na pozadí způsobem, který šetří omezené zdroje zařízení (baterii).
 \nV závislosti na stavu zdrojů zařízení může být sync operačním systémem odložen.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimalizováno pro reálný čas</string>
+    <string name="settings_background_sync_mode_real_time">Optimalizováno pro reálný čas</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} bude synchronizovat na pozadí periodicky v přesný čas (nastavitelné).
 \nTo bude mít vliv na využití rádia a baterie, stálé oznámení o tom, že ${app_name} čeká na události, bude zobrazeno.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Žádný sync na pozadí</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Neobdržíte oznámení o příchozích zprávách, je-li aplikace na pozadí.</string>
+    <string name="settings_background_sync_mode_disabled">Žádný sync na pozadí</string>
+    <string name="settings_background_sync_mode_disabled_description">Neobdržíte oznámení o příchozích zprávách, je-li aplikace na pozadí.</string>
     <string name="settings_start_on_boot">Start při zavádění</string>
     <string name="settings_set_sync_timeout">Čas požadavku na sync vypršel</string>
     <string name="settings_set_sync_delay">Prodleva mezi jednotlivými syncy</string>

--- a/vector/src/main/res/values-de/strings.xml
+++ b/vector/src/main/res/values-de/strings.xml
@@ -934,9 +934,9 @@
     <string name="none">Keine</string>
     <string name="action_revoke">Widerrufen</string>
     <string name="action_disconnect">Trennen</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimiert für die Batterie</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimiert für die Echtzeit</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Keine Hintergrundsynchronisation</string>
+    <string name="settings_background_sync_mode_battery">Optimiert für die Batterie</string>
+    <string name="settings_background_sync_mode_real_time">Optimiert für die Echtzeit</string>
+    <string name="settings_background_sync_mode_disabled">Keine Hintergrundsynchronisation</string>
     <string name="settings_discovery_category">Auffindbarkeit</string>
     <string name="widget_integration_review_terms">Um fortzufahren, musst du die Nutzungsbedingungen akzeptieren.</string>
     <string name="identity_server_not_defined">Du verwendest keinen Identitätsserver</string>
@@ -957,7 +957,7 @@
     <string name="settings_discovery_bad_identity_server">Konnte keine Verbindung zum Homeserver herstellen</string>
     <string name="login_error_no_homeserver_found">Dies ist keine Adresse eines Matrixservers</string>
     <string name="login_error_homeserver_not_found">Kann Homeserver nicht unter dieser URL erreichen. Bitte überprüfen</string>
-    <string name="settings_background_fdroid_sync_mode">Hintergrund-Synchronisierungsmodus</string>
+    <string name="settings_background_sync_mode">Hintergrund-Synchronisierungsmodus</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} wird sich im Hintergrund auf eine Art synchronisieren, die Ressourcen des Geräts (Akku) schont.
 \nAbhängig vom Ressourcen-Status deines Geräts kann dein System die Synchronisierung verschieben.</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} wird sich im Hintergrund periodisch zu einem bestimmten Zeitpunkt synchronisieren (konfigurierbar).
@@ -985,7 +985,7 @@
     <string name="room_widget_webview_access_camera">Kamera benutzen</string>
     <string name="room_widget_webview_access_microphone">Mikrofon benutzen</string>
     <string name="room_widget_webview_read_protected_media">Lese DRM-geschützte Medien</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Du wirst nicht über eingehende Nachrichten benachrichtigt, wenn die App im Hintergrund ist.</string>
+    <string name="settings_background_sync_mode_disabled_description">Du wirst nicht über eingehende Nachrichten benachrichtigt, wenn die App im Hintergrund ist.</string>
     <string name="settings_discovery_manage">Erkennungseinstellungen verwalten.</string>
     <string name="room_widget_revoke_access">Zugriff für mich zurückziehen</string>
     <string name="push_gateway_item_device_name">Sitzungsname:</string>

--- a/vector/src/main/res/values-en-rGB/strings.xml
+++ b/vector/src/main/res/values-en-rGB/strings.xml
@@ -9,8 +9,8 @@
     <string name="initialize_cross_signing">Initialise CrossSigning</string>
     <string name="login_error_threepid_denied">Your email domain is not authorised to register on this server</string>
     <string name="unrecognized_command">Unrecognised command: %s</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimised for real time</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimised for battery</string>
+    <string name="settings_background_sync_mode_real_time">Optimised for real time</string>
+    <string name="settings_background_sync_mode_battery">Optimised for battery</string>
     <string name="settings_background_sync">Background synchronisation</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignore Optimisation</string>
     <string name="settings_troubleshoot_test_battery_success">${app_name} is not affected by Battery Optimisation.</string>

--- a/vector/src/main/res/values-eo/strings.xml
+++ b/vector/src/main/res/values-eo/strings.xml
@@ -307,15 +307,15 @@
     <string name="settings_call_invitations">Invitoj al vokoj</string>
     <string name="settings_messages_sent_by_bot">Mesaĝoj senditaj de roboto</string>
     <string name="settings_background_sync">Fona spegulado</string>
-    <string name="settings_background_fdroid_sync_mode">Reĝimo de fona spegulado</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimumigita por baterio</string>
+    <string name="settings_background_sync_mode">Reĝimo de fona spegulado</string>
+    <string name="settings_background_sync_mode_battery">Optimumigita por baterio</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} spegulos fone, per maniero konservanta la limigitajn rimedojn de la aparato (ĉefe la baterion).
 \nDepende de la stato de la rimedoj de via aparato, la spegulado povus esti prokrastita de la operaciumo.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimumigita por tujeco</string>
+    <string name="settings_background_sync_mode_real_time">Optimumigita por tujeco</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} spegulos fone, ripete, je preciza tempo (agordebla).
 \nĈi tio influos uzadon de baterio kaj radiilo, kaj aperigos ĉiaman sciigon pri tio, ke ${app_name} aŭskultas okazojn.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Neniu fona spegulado</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Vi ne sciiĝos pri envenaj mesaĝoj dum la aplikaĵo estas fone.</string>
+    <string name="settings_background_sync_mode_disabled">Neniu fona spegulado</string>
+    <string name="settings_background_sync_mode_disabled_description">Vi ne sciiĝos pri envenaj mesaĝoj dum la aplikaĵo estas fone.</string>
     <string name="settings_start_on_boot">Ruliĝi je eko de sistemo</string>
     <string name="settings_set_sync_timeout">Tempolimo de petoj por spegulado</string>
     <string name="settings_set_sync_delay">Prokrasto inter ĉiu spegulado</string>

--- a/vector/src/main/res/values-es/strings.xml
+++ b/vector/src/main/res/values-es/strings.xml
@@ -892,20 +892,20 @@
     <string name="action_revoke">Revocar</string>
     <string name="action_disconnect">Desconectar</string>
     <string name="action_decline">Declinar</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimizado para batería</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimizado para operar en tiempo real</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Sin sincronización en segundo plano</string>
+    <string name="settings_background_sync_mode_battery">Optimizado para batería</string>
+    <string name="settings_background_sync_mode_real_time">Optimizado para operar en tiempo real</string>
+    <string name="settings_background_sync_mode_disabled">Sin sincronización en segundo plano</string>
     <string name="settings_integrations">Integraciones</string>
     <string name="settings_discovery_category">Descubrimiento</string>
     <string name="settings_discovery_manage">Gestione sus preferencias de descubrimiento.</string>
     <string name="login_error_no_homeserver_found">Esta no es una dirección de servidor Matrix válida</string>
     <string name="login_error_homeserver_not_found">No se puede acceder al servidor en esta URL, por favor, compruébelo</string>
-    <string name="settings_background_fdroid_sync_mode">Modo Sincronización en segundo plano</string>
+    <string name="settings_background_sync_mode">Modo Sincronización en segundo plano</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} se sincronizará en segundo plano de manera que se preserven los recursos del dispositivo (batería).
 \nDependiendo del estado de los recursos del dispositivo, la sincronización puede ser aplazada por el sistema operativo.</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} se sincronizará en segundo plano periódicamente en un momento preciso (configurable).
 \nEsto afectará al uso de la radio y la batería, se mostrará una notificación permanente que indica que ${app_name} está escuchando a nuevos acontecimientos.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">No se le notificará de los mensajes entrantes cuando la aplicación esté en segundo plano.</string>
+    <string name="settings_background_sync_mode_disabled_description">No se le notificará de los mensajes entrantes cuando la aplicación esté en segundo plano.</string>
     <string name="settings_integrations_summary">Utiliza un Gestor de Integración para gestionar los bots, puentes, widgets y paquetes de pegatinas.
 \nLos Gestores de Integración reciben los datos de configuración y pueden modificar los widgets, enviar invitaciones a salas y establecer niveles de poder en su nombre.</string>
     <string name="settings_integration_allow">Permitir integraciones</string>

--- a/vector/src/main/res/values-et/strings.xml
+++ b/vector/src/main/res/values-et/strings.xml
@@ -874,15 +874,15 @@
     <string name="settings_call_invitations">Saabuvad kõned</string>
     <string name="settings_messages_sent_by_bot">Robotite saadetud sõnumid</string>
     <string name="settings_background_sync">Andmete sünkroniseerimine taustal</string>
-    <string name="settings_background_fdroid_sync_mode">Andmete taustal sünkroniseerimise režiim</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimeeritud akukestust silmas pidades</string>
+    <string name="settings_background_sync_mode">Andmete taustal sünkroniseerimise režiim</string>
+    <string name="settings_background_sync_mode_battery">Optimeeritud akukestust silmas pidades</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} sünkroniseerib taustal nii, et see arvestab seadme piiratud ressursse (aku).
 \nSõltuvalt seadme olekust võib operatsioonisüsteem sünkroniseerimist edasi lükata.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimeeritud reaalajas</string>
+    <string name="settings_background_sync_mode_real_time">Optimeeritud reaalajas</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} sünkroniseerib sõnumeid taustal etteantud aja järel (aeg on seadistatav).
 \nSee mõjutab seadme saatjat/vastuvõtjat ja akukasutust ning kuvatakse püsiteade, et ${app_name} kuulab sündmusi.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Taustasünkroonimine puudub</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Kui rakendus töötab taustal, siis sa ei saa saabunud sõnumite kohta teavitusi.</string>
+    <string name="settings_background_sync_mode_disabled">Taustasünkroonimine puudub</string>
+    <string name="settings_background_sync_mode_disabled_description">Kui rakendus töötab taustal, siis sa ei saa saabunud sõnumite kohta teavitusi.</string>
     <string name="settings_start_on_boot">Käivita teenus seadme käivitamisel</string>
     <string name="settings_set_sync_timeout">Sünkroniseerimispäring aegus</string>
     <string name="settings_set_sync_delay">Viivitus sünkroonimiste vahel</string>

--- a/vector/src/main/res/values-eu/strings.xml
+++ b/vector/src/main/res/values-eu/strings.xml
@@ -1139,15 +1139,15 @@ Errore hau ${app_name}-en kontroletik kanpo dago. Ez dago Google konturik gailua
 
 
     <string name="login_error_homeserver_not_found">Ezin izan da hasiera-zerbitzari bat atzitu URL honetan, egiaztatu ezazu</string>
-    <string name="settings_background_fdroid_sync_mode">Bigarren planoko sinkronizazio modua (Esperimentala)</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Bateria erabilerarako optimizatua</string>
+    <string name="settings_background_sync_mode">Bigarren planoko sinkronizazio modua (Esperimentala)</string>
+    <string name="settings_background_sync_mode_battery">Bateria erabilerarako optimizatua</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} bigarren planoan sinkronizatuko da gailuaren baliabide mugatuen erabilera ahal beste murriztuz (bateria).
 \nZure gailuaren baliabideen egoeraren arabera, sistema eragileak sinkronizazioa atzeratu dezake.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Denbora errealerako optimizatua</string>
+    <string name="settings_background_sync_mode_real_time">Denbora errealerako optimizatua</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} bigarren planoan sinkronizatuko da maiztasun finkoarekin (konfiguragarria).
 \nHonek irrati eta bateriaren erabileran eragina izango du, eta ${app_name} gertaerei adi dagoela dion jakinarazpen bat bistaratuko da etengabe.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Ez sinkronizatu bigarren planoan</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Ez zaizu jasotako mezuei buruz jakinaraziko aplikazioa bigarren planoan dagoenean.</string>
+    <string name="settings_background_sync_mode_disabled">Ez sinkronizatu bigarren planoan</string>
+    <string name="settings_background_sync_mode_disabled_description">Ez zaizu jasotako mezuei buruz jakinaraziko aplikazioa bigarren planoan dagoenean.</string>
 
 
 

--- a/vector/src/main/res/values-fa/strings.xml
+++ b/vector/src/main/res/values-fa/strings.xml
@@ -638,11 +638,11 @@
     <string name="settings_call_invitations">دعوت‌های تماس</string>
     <string name="settings_messages_sent_by_bot">پیام‌های ارسالی از بات‌ها</string>
     <string name="settings_background_sync">همگام‌سازی پس‌زمینه</string>
-    <string name="settings_background_fdroid_sync_mode">حالت همگام‌سازی پس‌زمینه</string>
-    <string name="settings_background_fdroid_sync_mode_battery">بهینه برای باتری</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">بهینه برای بلادرنگ</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">بدون همگام‌سازی پس‌زمینه</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">هنگامی که کاره در پس‌زمینه‌است، از پیام‌های ورودی آگاه نخواهید شد.</string>
+    <string name="settings_background_sync_mode">حالت همگام‌سازی پس‌زمینه</string>
+    <string name="settings_background_sync_mode_battery">بهینه برای باتری</string>
+    <string name="settings_background_sync_mode_real_time">بهینه برای بلادرنگ</string>
+    <string name="settings_background_sync_mode_disabled">بدون همگام‌سازی پس‌زمینه</string>
+    <string name="settings_background_sync_mode_disabled_description">هنگامی که کاره در پس‌زمینه‌است، از پیام‌های ورودی آگاه نخواهید شد.</string>
     <string name="settings_start_on_boot">شروع هنگام راه‌اندازی</string>
     <string name="settings_set_sync_timeout">پایان زمان درخواست همگام‌سازی</string>
     <plurals name="seconds">

--- a/vector/src/main/res/values-fi/strings.xml
+++ b/vector/src/main/res/values-fi/strings.xml
@@ -868,9 +868,9 @@
     <string name="action_disconnect">Katkaise yhteys</string>
     <string name="action_decline">Kieltäydy</string>
     <string name="login_error_homeserver_not_found">Kotipalvelinta ei voi tavoittaa tästä URL-osoitteesta, tarkista osoite</string>
-    <string name="settings_background_fdroid_sync_mode">Taustasynkronointitila</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Ei taustasynkronointia</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Et saa ilmoituksia saapuvista viesteistä, kun sovellus on taustalla.</string>
+    <string name="settings_background_sync_mode">Taustasynkronointitila</string>
+    <string name="settings_background_sync_mode_disabled">Ei taustasynkronointia</string>
+    <string name="settings_background_sync_mode_disabled_description">Et saa ilmoituksia saapuvista viesteistä, kun sovellus on taustalla.</string>
     <string name="widget_integration_review_terms">Jatkaaksesi sinun täytyy hyväksyä palvelun käyttöehdot.</string>
     <string name="identity_server_not_defined">Et käytä mitään identiteettipalvelinta</string>
     <string name="error_user_already_logged_in">Näyttää, että yrität yhdistää toiseen kotipalvelimeen. Haluatko kirjautua ulos\?</string>
@@ -913,10 +913,10 @@
     <string name="report_content_spam">Se on roskapostia</string>
     <string name="report_content_inappropriate">Se on sopimaton</string>
     <string name="none">Ei mitään</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimoitu akunkestoa varten</string>
+    <string name="settings_background_sync_mode_battery">Optimoitu akunkestoa varten</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} synkronoi taustalla laitteen rajallisia resursseja (akkua) säästäen.
 \nLaitteesi resurssien tilasta riippuen käyttöjärjestelmä saattaa lykätä synkronointia.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimoitu reaaliaikaa varten</string>
+    <string name="settings_background_sync_mode_real_time">Optimoitu reaaliaikaa varten</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} synkronoi taustalla täsmällisin aikavälein (säädettävä).
 \nTämä vaikuttaa radion ja akun käyttöön. Näet pysyvän ilmoituksen, joka kertoo, että ${app_name} kuuntelee tapahtumia.</string>
     <string name="message_edits">Viestimuokkaukset</string>

--- a/vector/src/main/res/values-fr-rCA/strings.xml
+++ b/vector/src/main/res/values-fr-rCA/strings.xml
@@ -1653,15 +1653,15 @@
     <string name="settings_set_sync_delay">Délai entre chaque synchronisation</string>
     <string name="settings_set_sync_timeout">Délai d’attente de la requête de synchronisation</string>
     <string name="settings_start_on_boot">Lancer au démarrage</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Vous ne serez pas notifié des messages entrants quand l’application est en arrière-plan.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Aucune synchronisation en arrière-plan</string>
+    <string name="settings_background_sync_mode_disabled_description">Vous ne serez pas notifié des messages entrants quand l’application est en arrière-plan.</string>
+    <string name="settings_background_sync_mode_disabled">Aucune synchronisation en arrière-plan</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} se synchronisera en arrière-plan de façon périodique à un moment précis (configurable).
 \nCela aura un impact sur l’utilisation des données mobiles et de la batterie, une notification permanente sera affichée indiquant que ${app_name} est à l’écoute des évènements.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimisé pour le temps réel</string>
+    <string name="settings_background_sync_mode_real_time">Optimisé pour le temps réel</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} se synchronisera en arrière-plan de façon à préserver les ressources limitées de l’appareil (batterie).
 \nSelon l’état des ressources de votre appareil, la synchronisation peut être retardée par le système d’exploitation.</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimisé pour préserver la batterie</string>
-    <string name="settings_background_fdroid_sync_mode">Mode de synchronisation en arrière-plan</string>
+    <string name="settings_background_sync_mode_battery">Optimisé pour préserver la batterie</string>
+    <string name="settings_background_sync_mode">Mode de synchronisation en arrière-plan</string>
     <string name="settings_background_sync">Synchronisation en arrière-plan</string>
     <string name="settings_messages_sent_by_bot">Messages envoyés par un robot</string>
     <string name="settings_call_invitations">Appels entrants</string>

--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -919,15 +919,15 @@
     <string name="action_revoke">Révoquer</string>
     <string name="action_disconnect">Déconnecter</string>
     <string name="login_error_homeserver_not_found">Impossible de joindre le serveur d’accueil à cette URL, veuillez la vérifier</string>
-    <string name="settings_background_fdroid_sync_mode">Mode de synchronisation en arrière-plan</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimisé pour préserver la batterie</string>
+    <string name="settings_background_sync_mode">Mode de synchronisation en arrière-plan</string>
+    <string name="settings_background_sync_mode_battery">Optimisé pour préserver la batterie</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} se synchronisera en arrière-plan de façon à préserver les ressources limitées de l’appareil (batterie).
 \nSelon l’état des ressources de votre appareil, la synchronisation peut être retardée par le système d’exploitation.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimisé pour le temps réel</string>
+    <string name="settings_background_sync_mode_real_time">Optimisé pour le temps réel</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} se synchronisera en arrière-plan de façon périodique à un moment précis (configurable).
 \nCela aura un impact sur l’utilisation des données mobiles et de la batterie, une notification permanente sera affichée indiquant que ${app_name} est à l’écoute des évènements.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Aucune synchronisation en arrière-plan</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Vous ne serez pas notifié des messages entrants quand l’application est en arrière-plan.</string>
+    <string name="settings_background_sync_mode_disabled">Aucune synchronisation en arrière-plan</string>
+    <string name="settings_background_sync_mode_disabled_description">Vous ne serez pas notifié des messages entrants quand l’application est en arrière-plan.</string>
     <string name="settings_discovery_category">Découverte</string>
     <string name="settings_discovery_manage">Gérer vos paramètres de découverte.</string>
     <string name="identity_server_not_defined">Vous n’utilisez aucun serveur d’identité</string>

--- a/vector/src/main/res/values-fy/strings.xml
+++ b/vector/src/main/res/values-fy/strings.xml
@@ -582,8 +582,8 @@
     <string name="settings_user_settings">Brûkersynstellingen</string>
     <string name="settings_olm_version">olm-ferzje</string>
     <string name="settings_version">Ferzje</string>
-    <string name="settings_background_fdroid_sync_mode">Eftergrûnsyngronisaasjemodus</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimalisearre foar batterij</string>
+    <string name="settings_background_sync_mode">Eftergrûnsyngronisaasjemodus</string>
+    <string name="settings_background_sync_mode_battery">Optimalisearre foar batterij</string>
     <string name="settings_invited_to_room">Wannear’t ik útnûge wurd foar in keamer</string>
     <string name="settings_silent_notifications_preferences">Stille notifikaasjes konfigurearje</string>
     <string name="settings_troubleshoot_test_bg_restricted_quickfix">Restriksjes útskeakelje</string>

--- a/vector/src/main/res/values-hr/strings.xml
+++ b/vector/src/main/res/values-hr/strings.xml
@@ -287,15 +287,15 @@
     <string name="settings_call_invitations">Pozivnice za pozive</string>
     <string name="settings_messages_sent_by_bot">Poruke koje je poslao bot</string>
     <string name="settings_background_sync">Pozadinska sinkronizacija</string>
-    <string name="settings_background_fdroid_sync_mode">Način pozadinske sinkronizacije (eksperimentalno)</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimirano za bateriju</string>
+    <string name="settings_background_sync_mode">Način pozadinske sinkronizacije (eksperimentalno)</string>
+    <string name="settings_background_sync_mode_battery">Optimirano za bateriju</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} će sinkronizirati u pozadini na način koji čuva ograničena sredstva uređaja (baterija).
 \nOvisno o stanju sredstava uređaja, operacijski sustav može odgoditi sinkronizaciju.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimirano za stvarno vrijeme</string>
+    <string name="settings_background_sync_mode_real_time">Optimirano za stvarno vrijeme</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} će u pozadini i periodično u točno određeno vrijeme koje je podesivo vršiti sinkronizaciju.
 \nOvo će imati utjecaja na korištenje radijskog sustava i potrošnju baterije. Uočit ćete stalno prikazanu obavijest da ${app_name} osluškuje događaje.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Bez pozadinske sinkronizacije</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Nećete primati obavijesti o dolaznim porukama kada je aplikacija u pozadini.</string>
+    <string name="settings_background_sync_mode_disabled">Bez pozadinske sinkronizacije</string>
+    <string name="settings_background_sync_mode_disabled_description">Nećete primati obavijesti o dolaznim porukama kada je aplikacija u pozadini.</string>
     <string name="settings_start_on_boot">Pokreni pri podizanju sustava</string>
     <string name="settings_set_sync_timeout">Istekao je sinkronizacijski zahtjev</string>
     <string name="settings_set_sync_delay">Razmak između dvije sinkronizacije</string>

--- a/vector/src/main/res/values-hu/strings.xml
+++ b/vector/src/main/res/values-hu/strings.xml
@@ -878,15 +878,15 @@ A Visszaállítási Kulcsot tartsd biztonságos helyen, mint pl. egy jelszókeze
     <string name="action_revoke">Visszavonás</string>
     <string name="action_disconnect">Bontás</string>
     <string name="login_error_homeserver_not_found">Nem érhető el Matrix-kiszolgáló ezen a címen, ellenőrizd</string>
-    <string name="settings_background_fdroid_sync_mode">Háttér Szinkronizálási Mód</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimalizált akkumulátor használat</string>
+    <string name="settings_background_sync_mode">Háttér Szinkronizálási Mód</string>
+    <string name="settings_background_sync_mode_battery">Optimalizált akkumulátor használat</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} a háttérben úgy szinkronizál, hogy a leginkább kímélje az eszköz korlátozott erőforrásait (akkumulátor).
 \nAz eszköz erőforrásainak állapotától függően a szinkronizációt az operációs rendszer elhalaszthatja.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimalizálás valós idejű használatra</string>
+    <string name="settings_background_sync_mode_real_time">Optimalizálás valós idejű használatra</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} a háttérben rendszeresen, pontosan a megadott időközönként, szinkronizálni fog (beállítható).
 \nEz befolyásolja a rádió és az akkumulátor használatot, és folyamatosan egy értesítés fog megjelenni arról, hogy a ${app_name} figyel a neki küldött eseményekre.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Nincs szinkroniziálás a háttérben</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Nem leszel értesítve az érkező üzenetekről, ha az alkalmazás csak a háttérben fut.</string>
+    <string name="settings_background_sync_mode_disabled">Nincs szinkroniziálás a háttérben</string>
+    <string name="settings_background_sync_mode_disabled_description">Nem leszel értesítve az érkező üzenetekről, ha az alkalmazás csak a háttérben fut.</string>
     <string name="settings_discovery_category">Felderítés</string>
     <string name="settings_discovery_manage">Felderítési beállítások megváltoztatása.</string>
     <string name="identity_server_not_defined">Nem használsz Azonosítási Szervert</string>

--- a/vector/src/main/res/values-in/strings.xml
+++ b/vector/src/main/res/values-in/strings.xml
@@ -536,11 +536,11 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <string name="notice_room_created">%1$s membuat ruangan ini</string>
     <string name="notice_room_invite_no_invitee_by_you">Undangan Anda</string>
     <string name="notice_room_invite_no_invitee">Undangan %s</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Dioptimalkan untuk real-time</string>
+    <string name="settings_background_sync_mode_real_time">Dioptimalkan untuk real-time</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} akan mengsinkron di latar belakang dengan cara yang akan mempertahankan sumber daya (baterai) yang terbatas.
 \nTergantung pada keadaan sumber daya perangkat Anda, sinkronisasi dapat ditangguhkan oleh operasi sistem.</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Dioptimalkan untuk baterai</string>
-    <string name="settings_background_fdroid_sync_mode">Mode Sinkronisasi Latar Belakang</string>
+    <string name="settings_background_sync_mode_battery">Dioptimalkan untuk baterai</string>
+    <string name="settings_background_sync_mode">Mode Sinkronisasi Latar Belakang</string>
     <string name="settings_troubleshoot_test_notification_notification_clicked">Pemberitahuannya telah ditekan!</string>
     <string name="settings_troubleshoot_test_notification_notice">Silakan tekan notifikasinya. Jika Anda tidak melihat notifikasinya, silakan periksa pengaturan sistem.</string>
     <string name="settings_troubleshoot_test_notification_title">Tampilan Pemberitahuan</string>
@@ -1001,8 +1001,8 @@ Di masa mendatang proses verifikasi ini akan dimutakhirkan.</string>
     <plurals name="seconds">
         <item quantity="other">%d detik</item>
     </plurals>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Anda tidak akan diberitahu tentang pesan masuk saat aplikasi berada di latar belakang.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Tidak ada sinkronisasi latar belakang</string>
+    <string name="settings_background_sync_mode_disabled_description">Anda tidak akan diberitahu tentang pesan masuk saat aplikasi berada di latar belakang.</string>
+    <string name="settings_background_sync_mode_disabled">Tidak ada sinkronisasi latar belakang</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} akan disinkronkan di latar belakang secara berkala pada waktu yang tepat (dapat dikonfigurasi).
 \nIni akan memengaruhi penggunaan radio dan baterai, dan ada juga pemberitahuan yang ditampilkan permanen menyatakan bahwa ${app_name} sedang mendengarkan peristiwa.</string>
     <string name="settings_mentions_and_keywords_encryption_notice">Anda tidak akan mendapatkan notifikasi untuk sebutan &amp; keyword di ruangan terenkripsi di ponsel.</string>

--- a/vector/src/main/res/values-is/strings.xml
+++ b/vector/src/main/res/values-is/strings.xml
@@ -706,10 +706,10 @@
     <string name="encryption_exported_successfully">Útflutningur dulritunarlykla tókst</string>
     <string name="other_spaces_or_rooms_you_might_not_know">Önnur svæði sem þú gætir ekki vitað um</string>
     <string name="settings_play_shutter_sound">Spila hljóð við myndatöku</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Engin samstilling í bakgrunni</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Bestað gagnvart rauntíma</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Bestað gagnvart rafhleðslu</string>
-    <string name="settings_background_fdroid_sync_mode">Hamur samstillingar í bakgrunni</string>
+    <string name="settings_background_sync_mode_disabled">Engin samstilling í bakgrunni</string>
+    <string name="settings_background_sync_mode_real_time">Bestað gagnvart rauntíma</string>
+    <string name="settings_background_sync_mode_battery">Bestað gagnvart rafhleðslu</string>
+    <string name="settings_background_sync_mode">Hamur samstillingar í bakgrunni</string>
     <string name="settings_notification_notify_me_for">Láta mig vita fyrir</string>
     <string name="settings_emails_empty">Engu tölvupóstfangi hefur verið bætt við notandaaðganginn þinn</string>
     <string name="settings_phone_number_empty">Engu símanúmeri hefur verið bætt við notandaaðganginn þinn</string>

--- a/vector/src/main/res/values-it/strings.xml
+++ b/vector/src/main/res/values-it/strings.xml
@@ -940,15 +940,15 @@
     <string name="action_revoke">Revoca</string>
     <string name="action_disconnect">Disconnetti</string>
     <string name="login_error_homeserver_not_found">Non è stato trovato alcun Home Server seguendo questo URL. Per favore, controllalo</string>
-    <string name="settings_background_fdroid_sync_mode">Modalità sync in background</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Ottimizzato per la batteria</string>
+    <string name="settings_background_sync_mode">Modalità sync in background</string>
+    <string name="settings_background_sync_mode_battery">Ottimizzato per la batteria</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} si sincronizzerà in background in modo da non consumare la poca batteria disponibile.
 \nA seconda del livello della batteria, il sistema operativo potrebbe ritardare la sincronizzazione.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Ottimizzato per la performance</string>
+    <string name="settings_background_sync_mode_real_time">Ottimizzato per la performance</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} si sincronizzerà in background ad intervalli regolari (configurabili).
 \nCiò avrà un certo impatto sulla quantità di dati e batteria utilizzati. Una notifica sempre accesa comunicherà che ${app_name} è attivo.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Nessuna sincronizzazione in background</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Quando l\'App è in background non ti verranno notificati i messaggi in arrivo.</string>
+    <string name="settings_background_sync_mode_disabled">Nessuna sincronizzazione in background</string>
+    <string name="settings_background_sync_mode_disabled_description">Quando l\'App è in background non ti verranno notificati i messaggi in arrivo.</string>
     <string name="settings_discovery_category">Farsi trovare</string>
     <string name="settings_discovery_manage">Gestisci le impostazioni per farsi trovare.</string>
     <string name="identity_server_not_defined">Non stai usando alcun server di identità</string>

--- a/vector/src/main/res/values-iw/strings.xml
+++ b/vector/src/main/res/values-iw/strings.xml
@@ -229,15 +229,15 @@
     <string name="settings_set_sync_delay">עיכוב בין כל סינכרון</string>
     <string name="settings_set_sync_timeout">פסק-זמן לבקשה לסנכרון</string>
     <string name="settings_start_on_boot">החל באתחול</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">לא תקבל הודעה על הודעות נכנסות כאשר האפליקציה ברקע.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">אין סנכרון רקע</string>
+    <string name="settings_background_sync_mode_disabled_description">לא תקבל הודעה על הודעות נכנסות כאשר האפליקציה ברקע.</string>
+    <string name="settings_background_sync_mode_disabled">אין סנכרון רקע</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">אלמנט יסונכרן ברקע מעת לעת בזמן מדויק (ניתן להגדרה).
 \nזה ישפיע על השימוש ברדיו ובסוללה, תוצג הודעה קבועה לפיה אלמנט מאזין לאירועים.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">מותאם לזמן אמת</string>
+    <string name="settings_background_sync_mode_real_time">מותאם לזמן אמת</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">אלמנט יסונכרן ברקע באופן שישמור על המשאבים המוגבלים של המכשיר (סוללה).
 \nבהתאם למצב משאבי המכשיר שלך, ייתכן שהסנכרון יידחה על ידי מערכת ההפעלה.</string>
-    <string name="settings_background_fdroid_sync_mode_battery">מותאם לסוללה</string>
-    <string name="settings_background_fdroid_sync_mode">מצב סנכרון רקע</string>
+    <string name="settings_background_sync_mode_battery">מותאם לסוללה</string>
+    <string name="settings_background_sync_mode">מצב סנכרון רקע</string>
     <string name="settings_background_sync">סנכרון רקע</string>
     <string name="settings_messages_sent_by_bot">הודעות שנשלחו על ידי בוט</string>
     <string name="settings_call_invitations">הזמנות לשיחות</string>

--- a/vector/src/main/res/values-ja/strings.xml
+++ b/vector/src/main/res/values-ja/strings.xml
@@ -448,10 +448,10 @@
     <string name="title_activity_keys_backup_setup">鍵のバックアップ</string>
     <string name="title_activity_keys_backup_restore">鍵のバックアップを使用</string>
     <string name="settings_notification_advanced">詳細な通知設定</string>
-    <string name="settings_background_fdroid_sync_mode">バックグラウンド同期モード</string>
-    <string name="settings_background_fdroid_sync_mode_battery">バッテリーを考慮して最適化</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">リアルタイム性を重視して最適化</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">バックグラウンド同期を行わない</string>
+    <string name="settings_background_sync_mode">バックグラウンド同期モード</string>
+    <string name="settings_background_sync_mode_battery">バッテリーを考慮して最適化</string>
+    <string name="settings_background_sync_mode_real_time">リアルタイム性を重視して最適化</string>
+    <string name="settings_background_sync_mode_disabled">バックグラウンド同期を行わない</string>
     <string name="settings_send_typing_notifs">入力中通知を送信</string>
     <string name="settings_send_typing_notifs_summary">文字入力中であることを他のメンバーに伝えます。</string>
     <string name="settings_show_read_receipts">開封確認メッセージを表示</string>
@@ -959,7 +959,7 @@
     <string name="settings_integrations_summary">ボット、ブリッジ、ウィジェット、ステッカーパックを管理します。
 \nインテグレーションマネージャーは、構成データを受信し、ユーザーに代わってウィジェットの変更や、ルーム招待の送信、権限の設定などを行うことができます。</string>
     <string name="settings_integrations">インテグレーション（統合）</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">アプリがバックグラウンドにある場合、着信メッセージは通知されません。</string>
+    <string name="settings_background_sync_mode_disabled_description">アプリがバックグラウンドにある場合、着信メッセージは通知されません。</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name}は正確な時間に定期的にバックグラウンドで同期します（構成可能）。
 \nこれは無線とバッテリーの使用量に影響し、${app_name}がイベントを待機していることを示す永続的な通知が表示されます。</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name}は、端末の限られたリソース（バッテリーの残量）を維持する方法でバックグラウンド同期をします。

--- a/vector/src/main/res/values-kab/strings.xml
+++ b/vector/src/main/res/values-kab/strings.xml
@@ -958,8 +958,8 @@
     <string name="settings_messages_in_one_to_one">Iznan deg usqerdec gar sin kan</string>
     <string name="settings_messages_in_group_chat">Iznan n yisqerdicen n ugraw</string>
     <string name="settings_background_sync">Amtawi n ugilal</string>
-    <string name="settings_background_fdroid_sync_mode">Askar n umatawi n ugilal</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Ulac amtawi n ugilal</string>
+    <string name="settings_background_sync_mode">Askar n umatawi n ugilal</string>
+    <string name="settings_background_sync_mode_disabled">Ulac amtawi n ugilal</string>
     <string name="settings_start_on_boot">Bdu seg usenker</string>
     <string name="settings_app_term_conditions">Tiwtilin &amp; tfadiwin</string>
     <string name="settings_clear_cache">Sfeḍ takatut tuffirt</string>
@@ -1145,11 +1145,11 @@
     <string name="settings_enable_this_device">Rmed ilɣa i tɣimit-a</string>
     <string name="settings_containing_my_display_name">Iznan ideg yella yisem-iw yettwaskanen</string>
     <string name="settings_invited_to_room">Mi ara d-ttunecdeɣ ɣer texxamt</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Yettusesfer i uẓru</string>
+    <string name="settings_background_sync_mode_battery">Yettusesfer i uẓru</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} ad yemtawi deg ugilal akken ara yeḥrez tilisa n teɣbula n yibenk (aẓru).
 \nAlmend n waddad n teɣbalut n yibenk-inek·inem, amtawi yezmer ad iɛeṭṭel seg anagraw n wammud.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Yettusesfer i wakud ilaw</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Ur d-tetteṭṭfeḍ ara ulɣu n yiznan i d-ikecmen ma yili asnas ɣef ugilal i yella.</string>
+    <string name="settings_background_sync_mode_real_time">Yettusesfer i wakud ilaw</string>
+    <string name="settings_background_sync_mode_disabled_description">Ur d-tetteṭṭfeḍ ara ulɣu n yiznan i d-ikecmen ma yili asnas ɣef ugilal i yella.</string>
     <string name="settings_set_sync_timeout">Yemmed wakud n usuter n umtawi</string>
 
     <string name="settings_set_sync_delay">Tanzagt gar yal amtawi</string>

--- a/vector/src/main/res/values-ko/strings.xml
+++ b/vector/src/main/res/values-ko/strings.xml
@@ -764,15 +764,15 @@
     <string name="action_revoke">취소</string>
     <string name="action_disconnect">연결 해제</string>
     <string name="login_error_homeserver_not_found">이 URL로는 홈서버에 접근할 수 없습니다, 확인해주세요</string>
-    <string name="settings_background_fdroid_sync_mode">백그라운드 동기화 모드 (실험적)</string>
-    <string name="settings_background_fdroid_sync_mode_battery">배터리에 최적화됨</string>
+    <string name="settings_background_sync_mode">백그라운드 동기화 모드 (실험적)</string>
+    <string name="settings_background_sync_mode_battery">배터리에 최적화됨</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name}은 기기의 제한된 자원 (배터리)을 유지하기 위해 백그라운드에서 동기화합니다.
 \n기기 자원 상태에 따라 운영체제에 의해 동기화는 지연될 수 있습니다.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">실시간으로 최적화됨</string>
+    <string name="settings_background_sync_mode_real_time">실시간으로 최적화됨</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name}은 (설정할 수 있는) 특정 시간에 주기적으로 백그라운드에거 동기화됩니다.
 \n이는 라디오와 배터리 사용에 영향을 주며 ${app_name}이 이벤트를 수신하고 있는 상태라는 알림이 영구적으로 표시됩니다.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">백그라운드 동기화 없음</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">앱이 백그라운드에 있을 때 수신 메시지의 알림을 받지 않습니다.</string>
+    <string name="settings_background_sync_mode_disabled">백그라운드 동기화 없음</string>
+    <string name="settings_background_sync_mode_disabled_description">앱이 백그라운드에 있을 때 수신 메시지의 알림을 받지 않습니다.</string>
     <string name="settings_discovery_category">탐색</string>
     <string name="settings_discovery_manage">탐색 설정을 관리합니다.</string>
     <string name="identity_server_not_defined">ID 서버를 사용하고 있지 않습니다</string>

--- a/vector/src/main/res/values-lo/strings.xml
+++ b/vector/src/main/res/values-lo/strings.xml
@@ -1186,15 +1186,15 @@
     <string name="settings_set_sync_delay">ທ່ວງເວລາລະຫວ່າງSync</string>
     <string name="settings_set_sync_timeout">ໝົດເວລາການຮ້ອງຂໍການຊິງຄ໌</string>
     <string name="settings_start_on_boot">ເລີ່ມຕົ້ນໃນການboot</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">ທ່ານຈະບໍ່ໄດ້ຮັບການແຈ້ງເຕືອນກ່ຽວກັບຂໍ້ຄວາມທີ່ເຂົ້າມາເມື່ອແອັບຯຢູ່ໃນພື້ນຫຼັງ.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">ບໍ່ມີການຊິງຄ໌ພື້ນຫຼັງ</string>
+    <string name="settings_background_sync_mode_disabled_description">ທ່ານຈະບໍ່ໄດ້ຮັບການແຈ້ງເຕືອນກ່ຽວກັບຂໍ້ຄວາມທີ່ເຂົ້າມາເມື່ອແອັບຯຢູ່ໃນພື້ນຫຼັງ.</string>
+    <string name="settings_background_sync_mode_disabled">ບໍ່ມີການຊິງຄ໌ພື້ນຫຼັງ</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} ຈະຊິງຄ໌ໃນພື້ນຫຼັງເປັນໄລຍະໆຕາມເວລາທີ່ຊັດເຈນ (ກຳນົດໄດ້).
 \nນີ້ຈະສົ່ງຜົນກະທົບຕໍ່ການໃຊ້ວິທະຍຸ ແລະແບັດເຕີຣີ, ຈະມີການແຈ້ງເຕືອນແບບຖາວອນທີ່ສະແດງວ່າ ${app_name} ກຳລັງຟັງເຫດການ.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">ປັບໃຫ້ເຫມາະສໍາລັບເວລາທີ່ແທ້ຈິງ</string>
+    <string name="settings_background_sync_mode_real_time">ປັບໃຫ້ເຫມາະສໍາລັບເວລາທີ່ແທ້ຈິງ</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} ຈະຊິ້ງຂໍ້ມູນໃນພື້ນຫຼັງເພື່ອຮັກສາຊັບພະຍາກອນທີ່ຈຳກັດຂອງອຸປະກອນ (ແບັດເຕີຣີ).
 \nອີງຕາມສະຖານະຊັບພະຍາກອນອຸປະກອນຂອງທ່ານ, ການຊິງຄ໌ອາດຈະຖືກເລື່ອນໂດຍລະບົບປະຕິບັດການ.</string>
-    <string name="settings_background_fdroid_sync_mode_battery">ເຫມາະສໍາລັບເເບັດເຕີລີ</string>
-    <string name="settings_background_fdroid_sync_mode">ຮູບແບບການຊິງຄ໌ພື້ນຫຼັງ</string>
+    <string name="settings_background_sync_mode_battery">ເຫມາະສໍາລັບເເບັດເຕີລີ</string>
+    <string name="settings_background_sync_mode">ຮູບແບບການຊິງຄ໌ພື້ນຫຼັງ</string>
     <string name="settings_background_sync">ການຊິ້ງຂໍ້ມູນພື້ນຫຼັງ</string>
     <string name="settings_mentions_and_keywords_encryption_notice">ທ່ານຈະບໍ່ໄດ້ຮັບການແຈ້ງເຕືອນສໍາລັບການກ່າວເຖິງ &amp; ຄໍາສໍາຄັນຢູ່ໃນຫ້ອງທີ່ເຂົ້າລະຫັດຢູ່ໃນມືຖື.</string>
     <string name="settings_room_upgrades">ການຍົກລະດັບຫ້ອງ</string>

--- a/vector/src/main/res/values-lv/strings.xml
+++ b/vector/src/main/res/values-lv/strings.xml
@@ -1333,10 +1333,10 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="settings_integrations_summary">Izmantojiet Integrācijas Pārvaldnieku, lai pārvaldītu botus, tiltus, logrīkus un uzlīmes.
 \nIntegrācijas Pārvaldnieks saņem konfigurācijas datus un var modificēt logrīkus, sūtīt istabu uzaicinājumus jūsu vārdā.</string>
 
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Jūs nesaņemsiet jaunas notifikācijas, kad aplikācija ir fonā.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Bez fona sinhronizācijas</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimizēts reālajam laikam</string>
-    <string name="settings_background_fdroid_sync_mode">Fona Sinhronizācijas Režīms</string>
+    <string name="settings_background_sync_mode_disabled_description">Jūs nesaņemsiet jaunas notifikācijas, kad aplikācija ir fonā.</string>
+    <string name="settings_background_sync_mode_disabled">Bez fona sinhronizācijas</string>
+    <string name="settings_background_sync_mode_real_time">Optimizēts reālajam laikam</string>
+    <string name="settings_background_sync_mode">Fona Sinhronizācijas Režīms</string>
     <string name="settings_system_preferences_summary">Izvēlaites LED krāsu, vibrāciju, skaņu…</string>
     <string name="settings_silent_notifications_preferences">Konfigurēt Klusās Notifikācijas</string>
     <string name="settings_call_notifications_preferences">Konfigurēt Zvanu Notifikācijas</string>
@@ -1486,7 +1486,7 @@ Nākotnē šī pārbaudes procedūra plānota sarežģītāka.</string>
     <string name="settings_troubleshoot_test_fcm_title">Firebase Tokens</string>
     <string name="settings_troubleshoot_test_play_services_quickfix">Salabot Play Servisus</string>
     <string name="error_threepid_auth_failed">Pārliecinieties, ka esat nospiedis uz saites e-pasta ziņojumā, ko esam nosūtījuši jums.</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimizēts akumulatoram</string>
+    <string name="settings_background_sync_mode_battery">Optimizēts akumulatoram</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} sinhronizēsies fonā, tā lai ietaupītu telefona bateriju.
 \nAtkarībā no ierīces baterijas stāvokļa, sinhronizāciju var atcelt operētājsistēma.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignorēt optimizāciju</string>

--- a/vector/src/main/res/values-nb-rNO/strings.xml
+++ b/vector/src/main/res/values-nb-rNO/strings.xml
@@ -1080,9 +1080,9 @@
         <item quantity="one">%d sekund</item>
         <item quantity="other">%d sekunder</item>
     </plurals>
-    <string name="settings_background_fdroid_sync_mode_disabled">Ingen bakgrunnssynkronisering</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimalisert for sanntid</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimalisert for batteri</string>
+    <string name="settings_background_sync_mode_disabled">Ingen bakgrunnssynkronisering</string>
+    <string name="settings_background_sync_mode_real_time">Optimalisert for sanntid</string>
+    <string name="settings_background_sync_mode_battery">Optimalisert for batteri</string>
     <string name="settings_background_sync">Bakgrunnssynkronisering</string>
     <string name="settings_messages_sent_by_bot">Meldinger sendt av bot</string>
     <string name="settings_call_invitations">Ring invitasjoner</string>
@@ -1142,7 +1142,7 @@
     <string name="settings_set_sync_delay">Forsinkelse mellom hver synkronisering</string>
 
     <string name="settings_set_sync_timeout">Tidsavbrudd for synkroniseringsforespørsel</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Du vil ikke bli varslet om innkommende meldinger når appen er i bakgrunnen.</string>
+    <string name="settings_background_sync_mode_disabled_description">Du vil ikke bli varslet om innkommende meldinger når appen er i bakgrunnen.</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} vil synkroniseres i bakgrunnen med jevne mellomrom på presis tid (konfigurerbar).
 \nDette vil påvirke radio og batteribruk, det vises en permanent melding om at ${app_name} lytter etter hendelser.</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} synkroniseres i bakgrunnen på en måte som bevarer enhetens begrensede ressurser (batteri).

--- a/vector/src/main/res/values-nl/strings.xml
+++ b/vector/src/main/res/values-nl/strings.xml
@@ -713,15 +713,15 @@
     <string name="action_decline">Weigeren</string>
     <string name="login_error_no_homeserver_found">Dit is geen geldig Matrix-serveradres</string>
     <string name="login_error_homeserver_not_found">Kan geen verbinding maken met een server op deze URL, controleer de URL</string>
-    <string name="settings_background_fdroid_sync_mode">Synchroniseren op de achtergrond</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Geoptimaliseerd voor batterij</string>
+    <string name="settings_background_sync_mode">Synchroniseren op de achtergrond</string>
+    <string name="settings_background_sync_mode_battery">Geoptimaliseerd voor batterij</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} zal op een batterijzuinige manier synchroniseren op de achtergrond.
 \nAfhankelijk van de staat van uw apparaat kan het besturingssysteem de synchronisatie uitstellen.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Geoptimaliseerd voor snelheid</string>
+    <string name="settings_background_sync_mode_real_time">Geoptimaliseerd voor snelheid</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} zal periodiek op de achtergrond synchroniseren (configureerbaar).
 \nDit heeft een negatieve impact op uw batterij- en datagebruik. Er zal een melding getoond worden ter informatie.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Geen achtergrondssynchronisatie</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">U zal geen melding van berichten ontvangen als de app zich in de achtergrond bevindt.</string>
+    <string name="settings_background_sync_mode_disabled">Geen achtergrondssynchronisatie</string>
+    <string name="settings_background_sync_mode_disabled_description">U zal geen melding van berichten ontvangen als de app zich in de achtergrond bevindt.</string>
     <string name="settings_integrations">Integraties</string>
     <string name="settings_integrations_summary">Gebruik een integratiebeheerder om bots, bruggen, widgets en stickerpakketten te beheren.
 \nIntegratiebeheerders ontvangen configuratiedata en kunnen widgets aanpassen, gespreksuitnodigingen versturen en bestuursniveaus instellen namens u.</string>

--- a/vector/src/main/res/values-pl/strings.xml
+++ b/vector/src/main/res/values-pl/strings.xml
@@ -720,15 +720,15 @@
 \n%1$s</string>
     <string name="settings_troubleshoot_test_battery_success">Na ${app_name} nie ma wpływu Optymalizacja Baterii.</string>
     <string name="settings_troubleshoot_test_battery_failed">Jeżeli użytkownik pozostawi urządzenie odłączone od zasilania oraz nieużywane przez określony okres, z wyłączonym ekranem, urządzenie przejdzie w tryb Doze. Uniemożliwia to aplikacjom dostęp do sieci i opóźnia ich zadania, synchonizację oraz standardowe alarmy.</string>
-    <string name="settings_background_fdroid_sync_mode">Tryb synchronizacji w tle</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Zoptymalizowano dla baterii</string>
+    <string name="settings_background_sync_mode">Tryb synchronizacji w tle</string>
+    <string name="settings_background_sync_mode_battery">Zoptymalizowano dla baterii</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} będzie synchronizował się w tle w sposób który oszczędza limitowane zasoby urządzenia (baterię).
 \nW zależności od stanu zasobów urządzenia, synchronizacja może być opóźniania przez system operacyjny.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Zopytmalizowano dla działania w czasie rzeczywistym</string>
+    <string name="settings_background_sync_mode_real_time">Zopytmalizowano dla działania w czasie rzeczywistym</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} będzie synchornizował się okresowo o ściśle określonym czasie (konfigurowalne).
 \nWpłynie to na użycie baterii i sieci, na panelu powiadomień pozostanie wyświetlone stałe powiadomiene o nasłuchiwaniu zdarzeń.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Brak synchronizacji w tle</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Nie będziesz otrzymywać powiadomień o przychodzących wiadomościach gdy aplikacja będzie działać w tle.</string>
+    <string name="settings_background_sync_mode_disabled">Brak synchronizacji w tle</string>
+    <string name="settings_background_sync_mode_disabled_description">Nie będziesz otrzymywać powiadomień o przychodzących wiadomościach gdy aplikacja będzie działać w tle.</string>
     <string name="settings_integrations_summary">Użyj menedżera integracji aby zarządzać botami, mostami, widżetami i pakietami naklejek.
 \nMenedżerzy integracji odbierają dane konfiguracji, modyfikują widżety, wysyłają zaproszenia do pokojów i ustawiają poziomy uprawnień w Twoim imieniu.</string>
     <string name="settings_inline_url_preview_summary">Pokaż podgląd linków wewnątrz czatu jeśli twój serwer wspiera tę funkcję.</string>

--- a/vector/src/main/res/values-pt-rBR/strings.xml
+++ b/vector/src/main/res/values-pt-rBR/strings.xml
@@ -766,15 +766,15 @@
     <string name="room_participants_ban_reason">Razão de ban</string>
     <string name="room_participants_unban_title">Desbanir usuária(o)</string>
     <string name="room_participants_unban_prompt_msg">Desbanir usuária(o) vai permitir-lhe se juntar à sala de novo.</string>
-    <string name="settings_background_fdroid_sync_mode">Modo Sinc no Background</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimizado para bateria</string>
+    <string name="settings_background_sync_mode">Modo Sinc no Background</string>
+    <string name="settings_background_sync_mode_battery">Optimizado para bateria</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} vai sincar em background de maneira que preserva recursos limitados do dispositivo (bateria).
 \nDependendo do estado de recurso de seu dispositivo, a sinc pode ser adiada pelo sistema operacional.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimizado para tempo real</string>
+    <string name="settings_background_sync_mode_real_time">Optimizado para tempo real</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} vai sincar em background periodicamente em tempo preciso (configurável).
 \nIsto vai impactar uso de rádio e bateria, vai ter uma notificação permanente exibida declarando que ${app_name} está à escuta por eventos.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Sem sinc em background</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Você não vai ser notificada(o) sobre mensagens entrantes quando o app está em background.</string>
+    <string name="settings_background_sync_mode_disabled">Sem sinc em background</string>
+    <string name="settings_background_sync_mode_disabled_description">Você não vai ser notificada(o) sobre mensagens entrantes quando o app está em background.</string>
     <string name="settings_integrations">Integrações</string>
     <string name="settings_integrations_summary">Use um gerenciador de integrações para gerenciar bots, bridges, widgets e pacotes de stickers.
 \nGerenciadores de integrações recebem dados de configuração, e podem modificar widgets, enviar convites de sala e definir níveis de poder em seu nome.</string>

--- a/vector/src/main/res/values-ro/strings.xml
+++ b/vector/src/main/res/values-ro/strings.xml
@@ -156,7 +156,7 @@
     <string name="settings_app_term_conditions">Termene și condiții</string>
     <string name="settings_olm_version">Versiune olm</string>
     <string name="settings_version">Versiune</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimizat pentru baterie</string>
+    <string name="settings_background_sync_mode_battery">Optimizat pentru baterie</string>
     <string name="settings_invited_to_room">Când sunt invitat într-o cameră</string>
     <string name="settings_silent_notifications_preferences">Configurează notificările silențioase</string>
     <string name="settings_notification_ringtone">Sunet de notificare</string>

--- a/vector/src/main/res/values-ru/strings.xml
+++ b/vector/src/main/res/values-ru/strings.xml
@@ -980,16 +980,16 @@
     <string name="action_revoke">Отмена</string>
     <string name="action_disconnect">Отключить</string>
     <string name="login_error_homeserver_not_found">Не удается связаться с домашним сервером по этому URL, пожалуйста, проверьте его</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Оптимизирован для батареи</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Оптимизирован для работы в реальном времени</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Без фоновой синхронизации</string>
+    <string name="settings_background_sync_mode_battery">Оптимизирован для батареи</string>
+    <string name="settings_background_sync_mode_real_time">Оптимизирован для работы в реальном времени</string>
+    <string name="settings_background_sync_mode_disabled">Без фоновой синхронизации</string>
     <string name="settings_discovery_category">Обнаружение</string>
-    <string name="settings_background_fdroid_sync_mode">Режим фоновой синхронизации</string>
+    <string name="settings_background_sync_mode">Режим фоновой синхронизации</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} будет синхронизироваться в фоновом режиме таким образом, чтобы сохранить ограниченные ресурсы устройства (батарея).
 \nВ зависимости от состояния ресурса вашего устройства, синхронизация может быть отложена операционной системой.</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} будет синхронизироваться в фоновом режиме периодически в точное время (настраивается).
 \nЭто повлияет на использование радио и батареи, появится постоянное уведомление о том, что ${app_name} прислушивается к событиям.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Вы не будете уведомлены о входящих сообщениях, когда приложение находится в фоновом режиме.</string>
+    <string name="settings_background_sync_mode_disabled_description">Вы не будете уведомлены о входящих сообщениях, когда приложение находится в фоновом режиме.</string>
     <string name="settings_discovery_manage">Изменить настройки обнаружения.</string>
     <string name="identity_server_not_defined">Вы не используете какой-либо сервер обнаружения</string>
     <string name="error_user_already_logged_in">Похоже, вы пытаетесь подключиться к другому домашнему серверу. Вы хотите выйти\?</string>

--- a/vector/src/main/res/values-sk/strings.xml
+++ b/vector/src/main/res/values-sk/strings.xml
@@ -760,15 +760,15 @@
     <string name="room_participants_ban_reason">Dôvod zákazu vstupovať</string>
     <string name="room_participants_unban_title">Povoliť používateľovi vstupovať</string>
     <string name="room_participants_unban_prompt_msg">Povolením používateľovi vstupovať zaistíte, aby sa používateľ mohol vrátiť do miestnosti.</string>
-    <string name="settings_background_fdroid_sync_mode">Režim synchronizácie na pozadí</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimalizovaný na využívanie batérie</string>
+    <string name="settings_background_sync_mode">Režim synchronizácie na pozadí</string>
+    <string name="settings_background_sync_mode_battery">Optimalizovaný na využívanie batérie</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} sa bude synchronizovať na pozadí s cieľom ušetriť limitované zdroje (batériu).
 \nV závislosti od kapacity prostriedkov zariadenia môže byť synchronizácia odložená operačným systémom na neskôr.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimalizovaný na používanie v reálnom čase</string>
+    <string name="settings_background_sync_mode_real_time">Optimalizovaný na používanie v reálnom čase</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} sa bude pravidelne synchronizovať na pozadí v presne stanovenom čase (nastaviteľné).
 \nBude to mať vplyv na používanie rádia a batérie, bude sa zobrazovať trvalé oznámenie, že ${app_name} počúva udalosti.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Žiadna synchronizácia na pozadí</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Nebudete dostávať oznámenia o prichádzajúcich správach, keď aplikácia pracuje na pozadí.</string>
+    <string name="settings_background_sync_mode_disabled">Žiadna synchronizácia na pozadí</string>
+    <string name="settings_background_sync_mode_disabled_description">Nebudete dostávať oznámenia o prichádzajúcich správach, keď aplikácia pracuje na pozadí.</string>
     <string name="settings_integrations">Integrácie</string>
     <string name="settings_integrations_summary">Použite správcu integrácií na nastavenie botov, premostení, widgetov a balíčkov s nálepkami.
 \nSprávcovia integrácie dostávajú konfiguračné údaje a môžu vo vašom mene upravovať widgety, posielať pozvánky do miestnosti a nastavovať úrovne oprávnení.</string>

--- a/vector/src/main/res/values-sq/strings.xml
+++ b/vector/src/main/res/values-sq/strings.xml
@@ -934,15 +934,15 @@
     <string name="action_revoke">Shfuqizoje</string>
     <string name="action_disconnect">Shkëputu</string>
     <string name="login_error_homeserver_not_found">S’kapet dot shërbyes Home te kjo URL, ju lutemi, kontrollojeni</string>
-    <string name="settings_background_fdroid_sync_mode">Mënyrë Njëkohësimi Në Prapaskenë</string>
-    <string name="settings_background_fdroid_sync_mode_battery">E optimizuar për baterinë</string>
+    <string name="settings_background_sync_mode">Mënyrë Njëkohësimi Në Prapaskenë</string>
+    <string name="settings_background_sync_mode_battery">E optimizuar për baterinë</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name}-i do të bëjë njëkohësim në prapaskenë, në një mënyrë që kursen burimet e kufizuara të pajisjes (baterinë).
 \nNë varësi të gjendjes së burimeve tuaja, njëkohësimi mund të shtyhet për më vonë nga sistemi operativ.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">I optimizuar për kohë të njëmendtë</string>
+    <string name="settings_background_sync_mode_real_time">I optimizuar për kohë të njëmendtë</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name}0-i do të bëjë njëkohësim në prapaskenë periodikisht në një kohë të caktuar (e formësueshme).
 \nKjo do të ketë ndikim mbi përdorimin e baterisë dhe të transmetimit, do të shfaqet një njoftim i pandërprerë që pohon se ${app_name}-i po përgjon për akte.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Pa njëkohësim në prapraskenë</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">S’do të njoftoheni për mesazhe ardhës, kur aplikacioni gjendet në prapaskenë.</string>
+    <string name="settings_background_sync_mode_disabled">Pa njëkohësim në prapraskenë</string>
+    <string name="settings_background_sync_mode_disabled_description">S’do të njoftoheni për mesazhe ardhës, kur aplikacioni gjendet në prapaskenë.</string>
     <string name="settings_discovery_manage">Administroni rregullimet tuaja për zbulime.</string>
     <string name="identity_server_not_defined">S’po përdorni ndonjë shërbyes identitetesh</string>
     <string name="error_user_already_logged_in">Duket se po rrekeni të lidheni me një tjetër shërbyes Home. Doni të bëhet dalja\?</string>

--- a/vector/src/main/res/values-sv/strings.xml
+++ b/vector/src/main/res/values-sv/strings.xml
@@ -904,8 +904,8 @@
     <string name="settings_troubleshoot_test_battery_success">${app_name} påverkas inte av batterioptimering.</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Ignorera optimering</string>
     <string name="settings_background_sync">Bakgrundssynkronisering</string>
-    <string name="settings_background_fdroid_sync_mode">Bakgrundssynkläge</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimerad för batteri</string>
+    <string name="settings_background_sync_mode">Bakgrundssynkläge</string>
+    <string name="settings_background_sync_mode_battery">Optimerad för batteri</string>
     <string name="settings_app_term_conditions">Användarvillkor</string>
     <string name="settings_third_party_notices">Meddelanden från tredje part</string>
     <string name="settings_copyright">Upphovsrätt</string>
@@ -1086,9 +1086,9 @@
     <string name="bottom_sheet_setup_secure_backup_security_phrase_subtitle">Skriv in en hemlig fras endast du känner till, och generera en nyckel för säkerhetskopiering.</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} kommer att synka i bakgrunden på ett sätt som sparar på enhetens begränsade resurser (batteri).
 \nBeroende på din enhets resurser, så kan synkroniseringen bli uppskjuten av operativsystemet.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimerad för realtid</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Ingen bakgrundssynk</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Du kommer inte att bli aviserad om inkommande meddelanden när appen är i bakgrunden.</string>
+    <string name="settings_background_sync_mode_real_time">Optimerad för realtid</string>
+    <string name="settings_background_sync_mode_disabled">Ingen bakgrundssynk</string>
+    <string name="settings_background_sync_mode_disabled_description">Du kommer inte att bli aviserad om inkommande meddelanden när appen är i bakgrunden.</string>
     <string name="settings_start_on_boot">Starta vid boot</string>
     <string name="settings_set_sync_timeout">Timeout för synkbegäran</string>
     <string name="settings_set_sync_delay">Fördröjning mellan varje synkronisering</string>

--- a/vector/src/main/res/values-tr/strings.xml
+++ b/vector/src/main/res/values-tr/strings.xml
@@ -619,10 +619,10 @@
 
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name}, cihazın sınırlı kaynaklarını (pil) koruyacak şekilde arka planda senkronize olur.
 \nCihazınızın kaynak durumuna bağlı olarak, senkronizasyon işletim sistemi tarafından ertelenebilir.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Gerçek zamanlı için optimize</string>
+    <string name="settings_background_sync_mode_real_time">Gerçek zamanlı için optimize</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} periyodik olarak belirli bir zamanda (ayarlanabilir) arka planda senkronize olur.
 \nBu pil ve radyo kullanımını etkileyecek ve ${app_name}\'in olayları dinlediğini belirten kalıcı bir bildirim gösterecektir.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Arka plan senkronizasyonu yok</string>
+    <string name="settings_background_sync_mode_disabled">Arka plan senkronizasyonu yok</string>
 
     <string name="settings_integrations">Entegrasyonlar</string>
     <string name="settings_integrations_summary">Botları, köprüleri, widget\'ları ve çıkartma paketlerini yönetmek için bir entegrasyon yöneticisi kullanın.
@@ -739,9 +739,9 @@
     <string name="keys_backup_unable_to_get_keys_backup_data">Anahtar yedek verileri alınırken hata oluştu</string>
     <string name="login_error_no_homeserver_found">Bu geçerli bir Matrix sunucu adresi değil</string>
     <string name="login_error_homeserver_not_found">Bu URL ile ev-sunucusuna erişilemiyor, lütfen kontrol edin</string>
-    <string name="settings_background_fdroid_sync_mode">Arka plan Senkronizasyon Modu (Deneysel)</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Batarya için optimize edildi</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Uygulama arka plandayken gelen mesajlar için uyarılmayacaksınız.</string>
+    <string name="settings_background_sync_mode">Arka plan Senkronizasyon Modu (Deneysel)</string>
+    <string name="settings_background_sync_mode_battery">Batarya için optimize edildi</string>
+    <string name="settings_background_sync_mode_disabled_description">Uygulama arka plandayken gelen mesajlar için uyarılmayacaksınız.</string>
     <string name="action_play">Oynat</string>
     <string name="action_dismiss">Kapat</string>
     <string name="action_copy">Kopyala</string>

--- a/vector/src/main/res/values-uk/strings.xml
+++ b/vector/src/main/res/values-uk/strings.xml
@@ -929,15 +929,15 @@
         <item quantity="many">%d секунд</item>
         <item quantity="other">%d секунд</item>
     </plurals>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Ви не отримуватимете сповіщення про вхідні повідомлення, коли програма перебуває у фоновому режимі.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Немає фонової синхронізації</string>
+    <string name="settings_background_sync_mode_disabled_description">Ви не отримуватимете сповіщення про вхідні повідомлення, коли програма перебуває у фоновому режимі.</string>
+    <string name="settings_background_sync_mode_disabled">Немає фонової синхронізації</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} періодично синхронізуватиметься у фоновому режимі в певний час (налаштовується).
 \nЦе вплине на використання радіо та акумулятора, з’явиться постійне сповіщення про те, що ${app_name} очікує на події.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Оптимізовано для реального часу</string>
+    <string name="settings_background_sync_mode_real_time">Оптимізовано для реального часу</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} синхронізується у фоновому режимі так, щоб зберегти обмежені ресурси пристрою (акумулятор).
 \nЗалежно від стану ресурсів вашого пристрою, синхронізацію може бути відкладено операційною системою.</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Оптимізовано для батареї</string>
-    <string name="settings_background_fdroid_sync_mode">Режим фонової синхронізації</string>
+    <string name="settings_background_sync_mode_battery">Оптимізовано для батареї</string>
+    <string name="settings_background_sync_mode">Режим фонової синхронізації</string>
     <string name="settings_troubleshoot_test_battery_quickfix">Нехтувати оптимізацією</string>
     <string name="settings_troubleshoot_test_battery_failed">Якщо користувач залишає пристрій від\'єднаним та нерухомим впродовж певного часу з вимкненим екраном, пристрій переходить у режим сну. Це запобігає доступу застосунків до мережі та відкладає їхні завдання, синхронізацію та стандартні попередження.</string>
     <string name="settings_troubleshoot_test_battery_success">Оптимізація акумулятора не впливає на ${app_name}.</string>

--- a/vector/src/main/res/values-vi/strings.xml
+++ b/vector/src/main/res/values-vi/strings.xml
@@ -555,12 +555,12 @@
     <string name="denied_permission_generic">Vài quyền đang thiếu để thực hiện hành vi này, vui lòng cấp quyền từ cài đặt hệ thống.</string>
     <string name="settings_set_sync_timeout">Yêu cầu đồng bộ hết thời hạn</string>
     <string name="settings_start_on_boot">Chạy khi khởi động</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">Bạn sẽ không được báo tin nhắn đến khi App đang hoạt động ngầm.</string>
+    <string name="settings_background_sync_mode_disabled_description">Bạn sẽ không được báo tin nhắn đến khi App đang hoạt động ngầm.</string>
     <string name="settings_background_sync">Đồng bộ ngầm</string>
-    <string name="settings_background_fdroid_sync_mode">Chế độ đồng bộ ngầm</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">Không đồng bộ ngầm</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Được tối ưu cho thời gian thực</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Được tối ưu cho pin</string>
+    <string name="settings_background_sync_mode">Chế độ đồng bộ ngầm</string>
+    <string name="settings_background_sync_mode_disabled">Không đồng bộ ngầm</string>
+    <string name="settings_background_sync_mode_real_time">Được tối ưu cho thời gian thực</string>
+    <string name="settings_background_sync_mode_battery">Được tối ưu cho pin</string>
     <string name="settings_mentions_and_keywords_encryption_notice">Bạn sẽ không nhận được thông báo khi được đề cập tới trong phòng chat mã hóa trên mobile.</string>
     <string name="settings_room_upgrades">Nâng cấp phòng</string>
     <string name="settings_messages_by_bot">Các tin nhắn gửi bởi bot</string>

--- a/vector/src/main/res/values-zh-rCN/strings.xml
+++ b/vector/src/main/res/values-zh-rCN/strings.xml
@@ -876,15 +876,15 @@
     <string name="room_participants_ban_reason">封禁理由</string>
     <string name="room_participants_unban_title">取消封禁用户</string>
     <string name="room_participants_unban_prompt_msg">取消封禁用户将允许他们再次加入房间。</string>
-    <string name="settings_background_fdroid_sync_mode">后台同步模式</string>
-    <string name="settings_background_fdroid_sync_mode_battery">电池优化</string>
+    <string name="settings_background_sync_mode">后台同步模式</string>
+    <string name="settings_background_sync_mode_battery">电池优化</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} 将在后台以保留设备有限资源（电池）的方式同步。
 \n取决于你的设备资源状态，同步可能被操作系统推迟。</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">实时优化</string>
+    <string name="settings_background_sync_mode_real_time">实时优化</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} 将在后台定期准时同步（可配置）。
 \n这将影响网络和电池的使用，将显示一个永久通知表明 ${app_name} 正在监听事件。</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">无后台同步</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">应用在后台时你不会收到消息通知。</string>
+    <string name="settings_background_sync_mode_disabled">无后台同步</string>
+    <string name="settings_background_sync_mode_disabled_description">应用在后台时你不会收到消息通知。</string>
     <string name="settings_integrations">集成</string>
     <string name="settings_integrations_summary">使用集成管理器管理机器人、桥接、部件和贴纸包。
 \n集成管理器接收配置数据，可以代表你修改部件、发送房间邀请及设置权力级别。</string>

--- a/vector/src/main/res/values-zh-rTW/strings.xml
+++ b/vector/src/main/res/values-zh-rTW/strings.xml
@@ -923,15 +923,15 @@
     <string name="action_revoke">撤銷</string>
     <string name="action_disconnect">斷線</string>
     <string name="login_error_homeserver_not_found">無法在此 URL 找到家伺服器，請檢查</string>
-    <string name="settings_background_fdroid_sync_mode">背景同步模式</string>
-    <string name="settings_background_fdroid_sync_mode_battery">為電池最佳化</string>
+    <string name="settings_background_sync_mode">背景同步模式</string>
+    <string name="settings_background_sync_mode_battery">為電池最佳化</string>
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} 將會在背景同步以節省裝置的有限資源（電池）。
 \n取決於您裝置的資源狀態，作業系統可能會延遲同步。</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">為即時作業最佳化</string>
+    <string name="settings_background_sync_mode_real_time">為即時作業最佳化</string>
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} 將會精準地定期在背景同步（可設定）。
 \n這會影響到網路與電池的使用，並會顯示指出 ${app_name} 正在監聽某事件的永久通知。</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">無背景同步</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">當應用程式在背景時，您將不會收到訊息通知。</string>
+    <string name="settings_background_sync_mode_disabled">無背景同步</string>
+    <string name="settings_background_sync_mode_disabled_description">當應用程式在背景時，您將不會收到訊息通知。</string>
     <string name="settings_discovery_category">探索</string>
     <string name="settings_discovery_manage">管理您的探索設定。</string>
     <string name="identity_server_not_defined">您未使用任何身份識別伺服器</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -934,15 +934,15 @@
     <string name="settings_mentions_and_keywords_encryption_notice">You won’t get notifications for mentions &amp; keywords in encrypted rooms on mobile.</string>
 
     <string name="settings_background_sync">Background synchronization</string>
-    <string name="settings_background_fdroid_sync_mode">Background Sync Mode</string>
-    <string name="settings_background_fdroid_sync_mode_battery">Optimized for battery</string>
+    <string name="settings_background_sync_mode">Background Sync Mode</string>
+    <string name="settings_background_sync_mode_battery">Optimized for battery</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
     <string name="settings_background_fdroid_sync_mode_battery_description">${app_name} will sync in background in way that preserves the device’s limited resources (battery).\nDepending on your device resource state, the sync may be deferred by the operating system.</string>
-    <string name="settings_background_fdroid_sync_mode_real_time">Optimized for real time</string>
+    <string name="settings_background_sync_mode_real_time">Optimized for real time</string>
     <!-- Note to translators: the translation MUST contain the string "${app_name}", which will be replaced by the application name -->
     <string name="settings_background_fdroid_sync_mode_real_time_description">${app_name} will sync in background periodically at precise time (configurable).\nThis will impact radio and battery usage, there will be a permanent notification displayed stating that ${app_name} is listening for events.</string>
-    <string name="settings_background_fdroid_sync_mode_disabled">No background sync</string>
-    <string name="settings_background_fdroid_sync_mode_disabled_description">You will not be notified of incoming messages when the app is in background.</string>
+    <string name="settings_background_sync_mode_disabled">No background sync</string>
+    <string name="settings_background_sync_mode_disabled_description">You will not be notified of incoming messages when the app is in background.</string>
 
     <string name="settings_start_on_boot">Start on boot</string>
     <string name="settings_set_sync_timeout">Sync request timeout</string>

--- a/vector/src/main/res/xml/vector_settings_notifications.xml
+++ b/vector/src/main/res/xml/vector_settings_notifications.xml
@@ -88,12 +88,12 @@
     <im.vector.app.core.preference.VectorPreferenceCategory
         android:key="SETTINGS_BACKGROUND_SYNC_PREFERENCE_KEY"
         android:title="@string/settings_background_sync"
-        app:isPreferenceVisible="false">
+        app:isPreferenceVisible="true">
 
         <im.vector.app.core.preference.VectorPreference
-            android:key="SETTINGS_FDROID_BACKGROUND_SYNC_MODE"
+            android:key="SETTINGS_BACKGROUND_SYNC_MODE"
             android:persistent="false"
-            android:title="@string/settings_background_fdroid_sync_mode" />
+            android:title="@string/settings_background_sync_mode" />
 
         <im.vector.app.core.preference.VectorEditTextPreference
             android:inputType="numberDecimal"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change
Add the polling option to gplay variant. 

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content
Added all the code specific to FDroid to the gplay variant and edited the strings to be more generic.

<!-- Describe shortly what has been changed -->

## Motivation and context
This is useful for people who might have problems with push notifications on their phone or in general to speed up the process of calls and messages if a user so wish.

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- I changed the push server URL to be invalid and then allowed polling and I got notifications not via push.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)


Signed-off-by: Chagai Friedlander me@chagai.website
