### PR TITLE
[Crash] Autocomplete crashes on open 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,8 @@ org.gradle.vfs.watch=true
 org.gradle.caching=true
 
 # Android Settings
-android.enableJetifier=false
+android.enableJetifier=true
+android.jetifier.ignorelist=android-base-common,common
 android.useAndroidX=true
 
 #Project Settings


### PR DESCRIPTION
 ## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- re-enabling the jetifier, it's required by the autocomplete library
- the upstream library source doesn't require the jetifier however it hasn't been released  https://github.com/natario1/Autocomplete/issues/51

## Motivation and context

Fixes a crash when opening the autocomplete popup (typing a #) 

- Originally the jetifier was disable due to an incompatibility between the screenshot and unit tests, however this was resolved by switching the gradle tasks to be lazy instead of eager.

## Screenshots / GIFs

|Before|After|
|-|-|
|![before-autocomplete](https://user-images.githubusercontent.com/1848238/192740626-0abe3408-2883-40c2-b786-0730fce17938.gif)|![after-autocomplete](https://user-images.githubusercontent.com/1848238/192741341-b460ab46-76e3-4229-84db-6c81a954a46e.gif)|

## Tests

- In a room
- Type a `#`
- Notice a crash

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):