### PR TITLE
Remove Robolectric, make previous Robolectric test an instrumentation test

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -168,7 +168,6 @@ ext.libs = [
                 'kluent'                 : "org.amshove.kluent:kluent-android:1.68",
                 'timberJunitRule'        : "net.lachlanmckee:timber-junit-rule:1.0.1",
                 'junit'                  : "junit:junit:4.13.2",
-                'robolectric'            : "org.robolectric:robolectric:4.8",
         ]
 ]
 

--- a/dependencies_groups.gradle
+++ b/dependencies_groups.gradle
@@ -210,7 +210,6 @@ ext.groups = [
                         'org.ow2.asm',
                         'org.ow2.asm',
                         'org.reactivestreams',
-                        'org.robolectric',
                         'org.slf4j',
                         'org.sonatype.oss',
                         'org.testng',

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -290,7 +290,6 @@ dependencies {
     testImplementation libs.tests.kluent
     testImplementation libs.mockk.mockk
     testImplementation libs.androidx.coreTesting
-    testImplementation libs.tests.robolectric
     // Plant Timber tree for test
     testImplementation libs.tests.timberJunitRule
     testImplementation libs.airbnb.mavericksTesting

--- a/vector/src/androidTest/java/im/vector/app/features/RoomMemberListControllerTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/RoomMemberListControllerTest.kt
@@ -16,36 +16,26 @@
 
 package im.vector.app.features
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.airbnb.mvrx.Success
-import com.airbnb.mvrx.test.MvRxTestRule
 import im.vector.app.core.epoxy.profiles.ProfileMatrixItemWithPowerLevelWithPresence
+import im.vector.app.core.utils.waitUntil
 import im.vector.app.features.roomprofile.members.RoomMemberListCategories
 import im.vector.app.features.roomprofile.members.RoomMemberListController
 import im.vector.app.features.roomprofile.members.RoomMemberListViewState
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
-import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.matrix.android.sdk.api.session.crypto.model.UserVerificationLevel
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.model.RoomMemberSummary
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class RoomMemberListControllerTest {
 
-    @get:Rule
-    val mvrxTestRule = MvRxTestRule()
-
-    @get:Rule
-    val instantExecutorRule = InstantTaskExecutorRule()
-
     @Test
-    fun testControllerUserVerificationLevel() {
+    fun testControllerUserVerificationLevel() = runTest {
         val roomListController = RoomMemberListController(
                 avatarRenderer = mockk {
                 },
@@ -108,6 +98,8 @@ class RoomMemberListControllerTest {
         )
 
         roomListController.setData(state)
+
+        waitUntil { !roomListController.hasPendingModelBuild() }
 
         val models = roomListController.adapter.copyOfModels
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Removed Robolectric dependency, made the single Robolectric test we had `RoomMemberListControllerTest` an instrumentation test instead.

## Motivation and context

Since we're not actively using Robolectric at the moment we decided to remove it. If there is a need to add it back in the future we can always revert this.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Run `RoomMemberListControllerTest`.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 12.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
