### PR TITLE
Check if using `UiAutomation.grantRuntimePermission()` instead of rule fixes tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          # emulator-build: 7425822
+          emulator-build: 7425822
           script: |
             ./gradlew gatherGplayDebugStringTemplates $CI_GRADLE_ARG_PROPERTIES
             ./gradlew unitTestsWithCoverage $CI_GRADLE_ARG_PROPERTIES
@@ -129,26 +129,26 @@ jobs:
 # Unneeded as part of the test suite above, kept around in case we want to re-enable them.
 #
 #  # Build Android Tests
-#  build-android-tests: 
-#    name: Build Android Tests 
-#    runs-on: ubuntu-latest 
+#  build-android-tests:
+#    name: Build Android Tests
+#    runs-on: ubuntu-latest
 #    concurrency:
 #      group: ${{ github.ref == 'refs/heads/main' && format('unit-tests-main-{0}', github.sha) || github.ref == 'refs/heads/develop' && format('unit-tests-develop-{0}', github.sha) || format('build-android-tests-{0}', github.ref) }}
 #      cancel-in-progress: true
-#    steps: 
-#      - uses: actions/checkout@v3 
-#      - uses: actions/setup-java@v3 
-#        with: 
-#          distribution: 'adopt' 
-#          java-version: 11 
-#      - uses: actions/cache@v3 
-#        with: 
-#          path: | 
-#            ~/.gradle/caches 
-#            ~/.gradle/wrapper 
-#          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }} 
-#          restore-keys: | 
-#            ${{ runner.os }}-gradle- 
-#      - name: Build Android Tests  
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: actions/setup-java@v3
+#        with:
+#          distribution: 'adopt'
+#          java-version: 11
+#      - uses: actions/cache@v3
+#        with:
+#          path: |
+#            ~/.gradle/caches
+#            ~/.gradle/wrapper
+#          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+#          restore-keys: |
+#            ${{ runner.os }}-gradle-
+#      - name: Build Android Tests
 #        run: ./gradlew clean assembleAndroidTest $CI_GRADLE_ARG_PROPERTIES
 

--- a/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderLTests.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderLTests.kt
@@ -18,7 +18,6 @@ package im.vector.app.features.voice
 
 import android.Manifest
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.GrantPermissionRule
 import io.mockk.spyk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -26,17 +25,19 @@ import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldExist
 import org.amshove.kluent.shouldNotBeNull
 import org.amshove.kluent.shouldNotExist
-import org.junit.Rule
+import org.junit.Before
 import org.junit.Test
 import java.io.File
 
 class VoiceRecorderLTests {
 
-    @get:Rule
-    val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.RECORD_AUDIO)
-
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private val recorder = spyk(VoiceRecorderL(context, Dispatchers.IO))
+
+    @Before
+    fun setup() {
+        InstrumentationRegistry.getInstrumentation().uiAutomation.grantRuntimePermission(context.packageName, Manifest.permission.RECORD_AUDIO)
+    }
 
     @Test
     fun startRecordCreatesOggFile() = with(recorder) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
