### PR TITLE
obsolete settings are hidden when app layout flag is enabled

### DIFF
--- a/changelog.d/6646.misc
+++ b/changelog.d/6646.misc
@@ -1,0 +1,1 @@
+[App Layout] Obsolete settings are not shown when App Layout flag is enabled

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -165,6 +165,11 @@ class VectorPreferences @Inject constructor(
         const val SETTINGS_LABS_AUTO_REPORT_UISI = "SETTINGS_LABS_AUTO_REPORT_UISI"
         const val SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME = "SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME"
 
+        /**
+         * This is not preference, but category on preferences screen which contains [SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME].
+         * Needed to show/hide this category, depending on visibility of [SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME]. */
+        const val SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME_CATEGORY = "SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME_CATEGORY"
+
         private const val SETTINGS_DEVELOPER_MODE_PREFERENCE_KEY = "SETTINGS_DEVELOPER_MODE_PREFERENCE_KEY"
         private const val SETTINGS_LABS_SHOW_HIDDEN_EVENTS_PREFERENCE_KEY = "SETTINGS_LABS_SHOW_HIDDEN_EVENTS_PREFERENCE_KEY"
         private const val SETTINGS_LABS_ENABLE_SWIPE_TO_REPLY = "SETTINGS_LABS_ENABLE_SWIPE_TO_REPLY"

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -168,7 +168,7 @@ class VectorPreferences @Inject constructor(
         /**
          * This is not preference, but category on preferences screen which contains [SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME].
          * Needed to show/hide this category, depending on visibility of [SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME]. */
-        const val SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME_CATEGORY = "SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME_CATEGORY"
+        const val SETTINGS_PREF_SPACE_CATEGORY = "SETTINGS_PREF_SPACE_CATEGORY"
 
         private const val SETTINGS_DEVELOPER_MODE_PREFERENCE_KEY = "SETTINGS_DEVELOPER_MODE_PREFERENCE_KEY"
         private const val SETTINGS_LABS_SHOW_HIDDEN_EVENTS_PREFERENCE_KEY = "SETTINGS_LABS_SHOW_HIDDEN_EVENTS_PREFERENCE_KEY"

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsLabsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsLabsFragment.kt
@@ -27,6 +27,7 @@ import im.vector.app.R
 import im.vector.app.core.preference.VectorSwitchPreference
 import im.vector.app.features.MainActivity
 import im.vector.app.features.MainActivityArgs
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.analytics.plan.MobileScreen
 import im.vector.app.features.home.room.threads.ThreadsManager
 import org.matrix.android.sdk.api.settings.LightweightSettingsStorage
@@ -39,6 +40,7 @@ class VectorSettingsLabsFragment :
     @Inject lateinit var vectorPreferences: VectorPreferences
     @Inject lateinit var lightweightSettingsStorage: LightweightSettingsStorage
     @Inject lateinit var threadsManager: ThreadsManager
+    @Inject lateinit var vectorFeatures: VectorFeatures
 
     override var titleRes = R.string.room_settings_labs_pref_title
     override val preferenceXmlRes = R.xml.vector_settings_labs
@@ -71,6 +73,10 @@ class VectorSettingsLabsFragment :
                 MainActivity.restartApp(requireActivity(), MainActivityArgs(clearCache = true))
                 true
             }
+        }
+
+        findPreference<VectorSwitchPreference>(VectorPreferences.SETTINGS_LABS_UNREAD_NOTIFICATIONS_AS_TAB)!!.let {
+            it.isVisible = !vectorFeatures.isNewAppLayoutEnabled()
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsPreferencesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsPreferencesFragment.kt
@@ -28,7 +28,6 @@ import im.vector.app.core.dialogs.PhotoOrVideoDialog
 import im.vector.app.core.extensions.restart
 import im.vector.app.core.preference.VectorListPreference
 import im.vector.app.core.preference.VectorPreference
-import im.vector.app.core.preference.VectorPreferenceCategory
 import im.vector.app.core.preference.VectorSwitchPreference
 import im.vector.app.features.MainActivity
 import im.vector.app.features.MainActivityArgs
@@ -102,7 +101,7 @@ class VectorSettingsPreferencesFragment :
             }
         }
 
-        findPreference<VectorPreferenceCategory>(VectorPreferences.SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME_CATEGORY)!!.let { pref ->
+        findPreference<Preference>(VectorPreferences.SETTINGS_PREF_SPACE_CATEGORY)!!.let { pref ->
             pref.isVisible = !vectorFeatures.isNewAppLayoutEnabled()
         }
 

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsPreferencesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsPreferencesFragment.kt
@@ -28,9 +28,11 @@ import im.vector.app.core.dialogs.PhotoOrVideoDialog
 import im.vector.app.core.extensions.restart
 import im.vector.app.core.preference.VectorListPreference
 import im.vector.app.core.preference.VectorPreference
+import im.vector.app.core.preference.VectorPreferenceCategory
 import im.vector.app.core.preference.VectorSwitchPreference
 import im.vector.app.features.MainActivity
 import im.vector.app.features.MainActivityArgs
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.analytics.plan.MobileScreen
 import im.vector.app.features.settings.font.FontScaleSettingActivity
 import im.vector.app.features.themes.ThemeUtils
@@ -44,6 +46,7 @@ class VectorSettingsPreferencesFragment :
 
     @Inject lateinit var vectorPreferences: VectorPreferences
     @Inject lateinit var fontScalePreferences: FontScalePreferences
+    @Inject lateinit var vectorFeatures: VectorFeatures
 
     override var titleRes = R.string.settings_preferences
     override val preferenceXmlRes = R.xml.vector_settings_preferences
@@ -97,6 +100,10 @@ class VectorSettingsPreferencesFragment :
                 MainActivity.restartApp(requireActivity(), MainActivityArgs(clearCache = false))
                 true
             }
+        }
+
+        findPreference<VectorPreferenceCategory>(VectorPreferences.SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME_CATEGORY)!!.let { pref ->
+            pref.isVisible = !vectorFeatures.isNewAppLayoutEnabled()
         }
 
         // Url preview

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -32,7 +32,7 @@
 
     <im.vector.app.core.preference.VectorPreferenceCategory
         android:title="@string/spaces"
-        android:key="SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME_CATEGORY">
+        android:key="SETTINGS_PREF_SPACE_CATEGORY">
 
         <im.vector.app.core.preference.VectorSwitchPreference
             android:defaultValue="false"

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -30,7 +30,9 @@
 
     </im.vector.app.core.preference.VectorPreferenceCategory>
 
-    <im.vector.app.core.preference.VectorPreferenceCategory android:title="@string/spaces">
+    <im.vector.app.core.preference.VectorPreferenceCategory
+        android:title="@string/spaces"
+        android:key="SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME_CATEGORY">
 
         <im.vector.app.core.preference.VectorSwitchPreference
             android:defaultValue="false"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

some app settings became obsolete with new app layout, we should not display them when flag is enabled

## Motivation and context

closes #6646

