### PR TITLE
[Bugfix] Fix crash on previewing image to upload on Android P

### DIFF
--- a/changelog.d/7184.bugfix
+++ b/changelog.d/7184.bugfix
@@ -1,0 +1,1 @@
+Fix crash on previewing images to upload on Android Pie.

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/ImageUtils.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/ImageUtils.kt
@@ -32,9 +32,9 @@ object ImageUtils {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 val source = ImageDecoder.createSource(context.contentResolver, uri)
                 val listener = ImageDecoder.OnHeaderDecodedListener { decoder, _, _ ->
-                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.P) {
                         // Allocating hardware bitmap may cause a crash on framework versions prior to Android Q
-                        decoder.setAllocator(ImageDecoder.ALLOCATOR_SOFTWARE)
+                        decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
                     }
                 }
 

--- a/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/ImageUtils.kt
+++ b/library/multipicker/src/main/java/im/vector/lib/multipicker/utils/ImageUtils.kt
@@ -30,7 +30,15 @@ object ImageUtils {
     fun getBitmap(context: Context, uri: Uri): Bitmap? {
         return try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                ImageDecoder.decodeBitmap(ImageDecoder.createSource(context.contentResolver, uri))
+                val source = ImageDecoder.createSource(context.contentResolver, uri)
+                val listener = ImageDecoder.OnHeaderDecodedListener { decoder, _, _ ->
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                        // Allocating hardware bitmap may cause a crash on framework versions prior to Android Q
+                        decoder.setAllocator(ImageDecoder.ALLOCATOR_SOFTWARE)
+                    }
+                }
+
+                ImageDecoder.decodeBitmap(source, listener)
             } else {
                 context.contentResolver.openInputStream(uri)?.use { inputStream ->
                     BitmapFactory.decodeStream(inputStream)


### PR DESCRIPTION

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

Closes #1404, closes #1851, closes #4545

## Content

Use software bitmap allocation when previewing images to upload on devices with Android Pie.

## Motivation and context

Using hardware bitmap allocation on Android framework versions prior to Android Q causes a crash when decoding a bitmap if GL context wasn't initialised. The issue is not documented in ImageDecoder reference but it is mentioned in the comments of glide[1] with a link to internal google discussion.

[1] https://github.com/bumptech/glide/blob/f83cc274b42cf02af6611d2a8c21e4a9b1f5d592/library/src/main/java/com/bumptech/glide/load/resource/bitmap/HardwareConfigState.java#L22

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

1. Sending images from within Element
    - select "send images and videos" from attachment picker
    - select image that caused a native crash on develop branch

2. Sharing images to Element from external app
    - share an image from gallery app to Element

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 9

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
