### PR TITLE
Fix EventHtmlRendererTest

### DIFF
--- a/vector/src/androidTest/java/im/vector/app/features/html/EventHtmlRendererTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/html/EventHtmlRendererTest.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.html
 
 import androidx.core.text.toSpannable
 import androidx.test.platform.app.InstrumentationRegistry
+import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.utils.toTestSpan
 import im.vector.app.features.settings.VectorPreferences
@@ -36,11 +37,13 @@ class EventHtmlRendererTest {
     private val fakeVectorPreferences = mockk<VectorPreferences>().also {
         every { it.latexMathsIsEnabled() } returns false
     }
+    private val fakeSessionHolder = mockk<ActiveSessionHolder>()
 
     private val renderer = EventHtmlRenderer(
             MatrixHtmlPluginConfigure(ColorProvider(context), context.resources),
             context,
-            fakeVectorPreferences
+            fakeVectorPreferences,
+            fakeSessionHolder,
     )
 
     @Test


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Fix broken instrumented test

## Content

Fix broken `EventHtmlRendererTest`.

## Motivation and context

#5877 introduced changes to `EventHtmlRenderer` and some changes were needed to fix the UI tests.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- `EventHtmlRendererTest` should pass again.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
