### PR TITLE
Fix FCM token and UP endpoint inconsistency

### DIFF
--- a/changelog.d/6992.bugfix
+++ b/changelog.d/6992.bugfix
@@ -1,0 +1,1 @@
+Force FCM token renew on troubleshoot

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -264,7 +264,7 @@ dependencies {
     // UnifiedPush
     implementation 'com.github.UnifiedPush:android-connector:2.0.1'
     // UnifiedPush gplay flavor only
-    gplayImplementation('com.github.UnifiedPush:android-embedded_fcm_distributor:2.1.2') {
+    gplayImplementation('com.github.UnifiedPush:android-embedded_fcm_distributor:2.1.3') {
         exclude group: 'com.google.firebase', module: 'firebase-core'
         exclude group: 'com.google.firebase', module: 'firebase-analytics'
         exclude group: 'com.google.firebase', module: 'firebase-measurement-connector'

--- a/vector/src/fdroid/java/im/vector/app/push/fcm/FdroidFcmHelper.kt
+++ b/vector/src/fdroid/java/im/vector/app/push/fcm/FdroidFcmHelper.kt
@@ -36,14 +36,6 @@ class FdroidFcmHelper @Inject constructor(
 
     override fun isFirebaseAvailable(): Boolean = false
 
-    override fun getFcmToken(): String? {
-        return null
-    }
-
-    override fun storeFcmToken(token: String?) {
-        // No op
-    }
-
     override fun ensureFcmTokenIsRetrieved(activity: Activity, pushersManager: PushersManager, registerPusher: Boolean) {
         // No op
     }

--- a/vector/src/gplay/java/im/vector/app/gplay/features/settings/troubleshoot/TestFirebaseToken.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/features/settings/troubleshoot/TestFirebaseToken.kt
@@ -20,7 +20,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.FragmentActivity
 import com.google.firebase.messaging.FirebaseMessaging
 import im.vector.app.R
-import im.vector.app.core.pushers.FcmHelper
+import im.vector.app.core.pushers.UnifiedPushStore
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.utils.startAddGoogleAccountIntent
 import im.vector.app.features.settings.troubleshoot.TroubleshootTest
@@ -33,7 +33,7 @@ import javax.inject.Inject
 class TestFirebaseToken @Inject constructor(
         private val context: FragmentActivity,
         private val stringProvider: StringProvider,
-        private val fcmHelper: FcmHelper,
+        private val unifiedPushStore: UnifiedPushStore,
 ) : TroubleshootTest(R.string.settings_troubleshoot_test_fcm_title) {
 
     override fun perform(activityResultLauncher: ActivityResultLauncher<Intent>) {
@@ -69,7 +69,7 @@ class TestFirebaseToken @Inject constructor(
                                 description = stringProvider.getString(R.string.settings_troubleshoot_test_fcm_success, tok)
                                 Timber.e("Retrieved FCM token success [$tok].")
                                 // Ensure it is well store in our local storage
-                                fcmHelper.storeFcmToken(token)
+                                unifiedPushStore.storeFcmOrUpEndpoint(token)
                             }
                             status = TestStatus.SUCCESS
                         }

--- a/vector/src/gplay/java/im/vector/app/gplay/features/settings/troubleshoot/TestFirebaseToken.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/features/settings/troubleshoot/TestFirebaseToken.kt
@@ -15,7 +15,6 @@
  */
 package im.vector.app.gplay.features.settings.troubleshoot
 
-import android.content.Context
 import android.content.Intent
 import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.FragmentActivity
@@ -37,66 +36,43 @@ class TestFirebaseToken @Inject constructor(
         private val fcmHelper: FcmHelper,
 ) : TroubleshootTest(R.string.settings_troubleshoot_test_fcm_title) {
 
-    // Remove FCM related shared pref, the application
-    // will then act like FCM has never been initialized
-    // and GService will generate a new, valid token
-    //
-    // That's a bit hacky
-    private fun forceRemoveFCMToken(context: Context) {
-        listOf(
-                "com.google.firebase.messaging",
-                "com.google.android.gms.appid"
-        ).map {
-            context.getSharedPreferences(it, Context.MODE_PRIVATE)
-        }.forEach { prefs ->
-            prefs.all.forEach {
-                prefs.edit().remove(it.key).apply()
-            }
-        }
-    }
-
     override fun perform(activityResultLauncher: ActivityResultLauncher<Intent>) {
         status = TestStatus.RUNNING
         try {
-            FirebaseMessaging.getInstance().deleteToken()
-                    .addOnCompleteListener(context) {
-                        forceRemoveFCMToken(context)
-                        FirebaseMessaging.getInstance().token
-                                .addOnCompleteListener(context) { task ->
-                                    if (!task.isSuccessful) {
-                                        // Can't find where this constant is (not documented -or deprecated in docs- and all obfuscated)
-                                        description = when (val errorMsg = task.exception?.localizedMessage ?: "Unknown") {
-                                            "SERVICE_NOT_AVAILABLE" -> {
-                                                stringProvider.getString(R.string.settings_troubleshoot_test_fcm_failed_service_not_available, errorMsg)
-                                            }
-                                            "TOO_MANY_REGISTRATIONS" -> {
-                                                stringProvider.getString(R.string.settings_troubleshoot_test_fcm_failed_too_many_registration, errorMsg)
-                                            }
-                                            "ACCOUNT_MISSING" -> {
-                                                quickFix =
-                                                        object : TroubleshootQuickFix(R.string.settings_troubleshoot_test_fcm_failed_account_missing_quick_fix) {
-                                                            override fun doFix() {
-                                                                startAddGoogleAccountIntent(context, activityResultLauncher)
-                                                            }
-                                                        }
-                                                stringProvider.getString(R.string.settings_troubleshoot_test_fcm_failed_account_missing, errorMsg)
-                                            }
-                                            else -> {
-                                                stringProvider.getString(R.string.settings_troubleshoot_test_fcm_failed, errorMsg)
-                                            }
-                                        }
-                                        status = TestStatus.FAILED
-                                    } else {
-                                        task.result?.let { token ->
-                                            val tok = token.take(8) + "********************"
-                                            description = stringProvider.getString(R.string.settings_troubleshoot_test_fcm_success, tok)
-                                            Timber.e("Retrieved FCM token success [$tok].")
-                                            // Ensure it is well store in our local storage
-                                            fcmHelper.storeFcmToken(token)
-                                        }
-                                        status = TestStatus.SUCCESS
-                                    }
+            FirebaseMessaging.getInstance().token
+                    .addOnCompleteListener(context) { task ->
+                        if (!task.isSuccessful) {
+                            // Can't find where this constant is (not documented -or deprecated in docs- and all obfuscated)
+                            description = when (val errorMsg = task.exception?.localizedMessage ?: "Unknown") {
+                                "SERVICE_NOT_AVAILABLE" -> {
+                                    stringProvider.getString(R.string.settings_troubleshoot_test_fcm_failed_service_not_available, errorMsg)
                                 }
+                                "TOO_MANY_REGISTRATIONS" -> {
+                                    stringProvider.getString(R.string.settings_troubleshoot_test_fcm_failed_too_many_registration, errorMsg)
+                                }
+                                "ACCOUNT_MISSING" -> {
+                                    quickFix = object : TroubleshootQuickFix(R.string.settings_troubleshoot_test_fcm_failed_account_missing_quick_fix) {
+                                        override fun doFix() {
+                                            startAddGoogleAccountIntent(context, activityResultLauncher)
+                                        }
+                                    }
+                                    stringProvider.getString(R.string.settings_troubleshoot_test_fcm_failed_account_missing, errorMsg)
+                                }
+                                else -> {
+                                    stringProvider.getString(R.string.settings_troubleshoot_test_fcm_failed, errorMsg)
+                                }
+                            }
+                            status = TestStatus.FAILED
+                        } else {
+                            task.result?.let { token ->
+                                val tok = token.take(8) + "********************"
+                                description = stringProvider.getString(R.string.settings_troubleshoot_test_fcm_success, tok)
+                                Timber.e("Retrieved FCM token success [$tok].")
+                                // Ensure it is well store in our local storage
+                                fcmHelper.storeFcmToken(token)
+                            }
+                            status = TestStatus.SUCCESS
+                        }
                     }
         } catch (e: Throwable) {
             description = stringProvider.getString(R.string.settings_troubleshoot_test_fcm_failed, e.localizedMessage)

--- a/vector/src/gplay/java/im/vector/app/gplay/features/settings/troubleshoot/TestTokenRegistration.kt
+++ b/vector/src/gplay/java/im/vector/app/gplay/features/settings/troubleshoot/TestTokenRegistration.kt
@@ -23,8 +23,8 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
-import im.vector.app.core.pushers.FcmHelper
 import im.vector.app.core.pushers.PushersManager
+import im.vector.app.core.pushers.UnifiedPushHelper
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.features.settings.troubleshoot.TroubleshootTest
 import org.matrix.android.sdk.api.session.pushers.PusherState
@@ -38,13 +38,13 @@ class TestTokenRegistration @Inject constructor(
         private val stringProvider: StringProvider,
         private val pushersManager: PushersManager,
         private val activeSessionHolder: ActiveSessionHolder,
-        private val fcmHelper: FcmHelper,
+        private val unifiedPushHelper: UnifiedPushHelper,
 ) :
         TroubleshootTest(R.string.settings_troubleshoot_test_token_registration_title) {
 
     override fun perform(activityResultLauncher: ActivityResultLauncher<Intent>) {
         // Check if we have a registered pusher for this token
-        val fcmToken = fcmHelper.getFcmToken() ?: run {
+        val fcmToken = unifiedPushHelper.getPrivacyFriendlyUpEndpoint() ?: run {
             status = TestStatus.FAILED
             return
         }

--- a/vector/src/gplay/java/im/vector/app/push/fcm/GoogleFcmHelper.kt
+++ b/vector/src/gplay/java/im/vector/app/push/fcm/GoogleFcmHelper.kt
@@ -18,13 +18,11 @@ package im.vector.app.push.fcm
 import android.app.Activity
 import android.content.Context
 import android.widget.Toast
-import androidx.core.content.edit
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.messaging.FirebaseMessaging
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
-import im.vector.app.core.di.DefaultSharedPreferences
 import im.vector.app.core.pushers.FcmHelper
 import im.vector.app.core.pushers.PushersManager
 import im.vector.app.core.pushers.UnifiedPushStore
@@ -35,28 +33,11 @@ import javax.inject.Inject
  * This class store the FCM token in SharedPrefs and ensure this token is retrieved.
  * It has an alter ego in the fdroid variant.
  */
-class GoogleFcmHelper @Inject constructor(
-        context: Context,
-) : FcmHelper {
-    companion object {
-        private const val PREFS_KEY_FCM_TOKEN = "FCM_TOKEN"
-    }
+class GoogleFcmHelper @Inject constructor() : FcmHelper {
 
     @Inject lateinit var unifiedPushStore: UnifiedPushStore
-    private val sharedPrefs = DefaultSharedPreferences.getInstance(context)
 
     override fun isFirebaseAvailable(): Boolean = true
-
-    override fun getFcmToken(): String? {
-        return sharedPrefs.getString(PREFS_KEY_FCM_TOKEN, null)
-    }
-
-    override fun storeFcmToken(token: String?) {
-        // TODO Store in realm
-        sharedPrefs.edit {
-            putString(PREFS_KEY_FCM_TOKEN, token)
-        }
-    }
 
     override fun ensureFcmTokenIsRetrieved(activity: Activity, pushersManager: PushersManager, registerPusher: Boolean) {
         //        if (TextUtils.isEmpty(getFcmToken(activity))) {

--- a/vector/src/gplay/java/im/vector/app/push/fcm/GoogleFcmHelper.kt
+++ b/vector/src/gplay/java/im/vector/app/push/fcm/GoogleFcmHelper.kt
@@ -27,6 +27,7 @@ import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.di.DefaultSharedPreferences
 import im.vector.app.core.pushers.FcmHelper
 import im.vector.app.core.pushers.PushersManager
+import im.vector.app.core.pushers.UnifiedPushStore
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -41,6 +42,7 @@ class GoogleFcmHelper @Inject constructor(
         private const val PREFS_KEY_FCM_TOKEN = "FCM_TOKEN"
     }
 
+    @Inject lateinit var unifiedPushStore: UnifiedPushStore
     private val sharedPrefs = DefaultSharedPreferences.getInstance(context)
 
     override fun isFirebaseAvailable(): Boolean = true
@@ -63,7 +65,7 @@ class GoogleFcmHelper @Inject constructor(
             try {
                 FirebaseMessaging.getInstance().token
                         .addOnSuccessListener { token ->
-                            storeFcmToken(token)
+                            unifiedPushStore.storeFcmOrUpEndpoint(token)
                             if (registerPusher) {
                                 pushersManager.enqueueRegisterPusherWithFcmKey(token)
                             }

--- a/vector/src/main/java/im/vector/app/core/pushers/FcmHelper.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/FcmHelper.kt
@@ -23,20 +23,6 @@ interface FcmHelper {
     fun isFirebaseAvailable(): Boolean
 
     /**
-     * Retrieves the FCM registration token.
-     *
-     * @return the FCM token or null if not received from FCM.
-     */
-    fun getFcmToken(): String?
-
-    /**
-     * Store FCM token to the SharedPrefs.
-     *
-     * @param token the token to store.
-     */
-    fun storeFcmToken(token: String?)
-
-    /**
      * onNewToken may not be called on application upgrade, so ensure my shared pref is set.
      *
      * @param activity the first launch Activity.

--- a/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
@@ -188,7 +188,7 @@ class UnifiedPushHelper @Inject constructor(
         } catch (e: Exception) {
             Timber.d(e, "Probably unregistering a non existing pusher")
         }
-        unifiedPushStore.storeUpEndpoint(null)
+        unifiedPushStore.storeFcmOrUpEndpoint(null)
         unifiedPushStore.storePushGateway(null)
         UnifiedPush.unregisterApp(context)
     }

--- a/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushStore.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushStore.kt
@@ -40,7 +40,7 @@ class UnifiedPushStore @Inject constructor(
      *
      * @param endpoint the endpoint to store
      */
-    fun storeUpEndpoint(endpoint: String?) {
+    fun storeFcmOrUpEndpoint(endpoint: String?) {
         defaultPrefs.edit {
             putString(PREFS_ENDPOINT_OR_TOKEN, endpoint)
         }

--- a/vector/src/main/java/im/vector/app/core/pushers/VectorMessagingReceiver.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/VectorMessagingReceiver.kt
@@ -128,7 +128,7 @@ class VectorMessagingReceiver : MessagingReceiver() {
             // If the endpoint has changed
             // or the gateway has changed
             if (unifiedPushStore.getEndpointOrToken() != endpoint) {
-                unifiedPushStore.storeUpEndpoint(endpoint)
+                unifiedPushStore.storeFcmOrUpEndpoint(endpoint)
                 coroutineScope.launch {
                     unifiedPushHelper.storeCustomOrDefaultGateway(endpoint) {
                         unifiedPushStore.getPushGateway()?.let {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

* Bump embedded_fcm_distributor to 2.1.3 which fix a potential issue with fcmToken
* Force-delete the FCM token during the troubleshooting list : 
    * It acts like fcm has never been initialized (like data wipe) and make sure the new token is registered

This PR force the app to have a new FCM token during the troubleshoot tests, like if the app were re-installed. This solution is a bit rough, and recent changes have probably fix fcm issues (I'd still bump the embedded_distributor). But this PR make it easier for users to fix their notifications if the issues are still present.

## Motivation and context

There are many issue with push notifications like : 
https://github.com/vector-im/element-android/issues/6572
https://github.com/vector-im/element-android/issues/6975
https://github.com/vector-im/element-android/issues/6379

Some users even wipe the app data (or re-install element).

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
