### PR TITLE
Space response model

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/SpaceChildInfo.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/SpaceChildInfo.kt
@@ -34,5 +34,4 @@ data class SpaceChildInfo(
         val canonicalAlias: String?,
         val aliases: List<String>?,
         val worldReadable: Boolean
-
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/SpaceHierarchyData.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/SpaceHierarchyData.kt
@@ -16,13 +16,13 @@
 
 package org.matrix.android.sdk.api.session.space
 
-import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 import org.matrix.android.sdk.api.session.room.model.SpaceChildInfo
+import org.matrix.android.sdk.api.session.space.model.SpaceChildSummaryEvent
 
 data class SpaceHierarchyData(
         val rootSummary: RoomSummary,
         val children: List<SpaceChildInfo>,
-        val childrenState: List<Event>,
+        val childrenState: List<SpaceChildSummaryEvent>,
         val nextToken: String? = null
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/SpaceService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/SpaceService.kt
@@ -80,7 +80,7 @@ interface SpaceService {
 
     /**
      * Get a live list of space summaries. This list is refreshed as soon as the data changes.
-     * @return the [LiveData] of List[SpaceSummary]
+     * @return the [LiveData] of List[RoomSummary]
      */
     fun getSpaceSummariesLive(
             queryParams: SpaceSummaryQueryParams,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/SpaceService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/SpaceService.kt
@@ -18,10 +18,10 @@ package org.matrix.android.sdk.api.session.space
 
 import android.net.Uri
 import androidx.lifecycle.LiveData
-import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.room.RoomSortOrder
 import org.matrix.android.sdk.api.session.room.RoomSummaryQueryParams
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import org.matrix.android.sdk.api.session.space.model.SpaceChildSummaryEvent
 import org.matrix.android.sdk.api.session.space.peeking.SpacePeekResult
 
 typealias SpaceSummaryQueryParams = RoomSummaryQueryParams
@@ -75,7 +75,7 @@ interface SpaceService {
             suggestedOnly: Boolean? = null,
             limit: Int? = null,
             from: String? = null,
-            knownStateList: List<Event>? = null
+            knownStateList: List<SpaceChildSummaryEvent>? = null
     ): SpaceHierarchyData
 
     /**

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/model/SpaceChildSummaryEvent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/space/model/SpaceChildSummaryEvent.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.api.session.space.model
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import org.matrix.android.sdk.api.session.events.model.Content
+
+@JsonClass(generateAdapter = true)
+data class SpaceChildSummaryEvent(
+        @Json(name = "type") val type: String? = null,
+        @Json(name = "state_key") val stateKey: String? = null,
+        @Json(name = "content") val content: Content? = null,
+        @Json(name = "sender") val senderId: String? = null,
+        @Json(name = "origin_server_ts") val originServerTs: Long? = null,
+)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpaceService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpaceService.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.LiveData
 import kotlinx.coroutines.withContext
 import org.matrix.android.sdk.api.MatrixCoroutineDispatchers
 import org.matrix.android.sdk.api.query.QueryStringValue
-import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.events.model.toModel
@@ -45,6 +44,7 @@ import org.matrix.android.sdk.api.session.space.SpaceHierarchyData
 import org.matrix.android.sdk.api.session.space.SpaceService
 import org.matrix.android.sdk.api.session.space.SpaceSummaryQueryParams
 import org.matrix.android.sdk.api.session.space.model.SpaceChildContent
+import org.matrix.android.sdk.api.session.space.model.SpaceChildSummaryEvent
 import org.matrix.android.sdk.api.session.space.model.SpaceParentContent
 import org.matrix.android.sdk.api.session.space.peeking.SpacePeekResult
 import org.matrix.android.sdk.internal.di.UserId
@@ -128,7 +128,7 @@ internal class DefaultSpaceService @Inject constructor(
             suggestedOnly: Boolean?,
             limit: Int?,
             from: String?,
-            knownStateList: List<Event>?
+            knownStateList: List<SpaceChildSummaryEvent>?
     ): SpaceHierarchyData {
         val spacesResponse = getSpacesResponse(spaceId, suggestedOnly, limit, from)
         val spaceRootResponse = spacesResponse.getRoot(spaceId)
@@ -180,7 +180,7 @@ internal class DefaultSpaceService @Inject constructor(
     private fun List<SpaceChildSummaryResponse>?.mapSpaceChildren(
             spaceId: String,
             spaceRootResponse: SpaceChildSummaryResponse?,
-            knownStateList: List<Event>?,
+            knownStateList: List<SpaceChildSummaryEvent>?,
     ) = this?.filterIdIsNot(spaceId)
             ?.toSpaceChildInfoList(spaceId, spaceRootResponse, knownStateList)
             .orEmpty()
@@ -190,7 +190,7 @@ internal class DefaultSpaceService @Inject constructor(
     private fun List<SpaceChildSummaryResponse>.toSpaceChildInfoList(
             spaceId: String,
             rootRoomResponse: SpaceChildSummaryResponse?,
-            knownStateList: List<Event>?,
+            knownStateList: List<SpaceChildSummaryEvent>?,
     ) = flatMap { spaceChildSummary ->
         (rootRoomResponse?.childrenState ?: knownStateList)
                 ?.filter { it.isChildOf(spaceChildSummary) }
@@ -198,9 +198,9 @@ internal class DefaultSpaceService @Inject constructor(
                 .orEmpty()
     }
 
-    private fun Event.isChildOf(space: SpaceChildSummaryResponse) = stateKey == space.roomId && type == EventType.STATE_SPACE_CHILD
+    private fun SpaceChildSummaryEvent.isChildOf(space: SpaceChildSummaryResponse) = stateKey == space.roomId && type == EventType.STATE_SPACE_CHILD
 
-    private fun Event.toSpaceChildInfo(spaceId: String, summary: SpaceChildSummaryResponse) = content.toModel<SpaceChildContent>()?.let { content ->
+    private fun SpaceChildSummaryEvent.toSpaceChildInfo(spaceId: String, summary: SpaceChildSummaryResponse) = content.toModel<SpaceChildContent>()?.let { content ->
         createSpaceChildInfo(spaceId, summary, content)
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpaceService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/DefaultSpaceService.kt
@@ -255,7 +255,7 @@ internal class DefaultSpaceService @Inject constructor(
                     stateKey = QueryStringValue.IsEmpty
             )
             val powerLevelsContent = powerLevelsEvent?.content?.toModel<PowerLevelsContent>()
-                    ?: throw UnsupportedOperationException("Cannot add canonical child, missing powerlevel")
+                    ?: throw UnsupportedOperationException("Cannot add canonical child, missing power level")
             val powerLevelsHelper = PowerLevelsHelper(powerLevelsContent)
             if (!powerLevelsHelper.isUserAllowedToSend(userId, true, EventType.STATE_SPACE_CHILD)) {
                 throw UnsupportedOperationException("Cannot add canonical child, not enough power level")

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/SpaceChildSummaryResponse.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/space/SpaceChildSummaryResponse.kt
@@ -18,7 +18,7 @@ package org.matrix.android.sdk.internal.session.space
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.api.session.space.model.SpaceChildSummaryEvent
 
 /**
  * The fields are the same as those returned by /publicRooms (see spec), with the addition of:
@@ -36,10 +36,11 @@ internal data class SpaceChildSummaryResponse(
          */
         @Json(name = "room_type") val roomType: String? = null,
 
-        /**  The m.space.child events of the room. For each event, only the following fields are included:
-         *  type, state_key, content, room_id, sender, with the addition of origin_server_ts.
+        /**
+         * The m.space.child events of the room. For each event, only the following fields are included:
+         * type, state_key, content, sender, and of origin_server_ts.
          */
-        @Json(name = "children_state") val childrenState: List<Event>? = null,
+        @Json(name = "children_state") val childrenState: List<SpaceChildSummaryEvent>? = null,
 
         /**
          * Aliases of the room. May be empty.

--- a/vector/src/main/java/im/vector/app/features/spaces/manage/SpaceManageRoomsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/manage/SpaceManageRoomsViewModel.kt
@@ -189,7 +189,7 @@ class SpaceManageRoomsViewModel @AssistedInject constructor(
                 val apiResult = session.spaceService().querySpaceChildren(
                         spaceId = initialState.spaceId,
                         from = nextToken,
-                        knownStateList = knownResults.childrenState.orEmpty(),
+                        knownStateList = knownResults.childrenState,
                         limit = paginationLimit
                 )
                 val newKnown = apiResult.children.mapNotNull { session.getRoomSummary(it.childRoomId) }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Ensure that we do not expect Event field that won't be returned by the server by creating a dedicated Json model.

Assigning to Eric who made some change on this area.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Avoid future mistake of using field that are not provided in the server response.

The current implementation does not use `Event.roomId`, but with this change, we ensure that it's not the case (and it will not be the case in the future.

See https://github.com/matrix-org/synapse/pull/13506

## Screenshots / GIFs

NA

## Tests

The code is compiling, there is not behavior nor UI change.

## Tested devices

None.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
