### PR TITLE
Use `buildjet-4vcpu-ubuntu-2204` runner instead of `macos-latest` to …

### DIFF
--- a/.github/workflows/post-pr.yml
+++ b/.github/workflows/post-pr.yml
@@ -31,7 +31,7 @@ jobs:
   ui-tests:
     name: UI Tests (Synapse)
     needs: should-i-run
-    runs-on: macos-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/post-pr.yml
+++ b/.github/workflows/post-pr.yml
@@ -31,7 +31,7 @@ jobs:
   ui-tests:
     name: UI Tests (Synapse)
     needs: should-i-run
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/post-pr.yml
+++ b/.github/workflows/post-pr.yml
@@ -31,7 +31,7 @@ jobs:
   ui-tests:
     name: UI Tests (Synapse)
     needs: should-i-run
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: buildjet-2vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   tests:
     name: Runs all tests
-    runs-on: buildjet-4vcpu-ubuntu-2204 # for the emulator
+    runs-on: buildjet-2vcpu-ubuntu-2204
     # Allow all jobs on main and develop. Just one per PR.
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && format('unit-tests-main-{0}', github.sha) || github.ref == 'refs/heads/develop' && format('unit-tests-develop-{0}', github.sha) || format('unit-tests-{0}', github.ref) }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,9 @@ jobs:
   tests:
     name: Runs all tests
     runs-on: buildjet-4vcpu-ubuntu-2204
+    strategy:
+      matrix:
+        api-level: [28]
     # Allow all jobs on main and develop. Just one per PR.
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && format('unit-tests-main-{0}', github.sha) || github.ref == 'refs/heads/develop' && format('unit-tests-develop-{0}', github.sha) || format('unit-tests-{0}', github.ref) }}
@@ -36,18 +39,39 @@ jobs:
           httpPort: 8080
           disableRateLimiting: true
           public_baseurl: "http://10.0.2.2:8080/"
+
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86
+          profile: Nexus 5X
+          force-avd-creation: true # Is set to false in the doc https://github.com/ReactiveCircus/android-emulator-runner
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: echo "Generated AVD snapshot for caching."
+
       - name: Run all the codecoverage tests at once
-        id: tests
         uses: reactivecircus/android-emulator-runner@v2
         # continue-on-error: true
         with:
-          api-level: 28
+          api-level: ${{ matrix.api-level }}
           arch: x86
           profile: Nexus 5X
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          emulator-build: 7425822
+          # emulator-build: 7425822
           script: |
             ./gradlew gatherGplayDebugStringTemplates $CI_GRADLE_ARG_PROPERTIES
             ./gradlew unitTestsWithCoverage $CI_GRADLE_ARG_PROPERTIES

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run all the codecoverage tests at once
         id: tests
         uses: reactivecircus/android-emulator-runner@v2
-        continue-on-error: true
+        # continue-on-error: true
         with:
           api-level: 28
           arch: x86

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,15 @@ jobs:
       ###       ./gradlew instrumentationTestsWithCoverage $CI_GRADLE_ARG_PROPERTIES
       ###       ./gradlew generateCoverageReport $CI_GRADLE_ARG_PROPERTIES
 
+      - name: Upload Integration Test Report Log
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: integration-test-error-results
+          path: |
+            */build/outputs/androidTest-results/connected/
+            */build/reports/androidTests/connected/
+
       # we may have failed a previous step and retried, that's OK
       - name: Publish results to Sonar
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,22 +54,22 @@ jobs:
             ./gradlew instrumentationTestsWithCoverage $CI_GRADLE_ARG_PROPERTIES
             ./gradlew generateCoverageReport $CI_GRADLE_ARG_PROPERTIES
       # NB: continue-on-error marks steps.tests.conclusion = 'success' but leaves steps.tests.outcome = 'failure'
-      - name: Run all the codecoverage tests at once (retry if emulator failed)
-        uses: reactivecircus/android-emulator-runner@v2
-        if: always() && steps.tests.outcome == 'failure' # don't run if previous step succeeded.
-        with:
-          api-level: 28
-          arch: x86
-          profile: Nexus 5X
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          emulator-build: 7425822
-          script: |
-            ./gradlew gatherGplayDebugStringTemplates $CI_GRADLE_ARG_PROPERTIES
-            ./gradlew unitTestsWithCoverage $CI_GRADLE_ARG_PROPERTIES
-            ./gradlew instrumentationTestsWithCoverage $CI_GRADLE_ARG_PROPERTIES
-            ./gradlew generateCoverageReport $CI_GRADLE_ARG_PROPERTIES
+      ### - name: Run all the codecoverage tests at once (retry if emulator failed)
+      ###   uses: reactivecircus/android-emulator-runner@v2
+      ###   if: always() && steps.tests.outcome == 'failure' # don't run if previous step succeeded.
+      ###   with:
+      ###     api-level: 28
+      ###     arch: x86
+      ###     profile: Nexus 5X
+      ###     force-avd-creation: false
+      ###     emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+      ###     disable-animations: true
+      ###     emulator-build: 7425822
+      ###     script: |
+      ###       ./gradlew gatherGplayDebugStringTemplates $CI_GRADLE_ARG_PROPERTIES
+      ###       ./gradlew unitTestsWithCoverage $CI_GRADLE_ARG_PROPERTIES
+      ###       ./gradlew instrumentationTestsWithCoverage $CI_GRADLE_ARG_PROPERTIES
+      ###       ./gradlew generateCoverageReport $CI_GRADLE_ARG_PROPERTIES
 
       # we may have failed a previous step and retried, that's OK
       - name: Publish results to Sonar

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   tests:
     name: Runs all tests
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: buildjet-4vcpu-ubuntu-2204
     # Allow all jobs on main and develop. Just one per PR.
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && format('unit-tests-main-{0}', github.sha) || github.ref == 'refs/heads/develop' && format('unit-tests-develop-{0}', github.sha) || format('unit-tests-{0}', github.ref) }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   tests:
     name: Runs all tests
-    runs-on: macos-latest # for the emulator
+    runs-on: buildjet-4vcpu-ubuntu-2204 # for the emulator
     # Allow all jobs on main and develop. Just one per PR.
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && format('unit-tests-main-{0}', github.sha) || github.ref == 'refs/heads/develop' && format('unit-tests-develop-{0}', github.sha) || format('unit-tests-{0}', github.ref) }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
             ./gradlew unitTestsWithCoverage $CI_GRADLE_ARG_PROPERTIES
             ./gradlew instrumentationTestsWithCoverage $CI_GRADLE_ARG_PROPERTIES
             ./gradlew generateCoverageReport $CI_GRADLE_ARG_PROPERTIES
-      # NB: continue-on-error marks steps.tests.conclusion = 'success' but leaves stes.tests.outcome = 'failure'
+      # NB: continue-on-error marks steps.tests.conclusion = 'success' but leaves steps.tests.outcome = 'failure'
       - name: Run all the codecoverage tests at once (retry if emulator failed)
         uses: reactivecircus/android-emulator-runner@v2
         if: always() && steps.tests.outcome == 'failure' # don't run if previous step succeeded.

--- a/changelog.d/7108.misc
+++ b/changelog.d/7108.misc
@@ -1,0 +1,1 @@
+Move some GitHub action to buildjet runner, and remove the second attempt to run integration tests.

--- a/changelog.d/7108.misc
+++ b/changelog.d/7108.misc
@@ -1,1 +1,1 @@
-Move some GitHub action to buildjet runner, and remove the second attempt to run integration tests.
+Move some GitHub actions to buildjet runners, and remove the second attempt to run integration tests.


### PR DESCRIPTION
…build and run the integration tests.

Draft, to see how the CI will digest this change.

post build result (using `4vcpu` runner):

|Before|After|
|-|-|
|(from #7015) 74 minutes <img width="704" alt="image" src="https://user-images.githubusercontent.com/3940906/189901713-2f64bb09-6947-423f-89d9-7cc7fad5fac7.png">|23 minutes<img width="717" alt="image" src="https://user-images.githubusercontent.com/3940906/189901456-229856bc-8b92-4ae4-a0f4-b8f4787b3286.png">|

Just for this specific job. I will also remove the second attempt as discussed today, since it looks not very useful.