### PR TITLE
Mutualize the pending auth handling (PSG-742)

### DIFF
--- a/changelog.d/7193.misc
+++ b/changelog.d/7193.misc
@@ -1,0 +1,1 @@
+Mutualize the pending auth handling

--- a/vector/src/main/java/im/vector/app/features/auth/PendingAuthHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/auth/PendingAuthHandler.kt
@@ -20,6 +20,7 @@ import im.vector.app.core.di.ActiveSessionHolder
 import org.matrix.android.sdk.api.Matrix
 import org.matrix.android.sdk.api.auth.UIABaseAuth
 import org.matrix.android.sdk.api.auth.UserPasswordAuth
+import org.matrix.android.sdk.api.session.uia.exceptions.UiaCancelledException
 import org.matrix.android.sdk.api.util.fromBase64
 import timber.log.Timber
 import javax.inject.Inject
@@ -62,7 +63,7 @@ class PendingAuthHandler @Inject constructor(
 
     fun reAuthCancelled() {
         Timber.d("reAuthCancelled")
-        uiaContinuation?.resumeWithException(Exception())
+        uiaContinuation?.resumeWithException(UiaCancelledException())
         uiaContinuation = null
         pendingAuth = null
     }

--- a/vector/src/main/java/im/vector/app/features/auth/PendingAuthHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/auth/PendingAuthHandler.kt
@@ -32,15 +32,15 @@ class PendingAuthHandler @Inject constructor(
         private val matrix: Matrix,
         private val activeSessionHolder: ActiveSessionHolder,
 ) {
-
     var uiaContinuation: Continuation<UIABaseAuth>? = null
     var pendingAuth: UIABaseAuth? = null
 
     fun ssoAuthDone() {
-        Timber.d("ssoAuthDone $pendingAuth , continuation: $uiaContinuation")
         pendingAuth?.let {
+            Timber.d("ssoAuthDone, resuming action")
             uiaContinuation?.resume(it)
         } ?: run {
+            Timber.d("ssoAuthDone, cannot resume: no pendingAuth")
             uiaContinuation?.resumeWithException(IllegalArgumentException())
         }
     }

--- a/vector/src/main/java/im/vector/app/features/auth/PendingAuthHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/auth/PendingAuthHandler.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.auth
+
+import im.vector.app.core.di.ActiveSessionHolder
+import org.matrix.android.sdk.api.Matrix
+import org.matrix.android.sdk.api.auth.UIABaseAuth
+import org.matrix.android.sdk.api.auth.UserPasswordAuth
+import org.matrix.android.sdk.api.util.fromBase64
+import timber.log.Timber
+import javax.inject.Inject
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+class PendingAuthHandler @Inject constructor(
+        private val matrix: Matrix,
+        private val activeSessionHolder: ActiveSessionHolder,
+) {
+
+    var uiaContinuation: Continuation<UIABaseAuth>? = null
+    var pendingAuth: UIABaseAuth? = null
+
+    fun ssoAuthDone() {
+        Timber.d("ssoAuthDone $pendingAuth , continuation: $uiaContinuation")
+        pendingAuth?.let {
+            uiaContinuation?.resume(it)
+        } ?: run {
+            uiaContinuation?.resumeWithException(IllegalArgumentException())
+        }
+    }
+
+    fun passwordAuthDone(password: String) {
+        Timber.d("passwordAuthDone")
+        val decryptedPass = matrix.secureStorageService()
+                .loadSecureSecret<String>(
+                        inputStream = password.fromBase64().inputStream(),
+                        keyAlias = ReAuthActivity.DEFAULT_RESULT_KEYSTORE_ALIAS
+                )
+        uiaContinuation?.resume(
+                UserPasswordAuth(
+                        session = pendingAuth?.session,
+                        password = decryptedPass,
+                        user = activeSessionHolder.getActiveSession().myUserId
+                )
+        )
+    }
+
+    fun reAuthCancelled() {
+        Timber.d("reAuthCancelled")
+        uiaContinuation?.resumeWithException(Exception())
+        uiaContinuation = null
+        pendingAuth = null
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/account/deactivation/DeactivateAccountViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/account/deactivation/DeactivateAccountViewModel.kt
@@ -52,7 +52,10 @@ class DeactivateAccountViewModel @AssistedInject constructor(
     override fun handle(action: DeactivateAccountAction) {
         when (action) {
             is DeactivateAccountAction.DeactivateAccount -> handleDeactivateAccount(action)
-            DeactivateAccountAction.SsoAuthDone -> pendingAuthHandler.ssoAuthDone()
+            DeactivateAccountAction.SsoAuthDone -> {
+                _viewEvents.post(DeactivateAccountViewEvents.Loading())
+                pendingAuthHandler.ssoAuthDone()
+            }
             is DeactivateAccountAction.PasswordAuthDone -> {
                 _viewEvents.post(DeactivateAccountViewEvents.Loading())
                 pendingAuthHandler.passwordAuthDone(action.password)

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
@@ -32,7 +32,7 @@ import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.utils.PublishDataSource
-import im.vector.app.features.auth.ReAuthActivity
+import im.vector.app.features.auth.PendingAuthHandler
 import im.vector.app.features.login.ReAuthHelper
 import im.vector.app.features.settings.devices.v2.list.CheckIfSessionIsInactiveUseCase
 import im.vector.app.features.settings.devices.v2.verification.GetEncryptionTrustLevelForDeviceUseCase
@@ -45,7 +45,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.launch
-import org.matrix.android.sdk.api.Matrix
 import org.matrix.android.sdk.api.MatrixCallback
 import org.matrix.android.sdk.api.NoOpMatrixCallback
 import org.matrix.android.sdk.api.auth.UIABaseAuth
@@ -67,13 +66,11 @@ import org.matrix.android.sdk.api.session.crypto.verification.VerificationTransa
 import org.matrix.android.sdk.api.session.crypto.verification.VerificationTxState
 import org.matrix.android.sdk.api.session.uia.DefaultBaseAuth
 import org.matrix.android.sdk.api.util.awaitCallback
-import org.matrix.android.sdk.api.util.fromBase64
 import org.matrix.android.sdk.flow.flow
 import timber.log.Timber
 import javax.net.ssl.HttpsURLConnection
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 data class DevicesViewState(
         val myDeviceId: String = "",
@@ -100,14 +97,11 @@ class DevicesViewModel @AssistedInject constructor(
         private val session: Session,
         private val reAuthHelper: ReAuthHelper,
         private val stringProvider: StringProvider,
-        private val matrix: Matrix,
+        private val pendingAuthHandler: PendingAuthHandler,
         private val checkIfSessionIsInactiveUseCase: CheckIfSessionIsInactiveUseCase,
         getCurrentSessionCrossSigningInfoUseCase: GetCurrentSessionCrossSigningInfoUseCase,
         private val getEncryptionTrustLevelForDeviceUseCase: GetEncryptionTrustLevelForDeviceUseCase,
 ) : VectorViewModel<DevicesViewState, DevicesAction, DevicesViewEvents>(initialState), VerificationService.Listener {
-
-    var uiaContinuation: Continuation<UIABaseAuth>? = null
-    var pendingAuth: UIABaseAuth? = null
 
     @AssistedFactory
     interface Factory : MavericksAssistedViewModelFactory<DevicesViewModel, DevicesViewState> {
@@ -232,37 +226,9 @@ class DevicesViewModel @AssistedInject constructor(
             is DevicesAction.CompleteSecurity -> handleCompleteSecurity()
             is DevicesAction.MarkAsManuallyVerified -> handleVerifyManually(action)
             is DevicesAction.VerifyMyDeviceManually -> handleShowDeviceCryptoInfo(action)
-            is DevicesAction.SsoAuthDone -> {
-                // we should use token based auth
-                // _viewEvents.post(CrossSigningSettingsViewEvents.ShowModalWaitingView(null))
-                // will release the interactive auth interceptor
-                Timber.d("## UIA - FallBack success $pendingAuth , continuation: $uiaContinuation")
-                if (pendingAuth != null) {
-                    uiaContinuation?.resume(pendingAuth!!)
-                } else {
-                    uiaContinuation?.resumeWithException(IllegalArgumentException())
-                }
-                Unit
-            }
-            is DevicesAction.PasswordAuthDone -> {
-                val decryptedPass = matrix.secureStorageService()
-                        .loadSecureSecret<String>(action.password.fromBase64().inputStream(), ReAuthActivity.DEFAULT_RESULT_KEYSTORE_ALIAS)
-                uiaContinuation?.resume(
-                        UserPasswordAuth(
-                                session = pendingAuth?.session,
-                                password = decryptedPass,
-                                user = session.myUserId
-                        )
-                )
-                Unit
-            }
-            DevicesAction.ReAuthCancelled -> {
-                Timber.d("## UIA - Reauth cancelled")
-//                _viewEvents.post(DevicesViewEvents.Loading)
-                uiaContinuation?.resumeWithException(Exception())
-                uiaContinuation = null
-                pendingAuth = null
-            }
+            is DevicesAction.SsoAuthDone -> pendingAuthHandler.ssoAuthDone()
+            is DevicesAction.PasswordAuthDone -> pendingAuthHandler.passwordAuthDone(action.password)
+            DevicesAction.ReAuthCancelled -> pendingAuthHandler.reAuthCancelled()
             DevicesAction.ResetSecurity -> _viewEvents.post(DevicesViewEvents.PromptResetSecrets)
         }
     }
@@ -371,8 +337,8 @@ class DevicesViewModel @AssistedInject constructor(
                             } else {
                                 Timber.d("## UIA : deleteDevice UIA > start reauth activity")
                                 _viewEvents.post(DevicesViewEvents.RequestReAuth(flowResponse, errCode))
-                                pendingAuth = DefaultBaseAuth(session = flowResponse.session)
-                                uiaContinuation = promise
+                                pendingAuthHandler.pendingAuth = DefaultBaseAuth(session = flowResponse.session)
+                                pendingAuthHandler.uiaContinuation = promise
                             }
                         }
                     }, it)

--- a/vector/src/test/java/im/vector/app/features/auth/PendingAuthHandlerTest.kt
+++ b/vector/src/test/java/im/vector/app/features/auth/PendingAuthHandlerTest.kt
@@ -33,6 +33,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.matrix.android.sdk.api.auth.UIABaseAuth
 import org.matrix.android.sdk.api.auth.UserPasswordAuth
+import org.matrix.android.sdk.api.session.uia.exceptions.UiaCancelledException
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -90,7 +91,7 @@ class PendingAuthHandlerTest {
         pendingAuthHandler.ssoAuthDone()
 
         // Then
-        verify { continuation.resumeWithException(match { it is IllegalArgumentException })}
+        verify { continuation.resumeWithException(match { it is IllegalArgumentException }) }
     }
 
     @Test
@@ -138,6 +139,6 @@ class PendingAuthHandlerTest {
         // Then
         pendingAuthHandler.pendingAuth shouldBe null
         pendingAuthHandler.uiaContinuation shouldBe null
-        verify { continuation.resumeWithException(match { it is Exception })}
+        verify { continuation.resumeWithException(match { it is UiaCancelledException }) }
     }
 }

--- a/vector/src/test/java/im/vector/app/features/auth/PendingAuthHandlerTest.kt
+++ b/vector/src/test/java/im/vector/app/features/auth/PendingAuthHandlerTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.auth
+
+import android.util.Base64
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import im.vector.app.test.fakes.FakeMatrix
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.amshove.kluent.shouldBe
+import org.junit.After
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import org.matrix.android.sdk.api.auth.UIABaseAuth
+import org.matrix.android.sdk.api.auth.UserPasswordAuth
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+private const val A_PASSWORD = "a-password"
+private const val A_SESSION_ID = "session-id"
+
+class PendingAuthHandlerTest {
+
+    private val fakeMatrix = FakeMatrix()
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+
+    private val pendingAuthHandler = PendingAuthHandler(
+            matrix = fakeMatrix.instance,
+            activeSessionHolder = fakeActiveSessionHolder.instance,
+    )
+
+    @Before
+    fun setUp() {
+        mockkStatic(Base64::class)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `given a pending auth and continuation when SSO auth is done then continuation is resumed with pending auth`() {
+        // Given
+        val pendingAuth = mockk<UIABaseAuth>()
+        val continuation = mockk<Continuation<UIABaseAuth>>()
+        every { continuation.resume(any()) } just runs
+        pendingAuthHandler.pendingAuth = pendingAuth
+        pendingAuthHandler.uiaContinuation = continuation
+
+        // When
+        pendingAuthHandler.ssoAuthDone()
+
+        // Then
+        verify { continuation.resume(pendingAuth) }
+    }
+
+    @Test
+    @Ignore("Ignored due because of problem to mock the inline method continuation.resumeWithException")
+    fun `given missing pending auth and continuation when SSO auth is done then continuation is resumed with error`() {
+        // Given
+        val pendingAuth = null
+        val continuation = mockk<Continuation<UIABaseAuth>>()
+        every { continuation.resumeWithException(any()) } just runs
+        pendingAuthHandler.pendingAuth = pendingAuth
+        pendingAuthHandler.uiaContinuation = continuation
+
+        // When
+        pendingAuthHandler.ssoAuthDone()
+
+        // Then
+        verify { continuation.resumeWithException(match { it is IllegalArgumentException })}
+    }
+
+    @Test
+    fun `given a password, pending auth and continuation when password auth is done then continuation is resumed with correct auth`() {
+        // Given
+        val pendingAuth = mockk<UIABaseAuth>()
+        every { pendingAuth.session } returns A_SESSION_ID
+        val continuation = mockk<Continuation<UIABaseAuth>>()
+        every { continuation.resume(any()) } just runs
+        pendingAuthHandler.pendingAuth = pendingAuth
+        pendingAuthHandler.uiaContinuation = continuation
+        val decryptedPwd = "decrypted-pwd"
+        val decodedPwd = byteArrayOf()
+        every { Base64.decode(A_PASSWORD, any()) } returns decodedPwd
+        fakeMatrix.fakeSecureStorageService.givenLoadSecureSecretReturns(decryptedPwd)
+        val expectedAuth = UserPasswordAuth(
+                session = A_SESSION_ID,
+                password = decryptedPwd,
+                user = fakeActiveSessionHolder.fakeSession.myUserId
+        )
+
+        // When
+        pendingAuthHandler.passwordAuthDone(A_PASSWORD)
+
+        // Then
+        verify {
+            fakeMatrix.fakeSecureStorageService.loadSecureSecret<String>(any(), ReAuthActivity.DEFAULT_RESULT_KEYSTORE_ALIAS)
+            continuation.resume(expectedAuth)
+        }
+    }
+
+    @Test
+    @Ignore("Ignored because of problem to mock the inline method continuation.resumeWithException")
+    fun `given pending auth and continuation when reAuth is cancelled then pending auth and continuation are reset`() {
+        // Given
+        val pendingAuth = mockk<UIABaseAuth>()
+        val continuation = mockk<Continuation<UIABaseAuth>>()
+        every { continuation.resumeWithException(any()) } just runs
+        pendingAuthHandler.pendingAuth = pendingAuth
+        pendingAuthHandler.uiaContinuation = continuation
+
+        // When
+        pendingAuthHandler.reAuthCancelled()
+
+        // Then
+        pendingAuthHandler.pendingAuth shouldBe null
+        pendingAuthHandler.uiaContinuation shouldBe null
+        verify { continuation.resumeWithException(match { it is Exception })}
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeMatrix.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeMatrix.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import io.mockk.every
+import io.mockk.mockk
+import org.matrix.android.sdk.api.Matrix
+
+class FakeMatrix(
+        val fakeSecureStorageService: FakeSecureStorageService = FakeSecureStorageService(),
+) {
+
+    val instance = mockk<Matrix>()
+
+    init {
+        every { instance.secureStorageService() } returns fakeSecureStorageService
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeSecureStorageService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeSecureStorageService.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import io.mockk.every
+import io.mockk.mockk
+import org.matrix.android.sdk.api.securestorage.SecureStorageService
+
+class FakeSecureStorageService : SecureStorageService by mockk() {
+
+    fun <T> givenLoadSecureSecretReturns(value: T?) {
+        every { loadSecureSecret<T>(any(), any()) } returns value
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Creation of a new class `PendingAuthHandler` to mutualize the handling of pending auth for actions which require authentication. It was previously used in several `ViewModel`. I am doing this refactor to be able to test this and because we will need it for sign out action in the new device management screens.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7193 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Go to a screen using re-auth for example the device manager screen
- Go to settings -> Security & Privacy -> Show all sessions
- Long press on of your devices
- Press the sign out action
- Check the authentication flow is working well

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
