### PR TITLE
Try to fix flaky RoomMemberListControllerTest

### DIFF
--- a/vector/src/androidTest/java/im/vector/app/features/RoomMemberListControllerTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/RoomMemberListControllerTest.kt
@@ -18,7 +18,6 @@ package im.vector.app.features
 
 import com.airbnb.mvrx.Success
 import im.vector.app.core.epoxy.profiles.ProfileMatrixItemWithPowerLevelWithPresence
-import im.vector.app.core.utils.waitUntil
 import im.vector.app.features.roomprofile.members.RoomMemberListCategories
 import im.vector.app.features.roomprofile.members.RoomMemberListController
 import im.vector.app.features.roomprofile.members.RoomMemberListViewState
@@ -31,6 +30,8 @@ import org.matrix.android.sdk.api.session.crypto.model.UserVerificationLevel
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.model.RoomMemberSummary
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 class RoomMemberListControllerTest {
 
@@ -97,9 +98,12 @@ class RoomMemberListControllerTest {
                 )
         )
 
-        roomListController.setData(state)
-
-        waitUntil { !roomListController.hasPendingModelBuild() }
+        suspendCoroutine { continuation ->
+            roomListController.setData(state)
+            roomListController.addModelBuildListener {
+                continuation.resume(it)
+            }
+        }
 
         val models = roomListController.adapter.copyOfModels
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical: Flaky UI test
- [ ] Other :

## Content

Change the way `RoomMemberListControllerTest` waits for the models to be built, as it seems like `hasPendingModelBuild()` can return true before the model is actually updated.

## Motivation and context

`RoomMemberListControllerTest` is failing sometimes in our test workflow.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- UI tests should pass.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
