### PR TITLE
Small refactor UnifiedPushHelper

### DIFF
--- a/changelog.d/6936.misc
+++ b/changelog.d/6936.misc
@@ -1,0 +1,1 @@
+Smaff refactor of UnifiedPushHelper

--- a/changelog.d/6936.misc
+++ b/changelog.d/6936.misc
@@ -1,1 +1,1 @@
-Smaff refactor of UnifiedPushHelper
+Small refactor of UnifiedPushHelper

--- a/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
@@ -146,10 +146,6 @@ class UnifiedPushHelper @Inject constructor(
                 .setTitle(stringProvider.getString(R.string.unifiedpush_getdistributors_dialog_title))
                 .setItems(distributorsName.toTypedArray()) { _, which ->
                     val distributor = distributors[which]
-                    if (distributor == UnifiedPush.getDistributor(context)) {
-                        Timber.d("Same distributor selected again, no action")
-                        return@setItems
-                    }
 
                     activity.lifecycleScope.launch {
                         UnifiedPush.saveDistributor(context, distributor)

--- a/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
@@ -47,6 +47,8 @@ class UnifiedPushHelper @Inject constructor(
         private val fcmHelper: FcmHelper,
 ) {
 
+    // Called when the home activity starts
+    // or when notifications are enabled
     fun register(
             activity: FragmentActivity,
             onDoneRunnable: Runnable? = null,
@@ -117,6 +119,8 @@ class UnifiedPushHelper @Inject constructor(
         }
     }
 
+    // There is no case where this function is called
+    // with a saved distributor and/or a pusher
     private fun openDistributorDialogInternal(
             activity: FragmentActivity,
             onDoneRunnable: Runnable?,

--- a/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
@@ -104,8 +104,7 @@ class UnifiedPushHelper @Inject constructor(
                         pushersManager = pushersManager,
                         onDoneRunnable = onDoneRunnable,
                         distributors = distributors,
-                        unregisterFirst = force,
-                        cancellable = !force
+                        unregisterFirst = force
                 )
             }
         }
@@ -122,7 +121,6 @@ class UnifiedPushHelper @Inject constructor(
                 pushersManager,
                 onDoneRunnable, distributors,
                 unregisterFirst = true,
-                cancellable = true,
         )
     }
 
@@ -132,7 +130,6 @@ class UnifiedPushHelper @Inject constructor(
             onDoneRunnable: Runnable?,
             distributors: List<String>,
             unregisterFirst: Boolean,
-            cancellable: Boolean,
     ) {
         val internalDistributorName = stringProvider.getString(
                 if (fcmHelper.isFirebaseAvailable()) {
@@ -176,7 +173,7 @@ class UnifiedPushHelper @Inject constructor(
                     UnifiedPush.registerApp(context)
                     onDoneRunnable?.run()
                 }
-                .setCancelable(cancellable)
+                .setCancelable(true)
                 .show()
     }
 

--- a/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
@@ -46,6 +46,7 @@ class UnifiedPushHelper @Inject constructor(
         private val vectorFeatures: VectorFeatures,
         private val fcmHelper: FcmHelper,
 ) {
+
     fun register(
             activity: FragmentActivity,
             onDoneRunnable: Runnable? = null,
@@ -56,7 +57,14 @@ class UnifiedPushHelper @Inject constructor(
         )
     }
 
-    fun reRegister(
+    // If registration is forced:
+    // * the current distributor (if any) is removed
+    // * The dialog is opened
+    //
+    // The registration is forced in 2 cases :
+    // * in the settings
+    // * in the troubleshoot list (doFix)
+    fun forceRegister(
             activity: FragmentActivity,
             pushersManager: PushersManager,
             onDoneRunnable: Runnable? = null
@@ -86,7 +94,8 @@ class UnifiedPushHelper @Inject constructor(
                 // Un-register first
                 unregister(pushersManager)
             }
-            if (UnifiedPush.getDistributor(context).isNotEmpty()) {
+            // the !force should not be needed
+            if (!force && UnifiedPush.getDistributor(context).isNotEmpty()) {
                 UnifiedPush.registerApp(context)
                 onDoneRunnable?.run()
                 return@launch
@@ -94,42 +103,24 @@ class UnifiedPushHelper @Inject constructor(
 
             val distributors = UnifiedPush.getDistributors(context)
 
-            if (distributors.size == 1 && !force) {
+            if (!force && distributors.size == 1) {
                 UnifiedPush.saveDistributor(context, distributors.first())
                 UnifiedPush.registerApp(context)
                 onDoneRunnable?.run()
             } else {
                 openDistributorDialogInternal(
                         activity = activity,
-                        pushersManager = pushersManager,
                         onDoneRunnable = onDoneRunnable,
-                        distributors = distributors,
-                        unregisterFirst = force
+                        distributors = distributors
                 )
             }
         }
     }
 
-    fun openDistributorDialog(
-            activity: FragmentActivity,
-            pushersManager: PushersManager,
-            onDoneRunnable: Runnable,
-    ) {
-        val distributors = UnifiedPush.getDistributors(activity)
-        openDistributorDialogInternal(
-                activity,
-                pushersManager,
-                onDoneRunnable, distributors,
-                unregisterFirst = true,
-        )
-    }
-
     private fun openDistributorDialogInternal(
             activity: FragmentActivity,
-            pushersManager: PushersManager?,
             onDoneRunnable: Runnable?,
-            distributors: List<String>,
-            unregisterFirst: Boolean,
+            distributors: List<String>
     ) {
         val internalDistributorName = stringProvider.getString(
                 if (fcmHelper.isFirebaseAvailable()) {
@@ -157,10 +148,6 @@ class UnifiedPushHelper @Inject constructor(
                     }
 
                     activity.lifecycleScope.launch {
-                        if (unregisterFirst) {
-                            // Un-register first
-                            unregister(pushersManager)
-                        }
                         UnifiedPush.saveDistributor(context, distributor)
                         Timber.i("Saving distributor: $distributor")
                         UnifiedPush.registerApp(context)

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/VectorSettingsNotificationPreferenceFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/VectorSettingsNotificationPreferenceFragment.kt
@@ -158,7 +158,7 @@ class VectorSettingsNotificationPreferenceFragment :
             if (vectorFeatures.allowExternalUnifiedPushDistributors()) {
                 it.summary = unifiedPushHelper.getCurrentDistributorName()
                 it.onPreferenceClickListener = Preference.OnPreferenceClickListener {
-                    unifiedPushHelper.openDistributorDialog(requireActivity(), pushersManager) {
+                    unifiedPushHelper.forceRegister(requireActivity(), pushersManager) {
                         it.summary = unifiedPushHelper.getCurrentDistributorName()
                         session.pushersService().refreshPushers()
                         refreshBackgroundSyncPrefs()

--- a/vector/src/main/java/im/vector/app/features/settings/troubleshoot/TestEndpointAsTokenRegistration.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/troubleshoot/TestEndpointAsTokenRegistration.kt
@@ -60,7 +60,7 @@ class TestEndpointAsTokenRegistration @Inject constructor(
             )
             quickFix = object : TroubleshootQuickFix(R.string.settings_troubleshoot_test_endpoint_registration_quick_fix) {
                 override fun doFix() {
-                    unifiedPushHelper.reRegister(
+                    unifiedPushHelper.forceRegister(
                             context,
                             pushersManager
                     )


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : refactor

## Content

<!-- Describe shortly what has been changed -->
Small refactor of UnifiedPushHelper : simplified and redundancies removed.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
As shown in #6890, before this PR (6890), the `unregisterFirst` parameter was only used when there was no distributor. And it is set to true only when it is removed first (registerInternal with force = true). So this parameter is useless.

Simplifying this Helper may avoid other issues like the dialog opened without the `allowExternalUnifiedPushDistributors` feature. 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
