### PR TITLE
Fix add by QR code layout (#5424)

### DIFF
--- a/changelog.d/5424.bugfix
+++ b/changelog.d/5424.bugfix
@@ -1,0 +1,1 @@
+Fix text margin in QR code view when no display name is set

--- a/vector/src/main/res/layout/fragment_user_code_show.xml
+++ b/vector/src/main/res/layout/fragment_user_code_show.xml
@@ -69,6 +69,7 @@
                     android:textAlignment="center"
                     android:textColor="?vctr_content_tertiary"
                     app:layout_constraintTop_toBottomOf="@id/showUserCodeCardNameText"
+                    app:layout_goneMarginTop="54dp"
                     tools:text="@sample/users.json/data/id" />
 
                 <!--                android:id="@+id/itemShareQrCodeImage"-->


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

When `showUserCodeCardNameText` is gone, `showUserCodeCardUserIdText` top constraint is missing. Updated the top margin when the referenced view is gone.
54dp is from adding up both views margin tops (50dp + 4dp).

## Motivation and context

Addressing #5424

## Screenshots / GIFs

![01](https://user-images.githubusercontent.com/616399/189495654-3d55315a-1c29-4eac-be6f-c8ed1fd7fde3.png)
![02](https://user-images.githubusercontent.com/616399/189495655-8388b297-ec92-46c5-b652-f120b7d5d2eb.png)

## Tests

I tested this from the old UI flow and followed the steps in #5424

1. Enable the old flow
2. Open the hamburger menu on the top left
3. Tap the QR code icon

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 12 and also API 21

## Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
