### PR TITLE
Fixing /joinSpace and /addToSpace commands

### DIFF
--- a/changelog.d/6844.bugfix
+++ b/changelog.d/6844.bugfix
@@ -1,0 +1,1 @@
+Fixes /addToSpace and /joinSpace commands showing invalid syntax warnings

--- a/vector/src/main/java/im/vector/app/features/command/CommandParser.kt
+++ b/vector/src/main/java/im/vector/app/features/command/CommandParser.kt
@@ -374,15 +374,15 @@ class CommandParser @Inject constructor() {
                     }
                 }
                 Command.ADD_TO_SPACE.matches(slashCommand) -> {
-                    if (messageParts.size == 1) {
-                        ParsedCommand.AddToSpace(spaceId = message)
+                    if (messageParts.size == 2) {
+                        ParsedCommand.AddToSpace(spaceId = messageParts.last())
                     } else {
                         ParsedCommand.ErrorSyntax(Command.ADD_TO_SPACE)
                     }
                 }
                 Command.JOIN_SPACE.matches(slashCommand) -> {
-                    if (messageParts.size == 1) {
-                        ParsedCommand.JoinSpace(spaceIdOrAlias = message)
+                    if (messageParts.size == 2) {
+                        ParsedCommand.JoinSpace(spaceIdOrAlias = messageParts.last())
                     } else {
                         ParsedCommand.ErrorSyntax(Command.JOIN_SPACE)
                     }

--- a/vector/src/test/java/im/vector/app/features/command/CommandParserTest.kt
+++ b/vector/src/test/java/im/vector/app/features/command/CommandParserTest.kt
@@ -19,6 +19,8 @@ package im.vector.app.features.command
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 
+private const val A_SPACE_ID = "!my-space-id"
+
 class CommandParserTest {
     @Test
     fun parseSlashCommandEmpty() {
@@ -29,6 +31,15 @@ class CommandParserTest {
     fun parseSlashCommandUnknown() {
         test("/unknown", ParsedCommand.ErrorUnknownSlashCommand("/unknown"))
         test("/unknown with param", ParsedCommand.ErrorUnknownSlashCommand("/unknown"))
+    }
+
+    @Test
+    fun parseSlashAddToSpaceCommand() {
+        test("/addToSpace $A_SPACE_ID", ParsedCommand.AddToSpace(A_SPACE_ID))
+    }
+    @Test
+    fun parseSlashJoinSpaceCommand() {
+        test("/joinSpace $A_SPACE_ID", ParsedCommand.JoinSpace(A_SPACE_ID))
     }
 
     @Test


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes the join and add to space commands not working due to expecting only 1 message part, the command itself. This was incorrect as we need to pass the id/alias to the command

- Updates the unit tests 


## Motivation and context

Fixes #6844 

## Screenshots / GIFs

|Before|After|
|-|-|
|![before-add-to-space](https://user-images.githubusercontent.com/1848238/186696412-4bf4c122-383d-4965-b501-e929cb35be5f.png)|![after-add-to-space](https://user-images.githubusercontent.com/1848238/186696628-30c042b4-d424-4981-8396-5cbc34b4ba99.gif)|
 
## Tests

- In a room, use the `/addToSpace ${space id}` command
- Notice an error popup

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28


