### PR TITLE
Allowing optional email registration 

### DIFF
--- a/changelog.d/6969.bugfix
+++ b/changelog.d/6969.bugfix
@@ -1,0 +1,1 @@
+FTUE - Fixes optional email registration step always being mandatory

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthEmailEntryFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthEmailEntryFragment.kt
@@ -17,9 +17,11 @@
 package im.vector.app.features.onboarding.ftueauth
 
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import com.airbnb.mvrx.args
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
 import im.vector.app.core.extensions.associateContentStateWith
@@ -35,11 +37,18 @@ import im.vector.app.databinding.FragmentFtueEmailInputBinding
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingViewState
 import im.vector.app.features.onboarding.RegisterAction
+import kotlinx.parcelize.Parcelize
 import org.matrix.android.sdk.api.auth.registration.RegisterThreePid
 
+@Parcelize
+data class FtueAuthEmailEntryFragmentArgument(
+        val mandatory: Boolean,
+) : Parcelable
+
 @AndroidEntryPoint
-class FtueAuthEmailEntryFragment :
-        AbstractFtueAuthFragment<FragmentFtueEmailInputBinding>() {
+class FtueAuthEmailEntryFragment : AbstractFtueAuthFragment<FragmentFtueEmailInputBinding>() {
+
+    private val params: FtueAuthEmailEntryFragmentArgument by args()
 
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentFtueEmailInputBinding {
         return FragmentFtueEmailInputBinding.inflate(inflater, container, false)
@@ -51,7 +60,10 @@ class FtueAuthEmailEntryFragment :
     }
 
     private fun setupViews() {
-        views.emailEntryInput.associateContentStateWith(button = views.emailEntrySubmit, enabledPredicate = { it.isEmail() })
+        views.emailEntryInput.hint = getString(if (params.mandatory) R.string.ftue_auth_email_entry_title else R.string.login_set_email_optional_hint)
+        views.emailEntryInput.associateContentStateWith(button = views.emailEntrySubmit, enabledPredicate = {
+            it.isEmail() || it.isEmptyAndOptional()
+        })
         views.emailEntryInput.setOnImeDoneListener { updateEmail() }
         views.emailEntryInput.clearErrorOnChange(viewLifecycleOwner)
         views.emailEntrySubmit.debouncedClicks { updateEmail() }
@@ -60,8 +72,13 @@ class FtueAuthEmailEntryFragment :
 
     private fun updateEmail() {
         val email = views.emailEntryInput.content()
-        viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.AddThreePid(RegisterThreePid.Email(email))))
+        when {
+            email.isEmptyAndOptional() -> viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.RegisterDummy))
+            else -> viewModel.handle(OnboardingAction.PostRegisterAction(RegisterAction.AddThreePid(RegisterThreePid.Email(email))))
+        }
     }
+
+    private fun String.isEmptyAndOptional() = isEmpty() && !params.mandatory
 
     override fun updateWithState(state: OnboardingViewState) {
         views.emailEntryHeaderSubtitle.text = getString(R.string.ftue_auth_email_subtitle, state.selectedHomeserver.userFacingUrl.toReducedUrl())

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthEmailEntryFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthEmailEntryFragment.kt
@@ -61,9 +61,10 @@ class FtueAuthEmailEntryFragment : AbstractFtueAuthFragment<FragmentFtueEmailInp
 
     private fun setupViews() {
         views.emailEntryInput.hint = getString(if (params.mandatory) R.string.ftue_auth_email_entry_title else R.string.login_set_email_optional_hint)
-        views.emailEntryInput.associateContentStateWith(button = views.emailEntrySubmit, enabledPredicate = {
-            it.isEmail() || it.isEmptyAndOptional()
-        })
+        views.emailEntryInput.associateContentStateWith(
+                button = views.emailEntrySubmit,
+                enabledPredicate = { it.isEmail() || it.isEmptyAndOptional() },
+        )
         views.emailEntryInput.setOnImeDoneListener { updateEmail() }
         views.emailEntryInput.clearErrorOnChange(viewLifecycleOwner)
         views.emailEntrySubmit.debouncedClicks { updateEmail() }

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -411,7 +411,8 @@ class FtueAuthVariant(
     private fun onEmail(stage: Stage) {
         when {
             vectorFeatures.isOnboardingCombinedRegisterEnabled() -> addRegistrationStageFragmentToBackstack(
-                    FtueAuthEmailEntryFragment::class.java
+                    FtueAuthEmailEntryFragment::class.java,
+                    FtueAuthEmailEntryFragmentArgument(mandatory = stage.mandatory)
             )
             else -> addRegistrationStageFragmentToBackstack(
                     FtueAuthGenericTextInputFormFragment::class.java,

--- a/vector/src/main/res/layout/fragment_ftue_email_input.xml
+++ b/vector/src/main/res/layout/fragment_ftue_email_input.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     style="@style/LoginFormScrollView"
     android:layout_height="match_parent"
     android:background="?android:colorBackground"
@@ -88,11 +89,11 @@
             android:id="@+id/emailEntryInput"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:hint="@string/ftue_auth_email_entry_title"
             app:endIconMode="clear_text"
             app:layout_constraintEnd_toEndOf="@id/emailEntryGutterEnd"
             app:layout_constraintStart_toStartOf="@id/emailEntryGutterStart"
-            app:layout_constraintTop_toBottomOf="@id/titleContentSpacing">
+            app:layout_constraintTop_toBottomOf="@id/titleContentSpacing"
+            tools:hint="@string/ftue_auth_email_entry_title">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Takes into account the mandatory status of the email registration step and sends a "Dummy" event when it's empty, as per the previous legacy flow

## Motivation and context

Fixes #6969 by allowing non mandatory emails to submit empty emails 

## Screenshots / GIFs

|Before|After| Legacy |
|-|-|-|
|![before-optional-email](https://user-images.githubusercontent.com/1848238/187732065-30759289-4127-4bd2-a4c0-d8e2b9b630e6.gif)|![after-optional-email](https://user-images.githubusercontent.com/1848238/187732074-6a6759cd-371f-47e1-8bb3-970b2f5c4141.gif)|![legacy-optional-email](https://user-images.githubusercontent.com/1848238/187732097-78fc3ddf-85a2-496a-8b2b-0732b81ec393.gif)|
 
## Tests

- With a homeserver with optional email 

```
account_threepid_delegates:
    email: https://matrix.org
```

- Start the account creation process
- Attempt to skip the email entry

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):