### PR TITLE
fixed invites count badge bottom margin on a home screen

### DIFF
--- a/changelog.d/6947.wip
+++ b/changelog.d/6947.wip
@@ -1,0 +1,1 @@
+[App Layout] fixed invites count badge bottom margin on a home screen

--- a/vector/src/main/res/layout/item_invites_count.xml
+++ b/vector/src/main/res/layout/item_invites_count.xml
@@ -3,11 +3,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="36sp"
     android:background="?vctr_toolbar_background"
     android:clickable="true"
     android:focusable="true"
-
     tools:viewBindingIgnore="true">
 
     <im.vector.app.features.home.room.list.UnreadCounterBadgeView
@@ -44,5 +43,16 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/invites_count_badge"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <View
+        android:id="@+id/invites_divider"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_marginStart="22dp"
+        android:layout_marginEnd="16dp"
+        android:background="?vctr_list_separator_system"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

With recents carousel enabled, the Invites text button looks very close to the carousel

## Motivation and context

closes #6947 

## Screenshots / GIFs

![Screenshot 2022-08-26 at 14 54 03](https://user-images.githubusercontent.com/66663241/186908219-d94dc4cb-4c4a-4c96-848f-cc6441b2ab76.png)


