### PR TITLE
Fix VoiceRecorderLTests by faking OggOpusEncoder

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -99,7 +99,7 @@ ext.libs = [
                 'flipperNetworkPlugin'    : "com.facebook.flipper:flipper-network-plugin:$flipper",
         ],
         element     : [
-                'opusencoder'             : "io.element.android:opusencoder:1.0.4",
+                'opusencoder'             : "io.element.android:opusencoder:1.1.0",
         ],
         squareup    : [
                 'moshi'                  : "com.squareup.moshi:moshi:$moshi",

--- a/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderLTests.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderLTests.kt
@@ -19,7 +19,6 @@ package im.vector.app.features.voice
 import android.Manifest
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
-import io.mockk.spyk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBeNull
@@ -36,7 +35,7 @@ class VoiceRecorderLTests {
     val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.RECORD_AUDIO)
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
-    private val recorder = spyk(VoiceRecorderL(context, Dispatchers.IO))
+    private val recorder = VoiceRecorderL(context, Dispatchers.IO, createFakeOpusEncoder())
 
     @Test
     fun startRecordCreatesOggFile() = with(recorder) {

--- a/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderTestExt.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderTestExt.kt
@@ -17,6 +17,7 @@
 package im.vector.app.features.voice
 
 import im.vector.app.core.utils.waitUntil
+import im.vector.app.test.fakes.FakeOggOpusEncoder
 import org.amshove.kluent.shouldExist
 import org.amshove.kluent.shouldNotBeNull
 import java.io.File
@@ -34,3 +35,5 @@ suspend fun VoiceRecorder.waitUntilRecordingFileExists(timeout: Duration = 1.sec
     }
     return getVoiceMessageFile()
 }
+
+internal fun createFakeOpusEncoder() = FakeOggOpusEncoder().apply { createEmptyFileOnInit() }

--- a/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderTests.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderTests.kt
@@ -29,7 +29,7 @@ import java.io.File
 class VoiceRecorderTests {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
-    private val voiceRecorder = VoiceRecorderL(context, Dispatchers.IO)
+    private val voiceRecorder = VoiceRecorderL(context, Dispatchers.IO, createFakeOpusEncoder())
     private val audioDirectory = File(context.cacheDir, "voice_records")
 
     @After

--- a/vector/src/androidTest/java/im/vector/app/test/fakes/FakeOggOpusEncoder.kt
+++ b/vector/src/androidTest/java/im/vector/app/test/fakes/FakeOggOpusEncoder.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import io.element.android.opusencoder.OggOpusEncoder
+import io.mockk.every
+import io.mockk.mockk
+import java.io.File
+
+class FakeOggOpusEncoder : OggOpusEncoder by mockk() {
+
+    init {
+        every { init(any(), any()) } returns 0
+        every { setBitrate(any()) } returns 0
+        every { encode(any(), any()) } returns 0
+        every { release() } answers {}
+    }
+
+    fun createEmptyFileOnInit() {
+        every { init(any(), any()) } answers {
+            val filePath = arg<String>(0)
+            if (File(filePath).createNewFile()) 0 else 1
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/voice/VoiceRecorderL.kt
+++ b/vector/src/main/java/im/vector/app/features/voice/VoiceRecorderL.kt
@@ -42,6 +42,7 @@ import kotlin.coroutines.CoroutineContext
 class VoiceRecorderL(
         context: Context,
         coroutineContext: CoroutineContext,
+        private val codec: OggOpusEncoder,
 ) : VoiceRecorder {
 
     companion object {
@@ -58,7 +59,6 @@ class VoiceRecorderL(
     private var audioRecorder: AudioRecord? = null
     private var noiseSuppressor: NoiseSuppressor? = null
     private var automaticGainControl: AutomaticGainControl? = null
-    private val codec = OggOpusEncoder()
 
     // Size of the audio buffer for Short values
     private var bufferSizeInShorts = 0

--- a/vector/src/main/java/im/vector/app/features/voice/VoiceRecorderProvider.kt
+++ b/vector/src/main/java/im/vector/app/features/voice/VoiceRecorderProvider.kt
@@ -23,6 +23,7 @@ import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.annotation.VisibleForTesting
 import im.vector.app.features.VectorFeatures
+import io.element.android.opusencoder.OggOpusEncoder
 import kotlinx.coroutines.Dispatchers
 import org.matrix.android.sdk.api.util.BuildVersionSdkIntProvider
 import javax.inject.Inject
@@ -36,7 +37,7 @@ class VoiceRecorderProvider @Inject constructor(
         return if (useNativeRecorder()) {
             VoiceRecorderQ(context)
         } else {
-            VoiceRecorderL(context, Dispatchers.IO)
+            VoiceRecorderL(context, Dispatchers.IO, OggOpusEncoder.create())
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Fix broken tests.

## Content

Used a fake `OggOpusEncoder` in `VoiceRecorderLTests` to fix some broken tests.

## Motivation and context

`VoiceRecorderLTests` depended on the native Opus encoder to run. By using a fake and mimicking its behaviour we can avoid the tests failures we've seen in the CI.

## Tests

<!-- Explain how you tested your development -->

- Run `VoiceRecorderLTests` in the CI, see that they pass.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
