### PR TITLE
Fix autoplayed animated sticker

### DIFF
--- a/changelog.d/6982.bugfix
+++ b/changelog.d/6982.bugfix
@@ -1,0 +1,2 @@
+Fix autoplayed animated stickers
+Increase sticker size

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/MessageInformationDataFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/MessageInformationDataFactory.kt
@@ -34,9 +34,11 @@ import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.content.EncryptedEventContent
 import org.matrix.android.sdk.api.session.events.model.getMsgType
 import org.matrix.android.sdk.api.session.events.model.isAttachmentMessage
+import org.matrix.android.sdk.api.session.events.model.isSticker
 import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.room.model.ReferencesAggregatedContent
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import org.matrix.android.sdk.api.session.room.model.message.MessageType
 import org.matrix.android.sdk.api.session.room.model.message.MessageVerificationRequestContent
 import org.matrix.android.sdk.api.session.room.send.SendState
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
@@ -122,7 +124,7 @@ class MessageInformationDataFactory @Inject constructor(
                 isLastFromThisSender = isLastFromThisSender,
                 e2eDecoration = e2eDecoration,
                 sendStateDecoration = sendStateDecoration,
-                messageType = event.root.getMsgType()
+                messageType = if (event.root.isSticker()) { MessageType.MSGTYPE_STICKER_LOCAL } else { event.root.getMsgType() }
         )
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageImageVideoItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageImageVideoItem.kt
@@ -82,7 +82,7 @@ abstract class MessageImageVideoItem : AbsMessageItem<MessageImageVideoItem.Hold
         holder.mediaContentView.onClick(attributes.itemClickListener)
         holder.mediaContentView.setOnLongClickListener(attributes.itemLongClickListener)
 
-        val isImageMessage = attributes.informationData.messageType == MessageType.MSGTYPE_IMAGE
+        val isImageMessage = attributes.informationData.messageType in listOf(MessageType.MSGTYPE_IMAGE, MessageType.MSGTYPE_STICKER_LOCAL)
         val autoplayAnimatedImages = attributes.autoplayAnimatedImages
 
         holder.playContentView.visibility = if (playable && isImageMessage && autoplayAnimatedImages) {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/style/TimelineMessageLayoutFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/style/TimelineMessageLayoutFactory.kt
@@ -68,6 +68,7 @@ class TimelineMessageLayoutFactory @Inject constructor(
         private val MSG_TYPES_WITH_TIMESTAMP_INSIDE_MESSAGE = setOf(
                 MessageType.MSGTYPE_IMAGE,
                 MessageType.MSGTYPE_VIDEO,
+                MessageType.MSGTYPE_STICKER_LOCAL,
                 MessageType.MSGTYPE_BEACON_INFO,
                 MessageType.MSGTYPE_LOCATION,
                 MessageType.MSGTYPE_BEACON_LOCATION_DATA,

--- a/vector/src/main/java/im/vector/app/features/media/ImageContentRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/media/ImageContentRenderer.kt
@@ -275,8 +275,7 @@ class ImageContentRenderer @Inject constructor(
                 }
                 Mode.STICKER -> {
                     // limit on width
-                    val maxWidthDp = min(dimensionConverter.dpToPx(120), maxImageWidth / 2)
-                    finalWidth = min(dimensionConverter.dpToPx(width), maxWidthDp)
+                    finalWidth = min(dimensionConverter.dpToPx(width), maxImageWidth * 3 / 4)
                     finalHeight = finalWidth * height / width
                 }
             }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

It removes the play button on animated stickers and increase the stickers size.

## Motivation and context

* ATM, auto-played animated stickers are indeed auto-played but the play button is shown above it
* Stickers are very small, the same size than emojis sent alone

## Screenshots / GIFs

|Before|After|
|-|-|
|![screen2](https://user-images.githubusercontent.com/31284753/187788604-93842c2a-1c80-4ff2-8761-288fcc63fec1.gif)|![screen1](https://user-images.githubusercontent.com/31284753/187788662-070e5060-58fa-4693-b28c-127f9e4f4c03.gif)|
|![Screenshot_20220831-230338_Element dbg](https://user-images.githubusercontent.com/31284753/187786485-21b5c9fe-4c2e-4ef4-a59f-8e88df29d0fb.png)|![Screenshot_20220831-230920_Element dbg](https://user-images.githubusercontent.com/31284753/187786140-ea99b32b-3467-49d5-8ec5-ed4cf3265050.png)|

For information, on iOS it looks like this:

<img src="https://user-images.githubusercontent.com/31284753/187788836-46eaff99-d34d-4ada-a2f8-e379e03e4838.png" height=500>


## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
