### PR TITLE
Disable Flipper on API 21 and below

### DIFF
--- a/vector-app/src/debug/java/im/vector/app/flipper/VectorFlipperProxy.kt
+++ b/vector-app/src/debug/java/im/vector/app/flipper/VectorFlipperProxy.kt
@@ -17,6 +17,7 @@
 package im.vector.app.flipper
 
 import android.content.Context
+import android.os.Build
 import com.facebook.flipper.android.AndroidFlipperClient
 import com.facebook.flipper.android.utils.FlipperUtils
 import com.facebook.flipper.plugins.crashreporter.CrashReporterPlugin
@@ -43,6 +44,11 @@ class VectorFlipperProxy @Inject constructor(
 
     override fun init(matrix: Matrix) {
         SoLoader.init(context, false)
+
+        // https://github.com/facebook/flipper/issues/3572
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP_MR1) {
+            return
+        }
 
         if (FlipperUtils.shouldEnableFlipper(context)) {
             val client = AndroidFlipperClient.getInstance(context)


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Disable Flipper on API 21 and below as it causes a crash immediately on app startup.

## Motivation and context

- See the related  issue: https://github.com/facebook/flipper/issues/3572

## Screenshots / GIFs

N/A

## Tests

- Launch the app on an emulator running Android 5
- Observe no crash

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 21

## Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
