### PR TITLE
Add additional data in voice broadcast events 

### DIFF
--- a/changelog.d/7397.wip
+++ b/changelog.d/7397.wip
@@ -1,0 +1,1 @@
+[Voice Broadcast] Add additional data in events

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/send/SendService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/send/SendService.kt
@@ -45,18 +45,30 @@ interface SendService {
      * @param text the text message to send
      * @param msgType the message type: MessageType.MSGTYPE_TEXT (default) or MessageType.MSGTYPE_EMOTE
      * @param autoMarkdown If true, the SDK will generate a formatted HTML message from the body text if markdown syntax is present
+     * @param additionalContent additional content to put in the event content
      * @return a [Cancelable]
      */
-    fun sendTextMessage(text: CharSequence, msgType: String = MessageType.MSGTYPE_TEXT, autoMarkdown: Boolean = false): Cancelable
+    fun sendTextMessage(
+            text: CharSequence,
+            msgType: String = MessageType.MSGTYPE_TEXT,
+            autoMarkdown: Boolean = false,
+            additionalContent: Content? = null,
+    ): Cancelable
 
     /**
      * Method to send a text message with a formatted body.
      * @param text the text message to send
      * @param formattedText The formatted body using MessageType#FORMAT_MATRIX_HTML
      * @param msgType the message type: MessageType.MSGTYPE_TEXT (default) or MessageType.MSGTYPE_EMOTE
+     * @param additionalContent additional content to put in the event content
      * @return a [Cancelable]
      */
-    fun sendFormattedTextMessage(text: String, formattedText: String, msgType: String = MessageType.MSGTYPE_TEXT): Cancelable
+    fun sendFormattedTextMessage(
+            text: String,
+            formattedText: String,
+            msgType: String = MessageType.MSGTYPE_TEXT,
+            additionalContent: Content? = null,
+    ): Cancelable
 
     /**
      * Method to quote an events content.
@@ -65,6 +77,7 @@ interface SendService {
      * @param formattedText the formatted text message to send
      * @param autoMarkdown If true, the SDK will generate a formatted HTML message from the body text if markdown syntax is present
      * @param rootThreadEventId when this param is not null, the message will be sent in this specific thread
+     * @param additionalContent additional content to put in the event content
      * @return a [Cancelable]
      */
     fun sendQuotedTextMessage(
@@ -73,6 +86,7 @@ interface SendService {
             formattedText: String? = null,
             autoMarkdown: Boolean,
             rootThreadEventId: String? = null,
+            additionalContent: Content? = null,
     ): Cancelable
 
     /**
@@ -83,6 +97,7 @@ interface SendService {
      *                It can be useful to send media to multiple room. It's safe to include the current roomId in this set
      * @param rootThreadEventId when this param is not null, the Media will be sent in this specific thread
      * @param relatesTo add a relation content to the media event
+     * @param additionalContent additional content to put in the event content
      * @return a [Cancelable]
      */
     fun sendMedia(
@@ -91,6 +106,7 @@ interface SendService {
             roomIds: Set<String>,
             rootThreadEventId: String? = null,
             relatesTo: RelationDefaultContent? = null,
+            additionalContent: Content? = null,
     ): Cancelable
 
     /**
@@ -100,6 +116,7 @@ interface SendService {
      * @param roomIds set of roomIds to where the media will be sent. The current roomId will be add to this set if not present.
      *                It can be useful to send media to multiple room. It's safe to include the current roomId in this set
      * @param rootThreadEventId when this param is not null, all the Media will be sent in this specific thread
+     * @param additionalContent additional content to put in the event content
      * @return a [Cancelable]
      */
     fun sendMedias(
@@ -107,6 +124,7 @@ interface SendService {
             compressBeforeSending: Boolean,
             roomIds: Set<String>,
             rootThreadEventId: String? = null,
+            additionalContent: Content? = null,
     ): Cancelable
 
     /**
@@ -114,31 +132,35 @@ interface SendService {
      * @param pollType indicates open or closed polls
      * @param question the question
      * @param options list of options
+     * @param additionalContent additional content to put in the event content
      * @return a [Cancelable]
      */
-    fun sendPoll(pollType: PollType, question: String, options: List<String>): Cancelable
+    fun sendPoll(pollType: PollType, question: String, options: List<String>, additionalContent: Content? = null): Cancelable
 
     /**
      * Method to send a poll response.
      * @param pollEventId the poll currently replied to
      * @param answerId The id of the answer
+     * @param additionalContent additional content to put in the event content
      * @return a [Cancelable]
      */
-    fun voteToPoll(pollEventId: String, answerId: String): Cancelable
+    fun voteToPoll(pollEventId: String, answerId: String, additionalContent: Content? = null): Cancelable
 
     /**
      * End a poll in the room.
      * @param pollEventId event id of the poll
+     * @param additionalContent additional content to put in the event content
      * @return a [Cancelable]
      */
-    fun endPoll(pollEventId: String): Cancelable
+    fun endPoll(pollEventId: String, additionalContent: Content? = null): Cancelable
 
     /**
      * Redact (delete) the given event.
      * @param event The event to redact
      * @param reason Optional reason string
+     * @param additionalContent additional content to put in the event content
      */
-    fun redactEvent(event: Event, reason: String?): Cancelable
+    fun redactEvent(event: Event, reason: String?, additionalContent: Content? = null): Cancelable
 
     /**
      * Schedule this message to be resent.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/UploadContentWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/UploadContentWorker.kt
@@ -26,6 +26,7 @@ import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.listeners.ProgressListener
 import org.matrix.android.sdk.api.session.content.ContentAttachmentData
 import org.matrix.android.sdk.api.session.crypto.model.EncryptedFileInfo
+import org.matrix.android.sdk.api.session.events.model.Content
 import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.room.model.message.MessageAudioContent
@@ -407,7 +408,10 @@ internal class UploadContentWorker(val context: Context, params: WorkerParameter
             newAttachmentAttributes: NewAttachmentAttributes
     ) {
         localEchoRepository.updateEcho(eventId) { _, event ->
-            val messageContent: MessageContent? = event.asDomain().content.toModel()
+            val content: Content? = event.asDomain().content
+            val messageContent: MessageContent? = content.toModel()
+            // Retrieve potential additional content from the original event
+            val additionalContent = content.orEmpty() - messageContent?.toContent().orEmpty().keys
             val updatedContent = when (messageContent) {
                 is MessageImageContent -> messageContent.update(url, encryptedFileInfo, newAttachmentAttributes)
                 is MessageVideoContent -> messageContent.update(url, encryptedFileInfo, thumbnailUrl, thumbnailEncryptedFileInfo, newAttachmentAttributes)
@@ -415,7 +419,7 @@ internal class UploadContentWorker(val context: Context, params: WorkerParameter
                 is MessageAudioContent -> messageContent.update(url, encryptedFileInfo, newAttachmentAttributes.newFileSize)
                 else -> messageContent
             }
-            event.content = ContentMapper.map(updatedContent.toContent())
+            event.content = ContentMapper.map(updatedContent.toContent().plus(additionalContent))
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastConstants.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastConstants.kt
@@ -27,5 +27,5 @@ object VoiceBroadcastConstants {
     const val VOICE_BROADCAST_CHUNK_KEY = "io.element.voice_broadcast_chunk"
 
     /** Default voice broadcast chunk duration, in seconds. */
-    const val DEFAULT_CHUNK_LENGTH_IN_SECONDS = 10
+    const val DEFAULT_CHUNK_LENGTH_IN_SECONDS = 120
 }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastExtensions.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastExtensions.kt
@@ -23,6 +23,7 @@ import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.room.model.message.MessageAudioEvent
 
 fun MessageAudioEvent?.isVoiceBroadcast() = this?.root?.getClearContent()?.get(VoiceBroadcastConstants.VOICE_BROADCAST_CHUNK_KEY) != null
+
 fun MessageAudioEvent.getVoiceBroadcastEventId(): String? = if (isVoiceBroadcast()) root.getRelationContent()?.eventId else null
 
 fun MessageAudioEvent.getVoiceBroadcastChunk(): VoiceBroadcastChunk? {

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastExtensions.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastExtensions.kt
@@ -16,14 +16,18 @@
 
 package im.vector.app.features.voicebroadcast
 
-import org.matrix.android.sdk.api.session.events.model.RelationType
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcastChunk
+import org.matrix.android.sdk.api.session.events.model.Content
 import org.matrix.android.sdk.api.session.events.model.getRelationContent
+import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.room.model.message.MessageAudioEvent
 
-fun MessageAudioEvent?.isVoiceBroadcast() = this?.getVoiceBroadcastEventId() != null
+fun MessageAudioEvent?.isVoiceBroadcast() = this?.root?.getClearContent()?.get(VoiceBroadcastConstants.VOICE_BROADCAST_CHUNK_KEY) != null
+fun MessageAudioEvent.getVoiceBroadcastEventId(): String? = if (isVoiceBroadcast()) root.getRelationContent()?.eventId else null
 
-fun MessageAudioEvent.getVoiceBroadcastEventId(): String? =
-        // TODO Improve this condition by checking the referenced event type
-        root.takeIf { content.voiceMessageIndicator != null }
-                ?.getRelationContent()?.takeIf { it.type == RelationType.REFERENCE }
-                ?.eventId
+fun MessageAudioEvent.getVoiceBroadcastChunk(): VoiceBroadcastChunk? {
+    @Suppress("UNCHECKED_CAST")
+    return (root.getClearContent()?.get(VoiceBroadcastConstants.VOICE_BROADCAST_CHUNK_KEY) as? Content).toModel<VoiceBroadcastChunk>()
+}
+
+val MessageAudioEvent.sequence: Int? get() = getVoiceBroadcastChunk()?.sequence

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastPlayer.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastPlayer.kt
@@ -85,7 +85,7 @@ class VoiceBroadcastPlayer @Inject constructor(
     private fun updatePlaylist(room: Room, eventId: String) {
         val timelineEvents = room.timelineService().getTimelineEventsRelatedTo(RelationType.REFERENCE, eventId)
         val audioEvents = timelineEvents.mapNotNull { it.root.asMessageAudioEvent() }
-        playlist = audioEvents.sortedBy { it.root.originServerTs }
+        playlist = audioEvents.sortedBy { it.getVoiceBroadcastChunk()?.sequence?.toLong() ?: it.root.originServerTs }
     }
 
     private fun startPlayback() {

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/model/MessageVoiceBroadcastInfoContent.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/model/MessageVoiceBroadcastInfoContent.kt
@@ -38,6 +38,8 @@ data class MessageVoiceBroadcastInfoContent(
         @Json(name = "m.relates_to") override val relatesTo: RelationDefaultContent? = null,
         @Json(name = "m.new_content") override val newContent: Content? = null,
 
+        /** The device from which the broadcast has been started. */
+        @Json(name = "device_id") val deviceId: String? = null,
         /** The [VoiceBroadcastState] value. **/
         @Json(name = "state") val voiceBroadcastStateStr: String = "",
         /** The length of the voice chunks in seconds. **/

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/model/VoiceBroadcastChunk.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/model/VoiceBroadcastChunk.kt
@@ -14,18 +14,12 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.voicebroadcast
+package im.vector.app.features.voicebroadcast.model
 
-import org.matrix.android.sdk.api.session.room.model.message.MessageAudioContent
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
-object VoiceBroadcastConstants {
-
-    /** Voice Broadcast State Event. */
-    const val STATE_ROOM_VOICE_BROADCAST_INFO = "io.element.voice_broadcast_info"
-
-    /** Custom key passed to the [MessageAudioContent] with Voice Broadcast information. */
-    const val VOICE_BROADCAST_CHUNK_KEY = "io.element.voice_broadcast_chunk"
-
-    /** Default voice broadcast chunk duration, in seconds. */
-    const val DEFAULT_CHUNK_LENGTH_IN_SECONDS = 10
-}
+@JsonClass(generateAdapter = true)
+data class VoiceBroadcastChunk(
+        @Json(name = "sequence") val sequence: Int? = null
+)

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/StartVoiceBroadcastUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/StartVoiceBroadcastUseCase.kt
@@ -23,6 +23,7 @@ import im.vector.app.features.attachments.toContentAttachmentData
 import im.vector.app.features.voicebroadcast.VoiceBroadcastConstants
 import im.vector.app.features.voicebroadcast.VoiceBroadcastRecorder
 import im.vector.app.features.voicebroadcast.model.MessageVoiceBroadcastInfoContent
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcastChunk
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
 import im.vector.app.features.voicebroadcast.model.asVoiceBroadcastEvent
 import im.vector.lib.multipicker.utils.toMultiPickerAudioType
@@ -98,7 +99,10 @@ class StartVoiceBroadcastUseCase @Inject constructor(
                 attachment = audioType.toContentAttachmentData(isVoiceMessage = true),
                 compressBeforeSending = false,
                 roomIds = emptySet(),
-                relatesTo = RelationDefaultContent(RelationType.REFERENCE, referenceEventId)
+                relatesTo = RelationDefaultContent(RelationType.REFERENCE, referenceEventId),
+                additionalContent = mapOf(
+                        VoiceBroadcastConstants.VOICE_BROADCAST_CHUNK_KEY to VoiceBroadcastChunk(sequence = sequence).toContent()
+                )
         )
     }
 }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/StartVoiceBroadcastUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/StartVoiceBroadcastUseCase.kt
@@ -71,6 +71,7 @@ class StartVoiceBroadcastUseCase @Inject constructor(
                 eventType = VoiceBroadcastConstants.STATE_ROOM_VOICE_BROADCAST_INFO,
                 stateKey = session.myUserId,
                 body = MessageVoiceBroadcastInfoContent(
+                        deviceId = session.sessionParams.deviceId,
                         voiceBroadcastStateStr = VoiceBroadcastState.STARTED.value,
                         chunkLength = chunkLength,
                 ).toContent()

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/StartVoiceBroadcastUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/StartVoiceBroadcastUseCase.kt
@@ -95,7 +95,6 @@ class StartVoiceBroadcastUseCase @Inject constructor(
                 "Voice Broadcast Part ($sequence).${voiceMessageFile.extension}"
         )
         val audioType = outputFileUri.toMultiPickerAudioType(context) ?: return
-        // TODO put sequence in event content
         room.sendService().sendMedia(
                 attachment = audioType.toContentAttachmentData(isVoiceMessage = true),
                 compressBeforeSending = false,

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeSendService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeSendService.kt
@@ -17,6 +17,7 @@
 package im.vector.app.test.fakes
 
 import io.mockk.mockk
+import org.matrix.android.sdk.api.session.events.model.Content
 import org.matrix.android.sdk.api.session.room.model.message.PollType
 import org.matrix.android.sdk.api.session.room.send.SendService
 import org.matrix.android.sdk.api.util.Cancelable
@@ -25,5 +26,5 @@ class FakeSendService : SendService by mockk() {
 
     private val cancelable = mockk<Cancelable>()
 
-    override fun sendPoll(pollType: PollType, question: String, options: List<String>): Cancelable = cancelable
+    override fun sendPoll(pollType: PollType, question: String, options: List<String>, additionalContent: Content?): Cancelable = cancelable
 }


### PR DESCRIPTION
## Type of change

- [x] WIP Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Add `io.element.voice_broadcast_chunk` in voice message content
Add `device_id` in `io.element.voice_broadcast_info` state event
Add entries in matrix-sdk to add additional content fields to the events

## Motivation and context

Continue #7127 and follow the "specification" defined in https://github.com/vector-im/element-meta/discussions/632 

## Screenshots / GIFs

## Tests

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
