### PR TITLE
New Layout - Fixes recents background color not matching app bar

### DIFF
--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/recent/RecentRoomCarouselController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/recent/RecentRoomCarouselController.kt
@@ -45,6 +45,12 @@ class RecentRoomCarouselController @Inject constructor(
             resources.displayMetrics
     ).toInt()
 
+    private val topPadding = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            12f,
+            resources.displayMetrics
+    ).toInt()
+
     private val itemSpacing = TypedValue.applyDimension(
             TypedValue.COMPLEX_UNIT_DIP,
             24f,
@@ -63,13 +69,13 @@ class RecentRoomCarouselController @Inject constructor(
                 id("recents_carousel")
                 padding(Carousel.Padding(
                         host.hPadding,
-                        0,
+                        host.topPadding,
                         host.hPadding,
                         0,
                         host.itemSpacing)
                 )
                 onBind { _, view, _ ->
-                    val colorSurface = MaterialColors.getColor(view, R.attr.colorSurface)
+                    val colorSurface = MaterialColors.getColor(view, R.attr.vctr_toolbar_background)
                     view.setBackgroundColor(colorSurface)
                 }
                 withModelsFrom(data) { roomSummary ->

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/recent/RecentRoomCarouselController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/recent/RecentRoomCarouselController.kt
@@ -23,6 +23,8 @@ import com.airbnb.epoxy.CarouselModelBuilder
 import com.airbnb.epoxy.EpoxyController
 import com.airbnb.epoxy.EpoxyModel
 import com.airbnb.epoxy.carousel
+import com.google.android.material.color.MaterialColors
+import im.vector.app.R
 import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.list.RoomListListener
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
@@ -66,6 +68,10 @@ class RecentRoomCarouselController @Inject constructor(
                         0,
                         host.itemSpacing)
                 )
+                onBind { _, view, _ ->
+                    val colorSurface = MaterialColors.getColor(view, R.attr.colorSurface)
+                    view.setBackgroundColor(colorSurface)
+                }
                 withModelsFrom(data) { roomSummary ->
                     val onClick = host.listener?.let { it::onRoomClicked }
                     val onLongClick = host.listener?.let { it::onRoomLongClicked }

--- a/vector/src/main/res/layout/item_invites_count.xml
+++ b/vector/src/main/res/layout/item_invites_count.xml
@@ -50,7 +50,7 @@
         android:layout_height="1dp"
         android:layout_marginStart="22dp"
         android:layout_marginEnd="16dp"
-        android:background="?vctr_list_separator_system"
+        android:background="?vctr_list_separator"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/vector/src/main/res/layout/item_recent_room.xml
+++ b/vector/src/main/res/layout/item_recent_room.xml
@@ -5,7 +5,7 @@
     android:id="@+id/recentRoot"
     android:layout_width="60dp"
     android:layout_height="wrap_content"
-    android:background="?android:colorBackground"
+    android:background="?colorSurface"
     android:clickable="true"
     android:focusable="true"
     android:foreground="?attr/selectableItemBackground"

--- a/vector/src/main/res/layout/item_recent_room.xml
+++ b/vector/src/main/res/layout/item_recent_room.xml
@@ -5,7 +5,7 @@
     android:id="@+id/recentRoot"
     android:layout_width="60dp"
     android:layout_height="wrap_content"
-    android:background="?colorSurface"
+    android:background="?vctr_toolbar_background"
     android:clickable="true"
     android:focusable="true"
     android:foreground="?attr/selectableItemBackground"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes recents background color not matching app bar

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/6817

## Screenshots / GIFs

| Light | Dark | Black |
|-|-|-|
| <img width="200" alt="image" src="https://user-images.githubusercontent.com/20701752/188490781-916338ba-3fef-4e3e-b6ef-09d2c78a9d79.png"> | <img width="200" alt="image" src="https://user-images.githubusercontent.com/20701752/188490694-7652a283-8eea-49d2-86c0-b01b059f9144.png"> | <img width="200" alt="image" src="https://user-images.githubusercontent.com/20701752/188490913-e79aec0b-d0b3-47c8-ae3d-d87b23c6f73e.png"> |

## Tests

<!-- Explain how you tested your development -->

- Go to home with recents enabled. See that background is consistent with toolbar and divider under INVITES is visible on all themes

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
