### PR TITLE
add qr code option to home screen menu

### DIFF
--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -84,6 +84,7 @@ import im.vector.app.features.spaces.SpaceSettingsMenuBottomSheet
 import im.vector.app.features.spaces.invite.SpaceInviteBottomSheet
 import im.vector.app.features.spaces.share.ShareSpaceBottomSheet
 import im.vector.app.features.themes.ThemeUtils
+import im.vector.app.features.usercode.UserCodeActivity
 import im.vector.app.features.workers.signout.ServerBackupStatusViewModel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -634,8 +635,16 @@ class HomeActivity :
                 launchInviteFriends()
                 true
             }
+            R.id.menu_home_qr -> {
+                launchQrCode()
+                true
+            }
             else -> false
         }
+    }
+
+    private fun launchQrCode() {
+        startActivity(UserCodeActivity.newIntent(this, sharedActionViewModel.session.myUserId))
     }
 
     private fun launchInviteFriends() {

--- a/vector/src/main/res/menu/menu_new_home.xml
+++ b/vector/src/main/res/menu/menu_new_home.xml
@@ -13,6 +13,11 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/menu_home_qr"
+        android:title="@string/add_by_qr_code"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/menu_home_suggestion"
         android:icon="@drawable/ic_material_bug_report"
         android:title="@string/send_suggestion"
@@ -42,5 +47,7 @@
         android:title="@string/home_filter_placeholder_home"
         app:iconTint="?vctr_content_secondary"
         app:showAsAction="ifRoom" />
+
+
 
 </menu>

--- a/vector/src/main/res/menu/menu_new_home.xml
+++ b/vector/src/main/res/menu/menu_new_home.xml
@@ -47,7 +47,4 @@
         android:title="@string/home_filter_placeholder_home"
         app:iconTint="?vctr_content_secondary"
         app:showAsAction="ifRoom" />
-
-
-
 </menu>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

before new app layout we had "add by QR code" image button inside the drawer. Since we don't have drawer in new layour, we need to put corresponding option to a home screen's menu (three dots)

## Motivation and context

closes #7176

## Screenshots / GIFs

![Screenshot 2022-09-19 at 20 51 27](https://user-images.githubusercontent.com/66663241/191093374-f01a4ca2-7d7e-40cb-9763-c7cb93c8fa24.png)
