### PR TITLE
Fix crash when opening an unknown room

### DIFF
--- a/changelog.d/6978.bugfix
+++ b/changelog.d/6978.bugfix
@@ -1,0 +1,1 @@
+Fix crash when opening an unknown room

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -992,9 +992,9 @@ class TimelineFragment :
         views.jumpToBottomView.debouncedClicks {
             timelineViewModel.handle(RoomDetailAction.ExitTrackingUnreadMessagesState)
             views.jumpToBottomView.visibility = View.INVISIBLE
-            if (!timelineViewModel.timeline.isLive) {
+            if (timelineViewModel.timeline?.isLive == false) {
                 scrollOnNewMessageCallback.forceScrollOnNextUpdate()
-                timelineViewModel.timeline.restartWithEventId(null)
+                timelineViewModel.timeline?.restartWithEventId(null)
             } else {
                 layoutManager.scrollToPosition(0)
             }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1224,12 +1224,12 @@ class TimelineFragment :
         }
     }
 
-    private fun handleSearchAction() {
+    private fun handleSearchAction() = withState(timelineViewModel) { state ->
         navigator.openSearch(
                 context = requireContext(),
                 roomId = timelineArgs.roomId,
-                roomDisplayName = timelineViewModel.getRoomSummary()?.displayName,
-                roomAvatarUrl = timelineViewModel.getRoomSummary()?.avatarUrl
+                roomDisplayName = state.asyncRoomSummary()?.displayName,
+                roomAvatarUrl = state.asyncRoomSummary()?.avatarUrl
         )
     }
 
@@ -2520,15 +2520,19 @@ class TimelineFragment :
      * Navigate to Threads timeline for the specified rootThreadEventId
      * using the ThreadsActivity.
      */
-    private fun navigateToThreadTimeline(rootThreadEventId: String, startsThread: Boolean = false, showKeyboard: Boolean = false) {
+    private fun navigateToThreadTimeline(
+            rootThreadEventId: String,
+            startsThread: Boolean = false,
+            showKeyboard: Boolean = false,
+    ) = withState(timelineViewModel) { state ->
         analyticsTracker.capture(Interaction.Name.MobileRoomThreadSummaryItem.toAnalyticsInteraction())
         context?.let {
             val roomThreadDetailArgs = ThreadTimelineArgs(
                     startsThread = startsThread,
                     roomId = timelineArgs.roomId,
-                    displayName = timelineViewModel.getRoomSummary()?.displayName,
-                    avatarUrl = timelineViewModel.getRoomSummary()?.avatarUrl,
-                    roomEncryptionTrustLevel = timelineViewModel.getRoomSummary()?.roomEncryptionTrustLevel,
+                    displayName = state.asyncRoomSummary()?.displayName,
+                    avatarUrl = state.asyncRoomSummary()?.avatarUrl,
+                    roomEncryptionTrustLevel = state.asyncRoomSummary()?.roomEncryptionTrustLevel,
                     rootThreadEventId = rootThreadEventId,
                     showKeyboard = showKeyboard
             )
@@ -2559,14 +2563,14 @@ class TimelineFragment :
      * Navigate to Threads list for the current room
      * using the ThreadsActivity.
      */
-    private fun navigateToThreadList() {
+    private fun navigateToThreadList() = withState(timelineViewModel) { state ->
         analyticsTracker.capture(Interaction.Name.MobileRoomThreadListButton.toAnalyticsInteraction())
         context?.let {
             val roomThreadDetailArgs = ThreadTimelineArgs(
                     roomId = timelineArgs.roomId,
-                    displayName = timelineViewModel.getRoomSummary()?.displayName,
-                    roomEncryptionTrustLevel = timelineViewModel.getRoomSummary()?.roomEncryptionTrustLevel,
-                    avatarUrl = timelineViewModel.getRoomSummary()?.avatarUrl
+                    displayName = state.asyncRoomSummary()?.displayName,
+                    roomEncryptionTrustLevel = state.asyncRoomSummary()?.roomEncryptionTrustLevel,
+                    avatarUrl = state.asyncRoomSummary()?.avatarUrl
             )
             navigator.openThreadList(it, roomThreadDetailArgs)
         }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -195,7 +195,6 @@ class TimelineViewModel @AssistedInject constructor(
         observeActiveRoomWidgets()
         observePowerLevel()
         setupPreviewUrlObservers()
-        room.getRoomSummaryLive()
         viewModelScope.launch(Dispatchers.IO) {
             tryOrNull { room.readService().markAsRead(ReadService.MarkAsReadParams.READ_RECEIPT) }
         }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -402,8 +402,6 @@ class TimelineViewModel @AssistedInject constructor(
 
     fun getOtherUserIds() = room.roomSummary()?.otherMemberIds
 
-    fun getRoomSummary() = room.roomSummary()
-
     override fun handle(action: RoomDetailAction) {
         when (action) {
             is RoomDetailAction.ComposerFocusChange -> handleComposerFocusChange(action)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -400,8 +400,6 @@ class TimelineViewModel @AssistedInject constructor(
                 }
     }
 
-    fun getOtherUserIds() = room.roomSummary()?.otherMemberIds
-
     override fun handle(action: RoomDetailAction) {
         when (action) {
             is RoomDetailAction.ComposerFocusChange -> handleComposerFocusChange(action)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -48,6 +48,7 @@ import im.vector.app.features.call.webrtc.WebRtcCallManager
 import im.vector.app.features.createdirect.DirectRoomHelper
 import im.vector.app.features.crypto.keysrequest.OutboundSessionKeySharingStrategy
 import im.vector.app.features.crypto.verification.SupportedVerificationMethodsProvider
+import im.vector.app.features.home.room.detail.error.RoomNotFound
 import im.vector.app.features.home.room.detail.location.RedactLiveLocationShareEventUseCase
 import im.vector.app.features.home.room.detail.sticker.StickerPickerActionHandler
 import im.vector.app.features.home.room.detail.timeline.factory.TimelineFactory
@@ -1216,7 +1217,7 @@ class TimelineViewModel @AssistedInject constructor(
             Timber.w("Warning, room with Id ${initialState.roomId} is not found.")
             setState {
                 copy(
-                        asyncRoomSummary = Fail(IllegalStateException("Room Not Found"))
+                        asyncRoomSummary = Fail(RoomNotFound())
                 )
             }
         } else {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -93,6 +93,7 @@ import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.file.FileService
 import org.matrix.android.sdk.api.session.getRoom
+import org.matrix.android.sdk.api.session.room.Room
 import org.matrix.android.sdk.api.session.room.getStateEvent
 import org.matrix.android.sdk.api.session.room.getTimelineEvent
 import org.matrix.android.sdk.api.session.room.location.UpdateLiveLocationShareResult
@@ -143,16 +144,16 @@ class TimelineViewModel @AssistedInject constructor(
         private val cryptoConfig: CryptoConfig,
         buildMeta: BuildMeta,
         timelineFactory: TimelineFactory,
-        spaceStateHandler: SpaceStateHandler,
+        private val spaceStateHandler: SpaceStateHandler,
 ) : VectorViewModel<RoomDetailViewState, RoomDetailAction, RoomDetailViewEvents>(initialState),
         Timeline.Listener, ChatEffectManager.Delegate, CallProtocolsChecker.Listener, LocationSharingServiceConnection.Callback {
 
-    private val room = session.getRoom(initialState.roomId)!!
+    private val room = session.getRoom(initialState.roomId)
     private val eventId = initialState.eventId
     private val invisibleEventsSource = BehaviorDataSource<RoomDetailAction.TimelineEventTurnsInvisible>()
     private val visibleEventsSource = BehaviorDataSource<RoomDetailAction.TimelineEventTurnsVisible>()
     private var timelineEvents = MutableSharedFlow<List<TimelineEvent>>(0)
-    val timeline = timelineFactory.createTimeline(viewModelScope, room, eventId, initialState.rootThreadEventId)
+    val timeline: Timeline?
 
     // Same lifecycle than the ViewModel (survive to screen rotation)
     val previewUrlRetriever = PreviewUrlRetriever(session, viewModelScope, buildMeta)
@@ -181,9 +182,20 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     init {
+        // This method will take care of a null room to update the state.
+        observeRoomSummary()
+        if (room == null) {
+            timeline = null
+        } else {
+            // Nominal case, we have retrieved the room.
+            timeline = timelineFactory.createTimeline(viewModelScope, room, eventId, initialState.rootThreadEventId)
+            initSafe(room, timeline)
+        }
+    }
+
+    private fun initSafe(room: Room, timeline: Timeline) {
         timeline.start(initialState.rootThreadEventId)
         timeline.addListener(this)
-        observeRoomSummary()
         observeMembershipChanges()
         observeSummaryState()
         getUnreadState()
@@ -265,6 +277,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun prepareForEncryption() {
+        if (room == null) return
         // check if there is not already a call made, or if there has been an error
         if (prepareToEncrypt.shouldLoad) {
             prepareToEncrypt = Loading()
@@ -281,6 +294,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun observePowerLevel() {
+        if (room == null) return
         PowerLevelsFlowFactory(room).createFlow()
                 .onEach {
                     val canInvite = PowerLevelsHelper(it).isUserAbleToInvite(session.myUserId)
@@ -329,6 +343,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun observeMyRoomMember() {
+        if (room == null) return
         val queryParams = roomMemberQueryParams {
             this.userId = QueryStringValue.Equals(session.myUserId, QueryStringValue.Case.SENSITIVE)
         }
@@ -344,6 +359,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun setupPreviewUrlObservers() {
+        if (room == null) return
         if (!vectorPreferences.showUrlPreviews()) {
             return
         }
@@ -372,6 +388,7 @@ class TimelineViewModel @AssistedInject constructor(
      * This is a local implementation has nothing to do with APIs.
      */
     private fun markThreadTimelineAsReadLocal() {
+        if (room == null) return
         initialState.rootThreadEventId?.let {
             session.coroutineScope.launch {
                 room.threadsLocalService().markThreadAsRead(it)
@@ -383,6 +400,7 @@ class TimelineViewModel @AssistedInject constructor(
      * Observe local unread threads.
      */
     private fun observeLocalThreadNotifications() {
+        if (room == null) return
         room.flow()
                 .liveLocalUnreadThreadList()
                 .execute {
@@ -514,6 +532,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleSetNewAvatar(action: RoomDetailAction.SetAvatarAction) {
+        if (room == null) return
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 room.stateService().updateAvatar(action.newAvatarUri, action.newAvatarFileName)
@@ -533,11 +552,13 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleJumpToReadReceipt(action: RoomDetailAction.JumpToReadReceipt) {
+        if (room == null) return
         room.readService().getUserReadReceipt(action.userId)
                 ?.let { handleNavigateToEvent(RoomDetailAction.NavigateToEvent(it, true)) }
     }
 
     private fun handleSendSticker(action: RoomDetailAction.SendSticker) {
+        if (room == null) return
         val content = initialState.rootThreadEventId?.let {
             action.stickerContent.copy(
                     relatesTo = RelationDefaultContent(
@@ -552,6 +573,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleStartCall(action: RoomDetailAction.StartCall) {
+        if (room == null) return
         viewModelScope.launch {
             room.roomSummary()?.otherMemberIds?.firstOrNull()?.let {
                 callManager.startOutgoingCall(room.roomId, it, action.isVideo)
@@ -597,7 +619,7 @@ class TimelineViewModel @AssistedInject constructor(
         _viewEvents.post(RoomDetailViewEvents.ShowWaitingView)
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                val widget = jitsiService.createJitsiWidget(room.roomId, action.withVideo)
+                val widget = jitsiService.createJitsiWidget(initialState.roomId, action.withVideo)
                 _viewEvents.post(RoomDetailViewEvents.JoinJitsiConference(widget, action.withVideo))
             } catch (failure: Throwable) {
                 _viewEvents.post(RoomDetailViewEvents.ShowMessage(stringProvider.getString(R.string.failed_to_add_widget)))
@@ -616,7 +638,7 @@ class TimelineViewModel @AssistedInject constructor(
                 } else {
                     _viewEvents.post(RoomDetailViewEvents.ShowWaitingView)
                 }
-                session.widgetService().destroyRoomWidget(room.roomId, widgetId)
+                session.widgetService().destroyRoomWidget(initialState.roomId, widgetId)
                 // local echo
                 setState {
                     copy(
@@ -665,6 +687,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun stopTrackingUnreadMessages() {
+        if (room == null) return
         if (trackUnreadMessages.getAndSet(false)) {
             mostRecentDisplayedEvent?.root?.eventId?.also {
                 session.coroutineScope.launch {
@@ -681,10 +704,11 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     fun getMember(userId: String): RoomMemberSummary? {
-        return room.membershipService().getRoomMember(userId)
+        return room?.membershipService()?.getRoomMember(userId)
     }
 
     private fun handleComposerFocusChange(action: RoomDetailAction.ComposerFocusChange) {
+        if (room == null) return
         // Ensure outbound session keys
         if (room.roomCryptoService().isEncrypted()) {
             rawService.withElementWellKnown(viewModelScope, session.sessionParams) {
@@ -774,11 +798,12 @@ class TimelineViewModel @AssistedInject constructor(
     // PRIVATE METHODS *****************************************************************************
 
     private fun handleSendReaction(action: RoomDetailAction.SendReaction) {
+        if (room == null) return
         room.relationService().sendReaction(action.targetEventId, action.reaction)
     }
 
     private fun handleRedactEvent(action: RoomDetailAction.RedactAction) {
-        val event = room.getTimelineEvent(action.targetEventId) ?: return
+        val event = room?.getTimelineEvent(action.targetEventId) ?: return
         if (event.isLiveLocation()) {
             viewModelScope.launch {
                 redactLiveLocationShareEventUseCase.execute(event.root, room, action.reason)
@@ -789,6 +814,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleUndoReact(action: RoomDetailAction.UndoReaction) {
+        if (room == null) return
         viewModelScope.launch {
             tryOrNull {
                 room.relationService().undoReaction(action.targetEventId, action.reaction)
@@ -797,6 +823,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleUpdateQuickReaction(action: RoomDetailAction.UpdateQuickReactAction) {
+        if (room == null) return
         if (action.add) {
             room.relationService().sendReaction(action.targetEventId, action.selectedReaction)
         } else {
@@ -809,6 +836,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleSendMedia(action: RoomDetailAction.SendMedia) {
+        if (room == null) return
         room.sendService().sendMedias(
                 action.attachments,
                 action.compressBeforeSending,
@@ -818,6 +846,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleEventVisible(action: RoomDetailAction.TimelineEventTurnsVisible) {
+        if (room == null) return
         viewModelScope.launch(Dispatchers.Default) {
             if (action.event.root.sendState.isSent()) { // ignore pending/local events
                 visibleEventsSource.post(action)
@@ -845,6 +874,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleLoadMore(action: RoomDetailAction.LoadMoreTimelineEvents) {
+        if (timeline == null) return
         timeline.paginate(action.direction, PAGINATION_COUNT)
     }
 
@@ -852,7 +882,7 @@ class TimelineViewModel @AssistedInject constructor(
         notificationDrawerManager.updateEvents { it.clearMemberShipNotificationForRoom(initialState.roomId) }
         viewModelScope.launch {
             try {
-                session.roomService().leaveRoom(room.roomId)
+                session.roomService().leaveRoom(initialState.roomId)
             } catch (throwable: Throwable) {
                 _viewEvents.post(RoomDetailViewEvents.Failure(throwable, showInDialog = true))
             }
@@ -863,7 +893,7 @@ class TimelineViewModel @AssistedInject constructor(
         notificationDrawerManager.updateEvents { it.clearMemberShipNotificationForRoom(initialState.roomId) }
         viewModelScope.launch {
             try {
-                session.roomService().joinRoom(room.roomId)
+                session.roomService().joinRoom(initialState.roomId)
                 trackRoomJoined()
             } catch (throwable: Throwable) {
                 _viewEvents.post(RoomDetailViewEvents.Failure(throwable, showInDialog = true))
@@ -872,6 +902,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun trackRoomJoined() {
+        if (room == null) return
         val trigger = if (initialState.isInviteAlreadyAccepted) {
             JoinedRoom.Trigger.Invite
         } else {
@@ -929,6 +960,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleNavigateToEvent(action: RoomDetailAction.NavigateToEvent) {
+        if (timeline == null) return
         val targetEventId: String = action.eventId
         val indexOfEvent = timeline.getIndexOfEvent(targetEventId)
         if (indexOfEvent == null) {
@@ -942,6 +974,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleResendEvent(action: RoomDetailAction.ResendMessage) {
+        if (room == null) return
         val targetEventId = action.eventId
         room.getTimelineEvent(targetEventId)?.let {
             // State must be UNDELIVERED or Failed
@@ -960,6 +993,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleRemove(action: RoomDetailAction.RemoveFailedEcho) {
+        if (room == null) return
         val targetEventId = action.eventId
         room.getTimelineEvent(targetEventId)?.let {
             // State must be UNDELIVERED or Failed
@@ -972,6 +1006,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleCancel(action: RoomDetailAction.CancelSend) {
+        if (room == null) return
         if (action.force) {
             room.sendService().cancelSend(action.eventId)
             return
@@ -988,14 +1023,17 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleResendAll() {
+        if (room == null) return
         room.sendService().resendAllFailedMessages()
     }
 
     private fun handleRemoveAllFailedMessages() {
+        if (room == null) return
         room.sendService().cancelAllFailedMessages()
     }
 
     private fun observeEventDisplayedActions() {
+        if (room == null) return
         // We are buffering scroll events for one second
         // and keep the most recent one to set the read receipt on.
 
@@ -1027,9 +1065,10 @@ class TimelineViewModel @AssistedInject constructor(
      * Returns the index of event in the timeline.
      * Returns Int.MAX_VALUE if not found
      */
-    private fun TimelineEvent.indexOfEvent(): Int = timeline.getIndexOfEvent(eventId) ?: Int.MAX_VALUE
+    private fun TimelineEvent.indexOfEvent(): Int = timeline?.getIndexOfEvent(eventId) ?: Int.MAX_VALUE
 
     private fun handleMarkAllAsRead() {
+        if (room == null) return
         setState { copy(unreadState = UnreadState.HasNoUnread) }
         viewModelScope.launch {
             tryOrNull { room.readService().markAsRead(ReadService.MarkAsReadParams.BOTH) }
@@ -1037,6 +1076,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleReportContent(action: RoomDetailAction.ReportContent) {
+        if (room == null) return
         viewModelScope.launch {
             val event = try {
                 room.reportingService().reportContent(action.eventId, -100, action.reason)
@@ -1065,11 +1105,11 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleAcceptVerification(action: RoomDetailAction.AcceptVerificationRequest) {
-        Timber.v("## SAS handleAcceptVerification ${action.otherUserId},  roomId:${room.roomId}, txId:${action.transactionId}")
+        Timber.v("## SAS handleAcceptVerification ${action.otherUserId},  roomId:${initialState.roomId}, txId:${action.transactionId}")
         if (session.cryptoService().verificationService().readyPendingVerificationInDMs(
                         supportedVerificationMethodsProvider.provide(),
                         action.otherUserId,
-                        room.roomId,
+                        initialState.roomId,
                         action.transactionId
                 )) {
             _viewEvents.post(RoomDetailViewEvents.ActionSuccess(action))
@@ -1082,7 +1122,7 @@ class TimelineViewModel @AssistedInject constructor(
         session.cryptoService().verificationService().declineVerificationRequestInDMs(
                 action.otherUserId,
                 action.transactionId,
-                room.roomId
+                initialState.roomId
         )
     }
 
@@ -1093,7 +1133,7 @@ class TimelineViewModel @AssistedInject constructor(
 
     private fun handleResumeRequestVerification(action: RoomDetailAction.ResumeVerification) {
         // Check if this request is still active and handled by me
-        session.cryptoService().verificationService().getExistingVerificationRequestInRoom(room.roomId, action.transactionId)?.let {
+        session.cryptoService().verificationService().getExistingVerificationRequestInRoom(initialState.roomId, action.transactionId)?.let {
             if (it.handledByOtherSession) return
             if (!it.isFinished) {
                 _viewEvents.post(
@@ -1108,6 +1148,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleReRequestKeys(action: RoomDetailAction.ReRequestKeys) {
+        if (room == null) return
         // Check if this request is still active and handled by me
         room.getTimelineEvent(action.eventId)?.let {
             session.cryptoService().reRequestRoomKeyForEvent(it.root)
@@ -1116,6 +1157,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleTapOnFailedToDecrypt(action: RoomDetailAction.TapOnFailedToDecrypt) {
+        if (room == null) return
         room.getTimelineEvent(action.eventId)?.let {
             val code = when (it.root.mCryptoError) {
                 MXCryptoError.ErrorType.KEYS_WITHHELD -> {
@@ -1129,6 +1171,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleVoteToPoll(action: RoomDetailAction.VoteToPoll) {
+        if (room == null) return
         // Do not allow to vote unsent local echo of the poll event
         if (LocalEcho.isLocalEchoId(action.eventId)) return
         // Do not allow to vote the same option twice
@@ -1141,6 +1184,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun handleEndPoll(eventId: String) {
+        if (room == null) return
         room.sendService().endPoll(eventId)
     }
 
@@ -1160,7 +1204,7 @@ class TimelineViewModel @AssistedInject constructor(
 
     private fun handleStopLiveLocationSharing() {
         viewModelScope.launch {
-            val result = stopLiveLocationShareUseCase.execute(room.roomId)
+            val result = stopLiveLocationShareUseCase.execute(initialState.roomId)
             if (result is UpdateLiveLocationShareResult.Failure) {
                 _viewEvents.post(RoomDetailViewEvents.Failure(throwable = result.error, showInDialog = true))
             }
@@ -1168,16 +1212,26 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun observeRoomSummary() {
-        room.flow().liveRoomSummary()
-                .unwrap()
-                .execute { async ->
-                    copy(
-                            asyncRoomSummary = async
-                    )
-                }
+        if (room == null) {
+            Timber.w("Warning, room with Id ${initialState.roomId} is not found.")
+            setState {
+                copy(
+                        asyncRoomSummary = Fail(IllegalStateException("Room Not Found"))
+                )
+            }
+        } else {
+            room.flow().liveRoomSummary()
+                    .unwrap()
+                    .execute { async ->
+                        copy(
+                                asyncRoomSummary = async
+                        )
+                    }
+        }
     }
 
     private fun getUnreadState() {
+        if (room == null) return
         combine(
                 timelineEvents,
                 room.flow().liveRoomSummary().unwrap()
@@ -1202,6 +1256,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun computeUnreadState(events: List<TimelineEvent>, roomSummary: RoomSummary): UnreadState {
+        if (timeline == null) return UnreadState.Unknown
         if (events.isEmpty()) return UnreadState.Unknown
         val readMarkerIdSnapshot = roomSummary.readMarkerId ?: return UnreadState.Unknown
         val firstDisplayableEventIndex = timeline.getIndexOfEvent(readMarkerIdSnapshot)
@@ -1248,6 +1303,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     private fun observeSummaryState() {
+        if (room == null) return
         onAsync(RoomDetailViewState::asyncRoomSummary) { summary ->
             setState {
                 val typingMessage = typingHelper.getTypingMessage(summary.typingUsers)
@@ -1291,6 +1347,7 @@ class TimelineViewModel @AssistedInject constructor(
      */
     private var threadPermalinkHandled = false
     private fun navigateToThreadEventIfNeeded(snapshot: List<TimelineEvent>) {
+        if (timeline == null) return
         if (eventId != null && initialState.rootThreadEventId != null) {
             // When we have a permalink and we are in a thread timeline
             if (snapshot.firstOrNull { it.eventId == eventId } != null && !threadPermalinkHandled) {
@@ -1313,6 +1370,7 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     override fun onTimelineFailure(throwable: Throwable) {
+        if (timeline == null) return
         // If we have a critical timeline issue, we get back to live.
         timeline.restartWithEventId(null)
         _viewEvents.post(RoomDetailViewEvents.Failure(throwable))
@@ -1338,11 +1396,11 @@ class TimelineViewModel @AssistedInject constructor(
     }
 
     override fun onCleared() {
-        timeline.dispose()
-        timeline.removeAllListeners()
-        decryptionFailureTracker.onTimeLineDisposed(room.roomId)
+        timeline?.dispose()
+        timeline?.removeAllListeners()
+        decryptionFailureTracker.onTimeLineDisposed(initialState.roomId)
         if (vectorPreferences.sendTypingNotifs()) {
-            room.typingService().userStopsTyping()
+            room?.typingService()?.userStopsTyping()
         }
         chatEffectManager.delegate = null
         chatEffectManager.dispose()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/error/RoomNotFound.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/error/RoomNotFound.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home.room.detail.error
+
+class RoomNotFound: Throwable()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/error/RoomNotFound.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/error/RoomNotFound.kt
@@ -16,4 +16,4 @@
 
 package im.vector.app.features.home.room.detail.error
 
-class RoomNotFound: Throwable()
+class RoomNotFound : Throwable()

--- a/vector/src/main/res/layout/fragment_timeline.xml
+++ b/vector/src/main/res/layout/fragment_timeline.xml
@@ -194,4 +194,47 @@
         android:background="?vctr_chat_effect_snow_background"
         android:visibility="invisible" />
 
+    <!-- Room not found layout -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/roomNotFound"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="?android:colorBackground"
+        android:elevation="10dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="gone">
+
+        <ImageView
+            android:id="@+id/roomNotFoundIcon"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_alert_triangle"
+            app:layout_constraintBottom_toTopOf="@id/roomNotFoundText"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed" />
+
+        <TextView
+            android:id="@+id/roomNotFoundText"
+            style="@style/Widget.Vector.TextView.Subtitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/layout_vertical_margin"
+            android:gravity="center"
+            android:paddingHorizontal="16dp"
+            android:text="@string/timeline_error_room_not_found"
+            android:textColor="?vctr_content_primary"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/roomNotFoundIcon" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1349,6 +1349,9 @@
     <string name="settings_labs_native_camera_summary">Start the system camera instead of the custom camera screen.</string>
     <string name="widget_integration_review_terms">To continue you need to accept the Terms of this service.</string>
 
+    <!-- Room not found. %s will contain some debug info in developer mode.  -->
+    <string name="timeline_error_room_not_found">Sorry, this room has not been found.\nPlease retry later.%s</string>
+
     <!-- share keys -->
     <string name="you_added_a_new_device">You added a new session \'%s\', which is requesting encryption keys.</string>
     <string name="you_added_a_new_device_with_info">A new session is requesting encryption keys.\nSession name: %1$s\nLast seen: %2$s\nIf you didn’t log in on another session, ignore this request.</string>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Fix a crash when user opens a Timeline of a unknown room. This PR also contains some code cleanup, can be reviewed commit per commit if necessary.

This PR does not fix the root cause, which is quite unclear for now. This can be related to thread / space / etc. But it fixes the crash, and display a full screen error to the user.

If we got rageshake with the screen content in developer mode, we may have more info on the room which is tried to be open.

Note: I have seen #6543, but I think this is compatible with this change. I would prefer to first merge this PR, and then handle #6543.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Less crash.
fixes #5611 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->


|Before|After|
|-|-|
|**crash**|![RoomNotFound](https://user-images.githubusercontent.com/3940906/187687634-ab0909f0-551c-4afa-94ca-779770e40c1e.gif)|

In developer mode, more info will be displayed:

<img width="238" alt="image" src="https://user-images.githubusercontent.com/3940906/187688617-456ba162-9d7b-4e6b-8345-cb0b7fcaad80.png">


## Tests

<!-- Explain how you tested your development -->

- Update the line https://github.com/vector-im/element-android/blob/1ced47fbd2cfa6515cf0b52b40f0a304d9487fb9/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt#L152 for instance with `session.getRoom(initialState.roomId + "_you_will_not_find_me")`
- Try to open any room

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
