### PR TITLE
Fix crash on PIN code settings screen

### DIFF
--- a/changelog.d/6979.bugfix
+++ b/changelog.d/6979.bugfix
@@ -1,0 +1,1 @@
+Fix crash on PIN code settings screen.

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsPinFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsPinFragment.kt
@@ -50,7 +50,9 @@ class VectorSettingsPinFragment :
     override var titleRes = R.string.settings_security_application_protection_screen_title
     override val preferenceXmlRes = R.xml.vector_settings_pin
 
-    private val biometricHelper = biometricHelperFactory.create(defaultLockScreenConfiguration.copy(mode = LockScreenMode.CREATE))
+    private val biometricHelper by lazy {
+        biometricHelperFactory.create(defaultLockScreenConfiguration.copy(mode = LockScreenMode.CREATE))
+    }
 
     private val usePinCodePref by lazy {
         findPreference<SwitchPreference>(VectorPreferences.SETTINGS_SECURITY_USE_PIN_CODE_FLAG)!!


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Made `VectorSettingsPinFragment.biometricHelper` lazy so it's not instantiated before `biometricHelperFactory` is injected.

## Motivation and context

See #6979.

## Tests

<!-- Explain how you tested your development -->

- Go to Settings > Security & Privacy > Protect access.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 12.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
