### PR TITLE
Fix message sent even if the step `ui-tests` is successful.

### DIFF
--- a/.github/workflows/post-pr.yml
+++ b/.github/workflows/post-pr.yml
@@ -94,7 +94,7 @@ jobs:
     needs:
       - should-i-run
       - ui-tests
-    if: always() && (needs.should-i-run.result == 'success' ) && ((needs.codecov-units.result != 'success' ) || (needs.ui-tests.result != 'success') || (needs.integration-tests.result != 'success'))
+    if: always() && (needs.should-i-run.result == 'success' ) && (needs.ui-tests.result != 'success')
     # No concurrency required, runs every time on a schedule.
     steps:
       - uses: michaelkaye/matrix-hookshot-action@v1.0.0


### PR DESCRIPTION
Jobs `codecov-units` and `integration-tests` do not exist anymore.

This should fix wrong message that we receive like this one:

<img width="828" alt="image" src="https://user-images.githubusercontent.com/3940906/196372175-ab17f069-de2e-404e-ae06-9e31f12a74cb.png">

-> failed even when successful

No need for a changelog here.