### PR TITLE
[New Layout] Adds peek height (min height) to new layout bottom sheets

### DIFF
--- a/vector/src/main/java/im/vector/app/core/extensions/BottomSheetDialog.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/BottomSheetDialog.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.extensions
+
+import android.util.DisplayMetrics
+import androidx.annotation.FloatRange
+import com.google.android.material.bottomsheet.BottomSheetDialog
+
+@Suppress("DEPRECATION")
+fun BottomSheetDialog.setPeekHeightAsScreenPercentage(@FloatRange(from = 0.0, to = 1.0) percentage: Float) {
+    val displayMetrics = DisplayMetrics()
+    window?.windowManager?.defaultDisplay?.getMetrics(displayMetrics)
+    val height = displayMetrics.heightPixels
+    behavior.setPeekHeight((height * percentage).toInt(), true)
+}

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/NewChatBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/NewChatBottomSheet.kt
@@ -16,12 +16,15 @@
 
 package im.vector.app.features.home.room.list.home
 
+import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import im.vector.app.core.extensions.setPeekHeightAsScreenPercentage
 import im.vector.app.databinding.FragmentNewChatBottomSheetBinding
 import im.vector.app.features.navigation.Navigator
 import javax.inject.Inject
@@ -50,6 +53,12 @@ class NewChatBottomSheet @Inject constructor() : BottomSheetDialogFragment() {
 
         binding.exploreRooms.setOnClickListener {
             navigator.openRoomDirectory(requireContext())
+        }
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return super.onCreateDialog(savedInstanceState).apply {
+            (this as BottomSheetDialog).setPeekHeightAsScreenPercentage(0.5f)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceListBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceListBottomSheet.kt
@@ -27,6 +27,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import im.vector.app.R
 import im.vector.app.core.extensions.replaceChildFragment
+import im.vector.app.core.extensions.setPeekHeightAsScreenPercentage
 import im.vector.app.databinding.FragmentSpacesBottomSheetBinding
 
 class SpaceListBottomSheet : BottomSheetDialogFragment() {
@@ -46,14 +47,6 @@ class SpaceListBottomSheet : BottomSheetDialogFragment() {
         return super.onCreateDialog(savedInstanceState).apply {
             (this as BottomSheetDialog).setPeekHeightAsScreenPercentage(0.75f)
         }
-    }
-
-    @Suppress("DEPRECATION")
-    private fun BottomSheetDialog.setPeekHeightAsScreenPercentage(@FloatRange(from = 0.0, to = 1.0) percentage: Float) {
-        val displayMetrics = DisplayMetrics()
-        window?.windowManager?.defaultDisplay?.getMetrics(displayMetrics)
-        val height = displayMetrics.heightPixels
-        behavior.setPeekHeight((height * percentage).toInt(), true)
     }
 
     companion object {

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceListBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceListBottomSheet.kt
@@ -16,10 +16,14 @@
 
 package im.vector.app.features.spaces
 
+import android.app.Dialog
 import android.os.Bundle
+import android.util.DisplayMetrics
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.FloatRange
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import im.vector.app.R
 import im.vector.app.core.extensions.replaceChildFragment
@@ -35,6 +39,21 @@ class SpaceListBottomSheet : BottomSheetDialogFragment() {
             replaceChildFragment(R.id.space_list, SpaceListFragment::class.java)
         }
         return binding.root
+    }
+
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return super.onCreateDialog(savedInstanceState).apply {
+            (this as BottomSheetDialog).setPeekHeightAsScreenPercentage(0.75f)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun BottomSheetDialog.setPeekHeightAsScreenPercentage(@FloatRange(from = 0.0, to = 1.0) percentage: Float) {
+        val displayMetrics = DisplayMetrics()
+        window?.windowManager?.defaultDisplay?.getMetrics(displayMetrics)
+        val height = displayMetrics.heightPixels
+        behavior.setPeekHeight((height * percentage).toInt(), true)
     }
 
     companion object {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Adds peek height to new layout bottom sheets so they don't show at heights smaller than they should be

## Motivation and context

Fixes https://github.com/vector-im/element-android/issues/7027

## Screenshots / GIFs

## Tests

- Turn phone on landscape
- Open space list sheet and new chat sheets. See that they don't show at a height that's too small

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
