### PR TITLE
scroll recents carouse to start when item added/moved to start

### DIFF
--- a/changelog.d/6776.bugfix
+++ b/changelog.d/6776.bugfix
@@ -1,0 +1,1 @@
+[App Layout] Recents carousel now scrolled to first position when new item added to or moved to this position

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/header/HomeRoomsHeadersController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/header/HomeRoomsHeadersController.kt
@@ -47,7 +47,7 @@ class HomeRoomsHeadersController @Inject constructor(
 
     private var carousel: Carousel? = null
 
-    private val carouselAdapterObserver =  object : RecyclerView.AdapterDataObserver() {
+    private val carouselAdapterObserver = object : RecyclerView.AdapterDataObserver() {
         override fun onItemRangeMoved(fromPosition: Int, toPosition: Int, itemCount: Int) {
             if (toPosition == 0 || fromPosition == 0) {
                 carousel?.post {
@@ -120,7 +120,7 @@ class HomeRoomsHeadersController @Inject constructor(
                 try {
                     view.adapter?.registerAdapterDataObserver(host.carouselAdapterObserver)
                 } catch (e: IllegalStateException) {
-                    //do nothing
+                    // do nothing
                 }
             }
 
@@ -130,7 +130,7 @@ class HomeRoomsHeadersController @Inject constructor(
                 try {
                     view.adapter?.unregisterAdapterDataObserver(host.carouselAdapterObserver)
                 } catch (e: IllegalStateException) {
-                    //do nothing
+                    // do nothing
                 }
             }
 


### PR DESCRIPTION


<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

when item is added or moved to the first position of recents carousel, it needs to be scrolled to that item. Currently it keeps position instead

## Motivation and context

closes #6776

