### PR TITLE
fixed space switching dialog measured with wrong height sometimes

### DIFF
--- a/changelog.d/6750.wip
+++ b/changelog.d/6750.wip
@@ -1,0 +1,1 @@
+[App Layout] fixed space switching dialog measured with wrong height sometimes

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceListFragment.kt
@@ -193,7 +193,10 @@ class SpaceListFragment :
     override fun invalidate() = withState(viewModel) { state ->
         when (state.asyncSpaces) {
             Uninitialized,
-            is Loading -> views.stateView.state = StateView.State.Loading
+            is Loading -> {
+                views.stateView.state = StateView.State.Loading
+                return@withState
+            }
             is Success -> views.stateView.state = StateView.State.Content
             else -> Unit
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

sometimes space switching dialog appears with wrong height measured

## Motivation and context

closes #6750

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- navigate to home screen
- show space switcher dialog via FAB


## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s): Android 10
