### PR TITLE
Fix ReleaseNotesActivity displayed after login.

### DIFF
--- a/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/OnboardingViewModel.kt
@@ -628,6 +628,7 @@ class OnboardingViewModel @AssistedInject constructor(
             }
             AuthenticationDescription.Login -> {
                 setState { copy(isLoading = false, selectedAuthenticationState = SelectedAuthenticationState(authenticationDescription)) }
+                awaitState()
                 _viewEvents.post(OnboardingViewEvents.OnAccountSignedIn)
             }
         }


### PR DESCRIPTION
Ensure the state is up to date, when we will request it later with withState{}

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix. Not released so no changelog
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

Ensure the state is up to date, else at this point: https://github.com/vector-im/element-android/blob/62e8beadf8c0ece8e56e21b86d9e96c0ec68d3b2/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt#L498 the state is not up to date, and `it.selectedAuthenticationState.description` is null. So at this point https://github.com/vector-im/element-android/blob/16fad63e49eb408a4ccf066341e5b9cd5745fc66/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt#L123 `state.authenticationDescription` is null and we display ReleaseNotesActivity, if never displayed before.

The fix is maybe not the best thing to do, [I already had concern about it](https://github.com/vector-im/element-android/pull/7003#discussion_r962998511). But as a quick fix it seems acceptable. I think `OnboardingViewState.selectedAuthenticationState` should be set earlier.

Tested OK on my side.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
