### PR TITLE
New Layout Accessibility Fixes

### DIFF
--- a/changelog.d/7016.wip
+++ b/changelog.d/7016.wip
@@ -1,0 +1,1 @@
+[New Layout] Improves talkback accessibility

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -140,8 +140,10 @@
     <string name="start_chat">Start Chat</string>
     <string name="create_room">Create Room</string>
     <string name="explore_rooms">Explore Rooms</string>
-    <string name="a11y_expand_space_children">Expand space children</string>
-    <string name="a11y_collapse_space_children">Collapse space children</string>
+    <!-- Note to translators: %s refers to the space whose children is being expanded -->
+    <string name="a11y_expand_space_children">Expand %s children</string>
+    <!-- Note to translators: %s refers to the space whose children is being collapsed -->
+    <string name="a11y_collapse_space_children">Collapse %s children</string>
 
     <!-- Last seen time -->
 

--- a/vector/src/main/java/im/vector/app/features/spaces/NewSpaceSummaryItem.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/NewSpaceSummaryItem.kt
@@ -58,7 +58,10 @@ abstract class NewSpaceSummaryItem : VectorEpoxyModel<NewSpaceSummaryItem.Holder
         holder.chevron.setOnClickListener(onToggleExpandListener)
         holder.chevron.isVisible = hasChildren
         holder.chevron.setImageResource(if (expanded) R.drawable.ic_expand_more else R.drawable.ic_arrow_right)
-        holder.chevron.contentDescription = context.getString(if (expanded) R.string.a11y_collapse_space_children else R.string.a11y_expand_space_children)
+        holder.chevron.contentDescription = context.getString(
+                if (expanded) R.string.a11y_collapse_space_children else R.string.a11y_expand_space_children,
+                matrixItem.displayName,
+        )
 
         avatarRenderer.render(matrixItem, holder.avatar)
         holder.unreadCounter.render(countState)

--- a/vector/src/main/java/im/vector/app/features/spaces/NewSubSpaceSummaryItem.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/NewSubSpaceSummaryItem.kt
@@ -50,6 +50,7 @@ abstract class NewSubSpaceSummaryItem : VectorEpoxyModel<NewSubSpaceSummaryItem.
 
     override fun bind(holder: Holder) {
         super.bind(holder)
+        val context = holder.root.context
         holder.root.onClick(onSubSpaceSelectedListener)
         holder.name.text = matrixItem.displayName
         holder.root.isChecked = selected
@@ -63,6 +64,10 @@ abstract class NewSubSpaceSummaryItem : VectorEpoxyModel<NewSubSpaceSummaryItem.
         )
         holder.chevron.onClick(onToggleExpandListener)
         holder.chevron.isVisible = hasChildren
+        holder.chevron.contentDescription = context.getString(
+                if (expanded) R.string.a11y_collapse_space_children else R.string.a11y_expand_space_children,
+                matrixItem.displayName,
+        )
 
         holder.indent.isVisible = indent > 0
         holder.indent.updateLayoutParams {

--- a/vector/src/main/res/layout/fragment_new_home_detail.xml
+++ b/vector/src/main/res/layout/fragment_new_home_detail.xml
@@ -127,7 +127,6 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
-        android:accessibilityTraversalBefore="@id/roomListView"
         android:contentDescription="@string/a11y_create_message"
         android:src="@drawable/ic_new_chat"
         android:visibility="gone"

--- a/vector/src/main/res/layout/item_recent_room.xml
+++ b/vector/src/main/res/layout/item_recent_room.xml
@@ -50,6 +50,7 @@
         android:layout_marginTop="4dp"
         android:layout_marginBottom="16dp"
         android:ellipsize="end"
+        android:importantForAccessibility="no"
         android:lines="1"
         android:textColor="?vctr_content_primary"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes errors in the talkback accessibility of new layout

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/6756

See commit messages for specific changes

## Screenshots / GIFs

N/A

## Tests

Enable talkback and navigate around the new layout. See that everything is sensible

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
