### PR TITLE
Fix the wrong mic button direction to cancel on RTL languages

### DIFF
--- a/changelog.d/5968.bugfix
+++ b/changelog.d/5968.bugfix
@@ -1,0 +1,1 @@
+Fix wrong mic button direction to cancel on RTL languages

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/voice/DraggableStateProcessor.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/voice/DraggableStateProcessor.kt
@@ -21,6 +21,7 @@ import android.view.MotionEvent
 import im.vector.app.R
 import im.vector.app.core.utils.DimensionConverter
 import im.vector.app.features.home.room.detail.composer.voice.VoiceMessageRecorderView.DraggingState
+import kotlin.math.absoluteValue
 
 class DraggableStateProcessor(
         resources: Resources,
@@ -46,7 +47,7 @@ class DraggableStateProcessor(
     fun process(event: MotionEvent, draggingState: DraggingState): DraggingState {
         val currentX = event.rawX
         val currentY = event.rawY
-        val distanceX = firstX - currentX
+        val distanceX = (firstX - currentX).absoluteValue
         val distanceY = firstY - currentY
         return draggingState.nextDragState(currentX, currentY, distanceX, distanceY).also {
             lastDistanceX = distanceX


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Fix the wrong mic button direction to cancel on RTL languages.
The cause of this bug is due to the distance calculation of X coordinate in ```DraggableStateProcessor```.
The way to measure distance seems like not considering RTL languages.
So When it becomes RTL, the distance value becomes negative.
So I take the absolute value of the calculation.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix #5968 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->


|Before|After|
|-|-|
| <video src="https://user-images.githubusercontent.com/39683194/194820876-204a5b34-109f-4ac2-a8d3-00e2ea9ce4a7.mp4" /> |  <video src="https://user-images.githubusercontent.com/39683194/194820935-ee3e1ff3-78ae-4aed-8773-5f7aa05129e6.mp4" />|


## Tests

<!-- Explain how you tested your development -->

- Step 1
 Enter the chat room
- Step 2
 Test when it is not RTL. it works fine.
- Step 3
 Developer Options -> Turn on "Force RTL Layout direction"
- Step 4
 When dragging the mic button, it works differently with no RTL situation.

## Tested devices

- [x] Physical (SM-G981N)
- [ ] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
