### PR TITLE
Suggest @room when @channel, @everyone, or @here is typed in composer

### DIFF
--- a/changelog.d/6529.feature
+++ b/changelog.d/6529.feature
@@ -1,0 +1,1 @@
+Suggest @room when @channel, @everyone, or @here is typed in composer

--- a/vector/src/main/java/im/vector/app/features/autocomplete/member/AutocompleteMemberPresenter.kt
+++ b/vector/src/main/java/im/vector/app/features/autocomplete/member/AutocompleteMemberPresenter.kt
@@ -145,7 +145,12 @@ class AutocompleteMemberPresenter @AssistedInject constructor(
     private fun createEveryoneItem(query: CharSequence?) =
             room.roomSummary()
                     ?.takeIf { canNotifyEveryone() }
-                    ?.takeIf { query.isNullOrBlank() || MatrixItem.NOTIFY_EVERYONE.startsWith("@$query") }
+                    ?.takeIf {
+                        query.isNullOrBlank() ||
+                                SUGGEST_ROOM_KEYWORDS.any {
+                                    it.startsWith("@$query")
+                                }
+                    }
                     ?.let {
                         AutocompleteMemberItem.Everyone(it)
                     }
@@ -165,6 +170,7 @@ class AutocompleteMemberPresenter @AssistedInject constructor(
     companion object {
         private const val ID_HEADER_MEMBERS = "ID_HEADER_MEMBERS"
         private const val ID_HEADER_EVERYONE = "ID_HEADER_EVERYONE"
+        private val SUGGEST_ROOM_KEYWORDS = setOf(MatrixItem.NOTIFY_EVERYONE, "@channel", "@everyone", "@here")
     }
 }
 


### PR DESCRIPTION
Closes #6529

Signed-off-by: Prat T <pt2121@users.noreply.github.com>

## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Addressing #6529 - suggest @room when a user typed in comparable keywords in the compose view.

## Motivation and context

following the web client.

## Screenshots / GIFs
![01](https://user-images.githubusercontent.com/616399/188295683-5dc6bdab-307d-4d0f-b75c-d5691e48e57f.png)
![02](https://user-images.githubusercontent.com/616399/188295684-31b9c038-130e-4a3f-b9cf-6f2e5695d435.png)
![03](https://user-images.githubusercontent.com/616399/188295685-ec831bdd-9920-4e61-a856-a1e69fd2a705.png)

## Tests

- Log in
- Navigate to any room that you have a permission to notify the whole room by using `@room`
- Type in any `@channel`, `@everyone`, or `@here`
- See a suggestion for `@room`

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
  - N/A
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
