### PR TITLE
[Device management] Improve the parsing for OS of Desktop/Web sessions (PSG-823)

### DIFF
--- a/changelog.d/7321.wip
+++ b/changelog.d/7321.wip
@@ -1,0 +1,1 @@
+[Device management] Improve the parsing for OS of Desktop/Web sessions

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/ParseDeviceUserAgentUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/ParseDeviceUserAgentUseCase.kt
@@ -92,17 +92,17 @@ class ParseDeviceUserAgentUseCase @Inject constructor() {
         val browserSegments = userAgent.split(" ")
         return when {
             isFirefox(browserSegments) -> {
-                BrowserInfo("Firefox", getBrowserVersion(browserSegments, "Firefox"))
+                BrowserInfo(BROWSER_FIREFOX, getBrowserVersion(browserSegments, BROWSER_FIREFOX))
             }
             isEdge(browserSegments) -> {
-                BrowserInfo("Edge", getBrowserVersion(browserSegments, "Edge"))
+                BrowserInfo(BROWSER_EDGE, getBrowserVersion(browserSegments, BROWSER_EDGE))
             }
             isMobile(browserSegments) -> {
                 when (val name = getMobileBrowserName(browserSegments)) {
                     null -> {
                         BrowserInfo()
                     }
-                    "Safari" -> {
+                    BROWSER_SAFARI -> {
                         BrowserInfo(name, getBrowserVersion(browserSegments, "Version"))
                     }
                     else -> {
@@ -111,7 +111,7 @@ class ParseDeviceUserAgentUseCase @Inject constructor() {
                 }
             }
             isSafari(browserSegments) -> {
-                BrowserInfo("Safari", getBrowserVersion(browserSegments, "Version"))
+                BrowserInfo(BROWSER_SAFARI, getBrowserVersion(browserSegments, "Version"))
             }
             else -> {
                 when (val name = getRegularBrowserName(browserSegments)) {
@@ -182,7 +182,7 @@ class ParseDeviceUserAgentUseCase @Inject constructor() {
     }
 
     private fun isFirefox(browserSegments: List<String>): Boolean {
-        return browserSegments.lastOrNull()?.startsWith("Firefox").orFalse()
+        return browserSegments.lastOrNull()?.startsWith(BROWSER_FIREFOX).orFalse()
     }
 
     private fun getBrowserVersion(browserSegments: List<String>, browserName: String): String? {
@@ -194,11 +194,11 @@ class ParseDeviceUserAgentUseCase @Inject constructor() {
     }
 
     private fun isEdge(browserSegments: List<String>): Boolean {
-        return browserSegments.lastOrNull()?.startsWith("Edge").orFalse()
+        return browserSegments.lastOrNull()?.startsWith(BROWSER_EDGE).orFalse()
     }
 
     private fun isSafari(browserSegments: List<String>): Boolean {
-        return browserSegments.lastOrNull()?.startsWith("Safari").orFalse() &&
+        return browserSegments.lastOrNull()?.startsWith(BROWSER_SAFARI).orFalse() &&
                 browserSegments.getOrNull(browserSegments.size - 2)?.startsWith("Version").orFalse()
     }
 
@@ -209,7 +209,7 @@ class ParseDeviceUserAgentUseCase @Inject constructor() {
     private fun getMobileBrowserName(browserSegments: List<String>): String? {
         val possibleBrowserName = browserSegments.getOrNull(browserSegments.size - 3)?.split("/")?.firstOrNull()
         return if (possibleBrowserName == "Version") {
-            "Safari"
+            BROWSER_SAFARI
         } else {
             possibleBrowserName
         }
@@ -241,5 +241,9 @@ class ParseDeviceUserAgentUseCase @Inject constructor() {
         private const val OPERATING_SYSTEM_ANDROID_KEYWORD = "Android"
         private const val DEVICE_IPAD_KEYWORD = "iPad"
         private const val DEVICE_IPHONE_KEYWORD = "iPhone"
+
+        private const val BROWSER_FIREFOX = "Firefox"
+        private const val BROWSER_SAFARI = "Safari"
+        private const val BROWSER_EDGE = "Edge"
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/ParseDeviceUserAgentUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/ParseDeviceUserAgentUseCase.kt
@@ -75,17 +75,12 @@ class ParseDeviceUserAgentUseCase @Inject constructor() {
 
     private fun parseDesktopUserAgent(userAgent: String): DeviceExtendedInfo {
         val browserInfo = parseBrowserInfoFromDesktopUserAgent(userAgent)
+        val operatingSystem = parseOperatingSystemFromDesktopUserAgent(userAgent)
 
-        val deviceOperatingSystemSegments = userAgent.substringAfter("(").substringBefore(")").split("; ")
-        val deviceOperatingSystem = if (deviceOperatingSystemSegments.getOrNull(1)?.startsWith("Android").orFalse()) {
-            deviceOperatingSystemSegments.getOrNull(1)
-        } else {
-            deviceOperatingSystemSegments.getOrNull(0)
-        }
         return DeviceExtendedInfo(
                 deviceType = DeviceType.DESKTOP,
                 deviceModel = null,
-                deviceOperatingSystem = deviceOperatingSystem,
+                deviceOperatingSystem = operatingSystem,
                 clientName = browserInfo.name,
                 clientVersion = browserInfo.version,
         )
@@ -128,6 +123,15 @@ class ParseDeviceUserAgentUseCase @Inject constructor() {
                     }
                 }
             }
+        }
+    }
+
+    private fun parseOperatingSystemFromDesktopUserAgent(userAgent: String): String? {
+        val deviceOperatingSystemSegments = userAgent.substringAfter("(").substringBefore(")").split("; ")
+        return if (deviceOperatingSystemSegments.getOrNull(1)?.startsWith("Android").orFalse()) {
+            deviceOperatingSystemSegments.getOrNull(1)
+        } else {
+            deviceOperatingSystemSegments.getOrNull(0)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/ParseDeviceUserAgentUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/ParseDeviceUserAgentUseCase.kt
@@ -135,38 +135,14 @@ class ParseDeviceUserAgentUseCase @Inject constructor() {
         val secondSegment = deviceOperatingSystemSegments.getOrNull(1).orEmpty()
 
         return when {
-            firstSegment.startsWith(OPERATING_SYSTEM_MAC_KEYWORD) -> {
-                // e.g. (Macintosh; Intel Mac OS X 10_15_7) => macOS 10.15.7
-                val version = secondSegment
-                        .substringAfterLast(" ")
-                        .replace("_", ".")
-                if (version.isEmpty()) {
-                    OPERATING_SYSTEM_MAC
-                } else {
-                    "$OPERATING_SYSTEM_MAC $version"
-                }
-            }
-            firstSegment.startsWith(OPERATING_SYSTEM_WINDOWS_KEYWORD) -> {
-                // e.g. (Windows NT 10.0; Win64; x64) => Windows 10.0
-                firstSegment.replace("NT ", "")
-            }
-            firstSegment.startsWith(DEVICE_IPAD_KEYWORD) || firstSegment.startsWith(DEVICE_IPHONE_KEYWORD) -> {
-                // e.g. (iPad; CPU OS 8_4_1 like Mac OS X) => macOS 8.4.1
-                val version = secondSegment
-                        .split(" ")
-                        .find { it.contains("_") }
-                        ?.replace("_", ".")
-                        .orEmpty()
-                if (version.isEmpty()) {
-                    OPERATING_SYSTEM_IOS
-                } else {
-                    "$OPERATING_SYSTEM_IOS $version"
-                }
-            }
-            secondSegment.startsWith(OPERATING_SYSTEM_ANDROID_KEYWORD) -> {
-                // e.g. (Linux; Android 9; SM-G973U Build/PPR1.180610.011) => Android 9
-                secondSegment
-            }
+            // e.g. (Macintosh; Intel Mac OS X 10_15_7) => macOS
+            firstSegment.startsWith(OPERATING_SYSTEM_MAC_KEYWORD) -> OPERATING_SYSTEM_MAC
+            // e.g. (Windows NT 10.0; Win64; x64) => Windows
+            firstSegment.startsWith(OPERATING_SYSTEM_WINDOWS_KEYWORD) -> OPERATING_SYSTEM_WINDOWS_KEYWORD
+            // e.g. (iPad; CPU OS 8_4_1 like Mac OS X) => iOS
+            firstSegment.startsWith(DEVICE_IPAD_KEYWORD) || firstSegment.startsWith(DEVICE_IPHONE_KEYWORD) -> OPERATING_SYSTEM_IOS
+            // e.g. (Linux; Android 9; SM-G973U Build/PPR1.180610.011) => Android
+            secondSegment.startsWith(OPERATING_SYSTEM_ANDROID_KEYWORD) -> OPERATING_SYSTEM_ANDROID_KEYWORD
             else -> null
         }
     }

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/ParseDeviceUserAgentUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/ParseDeviceUserAgentUseCaseTest.kt
@@ -62,8 +62,8 @@ private val A_USER_AGENT_LIST_FOR_DESKTOP = listOf(
         "Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) ElementNightly/2022091301 Chrome/104.0.5112.102 Electron/20.1.1 Safari/537.36",
 )
 private val AN_EXPECTED_RESULT_LIST_FOR_DESKTOP = listOf(
-        DeviceExtendedInfo(DeviceType.DESKTOP, null, "Macintosh", "Electron", "20.1.1"),
-        DeviceExtendedInfo(DeviceType.DESKTOP, null, "Windows NT 10.0", "Electron", "20.1.1"),
+        DeviceExtendedInfo(DeviceType.DESKTOP, null, "macOS 10.15.7", "Electron", "20.1.1"),
+        DeviceExtendedInfo(DeviceType.DESKTOP, null, "Windows 10.0", "Electron", "20.1.1"),
 )
 
 private val A_USER_AGENT_LIST_FOR_WEB = listOf(
@@ -78,15 +78,15 @@ private val A_USER_AGENT_LIST_FOR_WEB = listOf(
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246",
         )
 private val AN_EXPECTED_RESULT_LIST_FOR_WEB = listOf(
-        DeviceExtendedInfo(DeviceType.WEB, null, "Macintosh", "Chrome", "104.0.5112.102"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "Windows NT 10.0", "Chrome", "104.0.5112.102"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "Macintosh", "Firefox", "39.0"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "Macintosh", "Safari", "8.0.3"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "macOS 10.15.7", "Chrome", "104.0.5112.102"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "Windows 10.0", "Chrome", "104.0.5112.102"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "macOS 10.10", "Firefox", "39.0"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "macOS 10.10.2", "Safari", "8.0.3"),
         DeviceExtendedInfo(DeviceType.WEB, null, "Android 9", "Chrome", "69.0.3497.100"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "iPad", "Safari", "8.0"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "iPhone", "Safari", "8.0"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "Windows NT 6.0", "Firefox", "40.0"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "Windows NT 10.0", "Edge", "12.246"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "iOS 8.4.1", "Safari", "8.0"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "iOS 8.4.1", "Safari", "8.0"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "Windows 6.0", "Firefox", "40.0"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "Windows 10.0", "Edge", "12.246"),
 )
 
 private val AN_UNKNOWN_USER_AGENT_LIST = listOf(

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/ParseDeviceUserAgentUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/ParseDeviceUserAgentUseCaseTest.kt
@@ -62,8 +62,8 @@ private val A_USER_AGENT_LIST_FOR_DESKTOP = listOf(
         "Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) ElementNightly/2022091301 Chrome/104.0.5112.102 Electron/20.1.1 Safari/537.36",
 )
 private val AN_EXPECTED_RESULT_LIST_FOR_DESKTOP = listOf(
-        DeviceExtendedInfo(DeviceType.DESKTOP, null, "macOS 10.15.7", "Electron", "20.1.1"),
-        DeviceExtendedInfo(DeviceType.DESKTOP, null, "Windows 10.0", "Electron", "20.1.1"),
+        DeviceExtendedInfo(DeviceType.DESKTOP, null, "macOS", "Electron", "20.1.1"),
+        DeviceExtendedInfo(DeviceType.DESKTOP, null, "Windows", "Electron", "20.1.1"),
 )
 
 private val A_USER_AGENT_LIST_FOR_WEB = listOf(
@@ -78,15 +78,15 @@ private val A_USER_AGENT_LIST_FOR_WEB = listOf(
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246",
         )
 private val AN_EXPECTED_RESULT_LIST_FOR_WEB = listOf(
-        DeviceExtendedInfo(DeviceType.WEB, null, "macOS 10.15.7", "Chrome", "104.0.5112.102"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "Windows 10.0", "Chrome", "104.0.5112.102"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "macOS 10.10", "Firefox", "39.0"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "macOS 10.10.2", "Safari", "8.0.3"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "Android 9", "Chrome", "69.0.3497.100"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "iOS 8.4.1", "Safari", "8.0"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "iOS 8.4.1", "Safari", "8.0"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "Windows 6.0", "Firefox", "40.0"),
-        DeviceExtendedInfo(DeviceType.WEB, null, "Windows 10.0", "Edge", "12.246"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "macOS", "Chrome", "104.0.5112.102"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "Windows", "Chrome", "104.0.5112.102"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "macOS", "Firefox", "39.0"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "macOS", "Safari", "8.0.3"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "Android", "Chrome", "69.0.3497.100"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "iOS", "Safari", "8.0"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "iOS", "Safari", "8.0"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "Windows", "Firefox", "40.0"),
+        DeviceExtendedInfo(DeviceType.WEB, null, "Windows", "Edge", "12.246"),
 )
 
 private val AN_UNKNOWN_USER_AGENT_LIST = listOf(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Improving the parsing of the user agent in the operating system fields.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7321 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

<img src="https://user-images.githubusercontent.com/46314705/194889464-620ab821-d00c-4408-944f-17e0cd433e4e.png" width=300 />

## Tests

<!-- Explain how you tested your development -->

- Enable the feature flag for new device management
- Sign-in a Web session using the test server: synapse-prefill.lab.element.dev
- Sign-in a mobile session
- Go to Settings -> Security & Privacy -> Show all sessions (V2, WIP)
- Go to the session details screen of the Web session
- Check the operating system is correct

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
