### PR TITLE
Deferred DMs - Handle the local rooms within the new AppLayout

### DIFF
--- a/changelog.d/7153.wip
+++ b/changelog.d/7153.wip
@@ -1,0 +1,1 @@
+Create DM room only on first message - Handle the local rooms within the new AppLayout

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/query/ReadReceiptEntityQueries.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/query/ReadReceiptEntityQueries.kt
@@ -33,6 +33,11 @@ internal fun ReadReceiptEntity.Companion.whereUserId(realm: Realm, userId: Strin
             .equalTo(ReadReceiptEntityFields.USER_ID, userId)
 }
 
+internal fun ReadReceiptEntity.Companion.whereRoomId(realm: Realm, roomId: String): RealmQuery<ReadReceiptEntity> {
+    return realm.where<ReadReceiptEntity>()
+            .equalTo(ReadReceiptEntityFields.ROOM_ID, roomId)
+}
+
 internal fun ReadReceiptEntity.Companion.createUnmanaged(roomId: String, eventId: String, userId: String, originServerTs: Double): ReadReceiptEntity {
     return ReadReceiptEntity().apply {
         this.primaryKey = "${roomId}_$userId"

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoomService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/DefaultRoomService.kt
@@ -33,6 +33,7 @@ import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.model.RoomMemberSummary
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 import org.matrix.android.sdk.api.session.room.model.create.CreateRoomParams
+import org.matrix.android.sdk.api.session.room.model.localecho.RoomLocalEcho
 import org.matrix.android.sdk.api.session.room.peeking.PeekResult
 import org.matrix.android.sdk.api.session.room.roomSummaryQueryParams
 import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
@@ -173,7 +174,10 @@ internal class DefaultRoomService @Inject constructor(
     }
 
     override suspend fun onRoomDisplayed(roomId: String) {
-        updateBreadcrumbsTask.execute(UpdateBreadcrumbsTask.Params(roomId))
+        // Do not add local rooms to the recent rooms list as they should not be known by the server
+        if (!RoomLocalEcho.isLocalEchoId(roomId)) {
+            updateBreadcrumbsTask.execute(UpdateBreadcrumbsTask.Params(roomId))
+        }
     }
 
     override suspend fun joinRoom(roomIdOrAlias: String, reason: String?, viaServers: List<String>) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/delete/DeleteLocalRoomTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/delete/DeleteLocalRoomTask.kt
@@ -22,12 +22,15 @@ import org.matrix.android.sdk.internal.database.model.ChunkEntity
 import org.matrix.android.sdk.internal.database.model.CurrentStateEventEntity
 import org.matrix.android.sdk.internal.database.model.EventEntity
 import org.matrix.android.sdk.internal.database.model.LocalRoomSummaryEntity
+import org.matrix.android.sdk.internal.database.model.ReadReceiptEntity
+import org.matrix.android.sdk.internal.database.model.ReadReceiptsSummaryEntity
 import org.matrix.android.sdk.internal.database.model.RoomEntity
 import org.matrix.android.sdk.internal.database.model.RoomMemberSummaryEntity
 import org.matrix.android.sdk.internal.database.model.RoomSummaryEntity
 import org.matrix.android.sdk.internal.database.model.TimelineEventEntity
 import org.matrix.android.sdk.internal.database.model.deleteOnCascade
 import org.matrix.android.sdk.internal.database.query.where
+import org.matrix.android.sdk.internal.database.query.whereInRoom
 import org.matrix.android.sdk.internal.database.query.whereRoomId
 import org.matrix.android.sdk.internal.di.SessionDatabase
 import org.matrix.android.sdk.internal.session.room.delete.DeleteLocalRoomTask.Params
@@ -50,6 +53,12 @@ internal class DefaultDeleteLocalRoomTask @Inject constructor(
         if (RoomLocalEcho.isLocalEchoId(roomId)) {
             monarchy.awaitTransaction { realm ->
                 Timber.i("## DeleteLocalRoomTask - delete local room id $roomId")
+                ReadReceiptsSummaryEntity.whereInRoom(realm, roomId = roomId).findAll()
+                        ?.also { Timber.i("## DeleteLocalRoomTask - ReadReceiptsSummaryEntity - delete ${it.size} entries") }
+                        ?.deleteAllFromRealm()
+                ReadReceiptEntity.whereRoomId(realm, roomId = roomId).findAll()
+                        ?.also { Timber.i("## DeleteLocalRoomTask - ReadReceiptEntity - delete ${it.size} entries") }
+                        ?.deleteAllFromRealm()
                 RoomMemberSummaryEntity.where(realm, roomId = roomId).findAll()
                         ?.also { Timber.i("## DeleteLocalRoomTask - RoomMemberSummaryEntity - delete ${it.size} entries") }
                         ?.deleteAllFromRealm()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/accountdata/UpdateBreadcrumbsTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/accountdata/UpdateBreadcrumbsTask.kt
@@ -17,6 +17,7 @@
 package org.matrix.android.sdk.internal.session.user.accountdata
 
 import com.zhuinden.monarchy.Monarchy
+import org.matrix.android.sdk.api.session.room.model.localecho.RoomLocalEcho
 import org.matrix.android.sdk.internal.database.model.BreadcrumbsEntity
 import org.matrix.android.sdk.internal.database.query.get
 import org.matrix.android.sdk.internal.di.SessionDatabase
@@ -41,6 +42,8 @@ internal class DefaultUpdateBreadcrumbsTask @Inject constructor(
 ) : UpdateBreadcrumbsTask {
 
     override suspend fun execute(params: UpdateBreadcrumbsTask.Params) {
+        // Do not add local rooms to the recent rooms list as they should not be known by the server
+        if (RoomLocalEcho.isLocalEchoId(params.newTopRoomId)) return
         val newBreadcrumbs =
                 // Get the breadcrumbs entity, if any
                 monarchy.fetchCopied { BreadcrumbsEntity.get(it) }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/accountdata/UpdateBreadcrumbsTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/accountdata/UpdateBreadcrumbsTask.kt
@@ -17,7 +17,6 @@
 package org.matrix.android.sdk.internal.session.user.accountdata
 
 import com.zhuinden.monarchy.Monarchy
-import org.matrix.android.sdk.api.session.room.model.localecho.RoomLocalEcho
 import org.matrix.android.sdk.internal.database.model.BreadcrumbsEntity
 import org.matrix.android.sdk.internal.database.query.get
 import org.matrix.android.sdk.internal.di.SessionDatabase
@@ -42,8 +41,6 @@ internal class DefaultUpdateBreadcrumbsTask @Inject constructor(
 ) : UpdateBreadcrumbsTask {
 
     override suspend fun execute(params: UpdateBreadcrumbsTask.Params) {
-        // Do not add local rooms to the recent rooms list as they should not be known by the server
-        if (RoomLocalEcho.isLocalEchoId(params.newTopRoomId)) return
         val newBreadcrumbs =
                 // Get the breadcrumbs entity, if any
                 monarchy.fetchCopied { BreadcrumbsEntity.get(it) }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListAction.kt
@@ -31,4 +31,5 @@ sealed class RoomListAction : VectorViewModelAction {
     data class LeaveRoom(val roomId: String) : RoomListAction()
     data class JoinSuggestedRoom(val roomId: String, val viaServers: List<String>?) : RoomListAction()
     data class ShowRoomDetails(val roomId: String, val viaServers: List<String>?) : RoomListAction()
+    object DeleteAllLocalRoom : RoomListAction()
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -149,10 +149,13 @@ class RoomListFragment :
                         (it.contentEpoxyController as? RoomSummaryPagedController)?.roomChangeMembershipStates = ms
                     }
         }
-        roomListViewModel.onEach(RoomListViewState::localRoomIds) {
-            // Local rooms should not exist anymore when the room list is shown
-            roomListViewModel.deleteLocalRooms(it)
-        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        // Local rooms should not exist anymore when the room list is shown
+        roomListViewModel.handle(RoomListAction.DeleteAllLocalRoom)
     }
 
     private fun refreshCollapseStates() {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
@@ -97,7 +97,6 @@ class RoomListViewModel @AssistedInject constructor(
 
     init {
         observeMembershipChanges()
-        observeLocalRooms()
 
         spaceStateHandler.getSelectedSpaceFlow()
                 .distinctUntilChanged()
@@ -123,16 +122,6 @@ class RoomListViewModel @AssistedInject constructor(
                 .setOnEach {
                     copy(roomMembershipChanges = it)
                 }
-    }
-
-    private fun observeLocalRooms() {
-        session
-                .flow()
-                .liveRoomSummaries(roomSummaryQueryParams {
-                    roomId = QueryStringValue.Contains(RoomLocalEcho.PREFIX)
-                })
-                .map { page -> page.map { it.roomId } }
-                .setOnEach { copy(localRoomIds = it) }
     }
 
     companion object : MavericksViewModelFactory<RoomListViewModel, RoomListViewState> by hiltMavericksViewModelFactory()
@@ -166,19 +155,12 @@ class RoomListViewModel @AssistedInject constructor(
             is RoomListAction.ToggleSection -> handleToggleSection(action.section)
             is RoomListAction.JoinSuggestedRoom -> handleJoinSuggestedRoom(action)
             is RoomListAction.ShowRoomDetails -> handleShowRoomDetails(action)
+            RoomListAction.DeleteAllLocalRoom -> handleDeleteLocalRooms()
         }
     }
 
     fun isPublicRoom(roomId: String): Boolean {
         return session.getRoom(roomId)?.stateService()?.isPublic().orFalse()
-    }
-
-    fun deleteLocalRooms(roomsIds: Iterable<String>) {
-        viewModelScope.launch {
-            roomsIds.forEach {
-                session.roomService().deleteLocalRoom(it)
-            }
-        }
     }
 
     // PRIVATE METHODS *****************************************************************************
@@ -336,6 +318,18 @@ class RoomListViewModel @AssistedInject constructor(
             val value = runCatching { session.roomService().leaveRoom(action.roomId) }
                     .fold({ RoomListViewEvents.Done }, { RoomListViewEvents.Failure(it) })
             _viewEvents.post(value)
+        }
+    }
+
+    private fun handleDeleteLocalRooms() {
+        val localRoomIds = session.roomService()
+                .getRoomSummaries(roomSummaryQueryParams { roomId = QueryStringValue.Contains(RoomLocalEcho.PREFIX) })
+                .map { it.roomId }
+
+        viewModelScope.launch {
+            localRoomIds.forEach {
+                session.roomService().deleteLocalRoom(it)
+            }
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewState.kt
@@ -31,7 +31,6 @@ data class RoomListViewState(
         val asyncSuggestedRooms: Async<List<SpaceChildInfo>> = Uninitialized,
         val currentUserName: String? = null,
         val asyncSelectedSpace: Async<RoomSummary?> = Uninitialized,
-        val localRoomIds: List<String> = emptyList()
 ) : MavericksState {
 
     constructor(args: RoomListParams) : this(displayMode = args.displayMode)

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListAction.kt
@@ -27,4 +27,5 @@ sealed class HomeRoomListAction : VectorViewModelAction {
     data class ToggleTag(val roomId: String, val tag: String) : HomeRoomListAction()
     data class LeaveRoom(val roomId: String) : HomeRoomListAction()
     data class ChangeRoomFilter(val filter: HomeRoomFilter) : HomeRoomListAction()
+    object DeleteAllLocalRoom : HomeRoomListAction()
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
@@ -40,7 +40,6 @@ import im.vector.app.databinding.FragmentRoomListBinding
 import im.vector.app.features.analytics.plan.ViewRoom
 import im.vector.app.features.home.room.list.RoomListAnimator
 import im.vector.app.features.home.room.list.RoomListListener
-import im.vector.app.features.home.room.list.RoomListViewState
 import im.vector.app.features.home.room.list.actions.RoomListQuickActionsBottomSheet
 import im.vector.app.features.home.room.list.actions.RoomListQuickActionsSharedAction
 import im.vector.app.features.home.room.list.actions.RoomListQuickActionsSharedActionViewModel

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
@@ -40,6 +40,7 @@ import im.vector.app.databinding.FragmentRoomListBinding
 import im.vector.app.features.analytics.plan.ViewRoom
 import im.vector.app.features.home.room.list.RoomListAnimator
 import im.vector.app.features.home.room.list.RoomListListener
+import im.vector.app.features.home.room.list.RoomListViewState
 import im.vector.app.features.home.room.list.actions.RoomListQuickActionsBottomSheet
 import im.vector.app.features.home.room.list.actions.RoomListQuickActionsSharedAction
 import im.vector.app.features.home.room.list.actions.RoomListQuickActionsSharedActionViewModel
@@ -97,6 +98,11 @@ class HomeRoomListFragment :
                 is HomeRoomListViewEvents.SelectRoom -> handleSelectRoom(it, it.isInviteAlreadyAccepted)
                 is HomeRoomListViewEvents.Done -> Unit
             }
+        }
+
+        roomListViewModel.onEach(HomeRoomListViewState::localRoomIds) {
+            // Local rooms should not exist anymore when the room list is shown
+            roomListViewModel.deleteLocalRooms(it)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
@@ -83,6 +83,13 @@ class HomeRoomListFragment :
         setupRecyclerView()
     }
 
+    override fun onStart() {
+        super.onStart()
+
+        // Local rooms should not exist anymore when the room list is shown
+        roomListViewModel.handle(HomeRoomListAction.DeleteAllLocalRoom)
+    }
+
     private fun setupObservers() {
         sharedQuickActionsViewModel = activityViewModelProvider[RoomListQuickActionsSharedActionViewModel::class.java]
         sharedQuickActionsViewModel
@@ -97,11 +104,6 @@ class HomeRoomListFragment :
                 is HomeRoomListViewEvents.SelectRoom -> handleSelectRoom(it, it.isInviteAlreadyAccepted)
                 is HomeRoomListViewEvents.Done -> Unit
             }
-        }
-
-        roomListViewModel.onEach(HomeRoomListViewState::localRoomIds) {
-            // Local rooms should not exist anymore when the room list is shown
-            roomListViewModel.deleteLocalRooms(it)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewState.kt
@@ -27,5 +27,4 @@ data class HomeRoomListViewState(
         val state: StateView.State = StateView.State.Content,
         val headersData: RoomsHeadersData = RoomsHeadersData(),
         val roomsLivePagedList: LiveData<PagedList<RoomSummary>>? = null,
-        val localRoomIds: List<String> = emptyList()
 ) : MavericksState

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewState.kt
@@ -26,5 +26,6 @@ import org.matrix.android.sdk.api.session.room.model.RoomSummary
 data class HomeRoomListViewState(
         val state: StateView.State = StateView.State.Content,
         val headersData: RoomsHeadersData = RoomsHeadersData(),
-        val roomsLivePagedList: LiveData<PagedList<RoomSummary>>? = null
+        val roomsLivePagedList: LiveData<PagedList<RoomSummary>>? = null,
+        val localRoomIds: List<String> = emptyList()
 ) : MavericksState


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

This PR adds the deletion of the local rooms from the database when the room list is shown within the new AppLayout feature enabled.

## Motivation and context

Close #7153

## Tests

- Start creating a DM with the start DM feature flag and the new App Layout enabled
- Activate the recent rooms display from the AppLayout configuration
- Write some text without sending it
- Abort the DM creation and go back to the home list
- Verify that the local rooms does not appear in the recent rooms
- Start creating again a DM with the same person
- Verify that the local room has not been retrieved (the draft is not persisted) 

We can also observe logs in the console about the deletion of the local rooms when the home room list is shown again.

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
