### PR TITLE
Add trim to username input when sign-in

### DIFF
--- a/changelog.d/7111.misc
+++ b/changelog.d/7111.misc
@@ -1,0 +1,1 @@
+Add trim to username input on the app side and SDK side when sign-in

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/DefaultLoginWizard.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/login/DefaultLoginWizard.kt
@@ -69,7 +69,7 @@ internal class DefaultLoginWizard(
             )
         } else {
             PasswordLoginParams.userIdentifier(
-                    user = login,
+                    user = login.trim(),
                     password = password,
                     deviceDisplayName = initialDeviceName,
                     deviceId = deviceId

--- a/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginViewModel.kt
@@ -684,7 +684,7 @@ class LoginViewModel @AssistedInject constructor(
             currentJob = viewModelScope.launch {
                 try {
                     safeLoginWizard.login(
-                            action.username,
+                            action.username.trim(),
                             action.password,
                             action.initialDeviceName
                     )


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Enhancement

## Content
Add trim to username input when sign-in on the app side and SDK side.
When the user inputs the username string, trailing whitespace can be added due to the autocomplete.
This issue can be solved by just warning about invalid characters like discussed in #7111
But This can lead to unnecessary user actions like deleting unnecessary whitespace.
So I add trim logic to the username's input so that the user's additional action is not needed.

## Motivation and context
Closes #7111 

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
No UI changes
<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): OS12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
