### PR TITLE
Adds dismissal to new chat bottom sheet actions

### DIFF
--- a/changelog.d/7132.bugfix
+++ b/changelog.d/7132.bugfix
@@ -1,0 +1,1 @@
+[New Layout] Fixes new chat dialog not getting dismissed after selecting its actions

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/NewChatBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/NewChatBottomSheet.kt
@@ -41,14 +41,17 @@ class NewChatBottomSheet : BottomSheetDialogFragment() {
 
     private fun initFABs() {
         binding.startChat.setOnClickListener {
+            dismiss()
             navigator.openCreateDirectRoom(requireActivity())
         }
 
         binding.createRoom.setOnClickListener {
+            dismiss()
             navigator.openCreateRoom(requireActivity())
         }
 
         binding.exploreRooms.setOnClickListener {
+            dismiss()
             navigator.openRoomDirectory(requireContext())
         }
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Dismisses new chat dialog when its actions are clicked

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/6950

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

- With new layout enabled, click the new chat FAB
- Select any of its options
- See dialog is dismissed when you go back

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
