### PR TITLE
[Device management] Hide the IP address and last activity date on current session (PSG-823)

### DIFF
--- a/changelog.d/7324.wip
+++ b/changelog.d/7324.wip
@@ -1,0 +1,1 @@
+[Device management] Hide the IP address and last activity date on current session

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
@@ -206,7 +206,7 @@ class SessionOverviewFragment :
                     isVerifyButtonVisible = isCurrentSession || viewState.isCurrentSessionTrusted,
                     isDetailsButtonVisible = false,
                     isLearnMoreLinkVisible = true,
-                    isLastSeenDetailsVisible = true,
+                    isLastSeenDetailsVisible = !isCurrentSession,
             )
             views.sessionOverviewInfo.render(infoViewState, dateFormatter, drawableProvider, colorProvider, stringProvider)
             views.sessionOverviewInfo.onLearnMoreClickListener = {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Hiding the last seen info details on the Session Info card view when it is the current session.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7324 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|<img src="https://user-images.githubusercontent.com/46314705/194884903-03e83124-00a0-4757-bd83-88b06984de1d.png" width=300 />|<img src="https://user-images.githubusercontent.com/46314705/194884909-063a82e8-3c77-492a-9de8-a3cecf4cd0ed.png" width=300 />|

## Tests

<!-- Explain how you tested your development -->

- Enable the feature flag for new device manager
- Go to Settings -> Security & Privacy -> Show all sessions (V2, WIP)
- Check the current session info card view does not show the last seen details in the main screen and in the overview screen
- Check the last seen details info is displayed for other sessions when on session overview screen

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
