### PR TITLE
Debug release note

### DIFF
--- a/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsFragment.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsFragment.kt
@@ -16,6 +16,8 @@
 
 package im.vector.app.features.debug.settings
 
+import android.annotation.SuppressLint
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -24,6 +26,7 @@ import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.withState
 import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.databinding.FragmentDebugPrivateSettingsBinding
+import im.vector.app.features.home.room.list.home.release.ReleaseNotesActivity
 
 class DebugPrivateSettingsFragment : VectorBaseFragment<FragmentDebugPrivateSettingsBinding>() {
 
@@ -35,7 +38,6 @@ class DebugPrivateSettingsFragment : VectorBaseFragment<FragmentDebugPrivateSett
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         setViewListeners()
     }
 
@@ -45,6 +47,12 @@ class DebugPrivateSettingsFragment : VectorBaseFragment<FragmentDebugPrivateSett
         }
         views.forceLoginFallback.setOnCheckedChangeListener { _, isChecked ->
             viewModel.handle(DebugPrivateSettingsViewActions.SetForceLoginFallbackEnabled(isChecked))
+        }
+        views.releaseNotesActivityHasBeenDisplayedReset.setOnClickListener {
+            viewModel.handle(DebugPrivateSettingsViewActions.ResetReleaseNotesActivityHasBeenDisplayed)
+        }
+        views.showReleaseNotesActivity.setOnClickListener {
+            startActivity(Intent(requireActivity(), ReleaseNotesActivity::class.java))
         }
     }
 
@@ -57,5 +65,7 @@ class DebugPrivateSettingsFragment : VectorBaseFragment<FragmentDebugPrivateSett
             viewModel.handle(DebugPrivateSettingsViewActions.SetAvatarCapabilityOverride(option))
         }
         views.forceLoginFallback.isChecked = it.forceLoginFallback
+        @SuppressLint("SetTextI18n")
+        views.releaseNotesActivityHasBeenDisplayed.text = "ReleaseNotesActivity has been displayed: ${it.releaseNotesActivityHasBeenDisplayed}"
     }
 }

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewActions.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewActions.kt
@@ -23,4 +23,5 @@ sealed interface DebugPrivateSettingsViewActions : VectorViewModelAction {
     data class SetForceLoginFallbackEnabled(val force: Boolean) : DebugPrivateSettingsViewActions
     data class SetDisplayNameCapabilityOverride(val option: BooleanHomeserverCapabilitiesOverride?) : DebugPrivateSettingsViewActions
     data class SetAvatarCapabilityOverride(val option: BooleanHomeserverCapabilitiesOverride?) : DebugPrivateSettingsViewActions
+    object ResetReleaseNotesActivityHasBeenDisplayed : DebugPrivateSettingsViewActions
 }

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewModel.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewModel.kt
@@ -27,11 +27,13 @@ import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.features.debug.features.DebugVectorOverrides
 import im.vector.app.features.debug.settings.DebugPrivateSettingsViewActions.SetAvatarCapabilityOverride
 import im.vector.app.features.debug.settings.DebugPrivateSettingsViewActions.SetDisplayNameCapabilityOverride
+import im.vector.app.features.home.room.list.home.release.ReleaseNotesPreferencesStore
 import kotlinx.coroutines.launch
 
 class DebugPrivateSettingsViewModel @AssistedInject constructor(
         @Assisted initialState: DebugPrivateSettingsViewState,
-        private val debugVectorOverrides: DebugVectorOverrides
+        private val debugVectorOverrides: DebugVectorOverrides,
+        private val releaseNotesPreferencesStore: ReleaseNotesPreferencesStore,
 ) : VectorViewModel<DebugPrivateSettingsViewState, DebugPrivateSettingsViewActions, EmptyViewEvents>(initialState) {
 
     @AssistedFactory
@@ -43,6 +45,15 @@ class DebugPrivateSettingsViewModel @AssistedInject constructor(
 
     init {
         observeVectorOverrides()
+        observeReleaseNotesPreferencesStore()
+    }
+
+    private fun observeReleaseNotesPreferencesStore() {
+        releaseNotesPreferencesStore.appLayoutOnboardingShown.setOnEach {
+            copy(
+                    releaseNotesActivityHasBeenDisplayed = it
+            )
+        }
     }
 
     private fun observeVectorOverrides() {
@@ -72,6 +83,13 @@ class DebugPrivateSettingsViewModel @AssistedInject constructor(
             is DebugPrivateSettingsViewActions.SetForceLoginFallbackEnabled -> handleSetForceLoginFallbackEnabled(action)
             is SetDisplayNameCapabilityOverride -> handleSetDisplayNameCapabilityOverride(action)
             is SetAvatarCapabilityOverride -> handleSetAvatarCapabilityOverride(action)
+            DebugPrivateSettingsViewActions.ResetReleaseNotesActivityHasBeenDisplayed -> handleResetReleaseNotesActivityHasBeenDisplayed()
+        }
+    }
+
+    private fun handleResetReleaseNotesActivityHasBeenDisplayed() {
+        viewModelScope.launch {
+            releaseNotesPreferencesStore.setAppLayoutOnboardingShown(false)
         }
     }
 

--- a/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewState.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/settings/DebugPrivateSettingsViewState.kt
@@ -22,7 +22,8 @@ import im.vector.app.features.debug.settings.OverrideDropdownView.OverrideDropdo
 data class DebugPrivateSettingsViewState(
         val dialPadVisible: Boolean = false,
         val forceLoginFallback: Boolean = false,
-        val homeserverCapabilityOverrides: HomeserverCapabilityOverrides = HomeserverCapabilityOverrides()
+        val homeserverCapabilityOverrides: HomeserverCapabilityOverrides = HomeserverCapabilityOverrides(),
+        val releaseNotesActivityHasBeenDisplayed: Boolean = false,
 ) : MavericksState
 
 data class HomeserverCapabilityOverrides(

--- a/vector/src/debug/res/layout/fragment_debug_private_settings.xml
+++ b/vector/src/debug/res/layout/fragment_debug_private_settings.xml
@@ -49,6 +49,27 @@
                 android:layout_marginEnd="16dp"
                 android:layout_marginBottom="4dp" />
 
+            <TextView
+                android:id="@+id/releaseNotesActivityHasBeenDisplayed"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                tools:text="ReleaseNotesActivity has been displayed: " />
+
+            <Button
+                android:id="@+id/releaseNotesActivityHasBeenDisplayedReset"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:text="Reset" />
+
+            <Button
+                android:id="@+id/showReleaseNotesActivity"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="SHOW ReleaseNotesActivity"
+                android:textAllCaps="false" />
+
         </LinearLayout>
 
     </ScrollView>

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -123,7 +123,6 @@ class HomeActivityViewModel @AssistedInject constructor(
         if (state.authenticationDescription == null && vectorFeatures.isNewAppLayoutEnabled()) {
             releaseNotesPreferencesStore.appLayoutOnboardingShown.onEach { isAppLayoutOnboardingShown ->
                 if (!isAppLayoutOnboardingShown) {
-                    releaseNotesPreferencesStore.setAppLayoutOnboardingShown(true)
                     _viewEvents.post(HomeActivityViewEvents.ShowReleaseNotes)
                 }
             }.launchIn(viewModelScope)

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/release/ReleaseNotesActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/release/ReleaseNotesActivity.kt
@@ -16,17 +16,20 @@
 
 package im.vector.app.features.home.room.list.home.release
 
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.core.extensions.addFragment
 import im.vector.app.core.platform.ScreenOrientationLocker
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.databinding.ActivitySimpleBinding
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class ReleaseNotesActivity : VectorBaseActivity<ActivitySimpleBinding>() {
 
     @Inject lateinit var orientationLocker: ScreenOrientationLocker
+    @Inject lateinit var releaseNotesPreferencesStore: ReleaseNotesPreferencesStore
 
     override fun getBinding() = ActivitySimpleBinding.inflate(layoutInflater)
 
@@ -36,6 +39,13 @@ class ReleaseNotesActivity : VectorBaseActivity<ActivitySimpleBinding>() {
         orientationLocker.lockPhonesToPortrait(this)
         if (isFirstCreation()) {
             addFragment(views.simpleFragmentContainer, ReleaseNotesFragment::class.java)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        lifecycleScope.launch {
+            releaseNotesPreferencesStore.setAppLayoutOnboardingShown(true)
         }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Add some debug tools about ReleaseNotesActivity.
- reset the show status
- display this Activity

Also moving `releaseNotesPreferencesStore.setAppLayoutOnboardingShown(true)` to the `ReleaseNotesActivity.onResume()`, which make more sense to me.

## Motivation and context

Help developer who work on this feature.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

![DebugTools](https://user-images.githubusercontent.com/3940906/188653288-f3b91d8d-bb31-4ddb-8bd8-50b0b76e7f33.gif)

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
