### PR TITLE
Aggregate voice broadcast state events

### DIFF
--- a/changelog.d/7283.wip
+++ b/changelog.d/7283.wip
@@ -1,0 +1,1 @@
+[Voice Broadcast] Aggregate state events in the timeline

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineEventsGroups.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/TimelineEventsGroups.kt
@@ -17,6 +17,9 @@
 package im.vector.app.features.home.room.detail.timeline.helper
 
 import im.vector.app.core.utils.TextUtils
+import im.vector.app.features.voicebroadcast.STATE_ROOM_VOICE_BROADCAST_INFO
+import im.vector.app.features.voicebroadcast.model.MessageVoiceBroadcastInfoContent
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
 import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.toModel
@@ -54,12 +57,18 @@ class TimelineEventsGroups {
     private fun TimelineEvent.getGroupIdOrNull(): String? {
         val type = root.getClearType()
         val content = root.getClearContent()
-        return if (EventType.isCallEvent(type)) {
-            (content?.get("call_id") as? String)
-        } else if (type == EventType.STATE_ROOM_WIDGET || type == EventType.STATE_ROOM_WIDGET_LEGACY) {
-            root.stateKey
-        } else {
-            null
+        return when {
+            EventType.isCallEvent(type) -> (content?.get("call_id") as? String)
+            type == STATE_ROOM_VOICE_BROADCAST_INFO -> {
+                root.content.toModel<MessageVoiceBroadcastInfoContent>()
+                        ?.takeUnless { it.voiceBroadcastState == VoiceBroadcastState.STARTED }
+                        ?.relatesTo?.eventId
+                        ?: eventId
+            }
+            type == EventType.STATE_ROOM_WIDGET || type == EventType.STATE_ROOM_WIDGET_LEGACY -> root.stateKey
+            else -> {
+                null
+            }
         }
     }
 
@@ -126,5 +135,13 @@ class CallSignalingEventsGroup(private val group: TimelineEventsGroup) {
 
     private fun getReject(): TimelineEvent? {
         return group.events.firstOrNull { it.root.getClearType() == EventType.CALL_REJECT }
+    }
+}
+
+class VoiceBroadcastEventsGroup(private val group: TimelineEventsGroup) {
+    fun getLastEvent(): TimelineEvent {
+        return group.events
+                .find { it.root.getClearContent().toModel<MessageVoiceBroadcastInfoContent>()?.voiceBroadcastState == VoiceBroadcastState.STOPPED }
+                ?: group.events.maxBy { it.root.originServerTs ?: 0L }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastItem.kt
@@ -35,6 +35,8 @@ abstract class MessageVoiceBroadcastItem : AbsMessageItem<MessageVoiceBroadcastI
     @EpoxyAttribute
     var voiceBroadcastState: VoiceBroadcastState? = null
 
+    override fun isCacheable(): Boolean = false
+
     override fun bind(holder: Holder) {
         super.bind(holder)
         bindVoiceBroadcastItem(holder)


### PR DESCRIPTION
## Type of change

- [X] WIP Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Display a single voice broadcast state event in the timeline. Each change related to the voice broadcast state will update the tile of the first state event. The position of the tile remains the same.

## Motivation and context

Continue #7127

## Screenshots / GIFs

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/11990514/193785715-d6d5461d-54ea-42a6-8d70-3252feb6c6bc.png)|![vb_tile_timeline_position](https://user-images.githubusercontent.com/11990514/193787566-2f2022ac-ae11-4bfb-89c7-0419eb83d0de.gif)|

## Tests

- Enable the voice broadcast feature flag
- Start a voice broadcast in a room
- Send several messages
- Update the voice broadcast state (pause/resume/stop)
- Verify that the voice broadcast tile is correctly updated and that the position of the tile has not changed

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
