### PR TITLE
Missing buildjet Emulator network

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 # Enrich gradle.properties for CI/CD
 env:
   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx3072m -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError" -Dkotlin.daemon.jvm.options="-Xmx2560m" -Dkotlin.incremental=false
-  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 2 --no-daemon
+  CI_GRADLE_ARG_PROPERTIES: --stacktrace -PpreDexEnable=false --max-workers 4 --no-daemon
 
 jobs:
   tests:
@@ -54,27 +54,6 @@ jobs:
           disableRateLimiting: true
           public_baseurl: "http://10.0.2.2:8080/"
 
-      - name: AVD cache
-        uses: actions/cache@v3
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
-
-      - name: create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          arch: x86
-          profile: Nexus 5X
-          force-avd-creation: true # Is set to false in the doc https://github.com/ReactiveCircus/android-emulator-runner
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: echo "Generated AVD snapshot for caching."
-
       - name: Run all the codecoverage tests at once
         uses: reactivecircus/android-emulator-runner@v2
         # continue-on-error: true
@@ -82,6 +61,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           arch: x86
           profile: Nexus 5X
+          target: playstore
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: gradle/gradle-build-action@v2
 
       - name: Run screenshot tests
-        run: ./gradlew verifyScreenshots
+        run: ./gradlew verifyScreenshots $CI_GRADLE_ARG_PROPERTIES
 
       - name: Archive Screenshot Results on Error
         if: failure()

--- a/vector-app/src/androidTest/java/im/vector/app/CantVerifyTest.kt
+++ b/vector-app/src/androidTest/java/im/vector/app/CantVerifyTest.kt
@@ -26,7 +26,6 @@ import androidx.test.filters.LargeTest
 import com.adevinta.android.barista.internal.viewaction.SleepViewAction
 import im.vector.app.features.MainActivity
 import im.vector.app.ui.robot.ElementRobot
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -35,7 +34,6 @@ import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
-@Ignore("Disabled temporarily so that we can unblock other PRs.")
 class CantVerifyTest {
 
     @get:Rule


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Fixes the `CantVerifyTest` failing when running on the buildjet github action runner, the cause seems to be related to the emulator not having access to the wider network, which meant the initial matrix.org requests would timeout.

For reasons unknown to me, switching the emulator image to use the play store version ensures that the outside network is accessible.

## Motivation and context

To re-enable an ignored test

## Screenshots / GIFs

No production code changes

## Tests

Run on the CI!

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):
