### PR TITLE
[Device management] Add lab flag for matrix client info account data event (PSG-800)

### DIFF
--- a/changelog.d/7344.feature
+++ b/changelog.d/7344.feature
@@ -1,0 +1,1 @@
+[Device management] Add lab flag for matrix client info account data event

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -3336,6 +3336,8 @@
     <string name="device_manager_learn_more_session_rename">Other users in direct messages and rooms that you join are able to view a full list of your sessions.\n\nThis provides them with confidence that they are really speaking to you, but it also means they can see the session name you enter here.</string>
     <string name="labs_enable_session_manager_title">Enable new session manager</string>
     <string name="labs_enable_session_manager_summary">Have greater visibility and control over all your sessions.</string>
+    <string name="labs_enable_client_info_recording_title">Enable client info recording</string>
+    <string name="labs_enable_client_info_recording_summary">Record the client name, version, and url to recognise sessions more easily in session manager.</string>
 
     <!-- Note to translators: %s will be replaces with selected space name -->
     <string name="home_empty_space_no_rooms_title">%s\nis looking a little empty.</string>

--- a/vector-config/src/main/res/values/config-settings.xml
+++ b/vector-config/src/main/res/values/config-settings.xml
@@ -42,7 +42,9 @@
     <bool name="settings_labs_thread_messages_default">false</bool>
     <bool name="settings_labs_new_app_layout_default">true</bool>
     <bool name="settings_labs_new_session_manager_default">false</bool>
+    <bool name="settings_labs_new_session_manager_visible">true</bool>
     <bool name="settings_labs_client_info_recording_default">false</bool>
+    <bool name="settings_labs_client_info_recording_visible">true</bool>
     <bool name="settings_timeline_show_live_sender_info_visible">true</bool>
     <bool name="settings_timeline_show_live_sender_info_default">false</bool>
     <bool name="settings_labs_rich_text_editor_visible">true</bool>

--- a/vector-config/src/main/res/values/config-settings.xml
+++ b/vector-config/src/main/res/values/config-settings.xml
@@ -42,6 +42,7 @@
     <bool name="settings_labs_thread_messages_default">false</bool>
     <bool name="settings_labs_new_app_layout_default">true</bool>
     <bool name="settings_labs_new_session_manager_default">false</bool>
+    <bool name="settings_labs_client_info_recording_default">false</bool>
     <bool name="settings_timeline_show_live_sender_info_visible">true</bool>
     <bool name="settings_timeline_show_live_sender_info_default">false</bool>
     <bool name="settings_labs_rich_text_editor_visible">true</bool>

--- a/vector/src/main/java/im/vector/app/core/di/MavericksViewModelModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/MavericksViewModelModule.kt
@@ -100,6 +100,7 @@ import im.vector.app.features.settings.devtools.KeyRequestViewModel
 import im.vector.app.features.settings.font.FontScaleSettingViewModel
 import im.vector.app.features.settings.homeserver.HomeserverSettingsViewModel
 import im.vector.app.features.settings.ignored.IgnoredUsersViewModel
+import im.vector.app.features.settings.labs.VectorSettingsLabsViewModel
 import im.vector.app.features.settings.legals.LegalsViewModel
 import im.vector.app.features.settings.locale.LocalePickerViewModel
 import im.vector.app.features.settings.push.PushGatewaysViewModel
@@ -665,4 +666,9 @@ interface MavericksViewModelModule {
     @IntoMap
     @MavericksViewModelKey(SessionLearnMoreViewModel::class)
     fun sessionLearnMoreViewModelFactory(factory: SessionLearnMoreViewModel.Factory): MavericksAssistedViewModelFactory<*, *>
+
+    @Binds
+    @IntoMap
+    @MavericksViewModelKey(VectorSettingsLabsViewModel::class)
+    fun vectorSettingsLabsViewModelFactory(factory: VectorSettingsLabsViewModel.Factory): MavericksAssistedViewModelFactory<*, *>
 }

--- a/vector/src/main/java/im/vector/app/core/session/ConfigureAndStartSessionUseCase.kt
+++ b/vector/src/main/java/im/vector/app/core/session/ConfigureAndStartSessionUseCase.kt
@@ -21,6 +21,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import im.vector.app.core.extensions.startSyncing
 import im.vector.app.core.session.clientinfo.UpdateMatrixClientInfoUseCase
 import im.vector.app.features.call.webrtc.WebRtcCallManager
+import im.vector.app.features.settings.VectorPreferences
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.sync.FilterService
 import timber.log.Timber
@@ -30,6 +31,7 @@ class ConfigureAndStartSessionUseCase @Inject constructor(
         @ApplicationContext private val context: Context,
         private val webRtcCallManager: WebRtcCallManager,
         private val updateMatrixClientInfoUseCase: UpdateMatrixClientInfoUseCase,
+        private val vectorPreferences: VectorPreferences,
 ) {
 
     suspend fun execute(session: Session, startSyncing: Boolean = true) {
@@ -41,6 +43,8 @@ class ConfigureAndStartSessionUseCase @Inject constructor(
         }
         session.pushersService().refreshPushers()
         webRtcCallManager.checkForProtocolsSupportIfNeeded()
-        updateMatrixClientInfoUseCase.execute(session)
+        if (vectorPreferences.isClientInfoRecordingEnabled()) {
+            updateMatrixClientInfoUseCase.execute(session)
+        }
     }
 }

--- a/vector/src/main/java/im/vector/app/core/session/clientinfo/DeleteMatrixClientInfoUseCase.kt
+++ b/vector/src/main/java/im/vector/app/core/session/clientinfo/DeleteMatrixClientInfoUseCase.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.session.clientinfo
+
+import im.vector.app.core.di.ActiveSessionHolder
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * This use case delete the account data event containing extended client info.
+ */
+class DeleteMatrixClientInfoUseCase @Inject constructor(
+        private val activeSessionHolder: ActiveSessionHolder,
+        private val setMatrixClientInfoUseCase: SetMatrixClientInfoUseCase,
+) {
+
+    // TODO add unit tests
+    suspend fun execute(): Result<Unit> = runCatching {
+        Timber.d("deleting recorded client info")
+        val session = activeSessionHolder.getActiveSession()
+        val emptyClientInfo = MatrixClientInfoContent(
+                name = "",
+                version = "",
+                url = "",
+        )
+        setMatrixClientInfoUseCase.execute(session, emptyClientInfo)
+    }
+}

--- a/vector/src/main/java/im/vector/app/core/session/clientinfo/DeleteMatrixClientInfoUseCase.kt
+++ b/vector/src/main/java/im/vector/app/core/session/clientinfo/DeleteMatrixClientInfoUseCase.kt
@@ -28,7 +28,6 @@ class DeleteMatrixClientInfoUseCase @Inject constructor(
         private val setMatrixClientInfoUseCase: SetMatrixClientInfoUseCase,
 ) {
 
-    // TODO add unit tests
     suspend fun execute(): Result<Unit> = runCatching {
         Timber.d("deleting recorded client info")
         val session = activeSessionHolder.getActiveSession()
@@ -37,6 +36,6 @@ class DeleteMatrixClientInfoUseCase @Inject constructor(
                 version = "",
                 url = "",
         )
-        setMatrixClientInfoUseCase.execute(session, emptyClientInfo)
+        return setMatrixClientInfoUseCase.execute(session, emptyClientInfo)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -73,6 +73,7 @@ class VectorPreferences @Inject constructor(
         const val SETTINGS_LABS_DEFERRED_DM_KEY = "SETTINGS_LABS_DEFERRED_DM_KEY"
         const val SETTINGS_LABS_RICH_TEXT_EDITOR_KEY = "SETTINGS_LABS_RICH_TEXT_EDITOR_KEY"
         const val SETTINGS_LABS_NEW_SESSION_MANAGER_KEY = "SETTINGS_LABS_NEW_SESSION_MANAGER_KEY"
+        const val SETTINGS_LABS_CLIENT_INFO_RECORDING_KEY = "SETTINGS_LABS_CLIENT_INFO_RECORDING_KEY"
         const val SETTINGS_CRYPTOGRAPHY_PREFERENCE_KEY = "SETTINGS_CRYPTOGRAPHY_PREFERENCE_KEY"
         const val SETTINGS_CRYPTOGRAPHY_DIVIDER_PREFERENCE_KEY = "SETTINGS_CRYPTOGRAPHY_DIVIDER_PREFERENCE_KEY"
         const val SETTINGS_CRYPTOGRAPHY_MANAGE_PREFERENCE_KEY = "SETTINGS_CRYPTOGRAPHY_MANAGE_PREFERENCE_KEY"
@@ -1186,6 +1187,13 @@ class VectorPreferences @Inject constructor(
      */
     fun isNewSessionManagerEnabled(): Boolean {
         return defaultPrefs.getBoolean(SETTINGS_LABS_NEW_SESSION_MANAGER_KEY, getDefault(R.bool.settings_labs_new_session_manager_default))
+    }
+
+    /**
+     * Indicates whether or not client info recording is enabled.
+     */
+    fun isClientInfoRecordingEnabled(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_LABS_CLIENT_INFO_RECORDING_KEY, getDefault(R.bool.settings_labs_client_info_recording_default))
     }
 
     fun showLiveSenderInfo(): Boolean {

--- a/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsAction.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsAction.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.labs
+
+import im.vector.app.core.platform.VectorViewModelAction
+
+sealed class VectorSettingsLabsAction : VectorViewModelAction {
+    object UpdateClientInfo : VectorSettingsLabsAction()
+    object DeleteRecordedClientInfo : VectorSettingsLabsAction()
+}

--- a/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 New Vector Ltd
+ * Copyright (c) 2022 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings
+package im.vector.app.features.settings.labs
 
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
@@ -30,6 +30,8 @@ import im.vector.app.features.MainActivityArgs
 import im.vector.app.features.VectorFeatures
 import im.vector.app.features.analytics.plan.MobileScreen
 import im.vector.app.features.home.room.threads.ThreadsManager
+import im.vector.app.features.settings.VectorPreferences
+import im.vector.app.features.settings.VectorSettingsBaseFragment
 import org.matrix.android.sdk.api.settings.LightweightSettingsStorage
 import javax.inject.Inject
 

--- a/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
@@ -20,7 +20,9 @@ import android.os.Bundle
 import android.text.method.LinkMovementMethod
 import android.widget.TextView
 import androidx.preference.Preference
+import androidx.preference.Preference.OnPreferenceChangeListener
 import androidx.preference.SwitchPreference
+import com.airbnb.mvrx.fragmentViewModel
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
@@ -38,6 +40,8 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class VectorSettingsLabsFragment :
         VectorSettingsBaseFragment() {
+
+    private val viewModel: VectorSettingsLabsViewModel by fragmentViewModel()
 
     @Inject lateinit var vectorPreferences: VectorPreferences
     @Inject lateinit var lightweightSettingsStorage: LightweightSettingsStorage
@@ -87,6 +91,7 @@ class VectorSettingsLabsFragment :
         }
 
         configureUnreadNotificationsAsTabPreference()
+        configureEnableClientInfoRecordingPreference()
     }
 
     private fun configureUnreadNotificationsAsTabPreference() {
@@ -141,5 +146,17 @@ class VectorSettingsLabsFragment :
      */
     private fun onNewLayoutPreferenceClicked() {
         configureUnreadNotificationsAsTabPreference()
+    }
+
+    private fun configureEnableClientInfoRecordingPreference() {
+        findPreference<VectorSwitchPreference>(VectorPreferences.SETTINGS_LABS_CLIENT_INFO_RECORDING_KEY)?.onPreferenceChangeListener =
+                OnPreferenceChangeListener { _, newValue ->
+                    when {
+                        (newValue as? Boolean) == false -> viewModel.handle(VectorSettingsLabsAction.DeleteRecordedClientInfo)
+                        (newValue as? Boolean) == true -> viewModel.handle(VectorSettingsLabsAction.UpdateClientInfo)
+                        else -> Unit
+                    }
+                    true
+                }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2019 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
@@ -151,9 +151,9 @@ class VectorSettingsLabsFragment :
     private fun configureEnableClientInfoRecordingPreference() {
         findPreference<VectorSwitchPreference>(VectorPreferences.SETTINGS_LABS_CLIENT_INFO_RECORDING_KEY)?.onPreferenceChangeListener =
                 OnPreferenceChangeListener { _, newValue ->
-                    when {
-                        (newValue as? Boolean) == false -> viewModel.handle(VectorSettingsLabsAction.DeleteRecordedClientInfo)
-                        (newValue as? Boolean) == true -> viewModel.handle(VectorSettingsLabsAction.UpdateClientInfo)
+                    when (newValue as? Boolean) {
+                        false -> viewModel.handle(VectorSettingsLabsAction.DeleteRecordedClientInfo)
+                        true -> viewModel.handle(VectorSettingsLabsAction.UpdateClientInfo)
                         else -> Unit
                     }
                     true

--- a/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsViewModel.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.labs
+
+import com.airbnb.mvrx.MavericksViewModelFactory
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.core.di.MavericksAssistedViewModelFactory
+import im.vector.app.core.di.hiltMavericksViewModelFactory
+import im.vector.app.core.platform.EmptyViewEvents
+import im.vector.app.core.platform.VectorViewModel
+import im.vector.app.core.session.clientinfo.DeleteMatrixClientInfoUseCase
+import im.vector.app.core.session.clientinfo.UpdateMatrixClientInfoUseCase
+import kotlinx.coroutines.launch
+
+class VectorSettingsLabsViewModel @AssistedInject constructor(
+        @Assisted initialState: VectorSettingsLabsViewState,
+        private val activeSessionHolder: ActiveSessionHolder,
+        private val updateMatrixClientInfoUseCase: UpdateMatrixClientInfoUseCase,
+        private val deleteMatrixClientInfoUseCase: DeleteMatrixClientInfoUseCase,
+) : VectorViewModel<VectorSettingsLabsViewState, VectorSettingsLabsAction, EmptyViewEvents>(initialState) {
+
+    @AssistedFactory
+    interface Factory : MavericksAssistedViewModelFactory<VectorSettingsLabsViewModel, VectorSettingsLabsViewState> {
+        override fun create(initialState: VectorSettingsLabsViewState): VectorSettingsLabsViewModel
+    }
+
+    companion object : MavericksViewModelFactory<VectorSettingsLabsViewModel, VectorSettingsLabsViewState> by hiltMavericksViewModelFactory()
+
+    // TODO add unit tests
+    override fun handle(action: VectorSettingsLabsAction) {
+        when (action) {
+            VectorSettingsLabsAction.UpdateClientInfo -> handleUpdateClientInfo()
+            VectorSettingsLabsAction.DeleteRecordedClientInfo -> handleDeleteRecordedClientInfo()
+        }
+    }
+
+    private fun handleUpdateClientInfo() {
+        viewModelScope.launch {
+            activeSessionHolder.getSafeActiveSession()
+                    ?.let { session ->
+                        updateMatrixClientInfoUseCase.execute(session)
+                    }
+        }
+    }
+
+    private fun handleDeleteRecordedClientInfo() {
+        viewModelScope.launch {
+            deleteMatrixClientInfoUseCase.execute()
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsViewModel.kt
@@ -43,7 +43,6 @@ class VectorSettingsLabsViewModel @AssistedInject constructor(
 
     companion object : MavericksViewModelFactory<VectorSettingsLabsViewModel, VectorSettingsLabsViewState> by hiltMavericksViewModelFactory()
 
-    // TODO add unit tests
     override fun handle(action: VectorSettingsLabsAction) {
         when (action) {
             VectorSettingsLabsAction.UpdateClientInfo -> handleUpdateClientInfo()

--- a/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsViewState.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.labs
+
+import com.airbnb.mvrx.MavericksState
+
+class VectorSettingsLabsViewState : MavericksState

--- a/vector/src/main/res/xml/vector_settings_labs.xml
+++ b/vector/src/main/res/xml/vector_settings_labs.xml
@@ -109,4 +109,10 @@
         android:summary="@string/labs_enable_session_manager_summary"
         android:title="@string/labs_enable_session_manager_title" />
 
+    <im.vector.app.core.preference.VectorSwitchPreference
+        android:defaultValue="@bool/settings_labs_client_info_recording_default"
+        android:key="SETTINGS_LABS_CLIENT_INFO_RECORDING_KEY"
+        android:summary="@string/labs_enable_client_info_recording_summary"
+        android:title="@string/labs_enable_client_info_recording_title" />
+
 </androidx.preference.PreferenceScreen>

--- a/vector/src/main/res/xml/vector_settings_labs.xml
+++ b/vector/src/main/res/xml/vector_settings_labs.xml
@@ -107,12 +107,14 @@
         android:defaultValue="@bool/settings_labs_new_session_manager_default"
         android:key="SETTINGS_LABS_NEW_SESSION_MANAGER_KEY"
         android:summary="@string/labs_enable_session_manager_summary"
-        android:title="@string/labs_enable_session_manager_title" />
+        android:title="@string/labs_enable_session_manager_title"
+        app:isPreferenceVisible="@bool/settings_labs_new_session_manager_visible" />
 
     <im.vector.app.core.preference.VectorSwitchPreference
         android:defaultValue="@bool/settings_labs_client_info_recording_default"
         android:key="SETTINGS_LABS_CLIENT_INFO_RECORDING_KEY"
         android:summary="@string/labs_enable_client_info_recording_summary"
-        android:title="@string/labs_enable_client_info_recording_title" />
+        android:title="@string/labs_enable_client_info_recording_title"
+        app:isPreferenceVisible="@bool/settings_labs_client_info_recording_visible" />
 
 </androidx.preference.PreferenceScreen>

--- a/vector/src/main/res/xml/vector_settings_root.xml
+++ b/vector/src/main/res/xml/vector_settings_root.xml
@@ -35,7 +35,7 @@
     <im.vector.app.core.preference.VectorPreference
         android:icon="@drawable/ic_settings_root_labs"
         android:title="@string/room_settings_labs_pref_title"
-        app:fragment="im.vector.app.features.settings.VectorSettingsLabsFragment"
+        app:fragment="im.vector.app.features.settings.labs.VectorSettingsLabsFragment"
         app:isPreferenceVisible="@bool/settings_root_labs_visible" />
 
     <im.vector.app.core.preference.VectorPreference

--- a/vector/src/test/java/im/vector/app/core/session/ConfigureAndStartSessionUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/core/session/ConfigureAndStartSessionUseCaseTest.kt
@@ -20,6 +20,7 @@ import im.vector.app.core.extensions.startSyncing
 import im.vector.app.core.session.clientinfo.UpdateMatrixClientInfoUseCase
 import im.vector.app.test.fakes.FakeContext
 import im.vector.app.test.fakes.FakeSession
+import im.vector.app.test.fakes.FakeVectorPreferences
 import im.vector.app.test.fakes.FakeWebRtcCallManager
 import io.mockk.coJustRun
 import io.mockk.coVerify
@@ -41,11 +42,13 @@ class ConfigureAndStartSessionUseCaseTest {
     private val fakeContext = FakeContext()
     private val fakeWebRtcCallManager = FakeWebRtcCallManager()
     private val fakeUpdateMatrixClientInfoUseCase = mockk<UpdateMatrixClientInfoUseCase>()
+    private val fakeVectorPreferences = FakeVectorPreferences()
 
     private val configureAndStartSessionUseCase = ConfigureAndStartSessionUseCase(
             context = fakeContext.instance,
             webRtcCallManager = fakeWebRtcCallManager.instance,
             updateMatrixClientInfoUseCase = fakeUpdateMatrixClientInfoUseCase,
+            vectorPreferences = fakeVectorPreferences.instance,
     )
 
     @Before
@@ -59,11 +62,12 @@ class ConfigureAndStartSessionUseCaseTest {
     }
 
     @Test
-    fun `given a session and start sync needed when configuring and starting the session then it should be configured properly`() = runTest {
+    fun `given start sync needed and client info recording enabled when configuring and starting the session then it should be configured properly`() = runTest {
         // Given
         val fakeSession = givenASession()
         fakeWebRtcCallManager.givenCheckForProtocolsSupportIfNeededSucceeds()
         coJustRun { fakeUpdateMatrixClientInfoUseCase.execute(any()) }
+        fakeVectorPreferences.givenIsClientInfoRecordingEnabled(isEnabled = true)
 
         // When
         configureAndStartSessionUseCase.execute(fakeSession, startSyncing = true)
@@ -77,11 +81,31 @@ class ConfigureAndStartSessionUseCaseTest {
     }
 
     @Test
+    fun `given start sync needed and client info recording disabled when configuring and starting the session then it should be configured properly`() = runTest {
+        // Given
+        val fakeSession = givenASession()
+        fakeWebRtcCallManager.givenCheckForProtocolsSupportIfNeededSucceeds()
+        coJustRun { fakeUpdateMatrixClientInfoUseCase.execute(any()) }
+        fakeVectorPreferences.givenIsClientInfoRecordingEnabled(isEnabled = false)
+
+        // When
+        configureAndStartSessionUseCase.execute(fakeSession, startSyncing = true)
+
+        // Then
+        verify { fakeSession.startSyncing(fakeContext.instance) }
+        fakeSession.fakeFilterService.verifySetFilter(FilterService.FilterPreset.ElementFilter)
+        fakeSession.fakePushersService.verifyRefreshPushers()
+        fakeWebRtcCallManager.verifyCheckForProtocolsSupportIfNeeded()
+        coVerify(inverse = true) { fakeUpdateMatrixClientInfoUseCase.execute(fakeSession) }
+    }
+
+    @Test
     fun `given a session and no start sync needed when configuring and starting the session then it should be configured properly`() = runTest {
         // Given
         val fakeSession = givenASession()
         fakeWebRtcCallManager.givenCheckForProtocolsSupportIfNeededSucceeds()
         coJustRun { fakeUpdateMatrixClientInfoUseCase.execute(any()) }
+        fakeVectorPreferences.givenIsClientInfoRecordingEnabled(isEnabled = true)
 
         // When
         configureAndStartSessionUseCase.execute(fakeSession, startSyncing = false)

--- a/vector/src/test/java/im/vector/app/core/session/ConfigureAndStartSessionUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/core/session/ConfigureAndStartSessionUseCaseTest.kt
@@ -62,7 +62,7 @@ class ConfigureAndStartSessionUseCaseTest {
     }
 
     @Test
-    fun `given start sync needed and client info recording enabled when configuring and starting the session then it should be configured properly`() = runTest {
+    fun `given start sync needed and client info recording enabled when execute then it should be configured properly`() = runTest {
         // Given
         val fakeSession = givenASession()
         fakeWebRtcCallManager.givenCheckForProtocolsSupportIfNeededSucceeds()
@@ -81,7 +81,7 @@ class ConfigureAndStartSessionUseCaseTest {
     }
 
     @Test
-    fun `given start sync needed and client info recording disabled when configuring and starting the session then it should be configured properly`() = runTest {
+    fun `given start sync needed and client info recording disabled when execute then it should be configured properly`() = runTest {
         // Given
         val fakeSession = givenASession()
         fakeWebRtcCallManager.givenCheckForProtocolsSupportIfNeededSucceeds()
@@ -100,7 +100,7 @@ class ConfigureAndStartSessionUseCaseTest {
     }
 
     @Test
-    fun `given a session and no start sync needed when configuring and starting the session then it should be configured properly`() = runTest {
+    fun `given a session and no start sync needed when execute then it should be configured properly`() = runTest {
         // Given
         val fakeSession = givenASession()
         fakeWebRtcCallManager.givenCheckForProtocolsSupportIfNeededSucceeds()

--- a/vector/src/test/java/im/vector/app/core/session/clientinfo/DeleteMatrixClientInfoUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/core/session/clientinfo/DeleteMatrixClientInfoUseCaseTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.session.clientinfo
+
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class DeleteMatrixClientInfoUseCaseTest {
+
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+    private val fakeSetMatrixClientInfoUseCase = mockk<SetMatrixClientInfoUseCase>()
+
+    private val deleteMatrixClientInfoUseCase = DeleteMatrixClientInfoUseCase(
+            activeSessionHolder = fakeActiveSessionHolder.instance,
+            setMatrixClientInfoUseCase = fakeSetMatrixClientInfoUseCase
+    )
+
+    @Test
+    fun `given current session when calling use case then empty client info is set and result is success`() = runTest {
+        // Given
+        givenSetMatrixClientInfoSucceeds()
+        val expectedClientInfoToBeSet = MatrixClientInfoContent(
+                name = "",
+                version = "",
+                url = "",
+        )
+
+        // When
+        val result = deleteMatrixClientInfoUseCase.execute()
+
+        // Then
+        result.isSuccess shouldBe true
+        coVerify {
+            fakeSetMatrixClientInfoUseCase.execute(
+                    fakeActiveSessionHolder.fakeSession,
+                    expectedClientInfoToBeSet
+            )
+        }
+    }
+
+    @Test
+    fun `given current session and error during the process when calling use case then result is failure`() = runTest {
+        // Given
+        val error = Exception()
+        givenSetMatrixClientInfoFails(error)
+
+        // When
+        val result = deleteMatrixClientInfoUseCase.execute()
+
+        // Then
+        result.isFailure shouldBe true
+        result.exceptionOrNull() shouldBeEqualTo error
+    }
+
+    private fun givenSetMatrixClientInfoSucceeds() {
+        coEvery { fakeSetMatrixClientInfoUseCase.execute(any(), any()) } returns Result.success(Unit)
+    }
+
+    private fun givenSetMatrixClientInfoFails(error: Exception) {
+        coEvery { fakeSetMatrixClientInfoUseCase.execute(any(), any()) } returns Result.failure(error)
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/settings/labs/VectorSettingsLabsViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/labs/VectorSettingsLabsViewModelTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.labs
+
+import com.airbnb.mvrx.test.MavericksTestRule
+import im.vector.app.core.session.clientinfo.DeleteMatrixClientInfoUseCase
+import im.vector.app.core.session.clientinfo.UpdateMatrixClientInfoUseCase
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import im.vector.app.test.test
+import im.vector.app.test.testDispatcher
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import org.junit.Rule
+import org.junit.Test
+
+class VectorSettingsLabsViewModelTest {
+
+    @get:Rule
+    val mavericksTestRule = MavericksTestRule(testDispatcher = testDispatcher)
+
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+    private val fakeUpdateMatrixClientInfoUseCase = mockk<UpdateMatrixClientInfoUseCase>()
+    private val fakeDeleteMatrixClientInfoUseCase = mockk<DeleteMatrixClientInfoUseCase>()
+
+    private fun createViewModel(): VectorSettingsLabsViewModel {
+        return VectorSettingsLabsViewModel(
+                initialState = VectorSettingsLabsViewState(),
+                activeSessionHolder = fakeActiveSessionHolder.instance,
+                updateMatrixClientInfoUseCase = fakeUpdateMatrixClientInfoUseCase,
+                deleteMatrixClientInfoUseCase = fakeDeleteMatrixClientInfoUseCase,
+        )
+    }
+
+    @Test
+    fun `given update client info action when handling this action then update client info use case is called`() {
+        // Given
+        givenUpdateClientInfoSucceeds()
+
+        // When
+        val viewModel = createViewModel()
+        val viewModelTest = viewModel.test()
+        viewModel.handle(VectorSettingsLabsAction.UpdateClientInfo)
+
+        // Then
+        viewModelTest.finish()
+        coVerify { fakeUpdateMatrixClientInfoUseCase.execute(fakeActiveSessionHolder.fakeSession) }
+    }
+
+    @Test
+    fun `given delete client info action when handling this action then delete client info use case is called`() {
+        // Given
+        givenDeleteClientInfoSucceeds()
+
+        // When
+        val viewModel = createViewModel()
+        val viewModelTest = viewModel.test()
+        viewModel.handle(VectorSettingsLabsAction.DeleteRecordedClientInfo)
+
+        // Then
+        viewModelTest.finish()
+        coVerify { fakeDeleteMatrixClientInfoUseCase.execute() }
+    }
+
+    private fun givenUpdateClientInfoSucceeds() {
+        coEvery { fakeUpdateMatrixClientInfoUseCase.execute(any()) } returns Result.success(Unit)
+    }
+
+    private fun givenDeleteClientInfoSucceeds() {
+        coEvery { fakeDeleteMatrixClientInfoUseCase.execute() } returns Result.success(Unit)
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorPreferences.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorPreferences.kt
@@ -36,4 +36,8 @@ class FakeVectorPreferences {
     fun verifySetSpaceBackstack(value: List<String?>, inverse: Boolean = false) {
         verify(inverse = inverse) { instance.setSpaceBackstack(value) }
     }
+
+    fun givenIsClientInfoRecordingEnabled(isEnabled: Boolean) {
+        every { instance.isClientInfoRecordingEnabled() } returns isEnabled
+    }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Adding a lab flag to toggle the client info recording used to provide Application info in the session details screen.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7344 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

<img src="https://user-images.githubusercontent.com/46314705/195537444-6787cbef-5477-4add-894d-4e63b7822418.png" width=300 />

## Tests

<!-- Explain how you tested your development -->

- Sign-in to synapse-prefill.lab.element.dev
- Go to Settings -> Labs
- Enable the new session manager
- Check the "Enable client info recording" flag
- Go to Settings -> Show all sessions
- Go to the session details screen of the current session
- Check the Application section is displayed
- Go to Settings -> Labs
- Uncheck the "Enable client info recording" flag
- Go to Settings -> Security & Privacy -> Show all sessions
- Go to the session details screen of the current session
- Check the Application section is not displayed

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
