### PR TITLE
Enables New App Layout in Labs

### DIFF
--- a/changelog.d/7166.misc
+++ b/changelog.d/7166.misc
@@ -1,0 +1,1 @@
+New App Layout is now enabled by default! Go to the Settings > Labs to toggle this

--- a/vector-app/src/androidTest/java/im/vector/app/VerifySessionInteractiveTest.kt
+++ b/vector-app/src/androidTest/java/im/vector/app/VerifySessionInteractiveTest.kt
@@ -225,8 +225,8 @@ class VerifySessionInteractiveTest : VerificationTestBase() {
 
         // Wait until local secrets are known (gossip)
         withIdlingResource(allSecretsKnownIdling(uiSession)) {
-            onView(withId(R.id.groupToolbarAvatarImageView))
-                    .perform(click())
+            onView(withId(R.id.roomListContainer))
+                    .check(matches(isDisplayed()))
         }
     }
 

--- a/vector-app/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
+++ b/vector-app/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
@@ -50,7 +50,7 @@ import im.vector.app.withIdlingResource
 import timber.log.Timber
 
 class ElementRobot(
-        private val labsPreferences: LabFeaturesPreferences = LabFeaturesPreferences(false)
+        private val labsPreferences: LabFeaturesPreferences = LabFeaturesPreferences(true)
 ) {
     fun onboarding(block: OnboardingRobot.() -> Unit) {
         block(OnboardingRobot())

--- a/vector-config/src/main/res/values/config-settings.xml
+++ b/vector-config/src/main/res/values/config-settings.xml
@@ -38,7 +38,7 @@
 
     <!-- Level 1: Labs -->
     <bool name="settings_labs_thread_messages_default">false</bool>
-    <bool name="settings_labs_new_app_layout_default">false</bool>
+    <bool name="settings_labs_new_app_layout_default">true</bool>
     <bool name="settings_timeline_show_live_sender_info_visible">true</bool>
     <bool name="settings_timeline_show_live_sender_info_default">false</bool>
     <!-- Level 1: Advanced settings -->


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Enables New App Layout in Labs (set default to true)

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/7165

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

Test this branch from having the labs flag disabled or clear your data and start the app from a fresh install. See that new app layout is enabled by default

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
