### PR TITLE
Missing push notifications on login

### DIFF
--- a/changelog.d/6891.bugfix
+++ b/changelog.d/6891.bugfix
@@ -1,0 +1,1 @@
+Fixes missing firebase notifications after logging in when UnifiedPush distributor is installed

--- a/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
@@ -92,8 +92,6 @@ class UnifiedPushHelper @Inject constructor(
                 return@launch
             }
 
-            // By default, use internal solution (fcm/background sync)
-            UnifiedPush.saveDistributor(context, context.packageName)
             val distributors = UnifiedPush.getDistributors(context)
 
             if (distributors.size == 1 && !force) {
@@ -101,7 +99,14 @@ class UnifiedPushHelper @Inject constructor(
                 UnifiedPush.registerApp(context)
                 onDoneRunnable?.run()
             } else {
-                openDistributorDialogInternal(activity, pushersManager, onDoneRunnable, distributors, !force, !force)
+                openDistributorDialogInternal(
+                        activity = activity,
+                        pushersManager = pushersManager,
+                        onDoneRunnable = onDoneRunnable,
+                        distributors = distributors,
+                        unregisterFirst = force,
+                        cancellable = !force
+                )
             }
         }
     }
@@ -164,6 +169,12 @@ class UnifiedPushHelper @Inject constructor(
                         UnifiedPush.registerApp(context)
                         onDoneRunnable?.run()
                     }
+                }
+                .setOnCancelListener {
+                    // By default, use internal solution (fcm/background sync)
+                    UnifiedPush.saveDistributor(context, context.packageName)
+                    UnifiedPush.registerApp(context)
+                    onDoneRunnable?.run()
                 }
                 .setCancelable(cancellable)
                 .show()


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- We were saving the default distributor before asking the user, which meant when the user selected the same option it was skipped from being registered
- Only _unregisters_ during the force flow, otherwise we'll crash due to no app being registered

## Motivation and context

Fixes #6891 relates to #6782 

## Screenshots / GIFs

No UI changes

## Tests

- Have a unified push distributor installed eg ntfy
- With a fresh install, login 
- Select `Google services` when prompted
- Exit the app, notice no push messages are received  

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28