### PR TITLE
Fixes Room List not getting updated when fragment is not in focus

### DIFF
--- a/changelog.d/7186.bugfix
+++ b/changelog.d/7186.bugfix
@@ -1,0 +1,1 @@
+Fixes Room List not getting updated when fragment is not in focus

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeFilteredRoomsController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeFilteredRoomsController.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.features.home.room.list.home
 
+import androidx.paging.PagedList
 import com.airbnb.epoxy.EpoxyModel
 import com.airbnb.epoxy.paging.PagedListEpoxyController
 import im.vector.app.core.platform.StateView
@@ -73,6 +74,13 @@ class HomeFilteredRoomsController @Inject constructor(
 
     fun submitEmptyStateData(state: StateView.State.Empty?) {
         this.emptyStateData = state
+    }
+
+    fun submitPagedList(newList: PagedList<RoomSummary>) {
+        submitList(newList)
+        if (newList.isEmpty()) {
+            requestForcedModelBuild()
+        }
     }
 
     override fun buildItemModel(currentPosition: Int, item: RoomSummary?): EpoxyModel<*> {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
@@ -152,10 +152,10 @@ class HomeRoomListFragment :
             headersController.submitData(it)
         }
 
-        roomListViewModel.onEach(HomeRoomListViewState::roomsLivePagedList) { roomsListLive ->
-            roomsListLive?.observe(viewLifecycleOwner) { roomsList ->
-                roomsController.submitList(roomsList)
-                if (roomsList.isEmpty()) {
+        roomListViewModel.onEach(HomeRoomListViewState::roomsLivePagedList) { roomsList ->
+            roomsList?.let {
+                roomsController.submitList(it)
+                if (it.isEmpty()) {
                     roomsController.requestForcedModelBuild()
                 }
             }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
@@ -152,7 +152,7 @@ class HomeRoomListFragment :
             headersController.submitData(it)
         }
 
-        roomListViewModel.onEach(HomeRoomListViewState::roomsLivePagedList) { roomsList ->
+        roomListViewModel.onEach(HomeRoomListViewState::roomsPagedList) { roomsList ->
             roomsList?.let {
                 roomsController.submitList(it)
                 if (it.isEmpty()) {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListFragment.kt
@@ -154,7 +154,7 @@ class HomeRoomListFragment :
 
         roomListViewModel.onEach(HomeRoomListViewState::roomsPagedList) { roomsList ->
             roomsList?.let {
-                roomsController.submitList(it)
+                roomsController.submitPagedList(it)
                 if (it.isEmpty()) {
                     roomsController.requestForcedModelBuild()
                 }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewModel.kt
@@ -259,7 +259,7 @@ class HomeRoomListViewModel @AssistedInject constructor(
         liveResults.livePagedList
                 .asFlow()
                 .onEach {
-                    setState { copy(roomsLivePagedList = it) }
+                    setState { copy(roomsPagedList = it) }
                 }
                 .flowOn(Dispatchers.Default)
                 .launchIn(viewModelScope)

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewModel.kt
@@ -19,7 +19,6 @@ package im.vector.app.features.home.room.list.home
 import android.widget.ImageView
 import androidx.lifecycle.asFlow
 import androidx.paging.PagedList
-import arrow.core.Option
 import arrow.core.toOption
 import com.airbnb.mvrx.MavericksViewModelFactory
 import dagger.assisted.Assisted
@@ -37,7 +36,6 @@ import im.vector.app.features.displayname.getBestName
 import im.vector.app.features.home.room.list.home.header.HomeRoomFilter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -46,7 +44,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -90,7 +87,6 @@ class HomeRoomListViewModel @AssistedInject constructor(
 
     companion object : MavericksViewModelFactory<HomeRoomListViewModel, HomeRoomListViewState> by hiltMavericksViewModelFactory()
 
-    private var roomsFlow: Flow<Option<RoomSummary>>? = null
     private val pagedListConfig = PagedList.Config.Builder()
             .setPageSize(10)
             .setInitialLoadSizeHint(20)
@@ -258,7 +254,6 @@ class HomeRoomListViewModel @AssistedInject constructor(
                     )
                     emitEmptyState()
                 }
-                .also { roomsFlow = it }
                 .launchIn(viewModelScope)
 
         roomsFlowJob?.cancel(CancellationException())
@@ -268,7 +263,6 @@ class HomeRoomListViewModel @AssistedInject constructor(
                 .onEach {
                     setState { copy(roomsPagedList = it) }
                 }
-                .flowOn(Dispatchers.Default)
                 .launchIn(viewModelScope)
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewModel.kt
@@ -17,6 +17,7 @@
 package im.vector.app.features.home.room.list.home
 
 import android.widget.ImageView
+import androidx.lifecycle.asFlow
 import androidx.paging.PagedList
 import arrow.core.Option
 import arrow.core.toOption
@@ -43,6 +44,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -254,7 +256,13 @@ class HomeRoomListViewModel @AssistedInject constructor(
                 .also { roomsFlow = it }
                 .launchIn(viewModelScope)
 
-        setState { copy(roomsLivePagedList = liveResults.livePagedList) }
+        liveResults.livePagedList
+                .asFlow()
+                .onEach {
+                    setState { copy(roomsLivePagedList = it) }
+                }
+                .flowOn(Dispatchers.Default)
+                .launchIn(viewModelScope)
     }
 
     private fun observeOrderPreferences() {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewState.kt
@@ -16,7 +16,6 @@
 
 package im.vector.app.features.home.room.list.home
 
-import androidx.lifecycle.LiveData
 import androidx.paging.PagedList
 import com.airbnb.mvrx.MavericksState
 import im.vector.app.core.platform.StateView
@@ -26,5 +25,5 @@ import org.matrix.android.sdk.api.session.room.model.RoomSummary
 data class HomeRoomListViewState(
         val state: StateView.State = StateView.State.Content,
         val headersData: RoomsHeadersData = RoomsHeadersData(),
-        val roomsLivePagedList: LiveData<PagedList<RoomSummary>>? = null,
+        val roomsLivePagedList: PagedList<RoomSummary>? = null,
 ) : MavericksState

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewState.kt
@@ -25,5 +25,5 @@ import org.matrix.android.sdk.api.session.room.model.RoomSummary
 data class HomeRoomListViewState(
         val state: StateView.State = StateView.State.Content,
         val headersData: RoomsHeadersData = RoomsHeadersData(),
-        val roomsLivePagedList: PagedList<RoomSummary>? = null,
+        val roomsPagedList: PagedList<RoomSummary>? = null,
 ) : MavericksState


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

We had a bug where if you join or leave a room from an activity/fragment other than room list, the list would often not update and would sometimes also crash. This fixes that by converting the room paged list livedata instead of passing livedata in a mavericks state update and observing it there

## Motivation and context

Fixes https://github.com/vector-im/element-android/issues/7152

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open room list
- Go into room
- Leave room from room settings
- Go back to list
- See list is updated

Try the above scenario but also for joining rooms

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
