### PR TITLE
FTUE - Allow changing server on onboarding start error

### DIFF
--- a/changelog.d/6718.bugfix
+++ b/changelog.d/6718.bugfix
@@ -1,0 +1,1 @@
+Fixes onboarding requiring matrix.org to be accessible on the first step, the server can now be manually changed

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/failure/Extensions.kt
@@ -89,6 +89,8 @@ fun Throwable.isInvalidUIAAuth() = this is Failure.ServerError &&
 fun Throwable.isHomeserverUnavailable() = this is Failure.NetworkConnection &&
         this.ioException is UnknownHostException
 
+fun Throwable.isHomeserverConnectionError() = this is Failure.NetworkConnection
+
 fun Throwable.isMissingEmailVerification() = this is Failure.ServerError &&
         error.code == MatrixError.M_UNAUTHORIZED &&
         error.message == "Unable to get validated threepid"

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewEvents.kt
@@ -29,7 +29,6 @@ import org.matrix.android.sdk.api.failure.Failure as SdkFailure
 sealed class OnboardingViewEvents : VectorViewEvents {
     data class Loading(val message: CharSequence? = null) : OnboardingViewEvents()
     data class Failure(val throwable: Throwable) : OnboardingViewEvents()
-    data class DeeplinkAuthenticationFailure(val retryAction: OnboardingAction) : OnboardingViewEvents()
     data class UnrecognisedCertificateFailure(val retryAction: OnboardingAction, val cause: SdkFailure.UnrecognizedCertificateFailure) : OnboardingViewEvents()
 
     object DisplayRegistrationFallback : OnboardingViewEvents()

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -701,9 +701,8 @@ class OnboardingViewModel @AssistedInject constructor(
 
     private fun onAuthenticationStartError(error: Throwable, trigger: OnboardingAction.HomeServerChange) {
         when {
-            error.isHomeserverUnavailable() && applicationContext.inferNoConnectivity(sdkIntProvider) -> _viewEvents.post(
-                    OnboardingViewEvents.Failure(error)
-            )
+            error.isHomeserverUnavailable() && applicationContext.inferNoConnectivity(sdkIntProvider) -> _viewEvents.post(OnboardingViewEvents.Failure(error))
+            isUnableToSelectServer(error, trigger) -> handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.EditServerSelection))
             deeplinkUrlIsUnavailable(error, trigger) -> _viewEvents.post(
                     OnboardingViewEvents.DeeplinkAuthenticationFailure(
                             retryAction = (trigger as OnboardingAction.HomeServerChange.SelectHomeServer).resetToDefaultUrl()
@@ -715,6 +714,9 @@ class OnboardingViewModel @AssistedInject constructor(
             else -> _viewEvents.post(OnboardingViewEvents.Failure(error))
         }
     }
+
+    private fun isUnableToSelectServer(error: Throwable, trigger: OnboardingAction.HomeServerChange) =
+            trigger is OnboardingAction.HomeServerChange.SelectHomeServer && error.isHomeserverUnavailable()
 
     private fun deeplinkUrlIsUnavailable(error: Throwable, trigger: OnboardingAction.HomeServerChange) = error.isHomeserverUnavailable() &&
             loginConfig != null &&
@@ -806,6 +808,8 @@ class OnboardingViewModel @AssistedInject constructor(
     fun getInitialHomeServerUrl(): String? {
         return loginConfig?.homeServerUrl
     }
+
+    fun getDefaultHomeserverUrl() = defaultHomeserverUrl
 
     fun fetchSsoUrl(redirectUrl: String, deviceId: String?, provider: SsoIdentityProvider?): String? {
         setState {

--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -703,11 +703,6 @@ class OnboardingViewModel @AssistedInject constructor(
         when {
             error.isHomeserverUnavailable() && applicationContext.inferNoConnectivity(sdkIntProvider) -> _viewEvents.post(OnboardingViewEvents.Failure(error))
             isUnableToSelectServer(error, trigger) -> handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.EditServerSelection))
-            deeplinkUrlIsUnavailable(error, trigger) -> _viewEvents.post(
-                    OnboardingViewEvents.DeeplinkAuthenticationFailure(
-                            retryAction = (trigger as OnboardingAction.HomeServerChange.SelectHomeServer).resetToDefaultUrl()
-                    )
-            )
             error.isUnrecognisedCertificate() -> {
                 _viewEvents.post(OnboardingViewEvents.UnrecognisedCertificateFailure(trigger, error as Failure.UnrecognizedCertificateFailure))
             }
@@ -717,12 +712,6 @@ class OnboardingViewModel @AssistedInject constructor(
 
     private fun isUnableToSelectServer(error: Throwable, trigger: OnboardingAction.HomeServerChange) =
             trigger is OnboardingAction.HomeServerChange.SelectHomeServer && error.isHomeserverUnavailable()
-
-    private fun deeplinkUrlIsUnavailable(error: Throwable, trigger: OnboardingAction.HomeServerChange) = error.isHomeserverUnavailable() &&
-            loginConfig != null &&
-            trigger is OnboardingAction.HomeServerChange.SelectHomeServer
-
-    private fun OnboardingAction.HomeServerChange.SelectHomeServer.resetToDefaultUrl() = copy(homeServerUrl = defaultHomeserverUrl)
 
     private suspend fun onAuthenticationStartedSuccess(
             trigger: OnboardingAction.HomeServerChange,

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedServerSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedServerSelectionFragment.kt
@@ -86,7 +86,7 @@ class FtueAuthCombinedServerSelectionFragment @Inject constructor() : AbstractFt
         )
 
         if (views.chooseServerInput.content().isEmpty()) {
-            val userUrlInput = state.selectedHomeserver.userFacingUrl?.toReducedUrlKeepingSchemaIfInsecure()
+            val userUrlInput = state.selectedHomeserver.userFacingUrl?.toReducedUrlKeepingSchemaIfInsecure() ?: viewModel.getDefaultHomeserverUrl()
             views.chooseServerInput.editText().setText(userUrlInput)
         }
     }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -238,7 +238,6 @@ class FtueAuthVariant(
                 ensureEditServerBackstack()
             }
             OnboardingViewEvents.OpenCombinedLogin -> onStartCombinedLogin()
-            is OnboardingViewEvents.DeeplinkAuthenticationFailure -> onDeeplinkedHomeserverUnavailable(viewEvents)
             OnboardingViewEvents.DisplayRegistrationFallback -> displayFallbackWebDialog()
             is OnboardingViewEvents.DisplayRegistrationStage -> doStage(viewEvents.stage)
             OnboardingViewEvents.DisplayStartRegistration -> when {
@@ -265,22 +264,6 @@ class FtueAuthVariant(
                 }
             }
         }
-    }
-
-    private fun onDeeplinkedHomeserverUnavailable(viewEvents: OnboardingViewEvents.DeeplinkAuthenticationFailure) {
-        showHomeserverUnavailableDialog(onboardingViewModel.getInitialHomeServerUrl().orEmpty()) {
-            onboardingViewModel.handle(OnboardingAction.ResetDeeplinkConfig)
-            onboardingViewModel.handle(viewEvents.retryAction)
-        }
-    }
-
-    private fun showHomeserverUnavailableDialog(url: String, action: () -> Unit) {
-        MaterialAlertDialogBuilder(activity)
-                .setTitle(R.string.dialog_title_error)
-                .setMessage(activity.getString(R.string.login_error_homeserver_from_url_not_found, url))
-                .setPositiveButton(R.string.login_error_homeserver_from_url_not_found_enter_manual) { _, _ -> action() }
-                .setNegativeButton(R.string.action_cancel, null)
-                .show()
     }
 
     private fun onStartCombinedLogin() {

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -412,27 +412,6 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun `given unavailable deeplink, when selecting homeserver, then emits failure with default homeserver as retry action`() = runTest {
-        fakeContext.givenHasConnection()
-        fakeHomeServerConnectionConfigFactory.givenConfigFor(A_HOMESERVER_URL, fingerprint = null, A_HOMESERVER_CONFIG)
-        fakeStartAuthenticationFlowUseCase.givenHomeserverUnavailable(A_HOMESERVER_CONFIG)
-        val test = viewModel.test()
-
-        viewModel.handle(OnboardingAction.InitWith(LoginConfig(A_HOMESERVER_URL, null)))
-        viewModel.handle(OnboardingAction.HomeServerChange.SelectHomeServer(A_HOMESERVER_URL))
-
-        val expectedRetryAction = OnboardingAction.HomeServerChange.SelectHomeServer("${R.string.matrix_org_server_url.toTestString()}/")
-        test
-                .assertStatesChanges(
-                        initialState,
-                        { copy(isLoading = true) },
-                        { copy(isLoading = false) }
-                )
-                .assertEvents(OnboardingViewEvents.DeeplinkAuthenticationFailure(expectedRetryAction))
-                .finish()
-    }
-
-    @Test
     fun `given in the sign up flow, when editing homeserver, then updates selected homeserver state and emits edited event`() = runTest {
         viewModelWith(initialState.copy(onboardingFlow = OnboardingFlow.SignUp))
         givenCanSuccessfullyUpdateHomeserver(A_HOMESERVER_URL, SELECTED_HOMESERVER_STATE)


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Checks for network errors on the initial homeserver selection (starting the login or account creation step) and forwards the user to Edit server screen instead to allow them to choose a different homeserver
- Removes the dedicated deeplink failure dialog in favour of reusing the edit server flow 

## Motivation and context

Fixes #6718 - Allowing the homeserver server to be changed on failure when starting the onboarding (matches iOS) 

## Screenshots / GIFs

|Before|After|
|-|-|
|![before-edit-server-on-error](https://user-images.githubusercontent.com/1848238/185615058-952351fb-c5d8-4f26-a151-949785fc1d09.gif)|![edit-server-on-error](https://user-images.githubusercontent.com/1848238/185615076-94107f41-110b-4e87-ace3-edd97b9f7d57.gif)|
 

## Tests

- Block matrix.org or within the code change the default matrix.org address to an invalid url
- Attempt to login or create and account
- Notice the error dialog

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28