### PR TITLE
Feature/bma/incr sync perf

### DIFF
--- a/changelog.d/6917.bugfix
+++ b/changelog.d/6917.bugfix
@@ -1,0 +1,1 @@
+Fix long incremental sync.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/DefaultCrossSigningService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/DefaultCrossSigningService.kt
@@ -779,6 +779,11 @@ internal class DefaultCrossSigningService @Inject constructor(
 
     override fun onUsersDeviceUpdate(userIds: List<String>) {
         Timber.d("## CrossSigning - onUsersDeviceUpdate for users: ${userIds.logLimit()}")
+        checkTrustAndAffectedRoomShields(userIds)
+    }
+
+    fun checkTrustAndAffectedRoomShields(userIds: List<String>) {
+        Timber.d("## CrossSigning - checkTrustAndAffectedRoomShields for users: ${userIds.logLimit()}")
         val workerParams = UpdateTrustWorker.Params(
                 sessionId = sessionId,
                 filename = updateTrustWorkerDataRepository.createParam(userIds)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/UpdateTrustWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/crosssigning/UpdateTrustWorker.kt
@@ -207,6 +207,7 @@ internal class UpdateTrustWorker(context: Context, params: WorkerParameters, ses
     private suspend fun updateTrustStep2(userList: List<String>, myCrossSigningInfo: MXCrossSigningInfo?) {
         Timber.d("## CrossSigning - Updating shields for impacted rooms...")
         awaitTransaction(sessionRealmConfiguration) { sessionRealm ->
+            Timber.d("## CrossSigning - Updating shields for impacted rooms - in transaction")
             Realm.getInstance(cryptoRealmConfiguration).use { cryptoRealm ->
                 sessionRealm.where(RoomMemberSummaryEntity::class.java)
                         .`in`(RoomMemberSummaryEntityFields.USER_ID, userList.toTypedArray())
@@ -239,6 +240,7 @@ internal class UpdateTrustWorker(context: Context, params: WorkerParameters, ses
                         }
             }
         }
+        Timber.d("## CrossSigning - Updating shields for impacted rooms - END")
     }
 
     private fun getCrossSigningInfo(cryptoRealm: Realm, userId: String): MXCrossSigningInfo? {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionComponent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionComponent.kt
@@ -55,6 +55,7 @@ import org.matrix.android.sdk.internal.session.space.SpaceModule
 import org.matrix.android.sdk.internal.session.sync.SyncModule
 import org.matrix.android.sdk.internal.session.sync.SyncTask
 import org.matrix.android.sdk.internal.session.sync.SyncTokenStore
+import org.matrix.android.sdk.internal.session.sync.handler.UpdateUserWorker
 import org.matrix.android.sdk.internal.session.sync.job.SyncWorker
 import org.matrix.android.sdk.internal.session.terms.TermsModule
 import org.matrix.android.sdk.internal.session.thirdparty.ThirdPartyModule
@@ -127,6 +128,8 @@ internal interface SessionComponent {
     fun inject(worker: AddPusherWorker)
 
     fun inject(worker: UpdateTrustWorker)
+
+    fun inject(worker: UpdateUserWorker)
 
     fun inject(worker: DeactivateLiveLocationShareWorker)
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/RoomMemberEventHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/RoomMemberEventHandler.kt
@@ -140,7 +140,8 @@ internal class RoomMemberEventHandler @Inject constructor(
             val previousDisplayName = prevContent?.get("displayname") as? String
             val previousAvatar = prevContent?.get("avatar_url") as? String
 
-            if (previousDisplayName != roomMember.displayName || previousAvatar != roomMember.avatarUrl) {
+            if ((previousDisplayName != null && previousDisplayName != roomMember.displayName) ||
+                    (previousAvatar != null && previousAvatar != roomMember.avatarUrl)) {
                 aggregator.userIdsToFetch.add(eventUserId)
             }
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
@@ -63,6 +63,7 @@ import org.matrix.android.sdk.internal.session.room.accountdata.RoomAccountDataD
 import org.matrix.android.sdk.internal.session.room.membership.RoomDisplayNameResolver
 import org.matrix.android.sdk.internal.session.room.membership.RoomMemberHelper
 import org.matrix.android.sdk.internal.session.room.relationship.RoomChildRelationInfo
+import org.matrix.android.sdk.internal.session.sync.SyncResponsePostTreatmentAggregator
 import timber.log.Timber
 import javax.inject.Inject
 import kotlin.system.measureTimeMillis
@@ -91,7 +92,8 @@ internal class RoomSummaryUpdater @Inject constructor(
             roomSummary: RoomSyncSummary? = null,
             unreadNotifications: RoomSyncUnreadNotifications? = null,
             updateMembers: Boolean = false,
-            inviterId: String? = null
+            inviterId: String? = null,
+            aggregator: SyncResponsePostTreatmentAggregator? = null
     ) {
         val roomSummaryEntity = RoomSummaryEntity.getOrCreate(realm, roomId)
         if (roomSummary != null) {
@@ -180,8 +182,14 @@ internal class RoomSummaryUpdater @Inject constructor(
             roomSummaryEntity.otherMemberIds.clear()
             roomSummaryEntity.otherMemberIds.addAll(otherRoomMembers)
             if (roomSummaryEntity.isEncrypted && otherRoomMembers.isNotEmpty()) {
-                // mmm maybe we could only refresh shield instead of checking trust also?
-                crossSigningService.onUsersDeviceUpdate(otherRoomMembers)
+                if (aggregator == null) {
+                    // Do it now
+                    // mmm maybe we could only refresh shield instead of checking trust also?
+                    crossSigningService.onUsersDeviceUpdate(otherRoomMembers) // This is very long and could maybe be done once per sync response.
+                } else {
+                    // Schedule it
+                    aggregator.userIdsWithDeviceUpdate.addAll(otherRoomMembers)
+                }
             }
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
@@ -185,10 +185,10 @@ internal class RoomSummaryUpdater @Inject constructor(
                 if (aggregator == null) {
                     // Do it now
                     // mmm maybe we could only refresh shield instead of checking trust also?
-                    crossSigningService.onUsersDeviceUpdate(otherRoomMembers)
+                    crossSigningService.checkTrustAndAffectedRoomShields(otherRoomMembers)
                 } else {
                     // Schedule it
-                    aggregator.userIdsWithDeviceUpdate.addAll(otherRoomMembers)
+                    aggregator.userIdsForCheckingTrustAndAffectedRoomShields.addAll(otherRoomMembers)
                 }
             }
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
@@ -185,7 +185,7 @@ internal class RoomSummaryUpdater @Inject constructor(
                 if (aggregator == null) {
                     // Do it now
                     // mmm maybe we could only refresh shield instead of checking trust also?
-                    crossSigningService.onUsersDeviceUpdate(otherRoomMembers) // This is very long and could maybe be done once per sync response.
+                    crossSigningService.onUsersDeviceUpdate(otherRoomMembers)
                 } else {
                     // Schedule it
                     aggregator.userIdsWithDeviceUpdate.addAll(otherRoomMembers)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
@@ -126,21 +126,33 @@ internal class SyncResponseHandler @Inject constructor(
         }
 
         // Everything else we need to do outside the transaction
-        aggregatorHandler.handle(aggregator)
-
-        syncResponse.rooms?.let {
-            checkPushRules(it, isInitialSync)
-            userAccountDataSyncHandler.synchronizeWithServerIfNeeded(it.invite)
-            dispatchInvitedRoom(it)
+        measureTimeMillis {
+            aggregatorHandler.handle(aggregator)
+        }.also {
+            Timber.v("Aggregator management took $it ms")
         }
 
-        Timber.v("On sync completed")
-        cryptoSyncHandler.onSyncCompleted(syncResponse)
+        measureTimeMillis {
+            syncResponse.rooms?.let {
+                checkPushRules(it, isInitialSync)
+                userAccountDataSyncHandler.synchronizeWithServerIfNeeded(it.invite)
+                dispatchInvitedRoom(it)
+            }.also {
+                Timber.v("SyncResponse.rooms post treatment took $it ms")
+            }
+        }
+
+        measureTimeMillis {
+            cryptoSyncHandler.onSyncCompleted(syncResponse)
+        }.also {
+            Timber.v("cryptoSyncHandler.onSyncCompleted took $it ms")
+        }
 
         // post sync stuffs
         monarchy.writeAsync {
             roomSyncHandler.postSyncSpaceHierarchyHandle(it)
         }
+        Timber.v("On sync completed")
     }
 
     private fun dispatchInvitedRoom(roomsSyncResponse: RoomsSyncResponse) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
@@ -137,9 +137,9 @@ internal class SyncResponseHandler @Inject constructor(
                 checkPushRules(it, isInitialSync)
                 userAccountDataSyncHandler.synchronizeWithServerIfNeeded(it.invite)
                 dispatchInvitedRoom(it)
-            }.also {
-                Timber.v("SyncResponse.rooms post treatment took $it ms")
             }
+        }.also {
+            Timber.v("SyncResponse.rooms post treatment took $it ms")
         }
 
         measureTimeMillis {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregator.kt
@@ -23,7 +23,7 @@ internal class SyncResponsePostTreatmentAggregator {
     // Map of roomId to directUserId
     val directChatsToCheck = mutableMapOf<String, String>()
 
-    // List of userIds to fetch and update at the end of incremental syncs
+    // Set of userIds to fetch and update at the end of incremental syncs
     val userIdsToFetch = mutableSetOf<String>()
 
     // Set of users to call `crossSigningService.onUsersDeviceUpdate` once per sync

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregator.kt
@@ -25,4 +25,7 @@ internal class SyncResponsePostTreatmentAggregator {
 
     // List of userIds to fetch and update at the end of incremental syncs
     val userIdsToFetch = mutableListOf<String>()
+
+    // Set of users to call `crossSigningService.onUsersDeviceUpdate` once per sync
+    val userIdsWithDeviceUpdate = mutableSetOf<String>()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregator.kt
@@ -24,7 +24,7 @@ internal class SyncResponsePostTreatmentAggregator {
     val directChatsToCheck = mutableMapOf<String, String>()
 
     // List of userIds to fetch and update at the end of incremental syncs
-    val userIdsToFetch = mutableListOf<String>()
+    val userIdsToFetch = mutableSetOf<String>()
 
     // Set of users to call `crossSigningService.onUsersDeviceUpdate` once per sync
     val userIdsWithDeviceUpdate = mutableSetOf<String>()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregator.kt
@@ -26,6 +26,6 @@ internal class SyncResponsePostTreatmentAggregator {
     // Set of userIds to fetch and update at the end of incremental syncs
     val userIdsToFetch = mutableSetOf<String>()
 
-    // Set of users to call `crossSigningService.onUsersDeviceUpdate` once per sync
-    val userIdsWithDeviceUpdate = mutableSetOf<String>()
+    // Set of users to call `crossSigningService.checkTrustAndAffectedRoomShields` once per sync
+    val userIdsForCheckingTrustAndAffectedRoomShields = mutableSetOf<String>()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/SyncResponsePostTreatmentAggregatorHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/SyncResponsePostTreatmentAggregatorHandler.kt
@@ -30,6 +30,7 @@ import org.matrix.android.sdk.internal.session.user.UserEntityFactory
 import org.matrix.android.sdk.internal.session.user.accountdata.DirectChatsHelper
 import org.matrix.android.sdk.internal.session.user.accountdata.UpdateUserAccountDataTask
 import org.matrix.android.sdk.internal.util.awaitTransaction
+import timber.log.Timber
 import javax.inject.Inject
 
 internal class SyncResponsePostTreatmentAggregatorHandler @Inject constructor(
@@ -101,8 +102,11 @@ internal class SyncResponsePostTreatmentAggregatorHandler @Inject constructor(
 
     private suspend fun List<User>.saveLocally() {
         val userEntities = map { user -> UserEntityFactory.create(user) }
+        Timber.d("## saveLocally()")
         monarchy.awaitTransaction {
+            Timber.d("## saveLocally() - in transaction")
             it.insertOrUpdate(userEntities)
         }
+        Timber.d("## saveLocally() - END")
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/SyncResponsePostTreatmentAggregatorHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/SyncResponsePostTreatmentAggregatorHandler.kt
@@ -83,13 +83,13 @@ internal class SyncResponsePostTreatmentAggregatorHandler @Inject constructor(
         }
     }
 
-    private suspend fun fetchAndUpdateUsers(userIdsToFetch: List<String>) {
+    private suspend fun fetchAndUpdateUsers(userIdsToFetch: Collection<String>) {
         fetchUsers(userIdsToFetch)
                 .takeIf { it.isNotEmpty() }
                 ?.saveLocally()
     }
 
-    private suspend fun fetchUsers(userIdsToFetch: List<String>) = userIdsToFetch.mapNotNull {
+    private suspend fun fetchUsers(userIdsToFetch: Collection<String>) = userIdsToFetch.mapNotNull {
         tryOrNull {
             val profileJson = getProfileInfoTask.execute(GetProfileInfoTask.Params(it))
             User.fromJson(it, profileJson)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/SyncResponsePostTreatmentAggregatorHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/SyncResponsePostTreatmentAggregatorHandler.kt
@@ -48,7 +48,7 @@ internal class SyncResponsePostTreatmentAggregatorHandler @Inject constructor(
         cleanupEphemeralFiles(aggregator.ephemeralFilesToDelete)
         updateDirectUserIds(aggregator.directChatsToCheck)
         fetchAndUpdateUsers(aggregator.userIdsToFetch)
-        handleUserIdsWithDeviceUpdate(aggregator.userIdsWithDeviceUpdate)
+        handleUserIdsForCheckingTrustAndAffectedRoomShields(aggregator.userIdsForCheckingTrustAndAffectedRoomShields)
     }
 
     private fun cleanupEphemeralFiles(ephemeralFilesToDelete: List<String>) {
@@ -105,7 +105,7 @@ internal class SyncResponsePostTreatmentAggregatorHandler @Inject constructor(
                 .enqueue()
     }
 
-    private fun handleUserIdsWithDeviceUpdate(userIdsWithDeviceUpdate: Iterable<String>) {
-        crossSigningService.onUsersDeviceUpdate(userIdsWithDeviceUpdate.toList())
+    private fun handleUserIdsForCheckingTrustAndAffectedRoomShields(userIdsWithDeviceUpdate: Iterable<String>) {
+        crossSigningService.checkTrustAndAffectedRoomShields(userIdsWithDeviceUpdate.toList())
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/UpdateUserWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/UpdateUserWorker.kt
@@ -35,7 +35,7 @@ import timber.log.Timber
 import javax.inject.Inject
 
 /**
- * Note: We reuse the same type [UpdateTrustWorker.Params], since the inout data are the same.
+ * Note: We reuse the same type [UpdateTrustWorker.Params], since the input data are the same.
  */
 internal class UpdateUserWorker(context: Context, params: WorkerParameters, sessionManager: SessionManager) :
         SessionSafeCoroutineWorker<UpdateTrustWorker.Params>(context, params, sessionManager, UpdateTrustWorker.Params::class.java) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/UpdateUserWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/UpdateUserWorker.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.session.sync.handler
+
+import android.content.Context
+import androidx.work.WorkerParameters
+import com.zhuinden.monarchy.Monarchy
+import org.matrix.android.sdk.api.extensions.tryOrNull
+import org.matrix.android.sdk.api.session.user.model.User
+import org.matrix.android.sdk.internal.SessionManager
+import org.matrix.android.sdk.internal.crypto.crosssigning.UpdateTrustWorker
+import org.matrix.android.sdk.internal.crypto.crosssigning.UpdateTrustWorkerDataRepository
+import org.matrix.android.sdk.internal.di.SessionDatabase
+import org.matrix.android.sdk.internal.session.SessionComponent
+import org.matrix.android.sdk.internal.session.profile.GetProfileInfoTask
+import org.matrix.android.sdk.internal.session.user.UserEntityFactory
+import org.matrix.android.sdk.internal.util.awaitTransaction
+import org.matrix.android.sdk.internal.util.logLimit
+import org.matrix.android.sdk.internal.worker.SessionSafeCoroutineWorker
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * Note: We reuse the same type [UpdateTrustWorker.Params], since the inout data are the same.
+ */
+internal class UpdateUserWorker(context: Context, params: WorkerParameters, sessionManager: SessionManager) :
+        SessionSafeCoroutineWorker<UpdateTrustWorker.Params>(context, params, sessionManager, UpdateTrustWorker.Params::class.java) {
+
+    @SessionDatabase
+    @Inject lateinit var monarchy: Monarchy
+    @Inject lateinit var updateTrustWorkerDataRepository: UpdateTrustWorkerDataRepository
+    @Inject lateinit var getProfileInfoTask: GetProfileInfoTask
+
+    override fun injectWith(injector: SessionComponent) {
+        injector.inject(this)
+    }
+
+    override suspend fun doSafeWork(params: UpdateTrustWorker.Params): Result {
+        val userList = params.filename
+                ?.let { updateTrustWorkerDataRepository.getParam(it) }
+                ?.userIds
+                ?: params.updatedUserIds.orEmpty()
+
+        // List should not be empty, but let's avoid go further in case of empty list
+        if (userList.isNotEmpty()) {
+            Timber.v("## UpdateUserWorker - updating users: ${userList.logLimit()}")
+            fetchAndUpdateUsers(userList)
+        }
+
+        cleanup(params)
+        return Result.success()
+    }
+
+    private suspend fun fetchAndUpdateUsers(userIdsToFetch: Collection<String>) {
+        fetchUsers(userIdsToFetch)
+                .takeIf { it.isNotEmpty() }
+                ?.saveLocally()
+    }
+
+    private suspend fun fetchUsers(userIdsToFetch: Collection<String>) = userIdsToFetch.mapNotNull {
+        tryOrNull {
+            val profileJson = getProfileInfoTask.execute(GetProfileInfoTask.Params(it))
+            User.fromJson(it, profileJson)
+        }
+    }
+
+    private suspend fun List<User>.saveLocally() {
+        val userEntities = map { user -> UserEntityFactory.create(user) }
+        Timber.d("## saveLocally()")
+        monarchy.awaitTransaction {
+            Timber.d("## saveLocally() - in transaction")
+            it.insertOrUpdate(userEntities)
+        }
+        Timber.d("## saveLocally() - END")
+    }
+
+    private fun cleanup(params: UpdateTrustWorker.Params) {
+        params.filename
+                ?.let { updateTrustWorkerDataRepository.delete(it) }
+    }
+
+    override fun buildErrorParams(params: UpdateTrustWorker.Params, message: String): UpdateTrustWorker.Params {
+        return params.copy(lastFailureMessage = params.lastFailureMessage ?: message)
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/worker/MatrixWorkerFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/worker/MatrixWorkerFactory.kt
@@ -30,6 +30,7 @@ import org.matrix.android.sdk.internal.session.room.aggregation.livelocation.Dea
 import org.matrix.android.sdk.internal.session.room.send.MultipleEventSendingDispatcherWorker
 import org.matrix.android.sdk.internal.session.room.send.RedactEventWorker
 import org.matrix.android.sdk.internal.session.room.send.SendEventWorker
+import org.matrix.android.sdk.internal.session.sync.handler.UpdateUserWorker
 import org.matrix.android.sdk.internal.session.sync.job.SyncWorker
 import timber.log.Timber
 import javax.inject.Inject
@@ -62,6 +63,8 @@ internal class MatrixWorkerFactory @Inject constructor(private val sessionManage
                 SyncWorker(appContext, workerParameters, sessionManager)
             UpdateTrustWorker::class.java.name ->
                 UpdateTrustWorker(appContext, workerParameters, sessionManager)
+            UpdateUserWorker::class.java.name ->
+                UpdateUserWorker(appContext, workerParameters, sessionManager)
             UploadContentWorker::class.java.name ->
                 UploadContentWorker(appContext, workerParameters, sessionManager)
             DeactivateLiveLocationShareWorker::class.java.name ->


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

Improve incremental sync performance by moving some work in the background.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix #6027 
- other changes are regarding the fetch user mechanism, which is used to keep User database up to date.
- Also some logs have been added.
- [13f7A9f](https://github.com/vector-im/element-android/pull/6917/commits/13f7a9fc10df57b668f92607c5a02bfaef3946c4) has to be reviewed by the CryptoTeam (CC @BillCarsonFr ). This change is not strictly related to the performance issue, the work was already in BG. But I think the SDK were computing too many times the same thing.

A large incr sync is roughly passing from 70s to 8s here.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Use the app with a big account, after a moment offline to have a big incremental sync. Observe that the progress bar is displayed a relatively short time.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
