### PR TITLE
Excluding legacy support library annotation usages

### DIFF
--- a/changelog.d/7140.misc
+++ b/changelog.d/7140.misc
@@ -1,0 +1,1 @@
+Exclude legacy android support annotation library

--- a/dependencies_groups.gradle
+++ b/dependencies_groups.gradle
@@ -69,8 +69,6 @@ ext.groups = [
                         'com.gabrielittner.threetenbp',
                         'com.getkeepsafe.relinker',
                         'com.github.bumptech.glide',
-                        'com.github.filippudak',
-                        'com.github.filippudak.progresspieview',
                         'com.github.javaparser',
                         'com.github.piasy',
                         'com.github.shyiko.klob',

--- a/library/jsonviewer/build.gradle
+++ b/library/jsonviewer/build.gradle
@@ -55,8 +55,9 @@ dependencies {
 
     implementation libs.airbnb.mavericks
     // Span utils
-    implementation 'me.gujun.android:span:1.7'
-
+    implementation('me.gujun.android:span:1.7') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
 
     implementation libs.jetbrains.coroutinesCore
     implementation libs.jetbrains.coroutinesAndroid

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -208,7 +208,6 @@ dependencies {
     // Image Loading
     implementation libs.github.bigImageViewer
     implementation libs.github.glideImageLoader
-    implementation libs.github.progressPieIndicator
     implementation libs.github.glideImageViewFactory
 
     // implementation 'com.github.MikeOrtiz:TouchImageView:3.0.2'

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -177,7 +177,9 @@ dependencies {
     // UI
     implementation 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
     implementation libs.google.material
-    api 'me.gujun.android:span:1.7'
+    api('me.gujun.android:span:1.7') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
     implementation libs.markwon.core
     implementation libs.markwon.extLatex
     implementation libs.markwon.inlineParser
@@ -225,7 +227,9 @@ dependencies {
     kapt libs.dagger.hiltCompiler
 
     // Analytics
-    implementation 'com.posthog.android:posthog:1.1.2'
+    implementation('com.posthog.android:posthog:1.1.2') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
 
     // UnifiedPush
     implementation 'com.github.UnifiedPush:android-connector:2.0.1'

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -100,7 +100,6 @@ android {
         viewBinding true
     }
 }
-
 dependencies {
     implementation project(":vector-config")
     api project(":matrix-sdk-android")
@@ -240,12 +239,26 @@ dependencies {
     // implementation 'org.webrtc:google-webrtc:1.0.+'
     implementation('com.facebook.react:react-native-webrtc:1.94.2-jitsi-10227332@aar')
 
+    // Exclude jitsi's android-scalablevideoview fork's support library
+    // The library exports a jetified artifact but doesn't remove the support library dependency
+    // https://github.com/MatrixFrog/Android-ScalableVideoView/blob/master/gradle.properties#L1
+    components {
+        withModule("com.github.MatrixFrog:android-scalablevideoview") {
+            allVariants {
+                withDependencies {
+                    removeAll { it.group == "com.android.support" && it.name == "appcompat-v7" }
+                }
+            }
+        }
+    }
+
     // Jitsi
     api('org.jitsi.react:jitsi-meet-sdk:5.0.2') {
         exclude group: 'com.google.firebase'
         exclude group: 'com.google.android.gms'
         exclude group: 'com.android.installreferrer'
     }
+
 
     // QR-code
     // Stick to 3.3.3 because of https://github.com/zxing/zxing/issues/1170

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -259,7 +259,6 @@ dependencies {
         exclude group: 'com.android.installreferrer'
     }
 
-
     // QR-code
     // Stick to 3.3.3 because of https://github.com/zxing/zxing/issues/1170
     implementation 'com.google.zxing:core:3.3.3'

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -239,30 +239,27 @@ dependencies {
     // implementation 'org.webrtc:google-webrtc:1.0.+'
     implementation('com.facebook.react:react-native-webrtc:1.94.2-jitsi-10227332@aar')
 
-    // Exclude jitsi's android-scalablevideoview fork's support library
-    // The library exports a jetified artifact but doesn't remove the support library dependency
-    // https://github.com/MatrixFrog/Android-ScalableVideoView/blob/master/gradle.properties#L1
-    components {
-        withModule("com.github.MatrixFrog:android-scalablevideoview") {
-            allVariants {
-                withDependencies {
-                    removeAll { it.group == "com.android.support" && it.name == "appcompat-v7" }
-                }
-            }
-        }
-    }
-
     // Jitsi
     api('org.jitsi.react:jitsi-meet-sdk:5.0.2') {
         exclude group: 'com.google.firebase'
         exclude group: 'com.google.android.gms'
         exclude group: 'com.android.installreferrer'
+
+        // Exclude jitsi's android-scalablevideoview fork's support library
+        // The library exports a jetified artifact but doesn't remove the support library dependency
+        // https://github.com/MatrixFrog/Android-ScalableVideoView/blob/master/gradle.properties#L1
+        exclude group: 'com.android.support', module: 'appcompat-v7'
     }
 
     // QR-code
     // Stick to 3.3.3 because of https://github.com/zxing/zxing/issues/1170
     implementation 'com.google.zxing:core:3.3.3'
-    implementation 'me.dm7.barcodescanner:zxing:1.9.13'
+
+    // Excludes the legacy support library annotation usages
+    // https://github.com/dm77/barcodescanner/blob/d036996c8a6f36a68843ffe539c834c28944b2d5/core/src/main/java/me/dm7/barcodescanner/core/CameraWrapper.java#L4
+    implementation ('me.dm7.barcodescanner:zxing:1.9.13') {
+        exclude group: 'com.android.support', module: 'support-v4'
+    }
 
     // Emoji Keyboard
     api libs.vanniktech.emojiMaterial


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Excludes usages of the support annotation library, these are compile time hints and safe to remove.
- Removes unused `progressPieIndicator` dependency
- Excludes the appcompat library from jitsi's `android-scalablevideoview`, the library is pre-jetified but includes a redundant legacy support library transitive dependency  

## Motivation and context

The time has come to avoid using the Jetifier (the process of converting libraries from the legacy support library to androidx). The `Paparazzi` integration is blocked due to the plugin requiring the jetifier to be disabled for the base android libraries which causes the unit tests with android imports to fail. 

There is one more library to update `im.dlg:android-dialer:1.2.5` which will need to be manually included as the upstream project no longer exists, although it's mainly a wrapper around legacy AOSP classes.

Will slightly speed up the build and may improve the _cachability_ of the module dependencies (as they'll be statically cached from their maven repositories)

## Screenshots / GIFs
No UI changes


## Tests

Smoke test around the app 

- View markdown text
- Make video calls

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): 28