### PR TITLE
Let the doctor be less strict and just warn.

### DIFF
--- a/tools/gradle/doctor.gradle
+++ b/tools/gradle/doctor.gradle
@@ -54,7 +54,7 @@ doctor {
     /**
      * Warn when not using parallel GC. Parallel GC is faster for build type tasks and is no longer the default in Java 9+.
      */
-    warnWhenNotUsingParallelGC = !isCiBuild
+    warnWhenNotUsingParallelGC = true
     /**
      * Throws an error when the `Delete` or `clean` task has dependencies.
      * If a clean task depends on other tasks, clean can be reordered and made to run after the tasks that would produce
@@ -82,7 +82,7 @@ doctor {
         /**
          * Fail on any `JAVA_HOME` issues.
          */
-        failOnError.set(!isCiBuild)
+        failOnError.set(false)
         /**
          * Extra message text, if any, to show with the Gradle Doctor message. This is useful if you have a wiki page or
          * other instructions that you want to link for developers on your team if they encounter an issue.

--- a/tools/gradle/doctor.gradle
+++ b/tools/gradle/doctor.gradle
@@ -54,7 +54,8 @@ doctor {
     /**
      * Warn when not using parallel GC. Parallel GC is faster for build type tasks and is no longer the default in Java 9+.
      */
-    warnWhenNotUsingParallelGC = true
+    // Note: Actually, if set to true, it fails the build. See https://lightrun.com/answers/runningcode-gradle-doctor-warnwhennotusingparallelgc-fails-the-build-warn-is-a-confusing-keyword-here
+    warnWhenNotUsingParallelGC = false
     /**
      * Throws an error when the `Delete` or `clean` task has dependencies.
      * If a clean task depends on other tasks, clean can be reordered and made to run after the tasks that would produce


### PR DESCRIPTION
Keep the useful log "Is CI build: $isCiBuild".

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Avoid error on developers env.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
