### PR TITLE
room leaving prompt dialog now waits user to confirm 

### DIFF
--- a/changelog.d/7122.bugfix
+++ b/changelog.d/7122.bugfix
@@ -1,0 +1,1 @@
+[App Layout] Room leaving prompt dialog now waits user to confirm leaving before do so

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
@@ -123,7 +123,6 @@ class HomeRoomListFragment :
                 roomListViewModel.handle(HomeRoomListAction.ToggleTag(quickAction.roomId, RoomTag.ROOM_TAG_LOW_PRIORITY))
             }
             is RoomListQuickActionsSharedAction.Leave -> {
-                roomListViewModel.handle(HomeRoomListAction.LeaveRoom(quickAction.roomId))
                 promptLeaveRoom(quickAction.roomId)
             }
         }


### PR DESCRIPTION


<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Context:
given new App Layout is enabled when user at home screen and leaves room via long-press context menu

Expected:
then prompt dialog should be shown and when user press "leave" button in this dialog then room is left.

Actual:
then dialog is shown but room is left immediately

## Motivation and context

closes #7122

