### PR TITLE
Fixes Crash On Double Click Of Space FABs

### DIFF
--- a/changelog.d/7102.bugfix
+++ b/changelog.d/7102.bugfix
@@ -1,0 +1,1 @@
+Fixes crash when quickly double clicking FABs in the new app layout

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
@@ -201,13 +201,12 @@ class NewHomeDetailFragment :
     private fun setupFabs() {
         showFABs()
 
-        views.newLayoutCreateChatButton.setOnClickListener {
-            newChatBottomSheet.show(requireActivity().supportFragmentManager, NewChatBottomSheet.TAG)
+        views.newLayoutCreateChatButton.debouncedClicks {
+            newChatBottomSheet.takeIf { !it.isAdded }?.show(requireActivity().supportFragmentManager, NewChatBottomSheet.TAG)
         }
 
-        views.newLayoutOpenSpacesButton.setOnClickListener {
-            // Click action for open spaces modal goes here
-            spaceListBottomSheet.show(requireActivity().supportFragmentManager, SpaceListBottomSheet.TAG)
+        views.newLayoutOpenSpacesButton.debouncedClicks {
+            spaceListBottomSheet.takeIf { !it.isAdded }?.show(requireActivity().supportFragmentManager, SpaceListBottomSheet.TAG)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/NewChatBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/NewChatBottomSheet.kt
@@ -27,7 +27,7 @@ import im.vector.app.features.navigation.Navigator
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class NewChatBottomSheet @Inject constructor() : BottomSheetDialogFragment() {
+class NewChatBottomSheet : BottomSheetDialogFragment() {
 
     @Inject lateinit var navigator: Navigator
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes Crash On Double Click Of Space FABs

## Motivation and context

Fixes https://github.com/vector-im/element-android/issues/7087

## Screenshots / GIFs

N/A

## Tests

Double quick really quickly on the space list or new chat FABs in the new layout. These would have previously crashed the app.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
