### PR TITLE
Allow configurable sync timeout

### DIFF
--- a/changelog.d/7198.sdk
+++ b/changelog.d/7198.sdk
@@ -1,0 +1,1 @@
+Allow the sync timeout to be configured (mainly useful for testing)

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/CommonTestHelper.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/CommonTestHelper.kt
@@ -105,7 +105,7 @@ class CommonTestHelper internal constructor(context: Context) {
                     MatrixConfiguration(
                             applicationFlavor = "TestFlavor",
                             roomDisplayNameFallbackProvider = TestRoomDisplayNameFallbackProvider(),
-                            syncConfig = SyncConfig(longPollTimeout = 5_000L)
+                            syncConfig = SyncConfig(longPollTimeout = 5_000L),
                     )
             )
         }

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/CommonTestHelper.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/common/CommonTestHelper.kt
@@ -36,6 +36,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.matrix.android.sdk.api.MatrixCallback
 import org.matrix.android.sdk.api.MatrixConfiguration
+import org.matrix.android.sdk.api.SyncConfig
 import org.matrix.android.sdk.api.auth.data.HomeServerConnectionConfig
 import org.matrix.android.sdk.api.auth.registration.RegistrationResult
 import org.matrix.android.sdk.api.session.Session
@@ -103,7 +104,8 @@ class CommonTestHelper internal constructor(context: Context) {
                     context,
                     MatrixConfiguration(
                             applicationFlavor = "TestFlavor",
-                            roomDisplayNameFallbackProvider = TestRoomDisplayNameFallbackProvider()
+                            roomDisplayNameFallbackProvider = TestRoomDisplayNameFallbackProvider(),
+                            syncConfig = SyncConfig(longPollTimeout = 5_000L)
                     )
             )
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/MatrixConfiguration.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/MatrixConfiguration.kt
@@ -73,5 +73,5 @@ data class MatrixConfiguration(
         /**
          * Sync configuration.
          */
-        val syncConfig: SyncConfig = SyncConfig()
+        val syncConfig: SyncConfig = SyncConfig(),
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/MatrixConfiguration.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/MatrixConfiguration.kt
@@ -70,4 +70,8 @@ data class MatrixConfiguration(
          * List of network interceptors, they will be added when building an OkHttp client.
          */
         val networkInterceptors: List<Interceptor> = emptyList(),
+        /**
+         * Sync configuration.
+         */
+        val syncConfig: SyncConfig = SyncConfig()
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/SyncConfig.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/SyncConfig.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.api
+
+data class SyncConfig(
+        /**
+         * Time to keep sync connection alive for before making another request in milliseconds.
+         */
+        val longPollTimeout: Long = 30_000L
+)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/SyncConfig.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/SyncConfig.kt
@@ -20,5 +20,5 @@ data class SyncConfig(
         /**
          * Time to keep sync connection alive for before making another request in milliseconds.
          */
-        val longPollTimeout: Long = 30_000L
+        val longPollTimeout: Long = 30_000L,
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncThread.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncThread.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.matrix.android.sdk.api.MatrixConfiguration
 import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.failure.isTokenError
@@ -52,7 +53,6 @@ import javax.inject.Inject
 import kotlin.concurrent.schedule
 
 private const val RETRY_WAIT_TIME_MS = 10_000L
-private const val DEFAULT_LONG_POOL_TIMEOUT = 30_000L
 
 private val loggerTag = LoggerTag("SyncThread", LoggerTag.SYNC)
 
@@ -61,7 +61,8 @@ internal class SyncThread @Inject constructor(
         private val networkConnectivityChecker: NetworkConnectivityChecker,
         private val backgroundDetectionObserver: BackgroundDetectionObserver,
         private val activeCallHandler: ActiveCallHandler,
-        private val lightweightSettingsStorage: DefaultLightweightSettingsStorage
+        private val lightweightSettingsStorage: DefaultLightweightSettingsStorage,
+        private val matrixConfiguration: MatrixConfiguration,
 ) : Thread("Matrix-SyncThread"), NetworkConnectivityChecker.Listener, BackgroundDetectionObserver.Listener {
 
     private var state: SyncState = SyncState.Idle
@@ -181,7 +182,7 @@ internal class SyncThread @Inject constructor(
                 val timeout = when {
                     previousSyncResponseHasToDevice -> 0L /* Force timeout to 0 */
                     afterPause -> 0L /* No timeout after a pause */
-                    else -> DEFAULT_LONG_POOL_TIMEOUT
+                    else -> matrixConfiguration.syncConfig.longPollTimeout
                 }
                 Timber.tag(loggerTag.value).d("Execute sync request with timeout $timeout")
                 val presence = lightweightSettingsStorage.getSyncPresenceStatus()

--- a/vector-app/src/androidTest/java/im/vector/app/core/utils/TestMatrixHelper.kt
+++ b/vector-app/src/androidTest/java/im/vector/app/core/utils/TestMatrixHelper.kt
@@ -26,7 +26,7 @@ fun getMatrixInstance(): Matrix {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val configuration = MatrixConfiguration(
             roomDisplayNameFallbackProvider = VectorRoomDisplayNameFallbackProvider(context),
-            syncConfig = SyncConfig(longPollTimeout = 5_000L)
+            syncConfig = SyncConfig(longPollTimeout = 5_000L),
     )
     return Matrix(context, configuration)
 }

--- a/vector-app/src/androidTest/java/im/vector/app/core/utils/TestMatrixHelper.kt
+++ b/vector-app/src/androidTest/java/im/vector/app/core/utils/TestMatrixHelper.kt
@@ -20,11 +20,13 @@ import androidx.test.platform.app.InstrumentationRegistry
 import im.vector.app.features.room.VectorRoomDisplayNameFallbackProvider
 import org.matrix.android.sdk.api.Matrix
 import org.matrix.android.sdk.api.MatrixConfiguration
+import org.matrix.android.sdk.api.SyncConfig
 
 fun getMatrixInstance(): Matrix {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val configuration = MatrixConfiguration(
-            roomDisplayNameFallbackProvider = VectorRoomDisplayNameFallbackProvider(context)
+            roomDisplayNameFallbackProvider = VectorRoomDisplayNameFallbackProvider(context),
+            syncConfig = SyncConfig(longPollTimeout = 5_000L)
     )
     return Matrix(context, configuration)
 }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Allows the sync timeout to be configured via the `MatrixConfiguration`

## Motivation and context

Our instrumentation tests can use a shorter timeout (5 seconds instead of 30 seconds) 

Before: **23m 43s**
After: **16m 39s**

**30% reduction** in runtime, saving around 7 minutes~

## Screenshots / GIFs

|Before|After|
|-|-|
|![2022-09-21T15:28:49,352822323+01:00](https://user-images.githubusercontent.com/1848238/191531870-1040160a-642a-4401-b6b5-2d143cd31d75.png)|![2022-09-21T15:03:35,811981115+01:00](https://user-images.githubusercontent.com/1848238/191526056-b577e5a2-287a-4ff9-934a-9c4615be863d.png)|
 
## Tests

Run the `./gradlew matrix-sdk-android:connectedAndroidTest`, or all the `matrix-sdk-android androidTest` tests from within Android Studio 

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 31 
