### PR TITLE
Fix build cache misses

### DIFF
--- a/changelog.d/7157.misc
+++ b/changelog.d/7157.misc
@@ -1,0 +1,1 @@
+Fixing build cache misses when compiling the vector module

--- a/library/ui-strings/build.gradle
+++ b/library/ui-strings/build.gradle
@@ -20,3 +20,7 @@ android {
         jvmTarget = "11"
     }
 }
+
+tasks.withType( com.likethesalad.android.templates.common.tasks.BaseTask) {
+    it.outputs.cacheIf { true }
+}


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Forcing the stem string template generator tasks to be cachable, without this the templates are regenerated causing the `vector` module to recompile its sources (our slowest task!)

## Motivation and context

The build cache was enabled by default with #6788 but the `vector` module was getting constant cache misses when the `library/ui-strings` executed it's generator tasks 

## Screenshots / GIFs
N/A

## Tests

Compile the project twice (on a branch other than develop)

```
./gradlew clean assembleGplayDebug // 3 minutes
./gradlew clean assembleGplayDebug // 18 seconds
```

## Tested devices
N/A
