### PR TITLE
Deferred DMs - Add and enable the feature by default in the labs settings

### DIFF
--- a/changelog.d/7180.feature
+++ b/changelog.d/7180.feature
@@ -1,0 +1,1 @@
+Deferred DMs - Enable and move the feature to labs settings

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -442,6 +442,9 @@
     <string name="labs_enable_new_app_layout_title">Enable new layout</string>
     <string name="labs_enable_new_app_layout_summary">A simplified Element with optional tabs</string>
 
+    <string name="labs_enable_deferred_dm_title">Enable deferred DMs</string>
+    <string name="labs_enable_deferred_dm_summary">Direct rooms will be created after sending a first message.</string>
+
     <!-- Home fragment -->
     <string name="invitations_header">Invites</string>
     <string name="low_priority_header">Low priority</string>

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -443,7 +443,7 @@
     <string name="labs_enable_new_app_layout_summary">A simplified Element with optional tabs</string>
 
     <string name="labs_enable_deferred_dm_title">Enable deferred DMs</string>
-    <string name="labs_enable_deferred_dm_summary">Direct rooms will be created after sending a first message.</string>
+    <string name="labs_enable_deferred_dm_summary">Create DM only on first message</string>
 
     <!-- Home fragment -->
     <string name="invitations_header">Invites</string>

--- a/vector-app/src/debug/java/im/vector/app/features/debug/features/DebugFeaturesStateFactory.kt
+++ b/vector-app/src/debug/java/im/vector/app/features/debug/features/DebugFeaturesStateFactory.kt
@@ -81,11 +81,6 @@ class DebugFeaturesStateFactory @Inject constructor(
                                 factory = VectorFeatures::forceUsageOfOpusEncoder
                         ),
                         createBooleanFeature(
-                                label = "Start DM on first message",
-                                key = DebugFeatureKeys.startDmOnFirstMsg,
-                                factory = VectorFeatures::shouldStartDmOnFirstMessage
-                        ),
-                        createBooleanFeature(
                                 label = "Enable New App Layout",
                                 key = DebugFeatureKeys.newAppLayoutEnabled,
                                 factory = VectorFeatures::isNewAppLayoutFeatureEnabled

--- a/vector-app/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
+++ b/vector-app/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
@@ -73,9 +73,6 @@ class DebugVectorFeatures(
     override fun forceUsageOfOpusEncoder(): Boolean = read(DebugFeatureKeys.forceUsageOfOpusEncoder)
             ?: vectorFeatures.forceUsageOfOpusEncoder()
 
-    override fun shouldStartDmOnFirstMessage(): Boolean = read(DebugFeatureKeys.startDmOnFirstMsg)
-            ?: vectorFeatures.shouldStartDmOnFirstMessage()
-
     override fun isNewAppLayoutFeatureEnabled(): Boolean = read(DebugFeatureKeys.newAppLayoutEnabled)
             ?: vectorFeatures.isNewAppLayoutFeatureEnabled()
 

--- a/vector-config/src/main/res/values/config-settings.xml
+++ b/vector-config/src/main/res/values/config-settings.xml
@@ -37,6 +37,7 @@
     <bool name="settings_ignored_users_visible">true</bool>
 
     <!-- Level 1: Labs -->
+    <bool name="settings_labs_deferred_dm_default">true</bool>
     <bool name="settings_labs_thread_messages_default">false</bool>
     <bool name="settings_labs_new_app_layout_default">true</bool>
     <bool name="settings_timeline_show_live_sender_info_visible">true</bool>

--- a/vector-config/src/main/res/values/config-settings.xml
+++ b/vector-config/src/main/res/values/config-settings.xml
@@ -37,6 +37,7 @@
     <bool name="settings_ignored_users_visible">true</bool>
 
     <!-- Level 1: Labs -->
+    <bool name="settings_labs_deferred_dm_visible">true</bool>
     <bool name="settings_labs_deferred_dm_default">true</bool>
     <bool name="settings_labs_thread_messages_default">false</bool>
     <bool name="settings_labs_new_app_layout_default">true</bool>

--- a/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
+++ b/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
@@ -33,7 +33,6 @@ interface VectorFeatures {
     fun isScreenSharingEnabled(): Boolean
     fun isLocationSharingEnabled(): Boolean
     fun forceUsageOfOpusEncoder(): Boolean
-    fun shouldStartDmOnFirstMessage(): Boolean
 
     /**
      * This is only to enable if the labs flag should be visible and effective.
@@ -56,7 +55,6 @@ class DefaultVectorFeatures : VectorFeatures {
     override fun isScreenSharingEnabled(): Boolean = true
     override fun isLocationSharingEnabled() = Config.ENABLE_LOCATION_SHARING
     override fun forceUsageOfOpusEncoder(): Boolean = false
-    override fun shouldStartDmOnFirstMessage(): Boolean = false
     override fun isNewAppLayoutFeatureEnabled(): Boolean = true
     override fun isNewDeviceManagementEnabled(): Boolean = false
 }

--- a/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/CreateDirectRoomViewModel.kt
@@ -26,11 +26,11 @@ import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.mvrx.runCatchingToAsync
 import im.vector.app.core.platform.VectorViewModel
-import im.vector.app.features.VectorFeatures
 import im.vector.app.features.analytics.AnalyticsTracker
 import im.vector.app.features.analytics.plan.CreatedRoom
 import im.vector.app.features.raw.wellknown.getElementWellknown
 import im.vector.app.features.raw.wellknown.isE2EByDefault
+import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.userdirectory.PendingSelection
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -45,9 +45,9 @@ import org.matrix.android.sdk.api.session.room.model.create.CreateRoomParams
 class CreateDirectRoomViewModel @AssistedInject constructor(
         @Assisted initialState: CreateDirectRoomViewState,
         private val rawService: RawService,
+        private val vectorPreferences: VectorPreferences,
         val session: Session,
         val analyticsTracker: AnalyticsTracker,
-        val vectorFeatures: VectorFeatures
 ) :
         VectorViewModel<CreateDirectRoomViewState, CreateDirectRoomAction, CreateDirectRoomViewEvents>(initialState) {
 
@@ -124,7 +124,7 @@ class CreateDirectRoomViewModel @AssistedInject constructor(
                     }
 
             val result = runCatchingToAsync {
-                if (vectorFeatures.shouldStartDmOnFirstMessage()) {
+                if (vectorPreferences.isDeferredDmEnabled()) {
                     session.roomService().createLocalRoom(roomParams)
                 } else {
                     analyticsTracker.capture(CreatedRoom(isDM = roomParams.isDirect.orFalse()))

--- a/vector/src/main/java/im/vector/app/features/createdirect/DirectRoomHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/createdirect/DirectRoomHelper.kt
@@ -16,11 +16,11 @@
 
 package im.vector.app.features.createdirect
 
-import im.vector.app.features.VectorFeatures
 import im.vector.app.features.analytics.AnalyticsTracker
 import im.vector.app.features.analytics.plan.CreatedRoom
 import im.vector.app.features.raw.wellknown.getElementWellknown
 import im.vector.app.features.raw.wellknown.isE2EByDefault
+import im.vector.app.features.settings.VectorPreferences
 import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.raw.RawService
@@ -32,7 +32,7 @@ class DirectRoomHelper @Inject constructor(
         private val rawService: RawService,
         private val session: Session,
         private val analyticsTracker: AnalyticsTracker,
-        private val vectorFeatures: VectorFeatures,
+        private val vectorPreferences: VectorPreferences,
 ) {
 
     suspend fun ensureDMExists(userId: String): String {
@@ -50,7 +50,7 @@ class DirectRoomHelper @Inject constructor(
                 setDirectMessage()
                 enableEncryptionIfInvitedUsersSupportIt = adminE2EByDefault
             }
-            roomId = if (vectorFeatures.shouldStartDmOnFirstMessage()) {
+            roomId = if (vectorPreferences.isDeferredDmEnabled()) {
                 session.roomService().createLocalRoom(roomParams)
             } else {
                 analyticsTracker.capture(CreatedRoom(isDM = roomParams.isDirect.orFalse()))

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -39,6 +39,7 @@ import im.vector.app.core.utils.BehaviorDataSource
 import im.vector.app.features.analytics.AnalyticsTracker
 import im.vector.app.features.analytics.DecryptionFailureTracker
 import im.vector.app.features.analytics.extensions.toAnalyticsJoinedRoom
+import im.vector.app.features.analytics.plan.CreatedRoom
 import im.vector.app.features.analytics.plan.JoinedRoom
 import im.vector.app.features.call.conference.ConferenceEvent
 import im.vector.app.features.call.conference.JitsiActiveConferenceHolder
@@ -78,6 +79,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.matrix.android.sdk.api.MatrixPatterns
+import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.query.QueryStringValue
 import org.matrix.android.sdk.api.raw.RawService
@@ -1247,8 +1249,12 @@ class TimelineViewModel @AssistedInject constructor(
                             LocalRoomCreationState.FAILURE -> {
                                 _viewEvents.post(RoomDetailViewEvents.HideWaitingView)
                             }
-                            LocalRoomCreationState.CREATED ->
-                                _viewEvents.post(RoomDetailViewEvents.OpenRoom(room.localRoomSummary()?.replacementRoomId!!, true))
+                            LocalRoomCreationState.CREATED -> {
+                                room.localRoomSummary()?.let {
+                                    analyticsTracker.capture(CreatedRoom(isDM = it.roomSummary?.isDirect.orFalse()))
+                                    _viewEvents.post(RoomDetailViewEvents.OpenRoom(it.replacementRoomId!!, true))
+                                }
+                            }
                         }
                     }
                     .launchIn(viewModelScope)

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -66,6 +66,7 @@ class VectorPreferences @Inject constructor(
         const val SETTINGS_BACKGROUND_SYNC_DIVIDER_PREFERENCE_KEY = "SETTINGS_BACKGROUND_SYNC_DIVIDER_PREFERENCE_KEY"
         const val SETTINGS_LABS_PREFERENCE_KEY = "SETTINGS_LABS_PREFERENCE_KEY"
         const val SETTINGS_LABS_NEW_APP_LAYOUT_KEY = "SETTINGS_LABS_NEW_APP_LAYOUT_KEY"
+        const val SETTINGS_LABS_DEFERRED_DM_KEY = "SETTINGS_LABS_DEFERRED_DM_KEY"
         const val SETTINGS_CRYPTOGRAPHY_PREFERENCE_KEY = "SETTINGS_CRYPTOGRAPHY_PREFERENCE_KEY"
         const val SETTINGS_CRYPTOGRAPHY_DIVIDER_PREFERENCE_KEY = "SETTINGS_CRYPTOGRAPHY_DIVIDER_PREFERENCE_KEY"
         const val SETTINGS_CRYPTOGRAPHY_MANAGE_PREFERENCE_KEY = "SETTINGS_CRYPTOGRAPHY_MANAGE_PREFERENCE_KEY"
@@ -1160,6 +1161,13 @@ class VectorPreferences @Inject constructor(
     fun isNewAppLayoutEnabled(): Boolean {
         return vectorFeatures.isNewAppLayoutFeatureEnabled() &&
                 defaultPrefs.getBoolean(SETTINGS_LABS_NEW_APP_LAYOUT_KEY, getDefault(R.bool.settings_labs_new_app_layout_default))
+    }
+
+    /**
+     * Indicates whether or not deferred DMs are enabled.
+     */
+    fun isDeferredDmEnabled(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_LABS_DEFERRED_DM_KEY, getDefault(R.bool.settings_labs_deferred_dm_default))
     }
 
     fun showLiveSenderInfo(): Boolean {

--- a/vector/src/main/res/xml/vector_settings_labs.xml
+++ b/vector/src/main/res/xml/vector_settings_labs.xml
@@ -47,8 +47,8 @@
 
     <im.vector.app.core.preference.VectorSwitchPreference
         android:defaultValue="false"
-        android:persistent="false"
         android:key="SETTINGS_LABS_MSC3061_SHARE_KEYS_HISTORY"
+        android:persistent="false"
         android:summary="@string/labs_enable_msc3061_share_history_desc"
         android:title="@string/labs_enable_msc3061_share_history" />
 
@@ -93,6 +93,7 @@
         android:defaultValue="@bool/settings_labs_deferred_dm_default"
         android:key="SETTINGS_LABS_DEFERRED_DM_KEY"
         android:summary="@string/labs_enable_deferred_dm_summary"
-        android:title="@string/labs_enable_deferred_dm_title" />
+        android:title="@string/labs_enable_deferred_dm_title"
+        app:isPreferenceVisible="@bool/settings_labs_deferred_dm_visible" />
 
 </androidx.preference.PreferenceScreen>

--- a/vector/src/main/res/xml/vector_settings_labs.xml
+++ b/vector/src/main/res/xml/vector_settings_labs.xml
@@ -89,4 +89,10 @@
         android:summary="@string/labs_enable_new_app_layout_summary"
         android:title="@string/labs_enable_new_app_layout_title" />
 
+    <im.vector.app.core.preference.VectorSwitchPreference
+        android:defaultValue="@bool/settings_labs_deferred_dm_default"
+        android:key="SETTINGS_LABS_DEFERRED_DM_KEY"
+        android:summary="@string/labs_enable_deferred_dm_summary"
+        android:title="@string/labs_enable_deferred_dm_title" />
+
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
## Type of change

- [X] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Add the deferred DMs feature in the labs settings, enabled by default

## Motivation and context

Release #5525

## Screenshots / GIFs

<img width="522" alt="image" src="https://user-images.githubusercontent.com/11990514/191201120-a53c2e21-d2bf-40f5-928d-33fbb89ddbfb.png">

## Tests

1. Play with the labs setting (default / disabled / enabled)
2. Create a DM

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [X] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
