### PR TITLE
New Layout - Fixes padding of recents item selectable background

### DIFF
--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/recent/RecentRoomCarouselController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/recent/RecentRoomCarouselController.kt
@@ -41,19 +41,13 @@ class RecentRoomCarouselController @Inject constructor(
 
     private val hPadding = TypedValue.applyDimension(
             TypedValue.COMPLEX_UNIT_DIP,
-            16f,
+            4f,
             resources.displayMetrics
     ).toInt()
 
     private val topPadding = TypedValue.applyDimension(
             TypedValue.COMPLEX_UNIT_DIP,
             12f,
-            resources.displayMetrics
-    ).toInt()
-
-    private val itemSpacing = TypedValue.applyDimension(
-            TypedValue.COMPLEX_UNIT_DIP,
-            24f,
             resources.displayMetrics
     ).toInt()
 
@@ -72,7 +66,8 @@ class RecentRoomCarouselController @Inject constructor(
                         host.topPadding,
                         host.hPadding,
                         0,
-                        host.itemSpacing)
+                        0,
+                )
                 )
                 onBind { _, view, _ ->
                     val colorSurface = MaterialColors.getColor(view, R.attr.vctr_toolbar_background)

--- a/vector/src/main/res/layout/item_recent_room.xml
+++ b/vector/src/main/res/layout/item_recent_room.xml
@@ -3,12 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/recentRoot"
-    android:layout_width="60dp"
+    android:layout_width="84dp"
     android:layout_height="wrap_content"
     android:background="?vctr_toolbar_background"
     android:clickable="true"
     android:focusable="true"
     android:foreground="?attr/selectableItemBackground"
+    android:paddingHorizontal="12dp"
     tools:viewBindingIgnore="true">
 
     <ImageView


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes padding of recents item selectable background

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/7023

## Screenshots / GIFs

<img width="420" alt="image" src="https://user-images.githubusercontent.com/20701752/188586634-ea751ef3-b613-4ed9-8cda-23518fe8fa3f.png">


## Tests
 
With recents enabled press or hold on a recent item and see that the selection background doesn't look too thin

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
