### PR TITLE
[Device Management] Show correct device type icons (PSG-775)

### DIFF
--- a/changelog.d/7277.wip
+++ b/changelog.d/7277.wip
@@ -1,0 +1,1 @@
+[Device Management] Show correct device type icons

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -624,14 +624,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun saveMyDevicesInfo(info: List<DeviceInfo>) {
-        val entities = info.map {
-            MyDeviceLastSeenInfoEntity(
-                    lastSeenTs = it.lastSeenTs,
-                    lastSeenIp = it.lastSeenIp,
-                    displayName = it.displayName,
-                    deviceId = it.deviceId
-            )
-        }
+        val entities = info.map { myDeviceLastSeenInfoEntityMapper.map(it) }
         doRealmTransactionAsync(realmConfiguration) { realm ->
             realm.where<MyDeviceLastSeenInfoEntity>().findAll().deleteAllFromRealm()
             entities.forEach {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStoreMigration.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStoreMigration.kt
@@ -36,6 +36,7 @@ import org.matrix.android.sdk.internal.crypto.store.db.migration.MigrateCryptoTo
 import org.matrix.android.sdk.internal.crypto.store.db.migration.MigrateCryptoTo017
 import org.matrix.android.sdk.internal.crypto.store.db.migration.MigrateCryptoTo018
 import org.matrix.android.sdk.internal.crypto.store.db.migration.MigrateCryptoTo019
+import org.matrix.android.sdk.internal.crypto.store.db.migration.MigrateCryptoTo020
 import org.matrix.android.sdk.internal.util.database.MatrixRealmMigration
 import org.matrix.android.sdk.internal.util.time.Clock
 import javax.inject.Inject
@@ -50,7 +51,7 @@ internal class RealmCryptoStoreMigration @Inject constructor(
         private val clock: Clock,
 ) : MatrixRealmMigration(
         dbName = "Crypto",
-        schemaVersion = 19L,
+        schemaVersion = 20L,
 ) {
     /**
      * Forces all RealmCryptoStoreMigration instances to be equal.
@@ -79,5 +80,6 @@ internal class RealmCryptoStoreMigration @Inject constructor(
         if (oldVersion < 17) MigrateCryptoTo017(realm).perform()
         if (oldVersion < 18) MigrateCryptoTo018(realm).perform()
         if (oldVersion < 19) MigrateCryptoTo019(realm).perform()
+        if (oldVersion < 20) MigrateCryptoTo020(realm).perform()
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/mapper/MyDeviceLastSeenInfoEntityMapper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/mapper/MyDeviceLastSeenInfoEntityMapper.kt
@@ -22,12 +22,24 @@ import javax.inject.Inject
 
 internal class MyDeviceLastSeenInfoEntityMapper @Inject constructor() {
 
+    // TODO add unit tests
     fun map(entity: MyDeviceLastSeenInfoEntity): DeviceInfo {
         return DeviceInfo(
                 deviceId = entity.deviceId,
                 lastSeenIp = entity.lastSeenIp,
                 lastSeenTs = entity.lastSeenTs,
-                displayName = entity.displayName
+                displayName = entity.displayName,
+                unstableLastSeenUserAgent = entity.lastSeenUserAgent,
+        )
+    }
+
+    fun map(deviceInfo: DeviceInfo): MyDeviceLastSeenInfoEntity {
+        return MyDeviceLastSeenInfoEntity(
+                deviceId = deviceInfo.deviceId,
+                lastSeenIp = deviceInfo.lastSeenIp,
+                lastSeenTs = deviceInfo.lastSeenTs,
+                displayName = deviceInfo.displayName,
+                lastSeenUserAgent = deviceInfo.getBestLastSeenUserAgent(),
         )
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/mapper/MyDeviceLastSeenInfoEntityMapper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/mapper/MyDeviceLastSeenInfoEntityMapper.kt
@@ -22,7 +22,6 @@ import javax.inject.Inject
 
 internal class MyDeviceLastSeenInfoEntityMapper @Inject constructor() {
 
-    // TODO add unit tests
     fun map(entity: MyDeviceLastSeenInfoEntity): DeviceInfo {
         return DeviceInfo(
                 deviceId = entity.deviceId,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/migration/MigrateCryptoTo019.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/migration/MigrateCryptoTo019.kt
@@ -30,7 +30,7 @@ import org.matrix.android.sdk.internal.util.database.RealmMigrator
  * mark existing keys as safe.
  * This migration can take long depending on the account
  */
-internal class MigrateCryptoTo019(realm: DynamicRealm) : RealmMigrator(realm, 18) {
+internal class MigrateCryptoTo019(realm: DynamicRealm) : RealmMigrator(realm, 19) {
 
     override fun doMigrate(realm: DynamicRealm) {
         realm.schema.get("CrossSigningInfoEntity")

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/migration/MigrateCryptoTo020.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/migration/MigrateCryptoTo020.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.crypto.store.db.migration
+
+import io.realm.DynamicRealm
+import org.matrix.android.sdk.internal.crypto.store.db.model.MyDeviceLastSeenInfoEntityFields
+import org.matrix.android.sdk.internal.util.database.RealmMigrator
+
+/**
+ * This migration adds a new field into MyDeviceLastSeenInfoEntity corresponding to the last seen user agent.
+ */
+internal class MigrateCryptoTo020(realm: DynamicRealm) : RealmMigrator(realm, 20) {
+
+    override fun doMigrate(realm: DynamicRealm) {
+        realm.schema.get("MyDeviceLastSeenInfoEntity")
+                ?.addField(MyDeviceLastSeenInfoEntityFields.LAST_SEEN_USER_AGENT, String::class.java)
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/MyDeviceLastSeenInfoEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/model/MyDeviceLastSeenInfoEntity.kt
@@ -27,7 +27,9 @@ internal open class MyDeviceLastSeenInfoEntity(
         /** The last time this device has been seen. */
         var lastSeenTs: Long? = null,
         /** The last ip address. */
-        var lastSeenIp: String? = null
+        var lastSeenIp: String? = null,
+        /** The last user agent. */
+        var lastSeenUserAgent: String? = null,
 ) : RealmObject() {
 
     companion object

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/crypto/store/db/mapper/MyDeviceLastSeenInfoEntityMapperTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/crypto/store/db/mapper/MyDeviceLastSeenInfoEntityMapperTest.kt
@@ -25,6 +25,7 @@ private const val A_DEVICE_ID = "device-id"
 private const val AN_IP_ADDRESS = "ip-address"
 private const val A_TIMESTAMP = 123L
 private const val A_DISPLAY_NAME = "display-name"
+private const val A_USER_AGENT = "user-agent"
 
 class MyDeviceLastSeenInfoEntityMapperTest {
 
@@ -32,21 +33,55 @@ class MyDeviceLastSeenInfoEntityMapperTest {
 
     @Test
     fun `given an entity when mapping to model then all fields are correctly mapped`() {
+        // Given
         val entity = MyDeviceLastSeenInfoEntity(
                 deviceId = A_DEVICE_ID,
                 lastSeenIp = AN_IP_ADDRESS,
                 lastSeenTs = A_TIMESTAMP,
-                displayName = A_DISPLAY_NAME
+                displayName = A_DISPLAY_NAME,
+                lastSeenUserAgent = A_USER_AGENT,
         )
         val expectedDeviceInfo = DeviceInfo(
                 deviceId = A_DEVICE_ID,
                 lastSeenIp = AN_IP_ADDRESS,
                 lastSeenTs = A_TIMESTAMP,
-                displayName = A_DISPLAY_NAME
+                displayName = A_DISPLAY_NAME,
+                unstableLastSeenUserAgent = A_USER_AGENT,
         )
 
+        // When
         val deviceInfo = myDeviceLastSeenInfoEntityMapper.map(entity)
 
+        // Then
         deviceInfo shouldBeEqualTo expectedDeviceInfo
+    }
+
+    @Test
+    fun `given a device info when mapping to entity then all fields are correctly mapped`() {
+        // Given
+        val deviceInfo = DeviceInfo(
+                deviceId = A_DEVICE_ID,
+                lastSeenIp = AN_IP_ADDRESS,
+                lastSeenTs = A_TIMESTAMP,
+                displayName = A_DISPLAY_NAME,
+                unstableLastSeenUserAgent = A_USER_AGENT,
+        )
+        val expectedEntity = MyDeviceLastSeenInfoEntity(
+                deviceId = A_DEVICE_ID,
+                lastSeenIp = AN_IP_ADDRESS,
+                lastSeenTs = A_TIMESTAMP,
+                displayName = A_DISPLAY_NAME,
+                lastSeenUserAgent = A_USER_AGENT
+        )
+
+        // When
+        val entity = myDeviceLastSeenInfoEntityMapper.map(deviceInfo)
+
+        // Then
+        entity.deviceId shouldBeEqualTo expectedEntity.deviceId
+        entity.lastSeenIp shouldBeEqualTo expectedEntity.lastSeenIp
+        entity.lastSeenTs shouldBeEqualTo expectedEntity.lastSeenTs
+        entity.displayName shouldBeEqualTo expectedEntity.displayName
+        entity.lastSeenUserAgent shouldBeEqualTo expectedEntity.lastSeenUserAgent
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
@@ -33,6 +33,7 @@ import im.vector.app.core.dialogs.ManuallyVerifyDialog
 import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.DrawableProvider
+import im.vector.app.core.resources.StringProvider
 import im.vector.app.databinding.FragmentSettingsDevicesBinding
 import im.vector.app.features.crypto.recover.SetupMode
 import im.vector.app.features.crypto.verification.VerificationBottomSheet
@@ -60,6 +61,8 @@ class VectorSettingsDevicesFragment :
     @Inject lateinit var drawableProvider: DrawableProvider
 
     @Inject lateinit var colorProvider: ColorProvider
+
+    @Inject lateinit var stringProvider: StringProvider
 
     private val viewModel: DevicesViewModel by fragmentViewModel()
 
@@ -237,7 +240,7 @@ class VectorSettingsDevicesFragment :
                     isCurrentSession = true,
                     deviceFullInfo = it
             )
-            views.deviceListCurrentSession.render(viewState, dateFormatter, drawableProvider, colorProvider)
+            views.deviceListCurrentSession.render(viewState, dateFormatter, drawableProvider, colorProvider, stringProvider)
             views.deviceListCurrentSession.debouncedClicks {
                 currentDeviceInfo.deviceInfo.deviceId?.let { deviceId -> navigateToSessionOverview(deviceId) }
             }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/OtherSessionItem.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/OtherSessionItem.kt
@@ -59,6 +59,8 @@ abstract class OtherSessionItem : VectorEpoxyModel<OtherSessionItem.Holder>(R.la
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
     var clickListener: ClickListener? = null
 
+    private val setDeviceTypeIconUseCase = SetDeviceTypeIconUseCase()
+
     override fun bind(holder: Holder) {
         super.bind(holder)
         holder.view.onClick(clickListener)
@@ -66,24 +68,7 @@ abstract class OtherSessionItem : VectorEpoxyModel<OtherSessionItem.Holder>(R.la
             holder.view.isClickable = false
         }
 
-        when (deviceType) {
-            DeviceType.MOBILE -> {
-                holder.otherSessionDeviceTypeImageView.setImageResource(R.drawable.ic_device_type_mobile)
-                holder.otherSessionDeviceTypeImageView.contentDescription = stringProvider.getString(R.string.a11y_device_manager_device_type_mobile)
-            }
-            DeviceType.WEB -> {
-                holder.otherSessionDeviceTypeImageView.setImageResource(R.drawable.ic_device_type_web)
-                holder.otherSessionDeviceTypeImageView.contentDescription = stringProvider.getString(R.string.a11y_device_manager_device_type_web)
-            }
-            DeviceType.DESKTOP -> {
-                holder.otherSessionDeviceTypeImageView.setImageResource(R.drawable.ic_device_type_desktop)
-                holder.otherSessionDeviceTypeImageView.contentDescription = stringProvider.getString(R.string.a11y_device_manager_device_type_desktop)
-            }
-            DeviceType.UNKNOWN -> {
-                holder.otherSessionDeviceTypeImageView.setImageResource(R.drawable.ic_device_type_unknown)
-                holder.otherSessionDeviceTypeImageView.contentDescription = stringProvider.getString(R.string.a11y_device_manager_device_type_unknown)
-            }
-        }
+        setDeviceTypeIconUseCase.execute(deviceType, holder.otherSessionDeviceTypeImageView, stringProvider)
         holder.otherSessionVerificationStatusImageView.render(roomEncryptionTrustLevel)
         holder.otherSessionNameTextView.text = sessionName
         holder.otherSessionDescriptionTextView.text = sessionDescription

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/OtherSessionsController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/OtherSessionsController.kt
@@ -64,7 +64,7 @@ class OtherSessionsController @Inject constructor(
 
                 otherSessionItem {
                     id(device.deviceInfo.deviceId)
-                    deviceType(DeviceType.UNKNOWN) // TODO. We don't have this info yet. Update accordingly.
+                    deviceType(device.deviceExtendedInfo.deviceType)
                     roomEncryptionTrustLevel(device.roomEncryptionTrustLevel)
                     sessionName(device.deviceInfo.displayName)
                     sessionDescription(description)

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoView.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoView.kt
@@ -28,6 +28,7 @@ import im.vector.app.core.extensions.setTextOrHide
 import im.vector.app.core.extensions.setTextWithColoredPart
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.DrawableProvider
+import im.vector.app.core.resources.StringProvider
 import im.vector.app.databinding.ViewSessionInfoBinding
 import im.vector.app.features.themes.ThemeUtils
 import org.matrix.android.sdk.api.session.crypto.model.DeviceInfo
@@ -51,13 +52,20 @@ class SessionInfoView @JvmOverloads constructor(
     val viewDetailsButton = views.sessionInfoViewDetailsButton
     val viewVerifyButton = views.sessionInfoVerifySessionButton
 
+    private val setDeviceTypeIconUseCase = SetDeviceTypeIconUseCase()
+
     fun render(
             sessionInfoViewState: SessionInfoViewState,
             dateFormatter: VectorDateFormatter,
             drawableProvider: DrawableProvider,
             colorProvider: ColorProvider,
+            stringProvider: StringProvider,
     ) {
-        renderDeviceInfo(sessionInfoViewState.deviceFullInfo.deviceInfo.displayName.orEmpty())
+        renderDeviceInfo(
+                sessionInfoViewState.deviceFullInfo.deviceInfo.displayName.orEmpty(),
+                sessionInfoViewState.deviceFullInfo.deviceExtendedInfo.deviceType,
+                stringProvider,
+        )
         renderVerificationStatus(
                 sessionInfoViewState.deviceFullInfo.roomEncryptionTrustLevel,
                 sessionInfoViewState.isCurrentSession,
@@ -134,10 +142,8 @@ class SessionInfoView @JvmOverloads constructor(
         views.sessionInfoVerifySessionButton.isVisible = isVerifyButtonVisible
     }
 
-    // TODO. We don't have this info yet. Update later accordingly.
-    private fun renderDeviceInfo(sessionName: String) {
-        views.sessionInfoDeviceTypeImageView.setImageResource(R.drawable.ic_device_type_mobile)
-        views.sessionInfoDeviceTypeImageView.contentDescription = context.getString(R.string.a11y_device_manager_device_type_mobile)
+    private fun renderDeviceInfo(sessionName: String, deviceType: DeviceType, stringProvider: StringProvider) {
+        setDeviceTypeIconUseCase.execute(deviceType, views.sessionInfoDeviceTypeImageView, stringProvider)
         views.sessionInfoNameTextView.text = sessionName
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SetDeviceTypeIconUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SetDeviceTypeIconUseCase.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices.v2.list
+
+import android.widget.ImageView
+import im.vector.app.R
+import im.vector.app.core.resources.StringProvider
+
+class SetDeviceTypeIconUseCase {
+
+    fun execute(deviceType: DeviceType, imageView: ImageView, stringProvider: StringProvider) {
+        when (deviceType) {
+            DeviceType.MOBILE -> {
+                imageView.setImageResource(R.drawable.ic_device_type_mobile)
+                imageView.contentDescription = stringProvider.getString(R.string.a11y_device_manager_device_type_mobile)
+            }
+            DeviceType.WEB -> {
+                imageView.setImageResource(R.drawable.ic_device_type_web)
+                imageView.contentDescription = stringProvider.getString(R.string.a11y_device_manager_device_type_web)
+            }
+            DeviceType.DESKTOP -> {
+                imageView.setImageResource(R.drawable.ic_device_type_desktop)
+                imageView.contentDescription = stringProvider.getString(R.string.a11y_device_manager_device_type_desktop)
+            }
+            DeviceType.UNKNOWN -> {
+                imageView.setImageResource(R.drawable.ic_device_type_unknown)
+                imageView.contentDescription = stringProvider.getString(R.string.a11y_device_manager_device_type_unknown)
+            }
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
@@ -37,6 +37,7 @@ import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.core.platform.VectorMenuProvider
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.DrawableProvider
+import im.vector.app.core.resources.StringProvider
 import im.vector.app.databinding.FragmentSessionOverviewBinding
 import im.vector.app.features.auth.ReAuthActivity
 import im.vector.app.features.crypto.recover.SetupMode
@@ -63,6 +64,8 @@ class SessionOverviewFragment :
     @Inject lateinit var drawableProvider: DrawableProvider
 
     @Inject lateinit var colorProvider: ColorProvider
+
+    @Inject lateinit var stringProvider: StringProvider
 
     private val viewModel: SessionOverviewViewModel by fragmentViewModel()
 
@@ -205,7 +208,7 @@ class SessionOverviewFragment :
                     isLearnMoreLinkVisible = true,
                     isLastSeenDetailsVisible = true,
             )
-            views.sessionOverviewInfo.render(infoViewState, dateFormatter, drawableProvider, colorProvider)
+            views.sessionOverviewInfo.render(infoViewState, dateFormatter, drawableProvider, colorProvider, stringProvider)
             views.sessionOverviewInfo.onLearnMoreClickListener = {
                 showLearnMoreInfoVerificationStatus(deviceInfo.roomEncryptionTrustLevel == RoomEncryptionTrustLevel.Trusted)
             }

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/list/SetDeviceTypeIconUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/list/SetDeviceTypeIconUseCaseTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices.v2.list
+
+import android.widget.ImageView
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import im.vector.app.R
+import im.vector.app.test.fakes.FakeStringProvider
+import io.mockk.mockk
+import io.mockk.verifyAll
+import org.junit.Test
+
+private const val A_DESCRIPTION = "description"
+
+class SetDeviceTypeIconUseCaseTest {
+
+    private val fakeStringProvider = FakeStringProvider()
+
+    private val setDeviceTypeIconUseCase = SetDeviceTypeIconUseCase()
+
+    @Test
+    fun `given a device type when execute then correct icon and description is set to the ImageView`() {
+        testType(
+                deviceType = DeviceType.UNKNOWN,
+                drawableResId = R.drawable.ic_device_type_unknown,
+                descriptionResId = R.string.a11y_device_manager_device_type_unknown
+        )
+
+        testType(
+                deviceType = DeviceType.MOBILE,
+                drawableResId = R.drawable.ic_device_type_mobile,
+                descriptionResId = R.string.a11y_device_manager_device_type_mobile
+        )
+
+        testType(
+                deviceType = DeviceType.WEB,
+                drawableResId = R.drawable.ic_device_type_web,
+                descriptionResId = R.string.a11y_device_manager_device_type_web
+        )
+
+        testType(
+                deviceType = DeviceType.DESKTOP,
+                drawableResId = R.drawable.ic_device_type_desktop,
+                descriptionResId = R.string.a11y_device_manager_device_type_desktop
+        )
+    }
+
+    private fun testType(deviceType: DeviceType, @DrawableRes drawableResId: Int, @StringRes descriptionResId: Int) {
+        // Given
+        val imageView = mockk<ImageView>(relaxUnitFun = true)
+        fakeStringProvider.given(descriptionResId, A_DESCRIPTION)
+
+        // When
+        setDeviceTypeIconUseCase.execute(deviceType, imageView, fakeStringProvider.instance)
+
+        // Then
+        verifyAll {
+            imageView.setImageResource(drawableResId)
+            imageView.contentDescription = A_DESCRIPTION
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Display the correct device type icon on item in lists and in the session overview view.
Adding mapping from `DeviceInfo` to Realm entity for the user agent field with the corresponding migration.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7277 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

<img src="https://user-images.githubusercontent.com/46314705/194012360-b3332ff7-a2cc-4aed-b0ec-7127ebd38a83.png" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/194012374-41ed578d-5c2d-4c82-b731-3355f760537b.png" width=300 />

## Tests

<!-- Explain how you tested your development -->

- Login to an account in https://synapse-prefill.lab.element.dev (Synapse deployment with experimental feature flags for MSC3852 (exposure of user agent))
- Enable the new device manager feature flag
- Go to Settings -> Security & Privacy -> Show all sessions (WIP, V2)
- Check there are correct icons for device types of each of the sessions in the other sessions list and in the session overview views

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
