### PR TITLE
New Layout - Adds missing space list header

### DIFF
--- a/changelog.d/7040.wip
+++ b/changelog.d/7040.wip
@@ -1,0 +1,1 @@
+[New Layout] Adds header to spaces bottom sheet

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="all_chats">All Chats</string>
     <string name="start_chat">Start Chat</string>
     <string name="create_room">Create Room</string>
+    <string name="change_space">Change Space</string>
     <string name="explore_rooms">Explore Rooms</string>
     <!-- Note to translators: %s refers to the space whose children is being expanded -->
     <string name="a11y_expand_space_children">Expand %s children</string>

--- a/vector/src/main/java/im/vector/app/features/spaces/NewSpaceListHeaderItem.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/NewSpaceListHeaderItem.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.spaces
+
+import com.airbnb.epoxy.EpoxyModelClass
+import im.vector.app.R
+import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
+
+@EpoxyModelClass
+abstract class NewSpaceListHeaderItem : VectorEpoxyModel<NewSpaceListHeaderItem.Holder>(R.layout.item_new_space_list_header) {
+    class Holder : VectorEpoxyHolder()
+}

--- a/vector/src/main/java/im/vector/app/features/spaces/NewSpaceSummaryController.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/NewSpaceSummaryController.kt
@@ -52,10 +52,17 @@ class NewSpaceSummaryController @Inject constructor(
     }
 
     private fun buildGroupModels(viewState: SpaceListViewState) = with(viewState) {
+        addHeaderItem()
         addHomeItem(selectedSpace == null, homeAggregateCount)
         addSpaces(spaces, selectedSpace, rootSpacesOrdered, expandedStates)
         addInvites(selectedSpace, rootSpacesOrdered, inviters)
         addCreateItem()
+    }
+
+    private fun addHeaderItem() {
+        newSpaceListHeaderItem {
+            id("space_list_header")
+        }
     }
 
     private fun addHomeItem(selected: Boolean, homeCount: RoomAggregateNotificationCount) {

--- a/vector/src/main/res/layout/item_new_space_list_header.xml
+++ b/vector/src/main/res/layout/item_new_space_list_header.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/TextAppearance.Vector.Body.Medium"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_space_item"
+    android:ellipsize="middle"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:singleLine="true"
+    android:text="@string/change_space"
+    android:textAllCaps="true"
+    android:textColor="?vctr_content_tertiary"
+    android:textSize="14sp"
+    tools:viewBindingIgnore="true" />


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Adds the "CHANGE SPACE" header to the space list that got lost in a recent pr

## Motivation and context

Part 1/2 of work for https://github.com/vector-im/element-android/issues/7027

## Screenshots / GIFs

![image](https://user-images.githubusercontent.com/20701752/188652685-41a0eb6c-a95b-4b84-9df5-ab2aa78fea10.png)


## Tests

Open the space list. See CHANGE SPACE header

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
