### PR TITLE
Add support for `/tableflip` command (#12)

### DIFF
--- a/changelog.d/12.misc
+++ b/changelog.d/12.misc
@@ -1,0 +1,1 @@
+Add support for `/tableflip` command

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -2220,6 +2220,7 @@
 
     <string name="command_description_shrug">Prepends ¯\\_(ツ)_/¯ to a plain-text message</string>
     <string name="command_description_lenny">Prepends ( ͡° ͜ʖ ͡°) to a plain-text message</string>
+    <string name="command_description_table_flip">Prepends (╯°□°）╯︵ ┻━┻ to a plain-text message</string>
 
     <string name="create_room_encryption_title">"Enable encryption"</string>
     <string name="create_room_encryption_description">"Once enabled, encryption cannot be disabled."</string>

--- a/vector/src/main/java/im/vector/app/features/command/Command.kt
+++ b/vector/src/main/java/im/vector/app/features/command/Command.kt
@@ -66,7 +66,8 @@ enum class Command(
     ADD_TO_SPACE("/addToSpace", null, "spaceId", R.string.command_description_add_to_space, true, false),
     JOIN_SPACE("/joinSpace", null, "spaceId", R.string.command_description_join_space, true, false),
     LEAVE_ROOM("/leave", null, "<roomId?>", R.string.command_description_leave_room, true, false),
-    UPGRADE_ROOM("/upgraderoom", null, "newVersion", R.string.command_description_upgrade_room, true, false);
+    UPGRADE_ROOM("/upgraderoom", null, "newVersion", R.string.command_description_upgrade_room, true, false),
+    TABLE_FLIP("/tableflip", null, "<message>", R.string.command_description_table_flip, false, true);
 
     val allAliases = arrayOf(command, *aliases.orEmpty())
 

--- a/vector/src/main/java/im/vector/app/features/command/CommandParser.kt
+++ b/vector/src/main/java/im/vector/app/features/command/CommandParser.kt
@@ -344,6 +344,9 @@ class CommandParser @Inject constructor() {
                 Command.LENNY.matches(slashCommand) -> {
                     ParsedCommand.SendLenny(message)
                 }
+                Command.TABLE_FLIP.matches(slashCommand) -> {
+                    ParsedCommand.SendTableFlip(message)
+                }
                 Command.DISCARD_SESSION.matches(slashCommand) -> {
                     if (messageParts.size == 1) {
                         ParsedCommand.DiscardSession

--- a/vector/src/main/java/im/vector/app/features/command/ParsedCommand.kt
+++ b/vector/src/main/java/im/vector/app/features/command/ParsedCommand.kt
@@ -63,6 +63,7 @@ sealed interface ParsedCommand {
     object DevTools : ParsedCommand
     data class SendSpoiler(val message: String) : ParsedCommand
     data class SendShrug(val message: CharSequence) : ParsedCommand
+    data class SendTableFlip(val message: CharSequence) : ParsedCommand
     data class SendLenny(val message: CharSequence) : ParsedCommand
     object DiscardSession : ParsedCommand
     data class ShowUser(val userId: String) : ParsedCommand

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
@@ -366,6 +366,11 @@ class MessageComposerViewModel @AssistedInject constructor(
                             _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
                             popDraft()
                         }
+                        is ParsedCommand.SendTableFlip -> {
+                            sendPrefixedMessage("(╯°□°）╯︵ ┻━┻", parsedCommand.message, state.rootThreadEventId)
+                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
+                            popDraft()
+                        }
                         is ParsedCommand.SendChatEffect -> {
                             sendChatEffect(parsedCommand)
                             _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))


### PR DESCRIPTION
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content
re #12

## Motivation and context

(╯°□°）╯︵ ┻━┻

## Screenshots / GIFs

![Screenshot from 2022-09-24 15-02-21](https://user-images.githubusercontent.com/616399/192120482-c51b3041-f673-40b5-8c87-cf164027b904.png)

## Tests

1. Open the composer area
2. Type `/t` to see a list of commands starting with `t`
3. Select `/tableflip` or directly type in the command

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): API 21 and API 32

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
