### PR TITLE
Prevent modification of translations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ The string will be removed during the next sync with Weblate.
 This is possible to rename ids of the String resources, but since translation files cannot be edited, add TODO in the main strings.xml file above the strings you want to rename. 
 
 ```xml
-<!-- TODO Rename to [put_new_id_here] -->
+<!-- TODO Rename id to put_new_id_here -->
 <string name="current_id">Hello Matrix world!</string>
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,11 @@ The file `values/strings.xml` must only contain American English (U. S. English)
 
 New strings can be added anywhere in the file `values/strings.xml`, not necessarily at the end of the file. Generally, it's even better to add the new strings in some dedicated section per feature, and not at the end of the file, to avoid merge conflict between 2 PR adding strings at the end of the same file.
 
-Do not hesitate to use plurals when appropriate.
+##### Plurals
+
+Please use `plurals` resources when appropriate, and note that some languages have specific rules for `plurals`, so even if the string will always be at the plural form for English, please always create a `plurals` resource.
+
+Specific plural forms can be found [here](https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html).
 
 #### Editing existing strings
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,12 @@ This is possible to rename ids of the String resources, but since translation fi
 
 The string id(s) will be renamed during the next Weblate sync.
 
+#### Reordering strings
+
+To group strings per feature, or for any other reasons, it is possible to reorder string resources, but only in the [main strings.xml file](./library/ui-strings/src/main/res/values/strings.xml). ). We do not mind about ordering in the translation files, and anyway this is forbidden to edit manually the translation files.
+
+It is also possible to add empty lines between string resources, and to add XML comments. Please note that the XML comment just above a String resource will also appear on Weblate and be visible to the translators.
+
 ### Accessibility
 
 Please consider accessibility as an important point. As a minimum requirement, in layout XML files please use attributes such as `android:contentDescription` and `android:importantForAccessibility`, and test with a screen reader if it's working well. You can add new string resources, dedicated to accessibility, in this case, please prefix theirs id with `a11y_`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ You should consider adding Unit tests with your PR, and also integration tests (
 
 Translations are handled using an external tool: [Weblate](https://translate.element.io/projects/element-android/)
 
-As a general rule, please never edit or add or remove translations to the project in a Pull Request. It can lead to merge conflict if the translations are also modified in Weblate side.
+**As a general rule, please never edit or add or remove translations to the project in a Pull Request**. It can lead to merge conflict if the translations are also modified in Weblate side. Pull Request containing change(s) on the translation files cannot be merged.
 
 #### Adding new string
 
@@ -149,6 +149,17 @@ Instead, please comment the original string with:
 And add `tools:ignore="UnusedResources"` to the string, to let lint ignore that the string is not used.
 
 The string will be removed during the next sync with Weblate.
+
+#### Renaming string ids
+
+This is possible to rename ids of the String resources, but since translation files cannot be edited, add TODO in the main strings.xml file above the strings you want to rename. 
+
+```xml
+<!-- TODO Rename to [put_new_id_here] -->
+<string name="current_id">Hello Matrix world!</string>
+```
+
+The string id(s) will be renamed during the next Weblate sync.
 
 ### Accessibility
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,11 +124,11 @@ Translations are handled using an external tool: [Weblate](https://translate.ele
 
 #### Adding new string
 
-When adding new string resources, please only add new entries in the file `value/strings.xml`. Translations will be added later by the community of translators using Weblate.
+When adding new string resources, please only add new entries in the file `values/strings.xml` ([this file](./library/ui-strings/src/main/res/values/strings.xml)). Translations will be added later by the community of translators using Weblate.
 
-The file `value/strings.xml` must only contain American English (U. S. English) values, as this is the default language of the Android operating system. So for instance, please use "color" instead of "colour". Element Android will still use the language set on the system by the user, like any other Android applications which provide translations. The system language can be any other English language variants, or any other languages. Note that this is also possible to override the system language using the Element Android in-app language settings.
+The file `values/strings.xml` must only contain American English (U. S. English) values, as this is the default language of the Android operating system. So for instance, please use "color" instead of "colour". Element Android will still use the language set on the system by the user, like any other Android applications which provide translations. The system language can be any other English language variants, or any other languages. Note that this is also possible to override the system language using the Element Android in-app language settings.
 
-New strings can be added anywhere in the file `value/strings.xml`, not necessarily at the end of the file. Generally, it's even better to add the new strings in some dedicated section per feature, and not at the end of the file, to avoid merge conflict between 2 PR adding strings at the end of the same file.
+New strings can be added anywhere in the file `values/strings.xml`, not necessarily at the end of the file. Generally, it's even better to add the new strings in some dedicated section per feature, and not at the end of the file, to avoid merge conflict between 2 PR adding strings at the end of the same file.
 
 Do not hesitate to use plurals when appropriate.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,42 @@
-# Contributing code to Matrix
+# Contributing to Element Android
+
+<!--- TOC -->
+
+* [Contributing code to Matrix](#contributing-code-to-matrix)
+* [Android Studio settings](#android-studio-settings)
+  * [Template](#template)
+* [Compilation](#compilation)
+* [I want to help translating Element](#i-want-to-help-translating-element)
+* [I want to submit a PR to fix an issue](#i-want-to-submit-a-pr-to-fix-an-issue)
+  * [Kotlin](#kotlin)
+  * [Changelog](#changelog)
+  * [Code quality](#code-quality)
+    * [Internal tool](#internal-tool)
+    * [ktlint](#ktlint)
+    * [lint](#lint)
+  * [Unit tests](#unit-tests)
+  * [Tests](#tests)
+  * [Internationalisation](#internationalisation)
+    * [Adding new string](#adding-new-string)
+      * [Plurals](#plurals)
+    * [Editing existing strings](#editing-existing-strings)
+    * [Removing existing strings](#removing-existing-strings)
+    * [Renaming string ids](#renaming-string-ids)
+    * [Reordering strings](#reordering-strings)
+  * [Accessibility](#accessibility)
+  * [Layout](#layout)
+  * [Authors](#authors)
+* [Thanks](#thanks)
+
+<!--- END -->
+
+## Contributing code to Matrix
 
 Please read https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md
 
 Element Android support can be found in this room: [![Element Android Matrix room #element-android:matrix.org](https://img.shields.io/matrix/element-android:matrix.org.svg?label=%23element-android:matrix.org&logo=matrix&server_fqdn=matrix.org)](https://matrix.to/#/#element-android:matrix.org).
 
-# Specific rules for Matrix Android projects
+The rest of the document contains specific rules for Matrix Android projects
 
 ## Android Studio settings
 

--- a/changelog.d/7211.misc
+++ b/changelog.d/7211.misc
@@ -1,0 +1,1 @@
+ CI: Prevent modification of translations by developer.

--- a/docs/danger.md
+++ b/docs/danger.md
@@ -28,6 +28,7 @@ Here are the checks that Danger does so far:
 - PR with change on layout should include screenshot in the description
 - PR which adds png file warn about the usage of vector drawables
 - non draft PR should have a reviewer
+- files containing translations are not modified by developers
 
 ### Quality check
 

--- a/tools/danger/dangerfile.js
+++ b/tools/danger/dangerfile.js
@@ -118,3 +118,10 @@ if (hasPngs) {
 if (github.requested_reviewers.users.length == 0 && !pr.draft) {
     warn("Please add a reviewer to your PR.")
 }
+
+// Check that translations have not been modified by developers
+if (user != "RiotTranslateBot") {
+   if (editedFiles.some(file => file.endsWith("strings.xml") && !file.endsWith("values/strings.xml"))) {
+       fail("Some translation files have been edited. Only user `RiotTranslateBot` (i.e. translations coming from Weblate) is allowed to do that.\nPlease read more about translations management [in the doc](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#internationalisation).")
+   }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Fixes #7195 

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Avoid being blocked with merge conflicts when doing a Weblate sync.
Update the doc.

## Screenshots / GIFs

NA

## Tests

<!-- Explain how you tested your development -->

Running locally against various PRs, using `bundle exec danger pr PR_URL --dangerfile=./tools/danger/dangerfile.js`

### PR with modification of translations

Will throw an error.
For instance #7084, output:
```
## Failures
Some translation files have been edited. Only user `RiotTranslateBot` (i.e. translations coming from Weblate) is allowed to do that.
Please read more about translations management [in the doc](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#internationalisation).
```

### PR with modification of values/strings.xml

#6608, no error on output

### PR from Weblate

#7201, no error on output

## Tested devices

NA

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
