### PR TITLE
Start DM - Fix glitch in the room list

### DIFF
--- a/changelog.d/7121.wip
+++ b/changelog.d/7121.wip
@@ -1,0 +1,1 @@
+Create DM room only on first message - Fix glitch in the room list

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/query/QueryStringValue.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/query/QueryStringValue.kt
@@ -69,6 +69,11 @@ sealed interface QueryStringValue {
     data class Contains(override val string: String, override val case: Case = Case.SENSITIVE) : ContentQueryStringValue
 
     /**
+     * The tested field must not contain the [string].
+     */
+    data class NotContains(override val string: String, override val case: Case = Case.SENSITIVE) : ContentQueryStringValue
+
+    /**
      * Case enum for [ContentQueryStringValue].
      */
     enum class Case {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomSummaryQueryParams.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/RoomSummaryQueryParams.kt
@@ -20,8 +20,10 @@ import org.matrix.android.sdk.api.query.QueryStringValue
 import org.matrix.android.sdk.api.query.RoomCategoryFilter
 import org.matrix.android.sdk.api.query.RoomTagQueryFilter
 import org.matrix.android.sdk.api.query.SpaceFilter
+import org.matrix.android.sdk.api.session.room.RoomSummaryQueryParams.Builder
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.model.RoomType
+import org.matrix.android.sdk.api.session.room.model.localecho.RoomLocalEcho
 import org.matrix.android.sdk.api.session.space.SpaceSummaryQueryParams
 
 /**
@@ -52,6 +54,10 @@ fun spaceSummaryQueryParams(init: (RoomSummaryQueryParams.Builder.() -> Unit) = 
  * [roomSummaryQueryParams] and [spaceSummaryQueryParams] can also be used to build an instance of this class.
  */
 data class RoomSummaryQueryParams(
+        /**
+         * Query for the roomId.
+         */
+        val roomId: QueryStringValue,
         /**
          * Query for the displayName of the room. The display name can be the value of the state event,
          * or a value returned by [org.matrix.android.sdk.api.RoomDisplayNameFallbackProvider].
@@ -94,6 +100,7 @@ data class RoomSummaryQueryParams(
      * [roomSummaryQueryParams] and [spaceSummaryQueryParams] can also be used to build an instance of [RoomSummaryQueryParams].
      */
     class Builder {
+        var roomId: QueryStringValue = QueryStringValue.NotContains(RoomLocalEcho.PREFIX)
         var displayName: QueryStringValue = QueryStringValue.NoCondition
         var canonicalAlias: QueryStringValue = QueryStringValue.NoCondition
         var memberships: List<Membership> = Membership.all()
@@ -104,6 +111,7 @@ data class RoomSummaryQueryParams(
         var spaceFilter: SpaceFilter = SpaceFilter.NoFilter
 
         fun build() = RoomSummaryQueryParams(
+                roomId = roomId,
                 displayName = displayName,
                 canonicalAlias = canonicalAlias,
                 memberships = memberships,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/localecho/RoomLocalEcho.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/localecho/RoomLocalEcho.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 
 object RoomLocalEcho {
 
-    private const val PREFIX = "!local."
+    const val PREFIX = "!local."
 
     /**
      * Tell whether the provider room id is a local id.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/query/QueryStringValueProcessor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/query/QueryStringValueProcessor.kt
@@ -38,6 +38,7 @@ internal class QueryStringValueProcessor @Inject constructor(
             is ContentQueryStringValue -> when (queryStringValue) {
                 is QueryStringValue.Equals -> equalTo(field, queryStringValue.toRealmValue(), queryStringValue.case.toRealmCase())
                 is QueryStringValue.Contains -> contains(field, queryStringValue.toRealmValue(), queryStringValue.case.toRealmCase())
+                is QueryStringValue.NotContains -> not().process(field, QueryStringValue.Contains(queryStringValue.string, queryStringValue.case))
             }
         }
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryDataSource.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryDataSource.kt
@@ -272,6 +272,7 @@ internal class RoomSummaryDataSource @Inject constructor(
         val query = with(queryStringValueProcessor) {
             RoomSummaryEntity.where(realm)
                     .process(RoomSummaryEntityFields.ROOM_ID, QueryStringValue.IsNotEmpty)
+                    .process(RoomSummaryEntityFields.ROOM_ID, queryParams.roomId)
                     .process(queryParams.displayName.toDisplayNameField(), queryParams.displayName)
                     .process(RoomSummaryEntityFields.CANONICAL_ALIAS, queryParams.canonicalAlias)
                     .process(RoomSummaryEntityFields.MEMBERSHIP_STR, queryParams.memberships)

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
@@ -173,7 +173,7 @@ class RoomListViewModel @AssistedInject constructor(
         return session.getRoom(roomId)?.stateService()?.isPublic().orFalse()
     }
 
-    fun deleteLocalRooms(roomsIds: List<String>) {
+    fun deleteLocalRooms(roomsIds: Iterable<String>) {
         viewModelScope.launch {
             roomsIds.forEach {
                 session.roomService().deleteLocalRoom(it)

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
@@ -47,7 +47,6 @@ import org.matrix.android.sdk.api.session.getRoom
 import org.matrix.android.sdk.api.session.getRoomSummary
 import org.matrix.android.sdk.api.session.room.UpdatableLivePageResult
 import org.matrix.android.sdk.api.session.room.members.ChangeMembershipState
-import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.model.localecho.RoomLocalEcho
 import org.matrix.android.sdk.api.session.room.model.tag.RoomTag
 import org.matrix.android.sdk.api.session.room.roomSummaryQueryParams
@@ -127,20 +126,13 @@ class RoomListViewModel @AssistedInject constructor(
     }
 
     private fun observeLocalRooms() {
-        val queryParams = roomSummaryQueryParams {
-            memberships = listOf(Membership.JOIN)
-        }
         session
                 .flow()
-                .liveRoomSummaries(queryParams)
-                .map { roomSummaries ->
-                    roomSummaries.mapNotNull { summary ->
-                        summary.roomId.takeIf { RoomLocalEcho.isLocalEchoId(it) }
-                    }.toSet()
-                }
-                .setOnEach { roomIds ->
-                    copy(localRoomIds = roomIds)
-                }
+                .liveRoomSummaries(roomSummaryQueryParams {
+                    roomId = QueryStringValue.Contains(RoomLocalEcho.PREFIX)
+                })
+                .map { page -> page.map { it.roomId } }
+                .setOnEach { copy(localRoomIds = it) }
     }
 
     companion object : MavericksViewModelFactory<RoomListViewModel, RoomListViewState> by hiltMavericksViewModelFactory()
@@ -181,7 +173,7 @@ class RoomListViewModel @AssistedInject constructor(
         return session.getRoom(roomId)?.stateService()?.isPublic().orFalse()
     }
 
-    fun deleteLocalRooms(roomsIds: Set<String>) {
+    fun deleteLocalRooms(roomsIds: List<String>) {
         viewModelScope.launch {
             roomsIds.forEach {
                 session.roomService().deleteLocalRoom(it)

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewState.kt
@@ -31,7 +31,7 @@ data class RoomListViewState(
         val asyncSuggestedRooms: Async<List<SpaceChildInfo>> = Uninitialized,
         val currentUserName: String? = null,
         val asyncSelectedSpace: Async<RoomSummary?> = Uninitialized,
-        val localRoomIds: Set<String> = emptySet()
+        val localRoomIds: List<String> = emptyList()
 ) : MavericksState {
 
     constructor(args: RoomListParams) : this(displayMode = args.displayMode)


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fix a glitch when we go back to the room list from the DM creation screen

## Motivation and context

close #7121 

## Screenshots / GIFs

## Tests

- Start a DM creation with the start DM feature flag enabled
- Go back to the room list (after creating the DM, cancelling the flow or relaunching the app)
- The local room is not shown anymore in the room list

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
