### PR TITLE
Use libopus encoder for devices that lack the official codec

### DIFF
--- a/changelog.d/7010.feature
+++ b/changelog.d/7010.feature
@@ -1,0 +1,1 @@
+Try to detect devices that lack Opus encoder support, use bundled libopus library for those.

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/AudioMessageHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/AudioMessageHelper.kt
@@ -48,7 +48,7 @@ class AudioMessageHelper @Inject constructor(
 ) {
     private var mediaPlayer: MediaPlayer? = null
     private var currentPlayingId: String? = null
-    private var voiceRecorder: VoiceRecorder = voiceRecorderProvider.provideVoiceRecorder()
+    private val voiceRecorder: VoiceRecorder by lazy { voiceRecorderProvider.provideVoiceRecorder() }
 
     private val amplitudeList = mutableListOf<Int>()
 

--- a/vector/src/main/java/im/vector/app/features/voice/VoiceRecorderProvider.kt
+++ b/vector/src/main/java/im/vector/app/features/voice/VoiceRecorderProvider.kt
@@ -17,6 +17,8 @@
 package im.vector.app.features.voice
 
 import android.content.Context
+import android.media.MediaCodecList
+import android.media.MediaFormat
 import android.os.Build
 import im.vector.app.features.VectorFeatures
 import kotlinx.coroutines.Dispatchers
@@ -27,10 +29,20 @@ class VoiceRecorderProvider @Inject constructor(
         private val vectorFeatures: VectorFeatures,
 ) {
     fun provideVoiceRecorder(): VoiceRecorder {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && vectorFeatures.forceUsageOfOpusEncoder().not()) {
-            VoiceRecorderQ(context)
-        } else {
+        return if (useFallbackRecorder()) {
             VoiceRecorderL(context, Dispatchers.IO)
+        } else {
+            VoiceRecorderQ(context)
         }
+    }
+
+    private fun useFallbackRecorder(): Boolean {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || !hasOpusEncoder() || vectorFeatures.forceUsageOfOpusEncoder()
+    }
+
+    private fun hasOpusEncoder(): Boolean {
+        val codecList = MediaCodecList(MediaCodecList.ALL_CODECS)
+        val format = MediaFormat.createAudioFormat(MediaFormat.MIMETYPE_AUDIO_OPUS, 48000, 1)
+        return codecList.findEncoderForFormat(format) != null
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Try to detect if the OS has support for the Opus encoder, if it doesn't, use the bundled libopus one.

## Motivation and context

See #7010 .

## Tests

Testing this is probably impossible unless you're one of the few affected users. You could force the check to return true and verify that `VoiceRecorderL` is used instead, but that's not really helpful.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
