### PR TITLE
app layout labs flag is enabled by default

### DIFF
--- a/changelog.d/7166.misc
+++ b/changelog.d/7166.misc
@@ -1,0 +1,1 @@
+New App Layout is now enabled by default! Go to the Settings > Labs to toggle this

--- a/vector-app/src/androidTest/java/im/vector/app/VerifySessionInteractiveTest.kt
+++ b/vector-app/src/androidTest/java/im/vector/app/VerifySessionInteractiveTest.kt
@@ -225,8 +225,8 @@ class VerifySessionInteractiveTest : VerificationTestBase() {
 
         // Wait until local secrets are known (gossip)
         withIdlingResource(allSecretsKnownIdling(uiSession)) {
-            onView(withId(R.id.groupToolbarAvatarImageView))
-                    .perform(click())
+            onView(withId(R.id.roomListContainer))
+                    .check(matches(isDisplayed()))
         }
     }
 

--- a/vector-app/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
+++ b/vector-app/src/androidTest/java/im/vector/app/ui/robot/ElementRobot.kt
@@ -50,7 +50,7 @@ import im.vector.app.withIdlingResource
 import timber.log.Timber
 
 class ElementRobot(
-        private val labsPreferences: LabFeaturesPreferences = LabFeaturesPreferences(false)
+        private val labsPreferences: LabFeaturesPreferences = LabFeaturesPreferences(true)
 ) {
     fun onboarding(block: OnboardingRobot.() -> Unit) {
         block(OnboardingRobot())

--- a/vector-config/src/main/res/values/config-settings.xml
+++ b/vector-config/src/main/res/values/config-settings.xml
@@ -40,7 +40,7 @@
     <bool name="settings_labs_deferred_dm_visible">true</bool>
     <bool name="settings_labs_deferred_dm_default">true</bool>
     <bool name="settings_labs_thread_messages_default">false</bool>
-    <bool name="settings_labs_new_app_layout_default">false</bool>
+    <bool name="settings_labs_new_app_layout_default">true</bool>
     <bool name="settings_timeline_show_live_sender_info_visible">true</bool>
     <bool name="settings_timeline_show_live_sender_info_default">false</bool>
     <!-- Level 1: Advanced settings -->


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [] Other :

## Content

reenable app layout by default 
