### PR TITLE
Catch race condition while recording voice audio

### DIFF
--- a/changelog.d/6989.bugfix
+++ b/changelog.d/6989.bugfix
@@ -1,0 +1,1 @@
+Catch race condition crash in voice recording

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/AudioMessageHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/AudioMessageHelper.kt
@@ -79,18 +79,19 @@ class AudioMessageHelper @Inject constructor(
     }
 
     fun stopRecording(): MultiPickerAudioType? {
-        tryOrNull("Cannot stop media recording amplitude") {
-            stopRecordingAmplitudes()
-        }
         val voiceMessageFile = tryOrNull("Cannot stop media recorder!") {
             voiceRecorder.stopRecord()
             voiceRecorder.getVoiceMessageFile()
         }
 
-        try {
+        tryOrNull("Cannot stop media recording amplitude") {
+            stopRecordingAmplitudes()
+        }
+
+        return try {
             voiceMessageFile?.let {
                 val outputFileUri = FileProvider.getUriForFile(context, buildMeta.applicationId + ".fileProvider", it, "Voice message.${it.extension}")
-                return outputFileUri
+                outputFileUri
                         .toMultiPickerAudioType(context)
                         ?.apply {
                             waveform = if (amplitudeList.size < 50) {
@@ -99,10 +100,13 @@ class AudioMessageHelper @Inject constructor(
                                 amplitudeList.chunked(amplitudeList.size / 50) { items -> items.maxOrNull() ?: 0 }
                             }
                         }
-            } ?: return null
+            }
         } catch (e: FileNotFoundException) {
             Timber.e(e, "Cannot stop voice recording")
-            return null
+            null
+        } catch (e: RuntimeException) {
+            Timber.e(e, "Error while retrieving metadata")
+            null
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
@@ -883,7 +883,11 @@ class MessageComposerViewModel @AssistedInject constructor(
     }
 
     private fun handlePlayOrPauseRecordingPlayback() {
-        audioMessageHelper.startOrPauseRecordingPlayback()
+        try {
+            audioMessageHelper.startOrPauseRecordingPlayback()
+        } catch (failure: Throwable) {
+            _viewEvents.post(MessageComposerViewEvents.VoicePlaybackOrRecordingFailure(failure))
+        }
     }
 
     fun endAllVoiceActions(deleteRecord: Boolean = true) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Modified `AudioMessageHelper` to catch possible `RuntimeException` caused by race conditions while retrieving the audio file.

## Motivation and context

See #6989.

## Tests

This is difficult to reproduce, to be honest.

- On a room/DM, tap on the record voice message icon for 1-2s.
- Repeatedly tap on it again.

With some luck, you'll trigger this race condition.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
