### PR TITLE
Fix regression on our dependency, due to merge of #6788.

### DIFF
--- a/vector-app/build.gradle
+++ b/vector-app/build.gradle
@@ -372,7 +372,7 @@ dependencies {
 
     gplayImplementation "com.google.android.gms:play-services-location:20.0.0"
     // UnifiedPush gplay flavor only
-    gplayImplementation('com.github.UnifiedPush:android-embedded_fcm_distributor:2.1.2') {
+    gplayImplementation('com.google.firebase:firebase-messaging:23.0.8') {
         exclude group: 'com.google.firebase', module: 'firebase-core'
         exclude group: 'com.google.firebase', module: 'firebase-analytics'
         exclude group: 'com.google.firebase', module: 'firebase-measurement-connector'


### PR DESCRIPTION
We do not use `android-embedded_fcm_distributor` anymore (since #7068). The code was compiling because `android-embedded_fcm_distributor` has a dependency on `firebase-messaging`.

No need for a changelog, since the code is not released.