### PR TITLE
[Device management] Verify current session (PSG-722)

### DIFF
--- a/changelog.d/7114.wip
+++ b/changelog.d/7114.wip
@@ -1,1 +1,1 @@
-[Device management] Verify a session
+[Device management] Verify current session

--- a/changelog.d/7114.wip
+++ b/changelog.d/7114.wip
@@ -1,0 +1,1 @@
+[Device management] Verify a session

--- a/vector/src/main/java/im/vector/app/features/settings/devices/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/VectorSettingsDevicesFragment.kt
@@ -85,8 +85,7 @@ class VectorSettingsDevicesFragment :
                     ).show(childFragmentManager, "REQPOP")
                 }
                 is DevicesViewEvents.SelfVerification -> {
-                    VerificationBottomSheet.forSelfVerification(it.session)
-                            .show(childFragmentManager, "REQPOP")
+                    navigator.requestSelfSessionVerification(requireActivity())
                 }
                 is DevicesViewEvents.ShowManuallyVerify -> {
                     ManuallyVerifyDialog.show(requireActivity(), it.cryptoDeviceInfo) {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesAction.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesAction.kt
@@ -20,5 +20,6 @@ import im.vector.app.core.platform.VectorViewModelAction
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
 
 sealed class DevicesAction : VectorViewModelAction {
+    object VerifyCurrentSession : DevicesAction()
     data class MarkAsManuallyVerified(val cryptoDeviceInfo: CryptoDeviceInfo) : DevicesAction()
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewEvent.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewEvent.kt
@@ -18,7 +18,6 @@ package im.vector.app.features.settings.devices.v2
 
 import im.vector.app.core.platform.VectorViewEvents
 import org.matrix.android.sdk.api.auth.registration.RegistrationFlowResponse
-import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
 import org.matrix.android.sdk.api.session.crypto.model.DeviceInfo
 
@@ -28,7 +27,7 @@ sealed class DevicesViewEvent : VectorViewEvents {
     data class RequestReAuth(val registrationFlowResponse: RegistrationFlowResponse, val lastErrorCode: String?) : DevicesViewEvent()
     data class PromptRenameDevice(val deviceInfo: DeviceInfo) : DevicesViewEvent()
     data class ShowVerifyDevice(val userId: String, val transactionId: String?) : DevicesViewEvent()
-    data class SelfVerification(val session: Session) : DevicesViewEvent()
+    object SelfVerification : DevicesViewEvent()
     data class ShowManuallyVerify(val cryptoDeviceInfo: CryptoDeviceInfo) : DevicesViewEvent()
     object PromptResetSecrets : DevicesViewEvent()
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewModel.kt
@@ -105,9 +105,7 @@ class DevicesViewModel @AssistedInject constructor(
         viewModelScope.launch {
             val currentSessionCanBeVerified = checkIfCurrentSessionCanBeVerifiedUseCase.execute()
             if (currentSessionCanBeVerified) {
-                activeSessionHolder.getSafeActiveSession()?.let { session ->
-                    _viewEvents.post(DevicesViewEvent.SelfVerification(session))
-                }
+                _viewEvents.post(DevicesViewEvent.SelfVerification)
             } else {
                 _viewEvents.post(DevicesViewEvent.PromptResetSecrets)
             }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewModel.kt
@@ -37,8 +37,8 @@ class DevicesViewModel @AssistedInject constructor(
         private val getCurrentSessionCrossSigningInfoUseCase: GetCurrentSessionCrossSigningInfoUseCase,
         private val getDeviceFullInfoListUseCase: GetDeviceFullInfoListUseCase,
         private val refreshDevicesOnCryptoDevicesChangeUseCase: RefreshDevicesOnCryptoDevicesChangeUseCase,
-        refreshDevicesUseCase: RefreshDevicesUseCase,
         private val checkIfCurrentSessionCanBeVerifiedUseCase: CheckIfCurrentSessionCanBeVerifiedUseCase,
+        refreshDevicesUseCase: RefreshDevicesUseCase,
 ) : VectorSessionsListViewModel<DevicesViewState, DevicesAction, DevicesViewEvent>(initialState, activeSessionHolder, refreshDevicesUseCase) {
 
     @AssistedFactory

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewModel.kt
@@ -101,7 +101,6 @@ class DevicesViewModel @AssistedInject constructor(
         }
     }
 
-    // TODO add unit tests
     private fun handleVerifyCurrentSessionAction() {
         viewModelScope.launch {
             val currentSessionCanBeVerified = checkIfCurrentSessionCanBeVerifiedUseCase.execute()

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/IsCurrentSessionUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/IsCurrentSessionUseCase.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 New Vector Ltd
+ * Copyright (c) 2022 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.devices.v2.overview
+package im.vector.app.features.settings.devices.v2
 
-import im.vector.app.core.platform.VectorViewModelAction
+import im.vector.app.core.di.ActiveSessionHolder
+import javax.inject.Inject
 
-sealed class SessionOverviewAction : VectorViewModelAction {
-    data class VerifySession(val deviceId: String) : SessionOverviewAction()
+class IsCurrentSessionUseCase @Inject constructor(
+        private val activeSessionHolder: ActiveSessionHolder,
+) {
+
+    fun execute(deviceId: String): Boolean {
+        val currentDeviceId = activeSessionHolder.getSafeActiveSession()?.sessionParams?.deviceId.orEmpty()
+        return deviceId.isNotEmpty() && deviceId == currentDeviceId
+    }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
@@ -228,7 +228,7 @@ class VectorSettingsDevicesFragment :
                 currentDeviceInfo.deviceInfo.deviceId?.let { deviceId -> navigateToSessionOverview(deviceId) }
             }
             views.deviceListCurrentSession.viewVerifyButton.debouncedClicks {
-                // TODO show bottom Sheet verification process
+                viewModel.handle(DevicesAction.VerifyCurrentSession)
             }
         } ?: run {
             hideCurrentSessionView()

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
@@ -101,8 +101,7 @@ class VectorSettingsDevicesFragment :
                     ).show(childFragmentManager, "REQPOP")
                 }
                 is DevicesViewEvent.SelfVerification -> {
-                    VerificationBottomSheet.forSelfVerification(it.session)
-                            .show(childFragmentManager, "REQPOP")
+                    navigator.requestSelfSessionVerification(requireActivity())
                 }
                 is DevicesViewEvent.ShowManuallyVerify -> {
                     ManuallyVerifyDialog.show(requireActivity(), it.cryptoDeviceInfo) {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
@@ -227,6 +227,9 @@ class VectorSettingsDevicesFragment :
             views.deviceListCurrentSession.viewDetailsButton.debouncedClicks {
                 currentDeviceInfo.deviceInfo.deviceId?.let { deviceId -> navigateToSessionOverview(deviceId) }
             }
+            views.deviceListCurrentSession.viewVerifyButton.debouncedClicks {
+                // TODO show bottom Sheet verification process
+            }
         } ?: run {
             hideCurrentSessionView()
         }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoView.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoView.kt
@@ -49,6 +49,7 @@ class SessionInfoView @JvmOverloads constructor(
     }
 
     val viewDetailsButton = views.sessionInfoViewDetailsButton
+    val viewVerifyButton = views.sessionInfoVerifySessionButton
 
     fun render(
             sessionInfoViewState: SessionInfoViewState,

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewAction.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewAction.kt
@@ -19,5 +19,5 @@ package im.vector.app.features.settings.devices.v2.overview
 import im.vector.app.core.platform.VectorViewModelAction
 
 sealed class SessionOverviewAction : VectorViewModelAction {
-    data class VerifySession(val deviceId: String) : SessionOverviewAction()
+    object VerifySession : SessionOverviewAction()
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
@@ -81,6 +81,7 @@ class SessionOverviewFragment :
 
     override fun invalidate() = withState(viewModel) { state ->
         updateToolbar(state.isCurrentSession)
+        updateVerifyButton()
         updateEntryDetails(state.deviceId)
         if (state.deviceInfo is Success) {
             renderSessionInfo(state.isCurrentSession, state.deviceInfo.invoke())
@@ -94,6 +95,12 @@ class SessionOverviewFragment :
         (activity as? AppCompatActivity)
                 ?.supportActionBar
                 ?.setTitle(titleResId)
+    }
+
+    private fun updateVerifyButton() {
+        views.sessionOverviewInfo.viewVerifyButton.debouncedClicks {
+            // TODO show bottom Sheet verification process
+        }
     }
 
     private fun updateEntryDetails(deviceId: String) {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
@@ -62,13 +62,20 @@ class SessionOverviewFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initSessionInfoView()
         observeViewEvents()
+        initSessionInfoView()
+        initVerifyButton()
     }
 
     private fun initSessionInfoView() {
         views.sessionOverviewInfo.onLearnMoreClickListener = {
             Toast.makeText(context, "Learn more verification status", Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun initVerifyButton() {
+        views.sessionOverviewInfo.viewVerifyButton.debouncedClicks {
+            viewModel.handle(SessionOverviewAction.VerifySession)
         }
     }
 
@@ -96,7 +103,6 @@ class SessionOverviewFragment :
 
     override fun invalidate() = withState(viewModel) { state ->
         updateToolbar(state.isCurrentSession)
-        updateVerifyButton(state.deviceId)
         updateEntryDetails(state.deviceId)
         if (state.deviceInfo is Success) {
             renderSessionInfo(state.isCurrentSession, state.deviceInfo.invoke())
@@ -110,12 +116,6 @@ class SessionOverviewFragment :
         (activity as? AppCompatActivity)
                 ?.supportActionBar
                 ?.setTitle(titleResId)
-    }
-
-    private fun updateVerifyButton(deviceId: String) {
-        views.sessionOverviewInfo.viewVerifyButton.debouncedClicks {
-            viewModel.handle(SessionOverviewAction.VerifySession(deviceId))
-        }
     }
 
     private fun updateEntryDetails(deviceId: String) {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewEvent.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 New Vector Ltd
+ * Copyright (c) 2022 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 package im.vector.app.features.settings.devices.v2.overview
 
-import im.vector.app.core.platform.VectorViewModelAction
+import im.vector.app.core.platform.VectorViewEvents
+import org.matrix.android.sdk.api.session.Session
 
-sealed class SessionOverviewAction : VectorViewModelAction {
-    data class VerifySession(val deviceId: String) : SessionOverviewAction()
+sealed class SessionOverviewViewEvent : VectorViewEvents {
+    data class SelfVerification(val session: Session) : SessionOverviewViewEvent()
+    object PromptResetSecrets : SessionOverviewViewEvent()
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewEvent.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewEvent.kt
@@ -17,9 +17,8 @@
 package im.vector.app.features.settings.devices.v2.overview
 
 import im.vector.app.core.platform.VectorViewEvents
-import org.matrix.android.sdk.api.session.Session
 
 sealed class SessionOverviewViewEvent : VectorViewEvents {
-    data class SelfVerification(val session: Session) : SessionOverviewViewEvent()
+    object SelfVerification : SessionOverviewViewEvent()
     object PromptResetSecrets : SessionOverviewViewEvent()
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
@@ -63,12 +63,12 @@ class SessionOverviewViewModel @AssistedInject constructor(
 
     override fun handle(action: SessionOverviewAction) {
         when (action) {
-            is SessionOverviewAction.VerifySession -> handleVerifySessionAction(action)
+            is SessionOverviewAction.VerifySession -> handleVerifySessionAction()
         }
     }
 
-    private fun handleVerifySessionAction(verifySession: SessionOverviewAction.VerifySession) {
-        if (isCurrentSession(verifySession.deviceId)) {
+    private fun handleVerifySessionAction() = withState { viewState ->
+        if (isCurrentSession(viewState.deviceId)) {
             handleVerifyCurrentSession()
         }
     }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
@@ -21,7 +21,6 @@ import com.airbnb.mvrx.Success
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.VectorViewModel
@@ -33,7 +32,6 @@ import kotlinx.coroutines.launch
 
 class SessionOverviewViewModel @AssistedInject constructor(
         @Assisted val initialState: SessionOverviewViewState,
-        private val activeSessionHolder: ActiveSessionHolder,
         private val isCurrentSessionUseCase: IsCurrentSessionUseCase,
         private val getDeviceFullInfoUseCase: GetDeviceFullInfoUseCase,
         private val checkIfCurrentSessionCanBeVerifiedUseCase: CheckIfCurrentSessionCanBeVerifiedUseCase,
@@ -79,9 +77,7 @@ class SessionOverviewViewModel @AssistedInject constructor(
         viewModelScope.launch {
             val currentSessionCanBeVerified = checkIfCurrentSessionCanBeVerifiedUseCase.execute()
             if (currentSessionCanBeVerified) {
-                activeSessionHolder.getSafeActiveSession()?.let { session ->
-                    _viewEvents.post(SessionOverviewViewEvent.SelfVerification(session))
-                }
+                _viewEvents.post(SessionOverviewViewEvent.SelfVerification)
             } else {
                 _viewEvents.post(SessionOverviewViewEvent.PromptResetSecrets)
             }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
@@ -21,19 +21,23 @@ import com.airbnb.mvrx.Success
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
-import im.vector.app.core.platform.EmptyViewEvents
 import im.vector.app.core.platform.VectorViewModel
+import im.vector.app.features.settings.devices.v2.IsCurrentSessionUseCase
+import im.vector.app.features.settings.devices.v2.verification.CheckIfCurrentSessionCanBeVerifiedUseCase
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import org.matrix.android.sdk.api.session.Session
+import kotlinx.coroutines.launch
 
 class SessionOverviewViewModel @AssistedInject constructor(
         @Assisted val initialState: SessionOverviewViewState,
-        session: Session,
+        private val activeSessionHolder: ActiveSessionHolder,
+        private val isCurrentSessionUseCase: IsCurrentSessionUseCase,
         private val getDeviceFullInfoUseCase: GetDeviceFullInfoUseCase,
-) : VectorViewModel<SessionOverviewViewState, SessionOverviewAction, EmptyViewEvents>(initialState) {
+        private val checkIfCurrentSessionCanBeVerifiedUseCase: CheckIfCurrentSessionCanBeVerifiedUseCase,
+) : VectorViewModel<SessionOverviewViewState, SessionOverviewAction, SessionOverviewViewEvent>(initialState) {
 
     companion object : MavericksViewModelFactory<SessionOverviewViewModel, SessionOverviewViewState> by hiltMavericksViewModelFactory()
 
@@ -43,12 +47,14 @@ class SessionOverviewViewModel @AssistedInject constructor(
     }
 
     init {
-        val currentDeviceId = session.sessionParams.deviceId.orEmpty()
         setState {
-            copy(isCurrentSession = deviceId.isNotEmpty() && deviceId == currentDeviceId)
+            copy(isCurrentSession = isCurrentSession(deviceId))
         }
-
         observeSessionInfo(initialState.deviceId)
+    }
+
+    private fun isCurrentSession(deviceId: String): Boolean {
+        return isCurrentSessionUseCase.execute(deviceId)
     }
 
     private fun observeSessionInfo(deviceId: String) {
@@ -58,6 +64,27 @@ class SessionOverviewViewModel @AssistedInject constructor(
     }
 
     override fun handle(action: SessionOverviewAction) {
-        TODO("Implement when adding the first action")
+        when (action) {
+            is SessionOverviewAction.VerifySession -> handleVerifySessionAction(action)
+        }
+    }
+
+    private fun handleVerifySessionAction(verifySession: SessionOverviewAction.VerifySession) {
+        if (isCurrentSession(verifySession.deviceId)) {
+            handleVerifyCurrentSession()
+        }
+    }
+
+    private fun handleVerifyCurrentSession() {
+        viewModelScope.launch {
+            val currentSessionCanBeVerified = checkIfCurrentSessionCanBeVerifiedUseCase.execute()
+            if (currentSessionCanBeVerified) {
+                activeSessionHolder.getSafeActiveSession()?.let { session ->
+                    _viewEvents.post(SessionOverviewViewEvent.SelfVerification(session))
+                }
+            } else {
+                _viewEvents.post(SessionOverviewViewEvent.PromptResetSecrets)
+            }
+        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/CheckIfCurrentSessionCanBeVerifiedUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/CheckIfCurrentSessionCanBeVerifiedUseCase.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices.v2.verification
+
+import im.vector.app.core.di.ActiveSessionHolder
+import kotlinx.coroutines.flow.firstOrNull
+import org.matrix.android.sdk.api.extensions.orFalse
+import org.matrix.android.sdk.flow.flow
+import timber.log.Timber
+import javax.inject.Inject
+
+// TODO add unit tests
+class CheckIfCurrentSessionCanBeVerifiedUseCase @Inject constructor(
+        private val activeSessionHolder: ActiveSessionHolder,
+) {
+
+    suspend fun execute(): Boolean {
+        val session = activeSessionHolder.getSafeActiveSession()
+        val cryptoSessionsCount = session?.flow()
+                ?.liveUserCryptoDevices(session.myUserId)
+                ?.firstOrNull()
+                ?.size
+                ?: 0
+        val hasOtherSessions = cryptoSessionsCount > 1
+
+        val isRecoverySetup = session
+                ?.sharedSecretStorageService()
+                ?.isRecoverySetup()
+                .orFalse()
+
+        Timber.d("hasOtherSessions=$hasOtherSessions (otherSessionsCount=$cryptoSessionsCount), isRecoverySetup=$isRecoverySetup")
+        return hasOtherSessions || isRecoverySetup
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/CheckIfCurrentSessionCanBeVerifiedUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/CheckIfCurrentSessionCanBeVerifiedUseCase.kt
@@ -23,7 +23,6 @@ import org.matrix.android.sdk.flow.flow
 import timber.log.Timber
 import javax.inject.Inject
 
-// TODO add unit tests
 class CheckIfCurrentSessionCanBeVerifiedUseCase @Inject constructor(
         private val activeSessionHolder: ActiveSessionHolder,
 ) {

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/DevicesViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/DevicesViewModelTest.kt
@@ -55,8 +55,8 @@ class DevicesViewModelTest {
                 getCurrentSessionCrossSigningInfoUseCase,
                 getDeviceFullInfoListUseCase,
                 refreshDevicesOnCryptoDevicesChangeUseCase,
-                refreshDevicesUseCase,
                 checkIfCurrentSessionCanBeVerifiedUseCase,
+                refreshDevicesUseCase,
         )
     }
 

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/DevicesViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/DevicesViewModelTest.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.settings.devices.v2
 
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.test.MvRxTestRule
+import im.vector.app.features.settings.devices.v2.verification.CheckIfCurrentSessionCanBeVerifiedUseCase
 import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.fakes.FakeVerificationService
 import im.vector.app.test.test
@@ -45,6 +46,7 @@ class DevicesViewModelTest {
     private val getDeviceFullInfoListUseCase = mockk<GetDeviceFullInfoListUseCase>()
     private val refreshDevicesUseCase = mockk<RefreshDevicesUseCase>()
     private val refreshDevicesOnCryptoDevicesChangeUseCase = mockk<RefreshDevicesOnCryptoDevicesChangeUseCase>()
+    private val checkIfCurrentSessionCanBeVerifiedUseCase = mockk<CheckIfCurrentSessionCanBeVerifiedUseCase>()
 
     private fun createViewModel(): DevicesViewModel {
         return DevicesViewModel(
@@ -54,6 +56,7 @@ class DevicesViewModelTest {
                 getDeviceFullInfoListUseCase,
                 refreshDevicesOnCryptoDevicesChangeUseCase,
                 refreshDevicesUseCase,
+                checkIfCurrentSessionCanBeVerifiedUseCase,
         )
     }
 

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/IsCurrentSessionUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/IsCurrentSessionUseCaseTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices.v2
+
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.amshove.kluent.shouldBe
+import org.junit.Test
+import org.matrix.android.sdk.api.auth.data.SessionParams
+
+private const val A_SESSION_ID_1 = "session-id-1"
+private const val A_SESSION_ID_2 = "session-id-2"
+
+class IsCurrentSessionUseCaseTest {
+
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+
+    private val isCurrentSessionUseCase = IsCurrentSessionUseCase(
+            activeSessionHolder = fakeActiveSessionHolder.instance,
+    )
+
+    @Test
+    fun `given the session id of the current session when checking if id is current session then result is true`() {
+        // Given
+        val sessionParams = givenIdForCurrentSession(A_SESSION_ID_1)
+
+        // When
+        val result = isCurrentSessionUseCase.execute(A_SESSION_ID_1)
+
+        // Then
+        result shouldBe true
+        verify { sessionParams.deviceId }
+    }
+
+    @Test
+    fun `given a session id different from the current session id when checking if id is current session then result is false`() {
+        // Given
+        val sessionParams = givenIdForCurrentSession(A_SESSION_ID_1)
+
+        // When
+        val result = isCurrentSessionUseCase.execute(A_SESSION_ID_2)
+
+        // Then
+        result shouldBe false
+        verify { sessionParams.deviceId }
+    }
+
+    @Test
+    fun `given no current active session when checking if id is current session then result is false`() {
+        // Given
+        fakeActiveSessionHolder.givenGetSafeActiveSessionReturns(null)
+
+        // When
+        val result = isCurrentSessionUseCase.execute(A_SESSION_ID_1)
+
+        // Then
+        result shouldBe false
+    }
+
+    private fun givenIdForCurrentSession(deviceId: String): SessionParams {
+        val sessionParams = mockk<SessionParams>()
+        every { sessionParams.deviceId } returns deviceId
+        fakeActiveSessionHolder.fakeSession.givenSessionParams(sessionParams)
+        return sessionParams
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
@@ -21,7 +21,6 @@ import com.airbnb.mvrx.test.MvRxTestRule
 import im.vector.app.features.settings.devices.v2.DeviceFullInfo
 import im.vector.app.features.settings.devices.v2.IsCurrentSessionUseCase
 import im.vector.app.features.settings.devices.v2.verification.CheckIfCurrentSessionCanBeVerifiedUseCase
-import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.test
 import im.vector.app.test.testDispatcher
 import io.mockk.coEvery
@@ -43,14 +42,12 @@ class SessionOverviewViewModelTest {
     private val args = SessionOverviewArgs(
             deviceId = A_SESSION_ID
     )
-    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
     private val isCurrentSessionUseCase = mockk<IsCurrentSessionUseCase>()
     private val getDeviceFullInfoUseCase = mockk<GetDeviceFullInfoUseCase>()
     private val checkIfCurrentSessionCanBeVerifiedUseCase = mockk<CheckIfCurrentSessionCanBeVerifiedUseCase>()
 
     private fun createViewModel() = SessionOverviewViewModel(
             initialState = SessionOverviewViewState(args),
-            activeSessionHolder = fakeActiveSessionHolder.instance,
             isCurrentSessionUseCase = isCurrentSessionUseCase,
             getDeviceFullInfoUseCase = getDeviceFullInfoUseCase,
             checkIfCurrentSessionCanBeVerifiedUseCase = checkIfCurrentSessionCanBeVerifiedUseCase,

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
@@ -85,7 +85,7 @@ class SessionOverviewViewModelTest {
         val deviceFullInfo = mockk<DeviceFullInfo>()
         every { getDeviceFullInfoUseCase.execute(A_SESSION_ID) } returns flowOf(deviceFullInfo)
         every { isCurrentSessionUseCase.execute(any()) } returns true
-        val verifySessionAction = SessionOverviewAction.VerifySession(A_SESSION_ID)
+        val verifySessionAction = SessionOverviewAction.VerifySession
         coEvery { checkIfCurrentSessionCanBeVerifiedUseCase.execute() } returns true
 
         // When
@@ -108,7 +108,7 @@ class SessionOverviewViewModelTest {
         val deviceFullInfo = mockk<DeviceFullInfo>()
         every { getDeviceFullInfoUseCase.execute(A_SESSION_ID) } returns flowOf(deviceFullInfo)
         every { isCurrentSessionUseCase.execute(any()) } returns true
-        val verifySessionAction = SessionOverviewAction.VerifySession(A_SESSION_ID)
+        val verifySessionAction = SessionOverviewAction.VerifySession
         coEvery { checkIfCurrentSessionCanBeVerifiedUseCase.execute() } returns false
 
         // When

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
@@ -19,16 +19,19 @@ package im.vector.app.features.settings.devices.v2.overview
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.test.MvRxTestRule
 import im.vector.app.features.settings.devices.v2.DeviceFullInfo
-import im.vector.app.test.fakes.FakeSession
+import im.vector.app.features.settings.devices.v2.IsCurrentSessionUseCase
+import im.vector.app.features.settings.devices.v2.verification.CheckIfCurrentSessionCanBeVerifiedUseCase
+import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.test
 import im.vector.app.test.testDispatcher
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import org.junit.Rule
 import org.junit.Test
-import org.matrix.android.sdk.api.auth.data.SessionParams
 
 private const val A_SESSION_ID = "session-id"
 
@@ -40,24 +43,29 @@ class SessionOverviewViewModelTest {
     private val args = SessionOverviewArgs(
             deviceId = A_SESSION_ID
     )
-    private val fakeSession = FakeSession()
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+    private val isCurrentSessionUseCase = mockk<IsCurrentSessionUseCase>()
     private val getDeviceFullInfoUseCase = mockk<GetDeviceFullInfoUseCase>()
+    private val checkIfCurrentSessionCanBeVerifiedUseCase = mockk<CheckIfCurrentSessionCanBeVerifiedUseCase>()
 
     private fun createViewModel() = SessionOverviewViewModel(
             initialState = SessionOverviewViewState(args),
-            session = fakeSession,
-            getDeviceFullInfoUseCase = getDeviceFullInfoUseCase
+            activeSessionHolder = fakeActiveSessionHolder.instance,
+            isCurrentSessionUseCase = isCurrentSessionUseCase,
+            getDeviceFullInfoUseCase = getDeviceFullInfoUseCase,
+            checkIfCurrentSessionCanBeVerifiedUseCase = checkIfCurrentSessionCanBeVerifiedUseCase,
     )
 
     @Test
     fun `given the viewModel has been initialized then viewState is updated with session info`() {
         // Given
-        val sessionParams = givenIdForSession(A_SESSION_ID)
         val deviceFullInfo = mockk<DeviceFullInfo>()
         every { getDeviceFullInfoUseCase.execute(A_SESSION_ID) } returns flowOf(deviceFullInfo)
+        val isCurrentSession = true
+        every { isCurrentSessionUseCase.execute(any()) } returns isCurrentSession
         val expectedState = SessionOverviewViewState(
                 deviceId = A_SESSION_ID,
-                isCurrentSession = true,
+                isCurrentSession = isCurrentSession,
                 deviceInfo = Success(deviceFullInfo)
         )
 
@@ -68,14 +76,55 @@ class SessionOverviewViewModelTest {
         viewModel.test()
                 .assertLatestState { state -> state == expectedState }
                 .finish()
-        verify { sessionParams.deviceId }
-        verify { getDeviceFullInfoUseCase.execute(A_SESSION_ID) }
+        verify {
+            isCurrentSessionUseCase.execute(A_SESSION_ID)
+            getDeviceFullInfoUseCase.execute(A_SESSION_ID)
+        }
     }
 
-    private fun givenIdForSession(deviceId: String): SessionParams {
-        val sessionParams = mockk<SessionParams>()
-        every { sessionParams.deviceId } returns deviceId
-        fakeSession.givenSessionParams(sessionParams)
-        return sessionParams
+    @Test
+    fun `given current session can be verified when handling verify current session action then self verification event is posted`() {
+        // Given
+        val deviceFullInfo = mockk<DeviceFullInfo>()
+        every { getDeviceFullInfoUseCase.execute(A_SESSION_ID) } returns flowOf(deviceFullInfo)
+        every { isCurrentSessionUseCase.execute(any()) } returns true
+        val verifySessionAction = SessionOverviewAction.VerifySession(A_SESSION_ID)
+        coEvery { checkIfCurrentSessionCanBeVerifiedUseCase.execute() } returns true
+
+        // When
+        val viewModel = createViewModel()
+        val viewModelTest = viewModel.test()
+        viewModel.handle(verifySessionAction)
+
+        // Then
+        viewModelTest
+                .assertEvent { it is SessionOverviewViewEvent.SelfVerification }
+                .finish()
+        coVerify {
+            checkIfCurrentSessionCanBeVerifiedUseCase.execute()
+        }
+    }
+
+    @Test
+    fun `given current session cannot be verified when handling verify current session action then reset secrets event is posted`() {
+        // Given
+        val deviceFullInfo = mockk<DeviceFullInfo>()
+        every { getDeviceFullInfoUseCase.execute(A_SESSION_ID) } returns flowOf(deviceFullInfo)
+        every { isCurrentSessionUseCase.execute(any()) } returns true
+        val verifySessionAction = SessionOverviewAction.VerifySession(A_SESSION_ID)
+        coEvery { checkIfCurrentSessionCanBeVerifiedUseCase.execute() } returns false
+
+        // When
+        val viewModel = createViewModel()
+        val viewModelTest = viewModel.test()
+        viewModel.handle(verifySessionAction)
+
+        // Then
+        viewModelTest
+                .assertEvent { it is SessionOverviewViewEvent.PromptResetSecrets }
+                .finish()
+        coVerify {
+            checkIfCurrentSessionCanBeVerifiedUseCase.execute()
+        }
     }
 }

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/CheckIfCurrentSessionCanBeVerifiedUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/CheckIfCurrentSessionCanBeVerifiedUseCaseTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices.v2.verification
+
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
+import org.matrix.android.sdk.flow.FlowSession
+import org.matrix.android.sdk.flow.flow
+
+class CheckIfCurrentSessionCanBeVerifiedUseCaseTest {
+
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+
+    private val checkIfCurrentSessionCanBeVerifiedUseCase = CheckIfCurrentSessionCanBeVerifiedUseCase(
+            activeSessionHolder = fakeActiveSessionHolder.instance
+    )
+
+    @Before
+    fun setUp() {
+        mockkStatic("org.matrix.android.sdk.flow.FlowSessionKt")
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `given there are other sessions when checking if session can be verified then result is true`() = runTest {
+        // Given
+        val device1 = givenACryptoDevice()
+        val device2 = givenACryptoDevice()
+        val devices = listOf(device1, device2)
+        val fakeSession = fakeActiveSessionHolder.fakeSession
+        val flowSession = mockk<FlowSession>()
+        every { fakeSession.flow() } returns flowSession
+        every { flowSession.liveUserCryptoDevices(any()) } returns flowOf(devices)
+
+        fakeSession.fakeSharedSecretStorageService.givenIsRecoverySetupReturns(false)
+
+        // When
+        val result = checkIfCurrentSessionCanBeVerifiedUseCase.execute()
+
+        // Then
+        result shouldBeEqualTo true
+        verify {
+            flowSession.liveUserCryptoDevices(fakeSession.myUserId)
+            fakeSession.fakeSharedSecretStorageService.isRecoverySetup()
+        }
+    }
+
+    @Test
+    fun `given recovery is setup when checking if session can be verified then result is true`() = runTest {
+        // Given
+        val device1 = givenACryptoDevice()
+        val devices = listOf(device1)
+        val fakeSession = fakeActiveSessionHolder.fakeSession
+        val flowSession = mockk<FlowSession>()
+        every { fakeSession.flow() } returns flowSession
+        every { flowSession.liveUserCryptoDevices(any()) } returns flowOf(devices)
+
+        fakeSession.fakeSharedSecretStorageService.givenIsRecoverySetupReturns(true)
+
+        // When
+        val result = checkIfCurrentSessionCanBeVerifiedUseCase.execute()
+
+        // Then
+        result shouldBeEqualTo true
+        verify {
+            flowSession.liveUserCryptoDevices(fakeSession.myUserId)
+            fakeSession.fakeSharedSecretStorageService.isRecoverySetup()
+        }
+    }
+
+    @Test
+    fun `given recovery is not setup and there are no other sessions when checking if session can be verified then result is false`() = runTest {
+        // Given
+        val device1 = givenACryptoDevice()
+        val devices = listOf(device1)
+        val fakeSession = fakeActiveSessionHolder.fakeSession
+        val flowSession = mockk<FlowSession>()
+        every { fakeSession.flow() } returns flowSession
+        every { flowSession.liveUserCryptoDevices(any()) } returns flowOf(devices)
+
+        fakeSession.fakeSharedSecretStorageService.givenIsRecoverySetupReturns(false)
+
+        // When
+        val result = checkIfCurrentSessionCanBeVerifiedUseCase.execute()
+
+        // Then
+        result shouldBeEqualTo false
+        verify {
+            flowSession.liveUserCryptoDevices(fakeSession.myUserId)
+            fakeSession.fakeSharedSecretStorageService.isRecoverySetup()
+        }
+    }
+
+    private fun givenACryptoDevice(): CryptoDeviceInfo = mockk()
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeSharedSecretStorageService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeSharedSecretStorageService.kt
@@ -16,6 +16,8 @@
 
 package im.vector.app.test.fakes
 
+import io.mockk.every
+import io.mockk.mockk
 import org.matrix.android.sdk.api.listeners.ProgressListener
 import org.matrix.android.sdk.api.session.securestorage.IntegrityResult
 import org.matrix.android.sdk.api.session.securestorage.KeyInfoResult
@@ -26,7 +28,7 @@ import org.matrix.android.sdk.api.session.securestorage.SharedSecretStorageServi
 import org.matrix.android.sdk.api.session.securestorage.SsssKeyCreationInfo
 import org.matrix.android.sdk.api.session.securestorage.SsssKeySpec
 
-class FakeSharedSecretStorageService : SharedSecretStorageService {
+class FakeSharedSecretStorageService : SharedSecretStorageService by mockk() {
 
     var integrityResult: IntegrityResult = IntegrityResult.Error(SharedSecretStorageError.OtherError(IllegalStateException()))
     var _defaultKey: KeyInfoResult = KeyInfoResult.Error(SharedSecretStorageError.OtherError(IllegalStateException()))
@@ -75,5 +77,9 @@ class FakeSharedSecretStorageService : SharedSecretStorageService {
 
     override suspend fun requestSecret(name: String, myOtherDeviceId: String) {
         TODO("Not yet implemented")
+    }
+
+    fun givenIsRecoverySetupReturns(isRecoverySetup: Boolean) {
+        every { isRecoverySetup() } returns isRecoverySetup
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Start the verification process when pressing the "Verify" button only for the current Session.
Bonus: Fix missing sending of verification event to other verified sessions in the devices list V1.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7114 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->
No UI has been changed.

## Tests

<!-- Explain how you tested your development -->

- Enable the new device management feature flag
- Sign in on a new device
- Go to Settings -> Security & Privacy -> Show all sessions (V2, WIP)
- Check the current session is displayed as not verified
- Press the "Verify" button
- Check another verified session received the request
- Cancel it
- Go to the session overview screen by pressing the current Session card
- Press the "Verify" button
- Check another verified session received the request
- Do the verification process
- Check the current session is shown as verified in the overview screen
- Press back
- Check the current session is shown as verified in the sessions list screen

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
