### PR TITLE
Handle properly when getUser returns null - prefer using getUserOrDefault

### DIFF
--- a/changelog.d/7372.bugfix
+++ b/changelog.d/7372.bugfix
@@ -1,0 +1,1 @@
+Handle properly when getUser returns null - prefer using getUserOrDefault

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/profile/GetProfileInfoTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/profile/GetProfileInfoTask.kt
@@ -17,26 +17,39 @@
 
 package org.matrix.android.sdk.internal.session.profile
 
+import com.zhuinden.monarchy.Monarchy
+import org.matrix.android.sdk.api.session.user.model.User
 import org.matrix.android.sdk.api.util.JsonDict
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
+import org.matrix.android.sdk.internal.session.user.UserEntityFactory
 import org.matrix.android.sdk.internal.task.Task
+import org.matrix.android.sdk.internal.util.awaitTransaction
 import javax.inject.Inject
 
 internal abstract class GetProfileInfoTask : Task<GetProfileInfoTask.Params, JsonDict> {
     data class Params(
-            val userId: String
+            val userId: String,
+            val storeInDatabase: Boolean = true,
     )
 }
 
 internal class DefaultGetProfileInfoTask @Inject constructor(
         private val profileAPI: ProfileAPI,
-        private val globalErrorReceiver: GlobalErrorReceiver
+        private val globalErrorReceiver: GlobalErrorReceiver,
+        private val monarchy: Monarchy,
 ) : GetProfileInfoTask() {
 
     override suspend fun execute(params: Params): JsonDict {
         return executeRequest(globalErrorReceiver) {
             profileAPI.getProfile(params.userId)
+        }.also { user ->
+            if (params.storeInDatabase) {
+                // Insert into DB
+                monarchy.awaitTransaction {
+                    it.insertOrUpdate(UserEntityFactory.create(User.fromJson(params.userId, user)))
+                }
+            }
         }
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/profile/GetProfileInfoTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/profile/GetProfileInfoTask.kt
@@ -20,6 +20,7 @@ package org.matrix.android.sdk.internal.session.profile
 import com.zhuinden.monarchy.Monarchy
 import org.matrix.android.sdk.api.session.user.model.User
 import org.matrix.android.sdk.api.util.JsonDict
+import org.matrix.android.sdk.internal.di.SessionDatabase
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.session.user.UserEntityFactory
@@ -37,7 +38,7 @@ internal abstract class GetProfileInfoTask : Task<GetProfileInfoTask.Params, Jso
 internal class DefaultGetProfileInfoTask @Inject constructor(
         private val profileAPI: ProfileAPI,
         private val globalErrorReceiver: GlobalErrorReceiver,
-        private val monarchy: Monarchy,
+        @SessionDatabase private val monarchy: Monarchy,
 ) : GetProfileInfoTask() {
 
     override suspend fun execute(params: Params): JsonDict {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/UpdateUserWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/UpdateUserWorker.kt
@@ -71,10 +71,16 @@ internal class UpdateUserWorker(context: Context, params: WorkerParameters, sess
                 ?.saveLocally()
     }
 
-    private suspend fun fetchUsers(userIdsToFetch: Collection<String>) = userIdsToFetch.mapNotNull {
-        tryOrNull {
-            val profileJson = getProfileInfoTask.execute(GetProfileInfoTask.Params(it))
-            User.fromJson(it, profileJson)
+    private suspend fun fetchUsers(userIdsToFetch: Collection<String>): List<User> {
+        return userIdsToFetch.mapNotNull { userId ->
+            tryOrNull {
+                val profileJson = getProfileInfoTask.execute(GetProfileInfoTask.Params(
+                        userId = userId,
+                        // Bulk insert later, so tell the task not to store the User.
+                        storeInDatabase = false,
+                ))
+                User.fromJson(userId, profileJson)
+            }
         }
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/UserDataSource.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/user/UserDataSource.kt
@@ -66,6 +66,8 @@ internal class UserDataSource @Inject constructor(
         }
     }
 
+    fun getUserOrDefault(userId: String): User = getUser(userId) ?: User(userId)
+
     fun getUserLive(userId: String): LiveData<Optional<User>> {
         val liveData = monarchy.findAllMappedWithChanges(
                 { UserEntity.where(it, userId) },

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/widgets/helper/WidgetFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/widgets/helper/WidgetFactory.kt
@@ -20,7 +20,6 @@ import org.matrix.android.sdk.api.session.content.ContentUrlResolver
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.room.sender.SenderInfo
-import org.matrix.android.sdk.api.session.user.model.User
 import org.matrix.android.sdk.api.session.widgets.model.Widget
 import org.matrix.android.sdk.api.session.widgets.model.WidgetContent
 import org.matrix.android.sdk.api.session.widgets.model.WidgetType

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/widgets/helper/WidgetFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/widgets/helper/WidgetFactory.kt
@@ -74,7 +74,7 @@ internal class WidgetFactory @Inject constructor(
     // Ref: https://github.com/matrix-org/matrix-widget-api/blob/master/src/templating/url-template.ts#L29-L33
     fun computeURL(widget: Widget, isLightTheme: Boolean): String? {
         var computedUrl = widget.widgetContent.url ?: return null
-        val myUser = userDataSource.getUser(userId) ?: User(userId)
+        val myUser = userDataSource.getUserOrDefault(userId)
 
         val keyValue = widget.widgetContent.data.mapKeys { "\$${it.key}" }.toMutableMap()
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/LocationPinProvider.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/LocationPinProvider.kt
@@ -29,7 +29,7 @@ import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.glide.GlideApp
 import im.vector.app.core.utils.DimensionConverter
 import im.vector.app.features.home.AvatarRenderer
-import org.matrix.android.sdk.api.session.getUser
+import org.matrix.android.sdk.api.session.getUserOrDefault
 import org.matrix.android.sdk.api.util.toMatrixItem
 import timber.log.Timber
 import javax.inject.Inject
@@ -67,9 +67,9 @@ class LocationPinProvider @Inject constructor(
 
         activeSessionHolder
                 .getActiveSession()
-                .getUser(userId)
-                ?.toMatrixItem()
-                ?.let { userItem ->
+                .getUserOrDefault(userId)
+                .toMatrixItem()
+                .let { userItem ->
                     val size = dimensionConverter.dpToPx(44)
                     val bgTintColor = matrixItemColorProvider.getColor(userItem)
                     avatarRenderer.render(glideRequests, userItem, object : CustomTarget<Drawable>(size, size) {

--- a/vector/src/main/java/im/vector/app/features/html/PillsPostProcessor.kt
+++ b/vector/src/main/java/im/vector/app/features/html/PillsPostProcessor.kt
@@ -27,7 +27,7 @@ import im.vector.app.core.glide.GlideApp
 import im.vector.app.features.home.AvatarRenderer
 import io.noties.markwon.core.spans.LinkSpan
 import org.matrix.android.sdk.api.session.getRoomSummary
-import org.matrix.android.sdk.api.session.getUser
+import org.matrix.android.sdk.api.session.getUserOrDefault
 import org.matrix.android.sdk.api.session.permalinks.PermalinkData
 import org.matrix.android.sdk.api.session.permalinks.PermalinkParser
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
@@ -101,7 +101,7 @@ class PillsPostProcessor @AssistedInject constructor(
 
     private fun PermalinkData.UserLink.toMatrixItem(roomId: String?): MatrixItem? =
             if (roomId == null) {
-                sessionHolder.getSafeActiveSession()?.getUser(userId)?.toMatrixItem()
+                sessionHolder.getSafeActiveSession()?.getUserOrDefault(userId)?.toMatrixItem()
             } else {
                 sessionHolder.getSafeActiveSession()?.roomService()?.getRoomMember(userId, roomId)?.toMatrixItem()
             }

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingViewModel.kt
@@ -40,7 +40,7 @@ import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.getRoom
-import org.matrix.android.sdk.api.session.getUser
+import org.matrix.android.sdk.api.session.getUserOrDefault
 import org.matrix.android.sdk.api.session.room.powerlevels.PowerLevelsHelper
 import org.matrix.android.sdk.api.util.toMatrixItem
 import timber.log.Timber
@@ -101,7 +101,7 @@ class LocationSharingViewModel @AssistedInject constructor(
     }
 
     private fun setUserItem() {
-        setState { copy(userItem = session.getUser(session.myUserId)?.toMatrixItem()) }
+        setState { copy(userItem = session.getUserOrDefault(session.myUserId).toMatrixItem()) }
     }
 
     private fun updatePin(isUserPin: Boolean? = true) {

--- a/vector/src/main/java/im/vector/app/features/location/live/map/UserLiveLocationViewStateMapper.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/UserLiveLocationViewStateMapper.kt
@@ -20,7 +20,7 @@ import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.features.home.room.detail.timeline.helper.LocationPinProvider
 import im.vector.app.features.location.toLocationData
 import kotlinx.coroutines.suspendCancellableCoroutine
-import org.matrix.android.sdk.api.session.getUser
+import org.matrix.android.sdk.api.session.getUserOrDefault
 import org.matrix.android.sdk.api.session.room.model.livelocation.LiveLocationShareAggregatedSummary
 import org.matrix.android.sdk.api.util.toMatrixItem
 import javax.inject.Inject
@@ -45,19 +45,17 @@ class UserLiveLocationViewStateMapper @Inject constructor(
                     else -> {
                         locationPinProvider.create(userId) { pinDrawable ->
                             val session = activeSessionHolder.getActiveSession()
-                            session.getUser(userId)?.toMatrixItem()?.let { matrixItem ->
-                                val locationTimestampMillis = liveLocationShareAggregatedSummary.lastLocationDataContent?.getBestTimestampMillis()
-                                val viewState = UserLiveLocationViewState(
-                                        matrixItem = matrixItem,
-                                        pinDrawable = pinDrawable,
-                                        locationData = locationData,
-                                        endOfLiveTimestampMillis = liveLocationShareAggregatedSummary.endOfLiveTimestampMillis,
-                                        locationTimestampMillis = locationTimestampMillis,
-                                        showStopSharingButton = userId == session.myUserId
-                                )
-                                continuation.resume(viewState) {
-                                    // do nothing on cancellation
-                                }
+                            val locationTimestampMillis = liveLocationShareAggregatedSummary.lastLocationDataContent?.getBestTimestampMillis()
+                            val viewState = UserLiveLocationViewState(
+                                    matrixItem = session.getUserOrDefault(userId).toMatrixItem(),
+                                    pinDrawable = pinDrawable,
+                                    locationData = locationData,
+                                    endOfLiveTimestampMillis = liveLocationShareAggregatedSummary.endOfLiveTimestampMillis,
+                                    locationTimestampMillis = locationTimestampMillis,
+                                    showStopSharingButton = userId == session.myUserId
+                            )
+                            continuation.resume(viewState) {
+                                // do nothing on cancellation
                             }
                         }
                     }

--- a/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
@@ -38,7 +38,7 @@ import org.matrix.android.sdk.api.session.events.model.supportsNotification
 import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.getRoom
 import org.matrix.android.sdk.api.session.getRoomSummary
-import org.matrix.android.sdk.api.session.getUser
+import org.matrix.android.sdk.api.session.getUserOrDefault
 import org.matrix.android.sdk.api.session.room.getTimelineEvent
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.model.RoomMemberContent
@@ -112,7 +112,7 @@ class NotifiableEventResolver @Inject constructor(
         val notificationAction = actions.toNotificationAction()
 
         return if (notificationAction.shouldNotify) {
-            val user = session.getUser(event.senderId!!) ?: return null
+            val user = session.getUserOrDefault(event.senderId!!)
 
             val timelineEvent = TimelineEvent(
                     root = event,

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
@@ -27,7 +27,7 @@ import im.vector.app.features.displayname.getBestName
 import im.vector.app.features.settings.VectorPreferences
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.content.ContentUrlResolver
-import org.matrix.android.sdk.api.session.getUser
+import org.matrix.android.sdk.api.session.getUserOrDefault
 import org.matrix.android.sdk.api.util.toMatrixItem
 import timber.log.Timber
 import javax.inject.Inject
@@ -186,11 +186,11 @@ class NotificationDrawerManager @Inject constructor(
     }
 
     private fun renderEvents(session: Session, eventsToRender: List<ProcessedEvent<NotifiableEvent>>) {
-        val user = session.getUser(session.myUserId)
+        val user = session.getUserOrDefault(session.myUserId)
         // myUserDisplayName cannot be empty else NotificationCompat.MessagingStyle() will crash
-        val myUserDisplayName = user?.toMatrixItem()?.getBestName() ?: session.myUserId
+        val myUserDisplayName = user.toMatrixItem().getBestName()
         val myUserAvatarUrl = session.contentUrlResolver().resolveThumbnail(
-                contentUrl = user?.avatarUrl,
+                contentUrl = user.avatarUrl,
                 width = avatarSize,
                 height = avatarSize,
                 method = ContentUrlResolver.ThumbnailMethod.SCALE

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/devices/DeviceListBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/devices/DeviceListBottomSheetViewModel.kt
@@ -42,7 +42,6 @@ data class DeviceListViewState(
         val userId: String,
         val allowDeviceAction: Boolean,
         val userItem: MatrixItem? = null,
-        val isMine: Boolean = false,
         val memberCrossSigningKey: MXCrossSigningInfo? = null,
         val cryptoDevices: Async<List<CryptoDeviceInfo>> = Loading(),
         val selectedDevice: CryptoDeviceInfo? = null
@@ -70,14 +69,12 @@ class DeviceListBottomSheetViewModel @AssistedInject constructor(
                         userId = userId,
                         allowDeviceAction = args.allowDeviceAction,
                         userItem = it,
-                        isMine = userId == session.myUserId
                 )
             } ?: return super.initialState(viewModelContext)
         }
     }
 
     init {
-
         session.flow().liveUserCryptoDevices(initialState.userId)
                 .execute {
                     copy(cryptoDevices = it).also {

--- a/vector/src/main/java/im/vector/app/features/roommemberprofile/devices/DeviceListBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roommemberprofile/devices/DeviceListBottomSheetViewModel.kt
@@ -29,11 +29,13 @@ import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.SingletonEntryPoint
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.VectorViewModel
+import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.crypto.crosssigning.MXCrossSigningInfo
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
 import org.matrix.android.sdk.api.session.crypto.verification.VerificationMethod
-import org.matrix.android.sdk.api.session.getUser
+import org.matrix.android.sdk.api.session.getUserOrDefault
 import org.matrix.android.sdk.api.util.MatrixItem
 import org.matrix.android.sdk.api.util.toMatrixItem
 import org.matrix.android.sdk.flow.flow
@@ -60,17 +62,15 @@ class DeviceListBottomSheetViewModel @AssistedInject constructor(
 
     companion object : MavericksViewModelFactory<DeviceListBottomSheetViewModel, DeviceListViewState> by hiltMavericksViewModelFactory() {
 
-        override fun initialState(viewModelContext: ViewModelContext): DeviceListViewState? {
+        override fun initialState(viewModelContext: ViewModelContext): DeviceListViewState {
             val args = viewModelContext.args<DeviceListBottomSheet.Args>()
             val userId = args.userId
             val session = EntryPoints.get(viewModelContext.app(), SingletonEntryPoint::class.java).activeSessionHolder().getActiveSession()
-            return session.getUser(userId)?.toMatrixItem()?.let {
-                DeviceListViewState(
-                        userId = userId,
-                        allowDeviceAction = args.allowDeviceAction,
-                        userItem = it,
-                )
-            } ?: return super.initialState(viewModelContext)
+            return DeviceListViewState(
+                    userId = userId,
+                    allowDeviceAction = args.allowDeviceAction,
+                    userItem = session.getUserOrDefault(userId).toMatrixItem(),
+            )
         }
     }
 
@@ -86,6 +86,16 @@ class DeviceListBottomSheetViewModel @AssistedInject constructor(
                 .execute {
                     copy(memberCrossSigningKey = it.invoke()?.getOrNull())
                 }
+
+        updateMatrixItem()
+    }
+
+    private fun updateMatrixItem() {
+        viewModelScope.launch {
+            tryOrNull { session.userService().resolveUser(initialState.userId) }
+                    ?.toMatrixItem()
+                    ?.let { setState { copy(userItem = it) } }
+        }
     }
 
     override fun handle(action: DeviceListAction) {

--- a/vector/src/main/java/im/vector/app/features/signout/soft/SoftLogoutViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/signout/soft/SoftLogoutViewModel.kt
@@ -32,6 +32,7 @@ import im.vector.app.core.di.SingletonEntryPoint
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.extensions.hasUnsavedKeys
 import im.vector.app.core.platform.VectorViewModel
+import im.vector.app.features.displayname.getBestName
 import im.vector.app.features.login.LoginMode
 import im.vector.app.features.login.toSsoState
 import kotlinx.coroutines.launch
@@ -39,7 +40,8 @@ import org.matrix.android.sdk.api.auth.AuthenticationService
 import org.matrix.android.sdk.api.auth.LoginType
 import org.matrix.android.sdk.api.auth.data.LoginFlowTypes
 import org.matrix.android.sdk.api.session.Session
-import org.matrix.android.sdk.api.session.getUser
+import org.matrix.android.sdk.api.session.getUserOrDefault
+import org.matrix.android.sdk.api.util.toMatrixItem
 import timber.log.Timber
 
 class SoftLogoutViewModel @AssistedInject constructor(
@@ -68,7 +70,7 @@ class SoftLogoutViewModel @AssistedInject constructor(
                         homeServerUrl = session.sessionParams.homeServerUrl,
                         userId = userId,
                         deviceId = session.sessionParams.deviceId.orEmpty(),
-                        userDisplayName = session.getUser(userId)?.displayName ?: userId,
+                        userDisplayName = session.getUserOrDefault(userId).toMatrixItem().getBestName(),
                         hasUnsavedKeys = session.hasUnsavedKeys(),
                         loginType = session.sessionParams.loginType,
                 )

--- a/vector/src/main/java/im/vector/app/features/spaces/invite/SpaceInviteBottomSheetViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/invite/SpaceInviteBottomSheetViewModel.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.getRoomSummary
-import org.matrix.android.sdk.api.session.getUser
+import org.matrix.android.sdk.api.session.getUserOrDefault
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 import org.matrix.android.sdk.api.session.room.peeking.PeekResult
@@ -49,7 +49,7 @@ class SpaceInviteBottomSheetViewModel @AssistedInject constructor(
         session.getRoomSummary(initialState.spaceId)?.let { roomSummary ->
             val knownMembers = roomSummary.otherMemberIds.filter {
                 session.roomService().getExistingDirectRoomWithUser(it) != null
-            }.mapNotNull { session.getUser(it) }
+            }.map { session.getUserOrDefault(it) }
             // put one with avatar first, and take 5
             val peopleYouKnow = (knownMembers.filter { it.avatarUrl != null } + knownMembers.filter { it.avatarUrl == null })
                     .take(5)
@@ -57,7 +57,7 @@ class SpaceInviteBottomSheetViewModel @AssistedInject constructor(
             setState {
                 copy(
                         summary = Success(roomSummary),
-                        inviterUser = roomSummary.inviterId?.let { session.getUser(it) }?.let { Success(it) } ?: Uninitialized,
+                        inviterUser = roomSummary.inviterId?.let { session.getUserOrDefault(it) }?.let { Success(it) } ?: Uninitialized,
                         peopleYouKnow = Success(peopleYouKnow)
                 )
             }

--- a/vector/src/main/java/im/vector/app/features/usercode/UserCodeSharedViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/usercode/UserCodeSharedViewModel.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.Session
-import org.matrix.android.sdk.api.session.getUser
+import org.matrix.android.sdk.api.session.getUserOrDefault
 import org.matrix.android.sdk.api.session.permalinks.PermalinkData
 import org.matrix.android.sdk.api.session.permalinks.PermalinkParser
 import org.matrix.android.sdk.api.session.user.model.User
@@ -46,10 +46,10 @@ class UserCodeSharedViewModel @AssistedInject constructor(
     companion object : MavericksViewModelFactory<UserCodeSharedViewModel, UserCodeState> by hiltMavericksViewModelFactory()
 
     init {
-        val user = session.getUser(initialState.userId)
+        val user = session.getUserOrDefault(initialState.userId)
         setState {
             copy(
-                    matrixItem = user?.toMatrixItem(),
+                    matrixItem = user.toMatrixItem(),
                     shareLink = session.permalinkService().createPermalink(initialState.userId)
             )
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
getUser can return null, since the loading of profile is now async. It may lead to unexpected issue and a crash, fixed by this commit: 0a6d620f27d3160d273f6d0a2b5e13936a333d23

Other commits fixes similar things. Also when retrieved, the profile is now stored into DB for future usage.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

To reproduce the crash (but this is not 100% reproducible due to race condition)
- Do an initial sync on a big account
- Quickly open a room a start verifying a user.

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
