### PR TITLE
Voice broadcast - live listening

### DIFF
--- a/changelog.d/7419.wip
+++ b/changelog.d/7419.wip
@@ -1,0 +1,1 @@
+[Voice Broadcast] Live listening support

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
@@ -401,7 +401,7 @@ fun Event.getRelationContent(): RelationDefaultContent? {
             when (getClearType()) {
                 EventType.STICKER -> getClearContent().toModel<MessageStickerContent>()?.relatesTo
                 in EventType.BEACON_LOCATION_DATA -> getClearContent().toModel<MessageBeaconLocationDataContent>()?.relatesTo
-                else -> null
+                else -> getClearContent()?.get("m.relates_to")?.toContent().toModel()
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastHelper.kt
@@ -40,7 +40,7 @@ class VoiceBroadcastHelper @Inject constructor(
 
     suspend fun stopVoiceBroadcast(roomId: String) = stopVoiceBroadcastUseCase.execute(roomId)
 
-    fun playOrResumePlayback(roomId: String, eventId: String) = voiceBroadcastPlayer.play(roomId, eventId)
+    fun playOrResumePlayback(roomId: String, eventId: String) = voiceBroadcastPlayer.playOrResume(roomId, eventId)
 
     fun pausePlayback() = voiceBroadcastPlayer.pause()
 

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastPlayer.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastPlayer.kt
@@ -76,10 +76,8 @@ class VoiceBroadcastPlayer @Inject constructor(
 
     fun stop() {
         currentMediaPlayer?.stop()
-        currentMediaPlayer?.release()
-        currentMediaPlayer?.setOnInfoListener(null)
-        currentMediaPlayer = null
         currentVoiceBroadcastEventId?.let { playbackTracker.stopPlayback(it) }
+        release(currentMediaPlayer)
         playlist = emptyList()
         currentPlayingIndex = -1
     }
@@ -147,11 +145,21 @@ class VoiceBroadcastPlayer @Inject constructor(
         }
     }
 
+    private fun release(mp: MediaPlayer?) {
+        mp?.apply {
+            release()
+            setOnInfoListener(null)
+            setOnCompletionListener(null)
+            setOnErrorListener(null)
+        }
+    }
+
     inner class MediaPlayerListener : MediaPlayer.OnInfoListener, MediaPlayer.OnCompletionListener, MediaPlayer.OnErrorListener {
 
         override fun onInfo(mp: MediaPlayer, what: Int, extra: Int): Boolean {
             when (what) {
                 MediaPlayer.MEDIA_INFO_STARTED_AS_NEXT -> {
+                    release(currentMediaPlayer)
                     currentMediaPlayer = mp
                     currentPlayingIndex++
                     mediaPlayerScope.launch { prepareNextFile() }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastPlayer.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastPlayer.kt
@@ -116,8 +116,6 @@ class VoiceBroadcastPlayer @Inject constructor(
         voiceBroadcastStateJob = null
 
         // In case of live broadcast, stop observing new chunks
-        currentTimeline?.dispose()
-        currentTimeline?.removeAllListeners()
         currentTimeline = null
         timelineListener = null
 

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastPlayer.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastPlayer.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.voicebroadcast
 
 import android.media.AudioAttributes
 import android.media.MediaPlayer
+import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.features.home.room.detail.timeline.helper.AudioMessagePlaybackTracker
 import im.vector.app.features.home.room.detail.timeline.helper.AudioMessagePlaybackTracker.Listener.State
 import im.vector.app.features.voice.VoiceFailure
@@ -25,7 +26,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.extensions.orFalse
-import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.events.model.RelationType
 import org.matrix.android.sdk.api.session.events.model.getRelationContent
 import org.matrix.android.sdk.api.session.getRoom
@@ -39,9 +39,11 @@ import javax.inject.Singleton
 
 @Singleton
 class VoiceBroadcastPlayer @Inject constructor(
-        private val session: Session,
+        private val sessionHolder: ActiveSessionHolder,
         private val playbackTracker: AudioMessagePlaybackTracker,
 ) {
+
+    private val session get() = sessionHolder.getActiveSession()
 
     private val mediaPlayerScope = CoroutineScope(Dispatchers.IO)
 

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastPlayer.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastPlayer.kt
@@ -179,7 +179,11 @@ class VoiceBroadcastPlayer @Inject constructor(
         room.flow()
                 .liveStateEvent(VoiceBroadcastConstants.STATE_ROOM_VOICE_BROADCAST_INFO, QueryStringValue.Equals(voiceBroadcastEvent.root.stateKey!!))
                 .unwrap()
-                .mapNotNull { it.asVoiceBroadcastEvent()?.content?.voiceBroadcastState }
+                .mapNotNull { event ->
+                    event.asVoiceBroadcastEvent()
+                            ?.takeIf { it.reference?.eventId == eventId }
+                            ?.content?.voiceBroadcastState
+                }
                 .onEach { state ->
                     when (state) {
                         VoiceBroadcastState.STARTED,

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastPlayer.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastPlayer.kt
@@ -51,8 +51,8 @@ class VoiceBroadcastPlayer @Inject constructor(
     private var currentPlayingIndex: Int = -1
 
     private var playlist = emptyList<MessageAudioEvent>()
-    private val currentVoiceBroadcastEventId
-        get() = playlist.firstOrNull()?.root?.getRelationContent()?.eventId
+    private val currentVoiceBroadcastId
+        get() = playlist.getOrNull(currentPlayingIndex)?.root?.getRelationContent()?.eventId
 
     private val mediaPlayerListener = MediaPlayerListener()
 
@@ -60,7 +60,7 @@ class VoiceBroadcastPlayer @Inject constructor(
         val room = session.getRoom(roomId) ?: error("Unknown roomId: $roomId")
 
         when {
-            currentVoiceBroadcastEventId != eventId -> {
+            currentVoiceBroadcastId != eventId -> {
                 stop()
                 updatePlaylist(room, eventId)
                 startPlayback()
@@ -72,12 +72,12 @@ class VoiceBroadcastPlayer @Inject constructor(
 
     fun pause() {
         currentMediaPlayer?.pause()
-        currentVoiceBroadcastEventId?.let { playbackTracker.pausePlayback(it) }
+        currentVoiceBroadcastId?.let { playbackTracker.pausePlayback(it) }
     }
 
     fun stop() {
         currentMediaPlayer?.stop()
-        currentVoiceBroadcastEventId?.let { playbackTracker.stopPlayback(it) }
+        currentVoiceBroadcastId?.let { playbackTracker.stopPlayback(it) }
         release(currentMediaPlayer)
         playlist = emptyList()
         currentPlayingIndex = -1
@@ -96,7 +96,7 @@ class VoiceBroadcastPlayer @Inject constructor(
                 currentMediaPlayer = prepareMediaPlayer(content)
                 currentMediaPlayer?.start()
                 currentPlayingIndex = 0
-                currentVoiceBroadcastEventId?.let { playbackTracker.startPlayback(it) }
+                currentVoiceBroadcastId?.let { playbackTracker.startPlayback(it) }
                 prepareNextFile()
             } catch (failure: Throwable) {
                 Timber.e(failure, "Unable to start playback")
@@ -107,7 +107,7 @@ class VoiceBroadcastPlayer @Inject constructor(
 
     private fun resumePlayback() {
         currentMediaPlayer?.start()
-        currentVoiceBroadcastEventId?.let { playbackTracker.startPlayback(it) }
+        currentVoiceBroadcastId?.let { playbackTracker.startPlayback(it) }
     }
 
     private suspend fun prepareNextFile() {

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastRecorder.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastRecorder.kt
@@ -23,6 +23,7 @@ import java.io.File
 interface VoiceBroadcastRecorder : VoiceRecorder {
 
     var listener: Listener?
+    var currentSequence: Int
 
     fun startRecord(roomId: String, chunkLength: Int)
 

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastRecorderQ.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastRecorderQ.kt
@@ -30,8 +30,8 @@ class VoiceBroadcastRecorderQ(
 ) : AbstractVoiceRecorderQ(context), VoiceBroadcastRecorder {
 
     private var maxFileSize = 0L // zero or negative for no limit
-    private var currentSequence = 0
     private var currentRoomId: String? = null
+    override var currentSequence = 0
 
     override var listener: VoiceBroadcastRecorder.Listener? = null
 

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/model/MessageVoiceBroadcastInfoContent.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/model/MessageVoiceBroadcastInfoContent.kt
@@ -44,6 +44,8 @@ data class MessageVoiceBroadcastInfoContent(
         @Json(name = "state") val voiceBroadcastStateStr: String = "",
         /** The length of the voice chunks in seconds. **/
         @Json(name = "chunk_length") val chunkLength: Int? = null,
+        /** The sequence of the last sent chunk. **/
+        @Json(name = "last_chunk_sequence") val lastChunkSequence: Int? = null,
 ) : MessageContent {
 
     val voiceBroadcastState: VoiceBroadcastState? = VoiceBroadcastState.values()

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/GetVoiceBroadcastStateUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/GetVoiceBroadcastStateUseCase.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.voicebroadcast.usecase
+
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
+import im.vector.app.features.voicebroadcast.model.asVoiceBroadcastEvent
+import org.matrix.android.sdk.api.session.Session
+import org.matrix.android.sdk.api.session.events.model.RelationType
+import org.matrix.android.sdk.api.session.getRoom
+import timber.log.Timber
+import javax.inject.Inject
+
+class GetVoiceBroadcastStateUseCase @Inject constructor(
+        private val session: Session,
+) {
+
+    fun execute(roomId: String, eventId: String): VoiceBroadcastState? {
+        val room = session.getRoom(roomId) ?: error("Unknown roomId: $roomId")
+
+        Timber.d("## GetVoiceBroadcastStateUseCase: get voice broadcast state requested for $eventId")
+
+        val initialEvent = room.timelineService().getTimelineEvent(eventId)?.root?.asVoiceBroadcastEvent() // Fallback to initial event
+        val relatedEvents = room.timelineService().getTimelineEventsRelatedTo(RelationType.REFERENCE, eventId).sortedBy { it.root.originServerTs }
+        val lastVoiceBroadcastEvent = relatedEvents.mapNotNull { it.root.asVoiceBroadcastEvent() }.lastOrNull() ?: initialEvent
+        return lastVoiceBroadcastEvent?.content?.voiceBroadcastState
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/GetVoiceBroadcastUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/GetVoiceBroadcastUseCase.kt
@@ -16,7 +16,7 @@
 
 package im.vector.app.features.voicebroadcast.usecase
 
-import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcastEvent
 import im.vector.app.features.voicebroadcast.model.asVoiceBroadcastEvent
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.events.model.RelationType
@@ -24,18 +24,17 @@ import org.matrix.android.sdk.api.session.getRoom
 import timber.log.Timber
 import javax.inject.Inject
 
-class GetVoiceBroadcastStateUseCase @Inject constructor(
+class GetVoiceBroadcastUseCase @Inject constructor(
         private val session: Session,
 ) {
 
-    fun execute(roomId: String, eventId: String): VoiceBroadcastState? {
+    fun execute(roomId: String, eventId: String): VoiceBroadcastEvent? {
         val room = session.getRoom(roomId) ?: error("Unknown roomId: $roomId")
 
-        Timber.d("## GetVoiceBroadcastStateUseCase: get voice broadcast state requested for $eventId")
+        Timber.d("## GetVoiceBroadcastUseCase: get voice broadcast $eventId")
 
         val initialEvent = room.timelineService().getTimelineEvent(eventId)?.root?.asVoiceBroadcastEvent() // Fallback to initial event
         val relatedEvents = room.timelineService().getTimelineEventsRelatedTo(RelationType.REFERENCE, eventId).sortedBy { it.root.originServerTs }
-        val lastVoiceBroadcastEvent = relatedEvents.mapNotNull { it.root.asVoiceBroadcastEvent() }.lastOrNull() ?: initialEvent
-        return lastVoiceBroadcastEvent?.content?.voiceBroadcastState
+        return relatedEvents.mapNotNull { it.root.asVoiceBroadcastEvent() }.lastOrNull() ?: initialEvent
     }
 }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/PauseVoiceBroadcastUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/PauseVoiceBroadcastUseCase.kt
@@ -59,6 +59,7 @@ class PauseVoiceBroadcastUseCase @Inject constructor(
                 body = MessageVoiceBroadcastInfoContent(
                         relatesTo = reference,
                         voiceBroadcastStateStr = VoiceBroadcastState.PAUSED.value,
+                        lastChunkSequence = voiceBroadcastRecorder?.currentSequence,
                 ).toContent(),
         )
 

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/StartVoiceBroadcastUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/StartVoiceBroadcastUseCase.kt
@@ -55,7 +55,7 @@ class StartVoiceBroadcastUseCase @Inject constructor(
                 QueryStringValue.IsNotEmpty
         )
                 .mapNotNull { it.asVoiceBroadcastEvent() }
-                .filter { it.content?.voiceBroadcastState != VoiceBroadcastState.STOPPED }
+                .filter { it.content?.voiceBroadcastState != null && it.content?.voiceBroadcastState != VoiceBroadcastState.STOPPED }
 
         if (onGoingVoiceBroadcastEvents.isEmpty()) {
             startVoiceBroadcast(room)

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/StopVoiceBroadcastUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/StopVoiceBroadcastUseCase.kt
@@ -60,6 +60,7 @@ class StopVoiceBroadcastUseCase @Inject constructor(
                 body = MessageVoiceBroadcastInfoContent(
                         relatesTo = reference,
                         voiceBroadcastStateStr = VoiceBroadcastState.STOPPED.value,
+                        lastChunkSequence = voiceBroadcastRecorder?.currentSequence,
                 ).toContent(),
         )
 


### PR DESCRIPTION
## Type of change

- [x] WIP Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Be able to listen to an ongoing voice broadcast
When a voice broadcast is live, trigger the play action will start listening to the last received chunk and wait for the new ones with a "buffering" state in the meantime.
Also, when the recording is paused, the current chunk is now stopped and sent to the room. Resume the recording will start a new chunk file.

Note: the UI will be improved in a dedicated PR for a better rendering of the listening state

## Motivation and context

Continue #7127

## Screenshots / GIFs

## Tests

- Start playing a live voice broadcast
- Verify that we are able to listen it until it is stopped or paused by the recorder
- Verify that when the recorder resume the voice broadcast, you continue to listen to the new chunks
- Verify that the listener is able to pause and resume the listening without problem

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
