### PR TITLE
Fix the check script, some folders have changed.

### DIFF
--- a/tools/check/check_code_quality.sh
+++ b/tools/check/check_code_quality.sh
@@ -68,15 +68,14 @@ ${searchForbiddenStringsScript} ./tools/check/forbidden_strings_in_code.txt \
     ./matrix-sdk-android/src/main/java \
     ./matrix-sdk-android-flow/src/main/java \
     ./library/core-utils/src/main/java \
-    ./library/jsonviewer/src/main/java \
+    ./library/external/jsonviewer/src/main/java \
     ./library/ui-styles/src/main/java \
     ./vector/src/main/java \
-    ./vector/src/debug/java \
-    ./vector/src/release/java \
-    ./vector/src/fdroid/java \
-    ./vector/src/gplay/java \
+    ./vector-app/src/debug/java \
+    ./vector-app/src/fdroid/java \
     ./vector-app/src/gplay/java \
-    ./vector-app/src/main/java
+    ./vector-app/src/main/java \
+    ./vector-app/src/release/java
 
 resultForbiddenStringInCode=$?
 
@@ -93,13 +92,15 @@ echo
 echo "Search for forbidden patterns specific for App code..."
 
 ${searchForbiddenStringsScript} ./tools/check/forbidden_strings_in_code_app.txt \
+    ./library/core-utils/src/main/java \
+    ./library/external/jsonviewer/src/main/java \
+    ./library/ui-styles/src/main/java \
     ./vector/src/main/java \
-    ./vector/src/debug/java \
-    ./vector/src/release/java \
-    ./vector/src/fdroid/java \
-    ./vector/src/gplay/java \
+    ./vector-app/src/debug/java \
+    ./vector-app/src/fdroid/java \
     ./vector-app/src/gplay/java \
-    ./vector-app/src/main/java
+    ./vector-app/src/main/java \
+    ./vector-app/src/release/java
 
 resultForbiddenStringInCodeApp=$?
 
@@ -120,8 +121,7 @@ echo
 echo "Search for forbidden patterns in layouts..."
 
 ${searchForbiddenStringsScript} ./tools/check/forbidden_strings_in_layout.txt \
-    ./vector/src/main/res/layout \
-    ./vector-app/src/main/res/layout
+    ./vector/src/main/res/layout
 
 resultForbiddenStringInLayout=$?
 
@@ -154,17 +154,19 @@ echo "Search for kotlin files with more than ${maxLines} lines..."
 ${checkLongFilesScript} ${maxLines} \
     ./matrix-sdk-android/src/main/java \
     ./matrix-sdk-android-flow/src/main/java \
+    ./library/core-utils/src/main/java \
+    ./library/external/jsonviewer/src/main/java \
+    ./library/ui-styles/src/main/java \
     ./vector/src/androidTest/java \
-    ./vector/src/debug/java \
-    ./vector/src/fdroid/java \
-    ./vector/src/gplay/java \
     ./vector/src/main/java \
-    ./vector/src/release/java \
     ./vector/src/sharedTest/java \
     ./vector/src/test/java \
-    ./vector/src/androidTest/java \
-    ./vector/src/gplay/java \
-    ./vector/src/main/java
+    ./vector-app/src/androidTest/java \
+    ./vector-app/src/debug/java \
+    ./vector-app/src/fdroid/java \
+    ./vector-app/src/gplay/java \
+    ./vector-app/src/main/java \
+    ./vector-app/src/release/java
 
 
 resultLongFiles=$?
@@ -179,8 +181,11 @@ echo "Search for png files in /drawable..."
 ls -1U ./vector/src/main/res/drawable/*.png
 resultTmp=$?
 
+ls -1U ./vector-app/src/main/res/drawable/*.png
+resultTmp2=$?
+
 # Inverse the result, cause no file found is an error for ls but this is what we want!
-if [[ ${resultTmp} -eq 0 ]]; then
+if [[ ${resultTmp} -eq 0 ]] || [[ ${resultTmp2} -eq 0 ]]; then
    echo "ERROR, png files detected in /drawable"
    resultPngInDrawable=1
 else


### PR DESCRIPTION
Previous log:

```
Search for forbidden patterns in code...
Can't stat ./library/jsonviewer/src/main/java: No such file or directory
 at ./tmp/search_forbidden_strings.pl line 79.
Can't stat ./vector/src/debug/java: No such file or directory
 at ./tmp/search_forbidden_strings.pl line 79.
Can't stat ./vector/src/release/java: No such file or directory
 at ./tmp/search_forbidden_strings.pl line 79.
Can't stat ./vector/src/fdroid/java: No such file or directory
 at ./tmp/search_forbidden_strings.pl line 79.
Can't stat ./vector/src/gplay/java: No such file or directory
 at ./tmp/search_forbidden_strings.pl line 79.
All clear!

Search for forbidden patterns specific for SDK code...
All clear!

Search for forbidden patterns specific for App code...
Can't stat ./vector/src/debug/java: No such file or directory
 at ./tmp/search_forbidden_strings.pl line 79.
Can't stat ./vector/src/release/java: No such file or directory
 at ./tmp/search_forbidden_strings.pl line 79.
Can't stat ./vector/src/fdroid/java: No such file or directory
 at ./tmp/search_forbidden_strings.pl line 79.
Can't stat ./vector/src/gplay/java: No such file or directory
 at ./tmp/search_forbidden_strings.pl line 79.
All clear!

Search for forbidden patterns in layouts...
Can't stat ./vector-app/src/main/res/layout: No such file or directory
 at ./tmp/search_forbidden_strings.pl line 79.
All clear!

Search for kotlin files with more than 2800 lines...
Can't stat ./vector/src/debug/java: No such file or directory
 at ./tmp/check_long_files.pl line 31.
Can't stat ./vector/src/fdroid/java: No such file or directory
 at ./tmp/check_long_files.pl line 31.
Can't stat ./vector/src/gplay/java: No such file or directory
 at ./tmp/check_long_files.pl line 31.
Can't stat ./vector/src/release/java: No such file or directory
 at ./tmp/check_long_files.pl line 31.
Can't stat ./vector/src/gplay/java: No such file or directory
 at ./tmp/check_long_files.pl line 31.
All clear!

Search for png files in /drawable...
ls: cannot access './vector/src/main/res/drawable/*.png': No such file or directory
OK
```


New logs:

```
Check drawable quantity
ERROR, missing drawable alternative.

./tmp/search_forbidden_strings.pl already there
./tmp/search_forbidden_strings.pl is already executable

Search for forbidden patterns in code...
All clear!

Search for forbidden patterns specific for SDK code...
All clear!

Search for forbidden patterns specific for App code...
All clear!

Search for forbidden patterns in resources...
All clear!

Search for forbidden patterns in layouts...
All clear!
./tmp/check_long_files.pl already there
./tmp/check_long_files.pl is already executable

Search for kotlin files with more than 2800 lines...
All clear!

Search for png files in /drawable...
ls: ./vector/src/main/res/drawable/*.png: No such file or directory
ls: ./vector-app/src/main/res/drawable/*.png: No such file or directory
OK

MAIN OK
```

