### PR TITLE
Show release experience screen on app update

### DIFF
--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -119,17 +119,19 @@ class HomeActivityViewModel @AssistedInject constructor(
     }
 
     private fun observeReleaseNotes() = withState { state ->
-        // we don't want to show release notes for new users or after relogin
-        if (state.authenticationDescription == null && vectorPreferences.isNewAppLayoutEnabled()) {
-            releaseNotesPreferencesStore.appLayoutOnboardingShown.onEach { isAppLayoutOnboardingShown ->
-                if (!isAppLayoutOnboardingShown) {
-                    _viewEvents.post(HomeActivityViewEvents.ShowReleaseNotes)
+        if (vectorPreferences.isNewAppLayoutEnabled()) {
+            // we don't want to show release notes for new users or after relogin
+            if (state.authenticationDescription == null) {
+                releaseNotesPreferencesStore.appLayoutOnboardingShown.onEach { isAppLayoutOnboardingShown ->
+                    if (!isAppLayoutOnboardingShown) {
+                        _viewEvents.post(HomeActivityViewEvents.ShowReleaseNotes)
+                    }
+                }.launchIn(viewModelScope)
+            } else {
+                // we assume that users which came from auth flow either have seen updates already (relogin) or don't need them (new user)
+                viewModelScope.launch {
+                    releaseNotesPreferencesStore.setAppLayoutOnboardingShown(true)
                 }
-            }.launchIn(viewModelScope)
-        } else {
-            // we assume that users which came from auth flow either have seen updates already (relogin) or don't need them (new user)
-            viewModelScope.launch {
-                releaseNotesPreferencesStore.setAppLayoutOnboardingShown(true)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/release/ReleaseNotesPreferencesStore.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/release/ReleaseNotesPreferencesStore.kt
@@ -34,7 +34,7 @@ class ReleaseNotesPreferencesStore @Inject constructor(
         private val context: Context
 ) {
 
-    private val isAppLayoutOnboardingShown = booleanPreferencesKey("SETTINGS_APP_LAYOUT_ONBOARDING_SHOWN")
+    private val isAppLayoutOnboardingShown = booleanPreferencesKey("SETTINGS_APP_LAYOUT_ONBOARDING_DISPLAYED")
 
     val appLayoutOnboardingShown: Flow<Boolean> = context.dataStore.data
             .map { preferences -> preferences[isAppLayoutOnboardingShown].orFalse() }


### PR DESCRIPTION


<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

release notes screen is not shown shown on update to a version with app layout labs flag enabled by default

## Motivation and context

closes #7174

