### PR TITLE
FTUE: Make entering a custom Homeserver address faster by focusing the input

### DIFF
--- a/changelog.d/6926.misc
+++ b/changelog.d/6926.misc
@@ -1,0 +1,1 @@
+Focus input field when editing homeserver address to speed up login and registration.

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedServerSelectionFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedServerSelectionFragment.kt
@@ -28,6 +28,7 @@ import im.vector.app.core.extensions.content
 import im.vector.app.core.extensions.editText
 import im.vector.app.core.extensions.realignPercentagesToParent
 import im.vector.app.core.extensions.setOnImeDoneListener
+import im.vector.app.core.extensions.showKeyboard
 import im.vector.app.core.extensions.toReducedUrl
 import im.vector.app.core.utils.ensureProtocol
 import im.vector.app.core.utils.ensureTrailingSlash
@@ -91,6 +92,9 @@ class FtueAuthCombinedServerSelectionFragment :
             val userUrlInput = state.selectedHomeserver.userFacingUrl?.toReducedUrlKeepingSchemaIfInsecure() ?: viewModel.getDefaultHomeserverUrl()
             views.chooseServerInput.editText().setText(userUrlInput)
         }
+
+        views.chooseServerInput.editText().selectAll()
+        views.chooseServerInput.editText().showKeyboard(true)
     }
 
     override fun onError(throwable: Throwable) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : small enhancement, fixes #6926 

## Content

<!-- Describe shortly what has been changed -->
When the server selection fragment is shown and after the previously entered or default server address is set, the input for the server gets selected and requests focus. At the same time the keyboard is shown so you can immediately type away when the fragment is shown. That should remove the need for two additional clicks, one to focus the input field and one to clear it.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
#6926

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|Light|
|-|-|-|
|![Screenshot_20220824-145117](https://user-images.githubusercontent.com/39308834/186422993-a709414b-60a9-435e-8f90-cda22138d3dd.png)|![Screenshot_20220824-145338](https://user-images.githubusercontent.com/39308834/186423868-5fc4f900-6956-43aa-ba57-4edcb45829ea.png)|![Screenshot_20220824-145421](https://user-images.githubusercontent.com/39308834/186424003-f43192de-f9db-41a0-aa94-d8790f23aeaf.png)|


## Tests

<!-- Explain how you tested your development -->

- Start Element
- Press "I ALREADY HAVE AN ACCOUNT"
- Press "EDIT" next to the default homeserver adress
- Go back or apply apply a change
---
- Start Element
- Press "CREATE ACCOUNT"
- Press "Skip this question"
- Press "EDIT" next to the default homeserver adress
- Go back or apply apply a change

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

Signed-off-by: Timuçin Boldt <timucin.boldt@udo.edu>