### PR TITLE
Fix editing formatted messages in plain text editor

### DIFF
--- a/changelog.d/7359.bugfix
+++ b/changelog.d/7359.bugfix
@@ -1,0 +1,1 @@
+Fix editing formatted messages with plain text editor

--- a/changelog.d/7359.sdk
+++ b/changelog.d/7359.sdk
@@ -1,1 +1,1 @@
-Allow getting the formatted or plain text body of a message.
+Allow getting the formatted or plain text body of a message for the fun `TimelineEvent.getTextEditableContent()`.

--- a/changelog.d/7359.sdk
+++ b/changelog.d/7359.sdk
@@ -1,0 +1,1 @@
+Allow getting the formatted or plain text body of a message.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/timeline/TimelineEvent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/timeline/TimelineEvent.kt
@@ -181,9 +181,13 @@ fun TimelineEvent.isRootThread(): Boolean {
 /**
  * Get the latest message body, after a possible edition, stripping the reply prefix if necessary.
  */
-fun TimelineEvent.getTextEditableContent(): String {
+fun TimelineEvent.getTextEditableContent(formatted: Boolean): String {
     val lastMessageContent = getLastMessageContent()
-    val lastContentBody = lastMessageContent.getFormattedBody() ?: return ""
+    val lastContentBody = if (formatted && lastMessageContent is MessageContentWithFormattedBody) {
+        lastMessageContent.formattedBody
+    } else {
+        lastMessageContent?.body
+    } ?: return ""
     return if (isReply()) {
         extractUsefulTextFromReply(lastContentBody)
     } else {
@@ -200,12 +204,4 @@ fun MessageContent.getTextDisplayableContent(): String {
             ?: newContent?.toModel<MessageContent>()?.body
             ?: (this as MessageTextContent?)?.matrixFormattedBody?.let { ContentUtils.formatSpoilerTextFromHtml(it) }
             ?: body
-}
-
-fun MessageContent?.getFormattedBody(): String? {
-    return if (this is MessageContentWithFormattedBody) {
-        formattedBody
-    } else {
-        this?.body
-    }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
@@ -151,7 +151,8 @@ class MessageComposerViewModel @AssistedInject constructor(
 
     private fun handleEnterEditMode(action: MessageComposerAction.EnterEditMode) {
         room.getTimelineEvent(action.eventId)?.let { timelineEvent ->
-            setState { copy(sendMode = SendMode.Edit(timelineEvent, timelineEvent.getTextEditableContent())) }
+            val formatted = vectorPreferences.isRichTextEditorEnabled()
+            setState { copy(sendMode = SendMode.Edit(timelineEvent, timelineEvent.getTextEditableContent(formatted))) }
         }
     }
 
@@ -552,7 +553,7 @@ class MessageComposerViewModel @AssistedInject constructor(
                                     state.sendMode.timelineEvent,
                                     messageContent?.msgType ?: MessageType.MSGTYPE_TEXT,
                                     action.text,
-                                    (messageContent as? MessageContentWithFormattedBody)?.formattedBody,
+                                    action.formattedText,
                                     action.autoMarkdown
                             )
                         } else {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Changes to both the SDK and `MessageComposerViewModel` to retrieve and edit the right message body in the plain text editor.

## Motivation and context

See #7359 .

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Enable the rich text editor in labs in the Android app and send a formatted message. Alternatively, write some formatted message in the web version.
- Disable the rich text editor, try to edit the formatted message.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
