### PR TITLE
room summary now has constant height

### DIFF
--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItem.kt
@@ -103,6 +103,9 @@ abstract class RoomSummaryItem : VectorEpoxyModel<RoomSummaryItem.Holder>(R.layo
     @EpoxyAttribute
     var showSelected: Boolean = false
 
+    @EpoxyAttribute
+    var useSingleLineForLastEvent: Boolean = false
+
     override fun bind(holder: Holder) {
         super.bind(holder)
 
@@ -122,6 +125,10 @@ abstract class RoomSummaryItem : VectorEpoxyModel<RoomSummaryItem.Holder>(R.layo
         holder.roomAvatarFailSendingImageView.isVisible = hasFailedSending
         renderSelection(holder, showSelected)
         holder.roomAvatarPresenceImageView.render(showPresence, userPresence)
+
+        if (useSingleLineForLastEvent) {
+            holder.subtitleView.setLines(1)
+        }
     }
 
     private fun renderDisplayMode(holder: Holder) = when (displayMode) {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemFactory.kt
@@ -51,7 +51,8 @@ class RoomSummaryItemFactory @Inject constructor(
             roomChangeMembershipStates: Map<String, ChangeMembershipState>,
             selectedRoomIds: Set<String>,
             displayMode: RoomListDisplayMode,
-            listener: RoomListListener?
+            listener: RoomListListener?,
+            singleLineLastEvent: Boolean = false
     ): VectorEpoxyModel<*> {
         return when (roomSummary.membership) {
             Membership.INVITE -> {
@@ -59,7 +60,7 @@ class RoomSummaryItemFactory @Inject constructor(
                 createInvitationItem(roomSummary, changeMembershipState, listener)
             }
             else -> createRoomItem(
-                    roomSummary, selectedRoomIds, displayMode, listener?.let { it::onRoomClicked }, listener?.let { it::onRoomLongClicked }
+                    roomSummary, selectedRoomIds, displayMode, singleLineLastEvent, listener?.let { it::onRoomClicked }, listener?.let { it::onRoomLongClicked }
             )
         }
     }
@@ -118,8 +119,9 @@ class RoomSummaryItemFactory @Inject constructor(
             roomSummary: RoomSummary,
             selectedRoomIds: Set<String>,
             displayMode: RoomListDisplayMode,
+            singleLineLastEvent: Boolean,
             onClick: ((RoomSummary) -> Unit)?,
-            onLongClick: ((RoomSummary) -> Boolean)?
+            onLongClick: ((RoomSummary) -> Boolean)?,
     ): VectorEpoxyModel<*> {
         val subtitle = getSearchResultSubtitle(roomSummary)
         val unreadCount = roomSummary.notificationCount
@@ -140,7 +142,7 @@ class RoomSummaryItemFactory @Inject constructor(
         } else {
             createRoomSummaryItem(
                     roomSummary, displayMode, subtitle, latestEventTime, typingMessage,
-                    latestFormattedEvent, showHighlighted, showSelected, unreadCount, onClick, onLongClick
+                    latestFormattedEvent, showHighlighted, showSelected, unreadCount, singleLineLastEvent, onClick, onLongClick
             )
         }
     }
@@ -155,6 +157,7 @@ class RoomSummaryItemFactory @Inject constructor(
             showHighlighted: Boolean,
             showSelected: Boolean,
             unreadCount: Int,
+            singleLineLastEvent: Boolean,
             onClick: ((RoomSummary) -> Unit)?,
             onLongClick: ((RoomSummary) -> Boolean)?
     ) = RoomSummaryItem_()
@@ -177,6 +180,7 @@ class RoomSummaryItemFactory @Inject constructor(
             .unreadNotificationCount(unreadCount)
             .hasUnreadMessage(roomSummary.hasUnreadMessages)
             .hasDraft(roomSummary.userDrafts.isNotEmpty())
+            .useSingleLineForLastEvent(singleLineLastEvent)
             .itemLongClickListener { _ -> onLongClick?.invoke(roomSummary) ?: false }
             .itemClickListener { onClick?.invoke(roomSummary) }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemPlaceHolder.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemPlaceHolder.kt
@@ -16,6 +16,8 @@
 
 package im.vector.app.features.home.room.list
 
+import android.widget.TextView
+import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.core.epoxy.VectorEpoxyHolder
@@ -23,5 +25,18 @@ import im.vector.app.core.epoxy.VectorEpoxyModel
 
 @EpoxyModelClass
 abstract class RoomSummaryItemPlaceHolder : VectorEpoxyModel<RoomSummaryItemPlaceHolder.Holder>(R.layout.item_room_placeholder) {
-    class Holder : VectorEpoxyHolder()
+
+    @EpoxyAttribute
+    var useSingleLineForLastEvent: Boolean = false
+
+    override fun bind(holder: Holder) {
+        super.bind(holder)
+        if (useSingleLineForLastEvent) {
+            holder.subtitleView.setLines(1)
+        }
+    }
+
+    class Holder : VectorEpoxyHolder() {
+        val subtitleView by bind<TextView>(R.id.subtitleView)
+    }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryListController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryListController.kt
@@ -17,18 +17,26 @@
 package im.vector.app.features.home.room.list
 
 import im.vector.app.features.home.RoomListDisplayMode
+import im.vector.app.features.settings.FontScalePreferences
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 
 class RoomSummaryListController(
         private val roomSummaryItemFactory: RoomSummaryItemFactory,
-        private val displayMode: RoomListDisplayMode
+        private val displayMode: RoomListDisplayMode,
+        fontScalePreferences: FontScalePreferences
 ) : CollapsableTypedEpoxyController<List<RoomSummary>>() {
 
     var listener: RoomListListener? = null
+    private val shouldUseSingleLine: Boolean
+
+    init {
+        val fontScale = fontScalePreferences.getResolvedFontScaleValue()
+        shouldUseSingleLine = fontScale.scale > FontScalePreferences.SCALE_LARGE
+    }
 
     override fun buildModels(data: List<RoomSummary>?) {
         data?.forEach {
-            add(roomSummaryItemFactory.create(it, emptyMap(), emptySet(), displayMode, listener))
+            add(roomSummaryItemFactory.create(it, emptyMap(), emptySet(), displayMode, listener, shouldUseSingleLine))
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryPagedController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryPagedController.kt
@@ -20,18 +20,26 @@ import com.airbnb.epoxy.EpoxyModel
 import com.airbnb.epoxy.paging.PagedListEpoxyController
 import im.vector.app.core.utils.createUIHandler
 import im.vector.app.features.home.RoomListDisplayMode
+import im.vector.app.features.settings.FontScalePreferences
 import org.matrix.android.sdk.api.session.room.members.ChangeMembershipState
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 
 class RoomSummaryPagedController(
         private val roomSummaryItemFactory: RoomSummaryItemFactory,
-        private val displayMode: RoomListDisplayMode
+        private val displayMode: RoomListDisplayMode,
+        fontScalePreferences: FontScalePreferences
 ) : PagedListEpoxyController<RoomSummary>(
         // Important it must match the PageList builder notify Looper
         modelBuildingHandler = createUIHandler()
 ), CollapsableControllerExtension {
 
     var listener: RoomListListener? = null
+    private val shouldUseSingleLine: Boolean
+
+    init {
+        val fontScale = fontScalePreferences.getResolvedFontScaleValue()
+        shouldUseSingleLine = fontScale.scale > FontScalePreferences.SCALE_LARGE
+    }
 
     var roomChangeMembershipStates: Map<String, ChangeMembershipState>? = null
         set(value) {
@@ -57,8 +65,14 @@ class RoomSummaryPagedController(
     }
 
     override fun buildItemModel(currentPosition: Int, item: RoomSummary?): EpoxyModel<*> {
-        // for place holder if enabled
-        item ?: return RoomSummaryItemPlaceHolder_().apply { id(currentPosition) }
-        return roomSummaryItemFactory.create(item, roomChangeMembershipStates.orEmpty(), emptySet(), displayMode, listener)
+        return if (item == null) {
+            val host = this
+            RoomSummaryItemPlaceHolder_().apply {
+                id(currentPosition)
+                useSingleLineForLastEvent(host.shouldUseSingleLine)
+            }
+        } else {
+            roomSummaryItemFactory.create(item, roomChangeMembershipStates.orEmpty(), emptySet(), displayMode, listener, shouldUseSingleLine)
+        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryPagedControllerFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryPagedControllerFactory.kt
@@ -17,18 +17,20 @@
 package im.vector.app.features.home.room.list
 
 import im.vector.app.features.home.RoomListDisplayMode
+import im.vector.app.features.settings.FontScalePreferences
 import javax.inject.Inject
 
 class RoomSummaryPagedControllerFactory @Inject constructor(
-        private val roomSummaryItemFactory: RoomSummaryItemFactory
+        private val roomSummaryItemFactory: RoomSummaryItemFactory,
+        private val fontScalePreferences: FontScalePreferences
 ) {
 
     fun createRoomSummaryPagedController(displayMode: RoomListDisplayMode): RoomSummaryPagedController {
-        return RoomSummaryPagedController(roomSummaryItemFactory, displayMode)
+        return RoomSummaryPagedController(roomSummaryItemFactory, displayMode, fontScalePreferences)
     }
 
     fun createRoomSummaryListController(displayMode: RoomListDisplayMode): RoomSummaryListController {
-        return RoomSummaryListController(roomSummaryItemFactory, displayMode)
+        return RoomSummaryListController(roomSummaryItemFactory, displayMode, fontScalePreferences)
     }
 
     fun createSuggestedRoomListController(): SuggestedRoomListController {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeFilteredRoomsController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeFilteredRoomsController.kt
@@ -24,12 +24,14 @@ import im.vector.app.features.home.RoomListDisplayMode
 import im.vector.app.features.home.room.list.RoomListListener
 import im.vector.app.features.home.room.list.RoomSummaryItemFactory
 import im.vector.app.features.home.room.list.RoomSummaryItemPlaceHolder_
+import im.vector.app.features.settings.FontScalePreferences
 import org.matrix.android.sdk.api.session.room.members.ChangeMembershipState
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 import javax.inject.Inject
 
 class HomeFilteredRoomsController @Inject constructor(
         private val roomSummaryItemFactory: RoomSummaryItemFactory,
+        fontScalePreferences: FontScalePreferences
 ) : PagedListEpoxyController<RoomSummary>(
         // Important it must match the PageList builder notify Looper
         modelBuildingHandler = createUIHandler()
@@ -46,6 +48,13 @@ class HomeFilteredRoomsController @Inject constructor(
 
     private var emptyStateData: StateView.State.Empty? = null
     private var currentState: StateView.State = StateView.State.Content
+
+    private val shouldUseSingleLine: Boolean
+
+    init {
+        val fontScale = fontScalePreferences.getResolvedFontScaleValue()
+        shouldUseSingleLine = fontScale.scale > FontScalePreferences.SCALE_LARGE
+    }
 
     override fun addModels(models: List<EpoxyModel<*>>) {
         if (models.isEmpty() && emptyStateData != null) {
@@ -67,7 +76,14 @@ class HomeFilteredRoomsController @Inject constructor(
     }
 
     override fun buildItemModel(currentPosition: Int, item: RoomSummary?): EpoxyModel<*> {
-        item ?: return RoomSummaryItemPlaceHolder_().apply { id(currentPosition) }
-        return roomSummaryItemFactory.create(item, roomChangeMembershipStates.orEmpty(), emptySet(), RoomListDisplayMode.ROOMS, listener)
+        return if (item == null) {
+            val host = this
+            RoomSummaryItemPlaceHolder_().apply {
+                id(currentPosition)
+                useSingleLineForLastEvent(host.shouldUseSingleLine)
+            }
+        } else {
+            roomSummaryItemFactory.create(item, roomChangeMembershipStates.orEmpty(), emptySet(), RoomListDisplayMode.ROOMS, listener, shouldUseSingleLine)
+        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/FontScalePreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/FontScalePreferences.kt
@@ -57,6 +57,16 @@ interface FontScalePreferences {
      * @return list of values
      */
     fun getAvailableScales(): List<FontScaleValue>
+
+    companion object {
+        const val SCALE_TINY = 0.70f
+        const val SCALE_SMALL = 0.85f
+        const val SCALE_NORMAL = 1.00f
+        const val SCALE_LARGE = 1.15f
+        const val SCALE_LARGER = 1.30f
+        const val SCALE_LARGEST = 1.45f
+        const val SCALE_HUGE = 1.60f
+    }
 }
 
 /**
@@ -73,13 +83,13 @@ class FontScalePreferencesImpl @Inject constructor(
     }
 
     private val fontScaleValues = listOf(
-            FontScaleValue(0, "FONT_SCALE_TINY", 0.70f, R.string.tiny),
-            FontScaleValue(1, "FONT_SCALE_SMALL", 0.85f, R.string.small),
-            FontScaleValue(2, "FONT_SCALE_NORMAL", 1.00f, R.string.normal),
-            FontScaleValue(3, "FONT_SCALE_LARGE", 1.15f, R.string.large),
-            FontScaleValue(4, "FONT_SCALE_LARGER", 1.30f, R.string.larger),
-            FontScaleValue(5, "FONT_SCALE_LARGEST", 1.45f, R.string.largest),
-            FontScaleValue(6, "FONT_SCALE_HUGE", 1.60f, R.string.huge)
+            FontScaleValue(0, "FONT_SCALE_TINY", FontScalePreferences.SCALE_TINY, R.string.tiny),
+            FontScaleValue(1, "FONT_SCALE_SMALL", FontScalePreferences.SCALE_SMALL, R.string.small),
+            FontScaleValue(2, "FONT_SCALE_NORMAL", FontScalePreferences.SCALE_NORMAL, R.string.normal),
+            FontScaleValue(3, "FONT_SCALE_LARGE", FontScalePreferences.SCALE_LARGE, R.string.large),
+            FontScaleValue(4, "FONT_SCALE_LARGER", FontScalePreferences.SCALE_LARGER, R.string.larger),
+            FontScaleValue(5, "FONT_SCALE_LARGEST", FontScalePreferences.SCALE_LARGEST, R.string.largest),
+            FontScaleValue(6, "FONT_SCALE_HUGE", FontScalePreferences.SCALE_HUGE, R.string.huge)
     )
 
     private val normalFontScaleValue = fontScaleValues[2]

--- a/vector/src/main/java/im/vector/app/features/share/IncomingShareController.kt
+++ b/vector/src/main/java/im/vector/app/features/share/IncomingShareController.kt
@@ -60,6 +60,7 @@ class IncomingShareController @Inject constructor(
                                 roomSummary,
                                 data.selectedRoomIds,
                                 RoomListDisplayMode.FILTERED,
+                                singleLineLastEvent = false,
                                 callback?.let { it::onRoomClicked },
                                 callback?.let { it::onRoomLongClicked }
                         )

--- a/vector/src/main/res/drawable/placeholder_shape_8.xml
+++ b/vector/src/main/res/drawable/placeholder_shape_8.xml
@@ -2,7 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <size android:width="40dp" android:height="40dp"/>
 
     <solid android:color="?vctr_reaction_background_off" />
 

--- a/vector/src/main/res/layout/item_room.xml
+++ b/vector/src/main/res/layout/item_room.xml
@@ -190,7 +190,7 @@
         android:layout_marginTop="3dp"
         android:layout_marginEnd="8dp"
         android:ellipsize="end"
-        android:maxLines="2"
+        android:lines="2"
         android:textAlignment="viewStart"
         android:textColor="?vctr_content_secondary"
         app:layout_constraintEnd_toEndOf="parent"

--- a/vector/src/main/res/layout/item_room_placeholder.xml
+++ b/vector/src/main/res/layout/item_room_placeholder.xml
@@ -16,7 +16,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginTop="12dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
@@ -29,23 +29,20 @@
 
     </FrameLayout>
 
-    <!-- Margin bottom does not work, so I use space -->
-    <Space
-        android:id="@+id/roomAvatarBottomSpace"
-        android:layout_width="0dp"
-        android:layout_height="12dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/roomAvatarContainer"
-        tools:layout_marginStart="20dp" />
-
-    <View
+    <TextView
         android:id="@+id/roomNameView"
-        android:layout_width="wrap_content"
-        android:layout_height="15dp"
+        style="@style/Widget.Vector.TextView.Subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/layout_horizontal_margin"
         android:layout_marginTop="12dp"
         android:layout_marginEnd="70dp"
         android:background="@drawable/placeholder_shape_8"
+        android:duplicateParentState="true"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="?vctr_content_primary"
+        android:textStyle="bold"
         app:layout_constrainedWidth="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
@@ -53,16 +50,30 @@
         app:layout_constraintStart_toEndOf="@id/roomAvatarContainer"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <View
-        android:id="@+id/roomTypingView"
+    <TextView
+        android:id="@+id/subtitleView"
+        style="@style/Widget.Vector.TextView.Body"
         android:layout_width="0dp"
-        android:layout_height="30dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="20dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="3dp"
+        android:layout_marginEnd="8dp"
         android:background="@drawable/placeholder_shape_8"
+        android:ellipsize="end"
+        android:lines="2"
+        android:textAlignment="viewStart"
+        android:textColor="?vctr_content_secondary"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@id/roomNameView"
         app:layout_constraintTop_toBottomOf="@id/roomNameView" />
+
+    <!-- Margin bottom does not work, so I use space -->
+    <Space
+        android:id="@+id/roomAvatarBottomSpace"
+        android:layout_width="0dp"
+        android:layout_height="7dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/subtitleView"
+        tools:layout_marginStart="120dp" />
 
     <!-- We use vctr_list_separator_system here for a better rendering -->
     <View
@@ -70,6 +81,7 @@
         android:layout_width="0dp"
         android:layout_height="1dp"
         android:background="?vctr_list_separator_system"
+        app:layout_constraintTop_toBottomOf="@id/roomAvatarBottomSpace"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Currently room summary item height is not constant - it can vary depending if there is enough text in the last message/event to go on a second line. This cause some flickering and jumping scrolls when placeholders are replaced with actual items. To mitigate this I've forced last event text view to have constant amount of lines (2 normally, reduced to 1 if font scale is bigger than "Large"). Also Placeholder's items had height defined in dp, which caused them to have wrong height if font size is scaled. 

## Motivation and context

closes #7079

## Screenshots / GIFs

before changes:

![before](https://user-images.githubusercontent.com/66663241/190447695-b7d44f60-269c-43bf-b4a6-44166eb57ff8.png)

After changes:

![normal](https://user-images.githubusercontent.com/66663241/190447744-ee7d2456-911c-4ad0-881b-eb582ff2468a.png)

with font scaling (Huge):

![huge](https://user-images.githubusercontent.com/66663241/190447810-013545e8-6a9d-4374-bf65-c01779cf5339.png)