### PR TITLE
Feature/bma/fix fdroid crash

### DIFF
--- a/vector-app/build.gradle
+++ b/vector-app/build.gradle
@@ -340,10 +340,6 @@ android {
                 "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
         ]
     }
-
-    buildFeatures {
-        viewBinding true
-    }
 }
 
 dependencies {

--- a/vector-app/src/gplay/AndroidManifest.xml
+++ b/vector-app/src/gplay/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:name="im.vector.app.VectorApplication">
+    <application>
 
         <!-- Firebase components -->
         <meta-data

--- a/vector-app/src/main/AndroidManifest.xml
+++ b/vector-app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="im.vector.application">
 
     <application
+        android:name="im.vector.app.VectorApplication"
         android:allowBackup="false"
         android:hasFragileUserData="true"
         android:icon="@mipmap/ic_launcher"

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -78,17 +78,10 @@ android {
     productFlavors {
         gplay {
             dimension "store"
-            isDefault = true
-
-            buildConfigField "String", "SHORT_FLAVOR_DESCRIPTION", "\"G\""
-            buildConfigField "String", "FLAVOR_DESCRIPTION", "\"GooglePlay\""
         }
 
         fdroid {
             dimension "store"
-
-            buildConfigField "String", "SHORT_FLAVOR_DESCRIPTION", "\"F\""
-            buildConfigField "String", "FLAVOR_DESCRIPTION", "\"FDroid\""
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix (not released yet, so no changelog)
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Cleanup + fixes #6995, regression due to modularisation.
Please read commit messages for more details.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Make the F-Droid app usable.

## Screenshots / GIFs

NA

## Tests

<!-- Explain how you tested your development -->

- Compile and run fdroid app.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
