### PR TITLE
Fix new layout flicker/leaks

### DIFF
--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/HomeRoomListViewState.kt
@@ -21,6 +21,6 @@ import im.vector.app.core.platform.StateView
 import im.vector.app.features.home.room.list.home.header.RoomsHeadersData
 
 data class HomeRoomListViewState(
-        val state: StateView.State = StateView.State.Content,
+        val emptyState: StateView.State.Empty? = null,
         val headersData: RoomsHeadersData = RoomsHeadersData(),
 ) : MavericksState

--- a/vector/src/main/java/im/vector/app/features/home/room/list/home/header/RoomsHeadersData.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/home/header/RoomsHeadersData.kt
@@ -21,6 +21,6 @@ import org.matrix.android.sdk.api.session.room.model.RoomSummary
 data class RoomsHeadersData(
         val invitesCount: Int = 0,
         val filtersList: List<HomeRoomFilter>? = null,
-        val currentFilter: HomeRoomFilter? = null,
+        val currentFilter: HomeRoomFilter = HomeRoomFilter.ALL,
         val recents: List<RoomSummary>? = null
 )


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes an issue where the roomList wil continuously flicker from one space to another space.

## Motivation and context

2 things changed:
 - Multiple unneeded registration to spaceStateHandler.getSelectedSpaceFlow() (leak)
 - Race condition in observeRooms() that would cause the livepagedList to receveive udpdates from two different data source (space filter)

Race description
On launch observeRooms() is called twice quickly
- init()
- observeOrderPreferences

The first call starts and suspends on preferencesStore.isAZOrderingEnabledFlow.first()
The second call then proceed and call
`filteredPagedRoomSummariesLive?.livePagedList?.removeObserver`
With no effects as the first call suspended before setting  `filteredPagedRoomSummariesLive`

 After that both call continue their execution and call this twice
> liveResults.livePagedList.observeForever(internalPagedListObserver)
> liveResults.livePagedList.observeForever(internalPagedListObserver)

Eventually later you will switch space, updating the filter of one of the data sources (but not the other)

As a consequence the room list will alternatively showing space 1 and then space 2


As a quick fix I just put a mutex to prevent the race. Open to a more cleaner fix though

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
