### PR TITLE
[Device management] Verify another session (PSG-722)

### DIFF
--- a/changelog.d/7143.wip
+++ b/changelog.d/7143.wip
@@ -1,0 +1,1 @@
+[Device management] Verify another session

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
@@ -34,7 +34,7 @@ import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.utils.PublishDataSource
 import im.vector.app.features.auth.ReAuthActivity
 import im.vector.app.features.login.ReAuthHelper
-import im.vector.app.features.settings.devices.v2.GetEncryptionTrustLevelForDeviceUseCase
+import im.vector.app.features.settings.devices.v2.verification.GetEncryptionTrustLevelForDeviceUseCase
 import im.vector.app.features.settings.devices.v2.list.CheckIfSessionIsInactiveUseCase
 import im.vector.lib.core.utils.flow.throttleFirst
 import kotlinx.coroutines.Dispatchers

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
@@ -34,8 +34,8 @@ import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.utils.PublishDataSource
 import im.vector.app.features.auth.ReAuthActivity
 import im.vector.app.features.login.ReAuthHelper
-import im.vector.app.features.settings.devices.v2.verification.GetEncryptionTrustLevelForDeviceUseCase
 import im.vector.app.features.settings.devices.v2.list.CheckIfSessionIsInactiveUseCase
+import im.vector.app.features.settings.devices.v2.verification.GetEncryptionTrustLevelForDeviceUseCase
 import im.vector.lib.core.utils.flow.throttleFirst
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine

--- a/vector/src/main/java/im/vector/app/features/settings/devices/GetCurrentSessionCrossSigningInfoUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/GetCurrentSessionCrossSigningInfoUseCase.kt
@@ -17,7 +17,7 @@
 package im.vector.app.features.settings.devices
 
 import im.vector.app.core.di.ActiveSessionHolder
-import im.vector.app.features.settings.devices.v2.CurrentSessionCrossSigningInfo
+import im.vector.app.features.settings.devices.v2.verification.CurrentSessionCrossSigningInfo
 import javax.inject.Inject
 
 class GetCurrentSessionCrossSigningInfoUseCase @Inject constructor(

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewModel.kt
@@ -26,6 +26,7 @@ import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.features.settings.devices.v2.filter.DeviceManagerFilterType
 import im.vector.app.features.settings.devices.v2.verification.CheckIfCurrentSessionCanBeVerifiedUseCase
+import im.vector.app.features.settings.devices.v2.verification.GetCurrentSessionCrossSigningInfoUseCase
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewState.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.settings.devices.v2
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.Uninitialized
+import im.vector.app.features.settings.devices.v2.verification.CurrentSessionCrossSigningInfo
 
 data class DevicesViewState(
         val currentSessionCrossSigningInfo: CurrentSessionCrossSigningInfo = CurrentSessionCrossSigningInfo(),

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/GetDeviceFullInfoListUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/GetDeviceFullInfoListUseCase.kt
@@ -20,6 +20,9 @@ import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.features.settings.devices.v2.filter.DeviceManagerFilterType
 import im.vector.app.features.settings.devices.v2.filter.FilterDevicesUseCase
 import im.vector.app.features.settings.devices.v2.list.CheckIfSessionIsInactiveUseCase
+import im.vector.app.features.settings.devices.v2.verification.CurrentSessionCrossSigningInfo
+import im.vector.app.features.settings.devices.v2.verification.GetCurrentSessionCrossSigningInfoUseCase
+import im.vector.app.features.settings.devices.v2.verification.GetEncryptionTrustLevelForDeviceUseCase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoView.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoView.kt
@@ -62,6 +62,7 @@ class SessionInfoView @JvmOverloads constructor(
                 sessionInfoViewState.deviceFullInfo.roomEncryptionTrustLevel,
                 sessionInfoViewState.isCurrentSession,
                 sessionInfoViewState.isLearnMoreLinkVisible,
+                sessionInfoViewState.isVerifyButtonVisible,
         )
         renderDeviceLastSeenDetails(
                 sessionInfoViewState.deviceFullInfo.isInactive,
@@ -78,12 +79,13 @@ class SessionInfoView @JvmOverloads constructor(
             encryptionTrustLevel: RoomEncryptionTrustLevel,
             isCurrentSession: Boolean,
             hasLearnMoreLink: Boolean,
+            isVerifyButtonVisible: Boolean,
     ) {
         views.sessionInfoVerificationStatusImageView.render(encryptionTrustLevel)
         if (encryptionTrustLevel == RoomEncryptionTrustLevel.Trusted) {
             renderCrossSigningVerified(isCurrentSession)
         } else {
-            renderCrossSigningUnverified(isCurrentSession)
+            renderCrossSigningUnverified(isCurrentSession, isVerifyButtonVisible)
         }
         if (hasLearnMoreLink) {
             appendLearnMoreToVerificationStatus()
@@ -120,7 +122,7 @@ class SessionInfoView @JvmOverloads constructor(
         views.sessionInfoVerifySessionButton.isVisible = false
     }
 
-    private fun renderCrossSigningUnverified(isCurrentSession: Boolean) {
+    private fun renderCrossSigningUnverified(isCurrentSession: Boolean, isVerifyButtonVisible: Boolean) {
         views.sessionInfoVerificationStatusTextView.text = context.getString(R.string.device_manager_verification_status_unverified)
         views.sessionInfoVerificationStatusTextView.setTextColor(ThemeUtils.getColor(context, R.attr.colorError))
         val statusResId = if (isCurrentSession) {
@@ -129,7 +131,7 @@ class SessionInfoView @JvmOverloads constructor(
             R.string.device_manager_verification_status_detail_other_session_unverified
         }
         views.sessionInfoVerificationStatusDetailTextView.text = context.getString(statusResId)
-        views.sessionInfoVerifySessionButton.isVisible = true
+        views.sessionInfoVerifySessionButton.isVisible = isVerifyButtonVisible
     }
 
     // TODO. We don't have this info yet. Update later accordingly.

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoViewState.kt
@@ -21,6 +21,7 @@ import im.vector.app.features.settings.devices.v2.DeviceFullInfo
 data class SessionInfoViewState(
         val isCurrentSession: Boolean,
         val deviceFullInfo: DeviceFullInfo,
+        val isVerifyButtonVisible: Boolean = true,
         val isDetailsButtonVisible: Boolean = true,
         val isLearnMoreLinkVisible: Boolean = false,
         val isLastSeenDetailsVisible: Boolean = false,

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/GetDeviceFullInfoUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/GetDeviceFullInfoUseCase.kt
@@ -19,9 +19,9 @@ package im.vector.app.features.settings.devices.v2.overview
 import androidx.lifecycle.asFlow
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.features.settings.devices.v2.DeviceFullInfo
+import im.vector.app.features.settings.devices.v2.list.CheckIfSessionIsInactiveUseCase
 import im.vector.app.features.settings.devices.v2.verification.GetCurrentSessionCrossSigningInfoUseCase
 import im.vector.app.features.settings.devices.v2.verification.GetEncryptionTrustLevelForDeviceUseCase
-import im.vector.app.features.settings.devices.v2.list.CheckIfSessionIsInactiveUseCase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emptyFlow

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/GetDeviceFullInfoUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/GetDeviceFullInfoUseCase.kt
@@ -19,8 +19,8 @@ package im.vector.app.features.settings.devices.v2.overview
 import androidx.lifecycle.asFlow
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.features.settings.devices.v2.DeviceFullInfo
-import im.vector.app.features.settings.devices.v2.GetCurrentSessionCrossSigningInfoUseCase
-import im.vector.app.features.settings.devices.v2.GetEncryptionTrustLevelForDeviceUseCase
+import im.vector.app.features.settings.devices.v2.verification.GetCurrentSessionCrossSigningInfoUseCase
+import im.vector.app.features.settings.devices.v2.verification.GetEncryptionTrustLevelForDeviceUseCase
 import im.vector.app.features.settings.devices.v2.list.CheckIfSessionIsInactiveUseCase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
@@ -35,7 +35,6 @@ import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.DrawableProvider
 import im.vector.app.databinding.FragmentSessionOverviewBinding
 import im.vector.app.features.crypto.recover.SetupMode
-import im.vector.app.features.settings.devices.v2.DeviceFullInfo
 import im.vector.app.features.settings.devices.v2.list.SessionInfoViewState
 import javax.inject.Inject
 
@@ -107,11 +106,7 @@ class SessionOverviewFragment :
     override fun invalidate() = withState(viewModel) { state ->
         updateToolbar(state.isCurrentSession)
         updateEntryDetails(state.deviceId)
-        if (state.deviceInfo is Success) {
-            renderSessionInfo(state.isCurrentSession, state.deviceInfo.invoke(), state.isCurrentSessionTrusted)
-        } else {
-            hideSessionInfo()
-        }
+        updateSessionInfo(state)
     }
 
     private fun updateToolbar(isCurrentSession: Boolean) {
@@ -127,21 +122,22 @@ class SessionOverviewFragment :
         }
     }
 
-    private fun renderSessionInfo(
-            isCurrentSession: Boolean,
-            deviceFullInfo: DeviceFullInfo,
-            isCurrentSessionTrusted: Boolean,
-    ) {
-        views.sessionOverviewInfo.isVisible = true
-        val viewState = SessionInfoViewState(
-                isCurrentSession = isCurrentSession,
-                deviceFullInfo = deviceFullInfo,
-                isVerifyButtonVisible = isCurrentSession || isCurrentSessionTrusted,
-                isDetailsButtonVisible = false,
-                isLearnMoreLinkVisible = true,
-                isLastSeenDetailsVisible = true,
-        )
-        views.sessionOverviewInfo.render(viewState, dateFormatter, drawableProvider, colorProvider)
+    private fun updateSessionInfo(viewState: SessionOverviewViewState) {
+        if (viewState.deviceInfo is Success) {
+            views.sessionOverviewInfo.isVisible = true
+            val isCurrentSession = viewState.isCurrentSession
+            val infoViewState = SessionInfoViewState(
+                    isCurrentSession = isCurrentSession,
+                    deviceFullInfo = viewState.deviceInfo.invoke(),
+                    isVerifyButtonVisible = isCurrentSession || viewState.isCurrentSessionTrusted,
+                    isDetailsButtonVisible = false,
+                    isLearnMoreLinkVisible = true,
+                    isLastSeenDetailsVisible = true,
+            )
+            views.sessionOverviewInfo.render(infoViewState, dateFormatter, drawableProvider, colorProvider)
+        } else {
+            hideSessionInfo()
+        }
     }
 
     private fun hideSessionInfo() {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
@@ -82,8 +82,11 @@ class SessionOverviewFragment :
     private fun observeViewEvents() {
         viewModel.observeViewEvents {
             when (it) {
-                is SessionOverviewViewEvent.SelfVerification -> {
+                is SessionOverviewViewEvent.ShowVerifyCurrentSession -> {
                     navigator.requestSelfSessionVerification(requireActivity())
+                }
+                is SessionOverviewViewEvent.ShowVerifyOtherSession -> {
+                    navigator.requestSessionVerification(requireActivity(), it.deviceId)
                 }
                 is SessionOverviewViewEvent.PromptResetSecrets -> {
                     navigator.open4SSetup(requireActivity(), SetupMode.PASSPHRASE_AND_NEEDED_SECRETS_RESET)
@@ -105,7 +108,7 @@ class SessionOverviewFragment :
         updateToolbar(state.isCurrentSession)
         updateEntryDetails(state.deviceId)
         if (state.deviceInfo is Success) {
-            renderSessionInfo(state.isCurrentSession, state.deviceInfo.invoke())
+            renderSessionInfo(state.isCurrentSession, state.deviceInfo.invoke(), state.isCurrentSessionTrusted)
         } else {
             hideSessionInfo()
         }
@@ -124,11 +127,16 @@ class SessionOverviewFragment :
         }
     }
 
-    private fun renderSessionInfo(isCurrentSession: Boolean, deviceFullInfo: DeviceFullInfo) {
+    private fun renderSessionInfo(
+            isCurrentSession: Boolean,
+            deviceFullInfo: DeviceFullInfo,
+            isCurrentSessionTrusted: Boolean,
+    ) {
         views.sessionOverviewInfo.isVisible = true
         val viewState = SessionInfoViewState(
                 isCurrentSession = isCurrentSession,
                 deviceFullInfo = deviceFullInfo,
+                isVerifyButtonVisible = isCurrentSession || isCurrentSessionTrusted,
                 isDetailsButtonVisible = false,
                 isLearnMoreLinkVisible = true,
                 isLastSeenDetailsVisible = true,

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewEvent.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewEvent.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.settings.devices.v2.overview
 import im.vector.app.core.platform.VectorViewEvents
 
 sealed class SessionOverviewViewEvent : VectorViewEvents {
-    object SelfVerification : SessionOverviewViewEvent()
+    object ShowVerifyCurrentSession : SessionOverviewViewEvent()
+    data class ShowVerifyOtherSession(val deviceId: String) : SessionOverviewViewEvent()
     object PromptResetSecrets : SessionOverviewViewEvent()
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
@@ -45,6 +45,7 @@ class SessionOverviewViewModel @AssistedInject constructor(
     }
 
     init {
+        // TODO check if current session is trusted
         setState {
             copy(isCurrentSession = isCurrentSession(deviceId))
         }
@@ -70,6 +71,8 @@ class SessionOverviewViewModel @AssistedInject constructor(
     private fun handleVerifySessionAction() = withState { viewState ->
         if (isCurrentSession(viewState.deviceId)) {
             handleVerifyCurrentSession()
+        } else {
+            handleVerifyOtherSession(verifySession.deviceId)
         }
     }
 
@@ -77,10 +80,14 @@ class SessionOverviewViewModel @AssistedInject constructor(
         viewModelScope.launch {
             val currentSessionCanBeVerified = checkIfCurrentSessionCanBeVerifiedUseCase.execute()
             if (currentSessionCanBeVerified) {
-                _viewEvents.post(SessionOverviewViewEvent.SelfVerification)
+                _viewEvents.post(SessionOverviewViewEvent.ShowVerifyCurrentSession)
             } else {
                 _viewEvents.post(SessionOverviewViewEvent.PromptResetSecrets)
             }
         }
+    }
+
+    private fun handleVerifyOtherSession(deviceId: String) {
+        _viewEvents.post(SessionOverviewViewEvent.ShowVerifyOtherSession(deviceId))
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
@@ -87,11 +87,10 @@ class SessionOverviewViewModel @AssistedInject constructor(
     }
 
     private fun handleVerifySessionAction() = withState { viewState ->
-        val deviceId = viewState.deviceId
-        if (isCurrentSession(deviceId)) {
+        if (viewState.isCurrentSession) {
             handleVerifyCurrentSession()
         } else {
-            handleVerifyOtherSession(deviceId)
+            handleVerifyOtherSession(viewState.deviceId)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
@@ -45,7 +45,6 @@ class SessionOverviewViewModel @AssistedInject constructor(
     }
 
     init {
-        // TODO check if current session is trusted
         setState {
             copy(isCurrentSession = isCurrentSession(deviceId))
         }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
@@ -21,6 +21,7 @@ import com.airbnb.mvrx.Success
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.VectorViewModel
@@ -35,6 +36,7 @@ import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel
 
 class SessionOverviewViewModel @AssistedInject constructor(
         @Assisted val initialState: SessionOverviewViewState,
+        private val activeSessionHolder: ActiveSessionHolder,
         private val isCurrentSessionUseCase: IsCurrentSessionUseCase,
         private val getDeviceFullInfoUseCase: GetDeviceFullInfoUseCase,
         private val checkIfCurrentSessionCanBeVerifiedUseCase: CheckIfCurrentSessionCanBeVerifiedUseCase,
@@ -85,10 +87,11 @@ class SessionOverviewViewModel @AssistedInject constructor(
     }
 
     private fun handleVerifySessionAction() = withState { viewState ->
-        if (isCurrentSession(viewState.deviceId)) {
+        val deviceId = viewState.deviceId
+        if (isCurrentSession(deviceId)) {
             handleVerifyCurrentSession()
         } else {
-            handleVerifyOtherSession(verifySession.deviceId)
+            handleVerifyOtherSession(deviceId)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewState.kt
@@ -24,6 +24,7 @@ import im.vector.app.features.settings.devices.v2.DeviceFullInfo
 data class SessionOverviewViewState(
         val deviceId: String,
         val isCurrentSession: Boolean = false,
+        val isCurrentSessionTrusted: Boolean = false,
         val deviceInfo: Async<DeviceFullInfo> = Uninitialized,
 ) : MavericksState {
     constructor(args: SessionOverviewArgs) : this(

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/CurrentSessionCrossSigningInfo.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/CurrentSessionCrossSigningInfo.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.devices.v2
+package im.vector.app.features.settings.devices.v2.verification
 
 /**
  * Used to hold some info about the cross signing of the current Session.

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/GetCurrentSessionCrossSigningInfoUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/GetCurrentSessionCrossSigningInfoUseCase.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.devices.v2
+package im.vector.app.features.settings.devices.v2.verification
 
 import im.vector.app.core.di.ActiveSessionHolder
 import kotlinx.coroutines.flow.Flow

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForCurrentDeviceUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForCurrentDeviceUseCase.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.devices.v2
+package im.vector.app.features.settings.devices.v2.verification
 
 import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel
 import javax.inject.Inject

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForDeviceUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForDeviceUseCase.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.devices.v2
+package im.vector.app.features.settings.devices.v2.verification
 
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
 import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForOtherDeviceUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForOtherDeviceUseCase.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.devices.v2
+package im.vector.app.features.settings.devices.v2.verification
 
 import org.matrix.android.sdk.api.session.crypto.crosssigning.DeviceTrustLevel
 import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel

--- a/vector/src/test/java/im/vector/app/features/settings/devices/GetCurrentSessionCrossSigningInfoUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/GetCurrentSessionCrossSigningInfoUseCaseTest.kt
@@ -18,11 +18,8 @@ package im.vector.app.features.settings.devices
 
 import im.vector.app.features.settings.devices.v2.verification.CurrentSessionCrossSigningInfo
 import im.vector.app.test.fakes.FakeActiveSessionHolder
-import io.mockk.every
-import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
-import org.matrix.android.sdk.api.auth.data.SessionParams
 
 private const val A_DEVICE_ID = "device-id"
 
@@ -36,9 +33,7 @@ class GetCurrentSessionCrossSigningInfoUseCaseTest {
 
     @Test
     fun `given the active session when getting cross signing info then the result is correct`() {
-        val sessionParams = mockk<SessionParams>()
-        every { sessionParams.deviceId } returns A_DEVICE_ID
-        fakeActiveSessionHolder.fakeSession.givenSessionParams(sessionParams)
+        fakeActiveSessionHolder.fakeSession.givenSessionId(A_DEVICE_ID)
         val isCrossSigningInitialized = true
         fakeActiveSessionHolder.fakeSession
                 .fakeCryptoService

--- a/vector/src/test/java/im/vector/app/features/settings/devices/GetCurrentSessionCrossSigningInfoUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/GetCurrentSessionCrossSigningInfoUseCaseTest.kt
@@ -16,7 +16,7 @@
 
 package im.vector.app.features.settings.devices
 
-import im.vector.app.features.settings.devices.v2.CurrentSessionCrossSigningInfo
+import im.vector.app.features.settings.devices.v2.verification.CurrentSessionCrossSigningInfo
 import im.vector.app.test.fakes.FakeActiveSessionHolder
 import io.mockk.every
 import io.mockk.mockk

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/DevicesViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/DevicesViewModelTest.kt
@@ -19,6 +19,8 @@ package im.vector.app.features.settings.devices.v2
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.test.MvRxTestRule
 import im.vector.app.features.settings.devices.v2.verification.CheckIfCurrentSessionCanBeVerifiedUseCase
+import im.vector.app.features.settings.devices.v2.verification.CurrentSessionCrossSigningInfo
+import im.vector.app.features.settings.devices.v2.verification.GetCurrentSessionCrossSigningInfoUseCase
 import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.fakes.FakeVerificationService
 import im.vector.app.test.test

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/GetDeviceFullInfoListUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/GetDeviceFullInfoListUseCaseTest.kt
@@ -19,6 +19,9 @@ package im.vector.app.features.settings.devices.v2
 import im.vector.app.features.settings.devices.v2.filter.DeviceManagerFilterType
 import im.vector.app.features.settings.devices.v2.filter.FilterDevicesUseCase
 import im.vector.app.features.settings.devices.v2.list.CheckIfSessionIsInactiveUseCase
+import im.vector.app.features.settings.devices.v2.verification.CurrentSessionCrossSigningInfo
+import im.vector.app.features.settings.devices.v2.verification.GetCurrentSessionCrossSigningInfoUseCase
+import im.vector.app.features.settings.devices.v2.verification.GetEncryptionTrustLevelForDeviceUseCase
 import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.test
 import im.vector.app.test.testDispatcher

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/IsCurrentSessionUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/IsCurrentSessionUseCaseTest.kt
@@ -17,8 +17,6 @@
 package im.vector.app.features.settings.devices.v2
 
 import im.vector.app.test.fakes.FakeActiveSessionHolder
-import io.mockk.every
-import io.mockk.mockk
 import io.mockk.verify
 import org.amshove.kluent.shouldBe
 import org.junit.Test
@@ -73,10 +71,7 @@ class IsCurrentSessionUseCaseTest {
         result shouldBe false
     }
 
-    private fun givenIdForCurrentSession(deviceId: String): SessionParams {
-        val sessionParams = mockk<SessionParams>()
-        every { sessionParams.deviceId } returns deviceId
-        fakeActiveSessionHolder.fakeSession.givenSessionParams(sessionParams)
-        return sessionParams
+    private fun givenIdForCurrentSession(sessionId: String): SessionParams {
+        return fakeActiveSessionHolder.fakeSession.givenSessionId(sessionId)
     }
 }

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/GetDeviceFullInfoUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/GetDeviceFullInfoUseCaseTest.kt
@@ -18,11 +18,11 @@ package im.vector.app.features.settings.devices.v2.overview
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.asFlow
-import im.vector.app.features.settings.devices.v2.verification.CurrentSessionCrossSigningInfo
 import im.vector.app.features.settings.devices.v2.DeviceFullInfo
+import im.vector.app.features.settings.devices.v2.list.CheckIfSessionIsInactiveUseCase
+import im.vector.app.features.settings.devices.v2.verification.CurrentSessionCrossSigningInfo
 import im.vector.app.features.settings.devices.v2.verification.GetCurrentSessionCrossSigningInfoUseCase
 import im.vector.app.features.settings.devices.v2.verification.GetEncryptionTrustLevelForDeviceUseCase
-import im.vector.app.features.settings.devices.v2.list.CheckIfSessionIsInactiveUseCase
 import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.fakes.FakeFlowLiveDataConversions
 import im.vector.app.test.fakes.givenAsFlow

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/GetDeviceFullInfoUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/GetDeviceFullInfoUseCaseTest.kt
@@ -18,10 +18,10 @@ package im.vector.app.features.settings.devices.v2.overview
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.asFlow
-import im.vector.app.features.settings.devices.v2.CurrentSessionCrossSigningInfo
+import im.vector.app.features.settings.devices.v2.verification.CurrentSessionCrossSigningInfo
 import im.vector.app.features.settings.devices.v2.DeviceFullInfo
-import im.vector.app.features.settings.devices.v2.GetCurrentSessionCrossSigningInfoUseCase
-import im.vector.app.features.settings.devices.v2.GetEncryptionTrustLevelForDeviceUseCase
+import im.vector.app.features.settings.devices.v2.verification.GetCurrentSessionCrossSigningInfoUseCase
+import im.vector.app.features.settings.devices.v2.verification.GetEncryptionTrustLevelForDeviceUseCase
 import im.vector.app.features.settings.devices.v2.list.CheckIfSessionIsInactiveUseCase
 import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.fakes.FakeFlowLiveDataConversions

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
@@ -21,6 +21,7 @@ import com.airbnb.mvrx.test.MvRxTestRule
 import im.vector.app.features.settings.devices.v2.DeviceFullInfo
 import im.vector.app.features.settings.devices.v2.IsCurrentSessionUseCase
 import im.vector.app.features.settings.devices.v2.verification.CheckIfCurrentSessionCanBeVerifiedUseCase
+import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.test
 import im.vector.app.test.testDispatcher
 import io.mockk.coEvery
@@ -44,12 +45,14 @@ class SessionOverviewViewModelTest {
     private val args = SessionOverviewArgs(
             deviceId = A_SESSION_ID_1
     )
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
     private val isCurrentSessionUseCase = mockk<IsCurrentSessionUseCase>()
     private val getDeviceFullInfoUseCase = mockk<GetDeviceFullInfoUseCase>()
     private val checkIfCurrentSessionCanBeVerifiedUseCase = mockk<CheckIfCurrentSessionCanBeVerifiedUseCase>()
 
     private fun createViewModel() = SessionOverviewViewModel(
             initialState = SessionOverviewViewState(args),
+            activeSessionHolder = fakeActiveSessionHolder.instance,
             isCurrentSessionUseCase = isCurrentSessionUseCase,
             getDeviceFullInfoUseCase = getDeviceFullInfoUseCase,
             checkIfCurrentSessionCanBeVerifiedUseCase = checkIfCurrentSessionCanBeVerifiedUseCase,

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
@@ -95,7 +95,7 @@ class SessionOverviewViewModelTest {
 
         // Then
         viewModelTest
-                .assertEvent { it is SessionOverviewViewEvent.SelfVerification }
+                .assertEvent { it is SessionOverviewViewEvent.ShowVerifyCurrentSession }
                 .finish()
         coVerify {
             checkIfCurrentSessionCanBeVerifiedUseCase.execute()
@@ -123,5 +123,24 @@ class SessionOverviewViewModelTest {
         coVerify {
             checkIfCurrentSessionCanBeVerifiedUseCase.execute()
         }
+    }
+
+    @Test
+    fun `given another session when handling verify session action then verify session event is posted`() {
+        // Given
+        val deviceFullInfo = mockk<DeviceFullInfo>()
+        every { getDeviceFullInfoUseCase.execute(A_SESSION_ID) } returns flowOf(deviceFullInfo)
+        every { isCurrentSessionUseCase.execute(any()) } returns false
+        val verifySessionAction = SessionOverviewAction.VerifySession(A_SESSION_ID)
+
+        // When
+        val viewModel = createViewModel()
+        val viewModelTest = viewModel.test()
+        viewModel.handle(verifySessionAction)
+
+        // Then
+        viewModelTest
+                .assertEvent { it is SessionOverviewViewEvent.ShowVerifyOtherSession }
+                .finish()
     }
 }

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetCurrentSessionCrossSigningInfoUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetCurrentSessionCrossSigningInfoUseCaseTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.devices.v2
+package im.vector.app.features.settings.devices.v2.verification
 
 import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.fakes.FakeSession

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetCurrentSessionCrossSigningInfoUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetCurrentSessionCrossSigningInfoUseCaseTest.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.matrix.android.sdk.api.auth.data.SessionParams
 import org.matrix.android.sdk.api.session.crypto.crosssigning.MXCrossSigningInfo
 import org.matrix.android.sdk.api.util.toOptional
 

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetCurrentSessionCrossSigningInfoUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetCurrentSessionCrossSigningInfoUseCaseTest.kt
@@ -107,11 +107,8 @@ class GetCurrentSessionCrossSigningInfoUseCaseTest {
     }
 
     private fun givenSession(deviceId: String): FakeSession {
-        val sessionParams = mockk<SessionParams>()
-        every { sessionParams.deviceId } returns deviceId
-
         val fakeSession = fakeActiveSessionHolder.fakeSession
-        fakeSession.givenSessionParams(sessionParams)
+        fakeSession.givenSessionId(deviceId)
 
         return fakeSession
     }

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForCurrentDeviceUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForCurrentDeviceUseCaseTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.devices.v2
+package im.vector.app.features.settings.devices.v2.verification
 
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForDeviceUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForDeviceUseCaseTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.devices.v2
+package im.vector.app.features.settings.devices.v2.verification
 
 import io.mockk.every
 import io.mockk.mockk

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForOtherDeviceUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForOtherDeviceUseCaseTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.devices.v2
+package im.vector.app.features.settings.devices.v2.verification
 
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeSession.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeSession.kt
@@ -78,6 +78,13 @@ class FakeSession(
         every { this@FakeSession.sessionParams } returns sessionParams
     }
 
+    fun givenSessionId(sessionId: String): SessionParams {
+        val sessionParams = mockk<SessionParams>()
+        every { sessionParams.deviceId } returns sessionId
+        givenSessionParams(sessionParams)
+        return sessionParams
+    }
+
     /**
      * Do not forget to call mockkStatic("org.matrix.android.sdk.flow.FlowSessionKt") in the setup method of the tests.
      */


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Handling click on the "Verify" button in the session overview screen for other session than the current one.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7143 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

No UI changed.

## Tests

<!-- Explain how you tested your development -->

- Enable the new device management feature flag
- Go to Settings -> Security & Privacy -> Show All Sessions (V2, WIP)
- Find another session which is not verified
- Go to the session overview screen
- Check the "Verify" button is only visible when the current signed in session is verified
- Press the "Verify" button
- Check the verification request is received in the other session

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
