### PR TITLE
Fix unusable area when RTE is enabled and the user has no permissions in a room

### DIFF
--- a/changelog.d/7411.bugfix
+++ b/changelog.d/7411.bugfix
@@ -1,0 +1,1 @@
+Fix unusable area when Rich Text Editor is enabled and the user has no permissions in a room

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1131,6 +1131,8 @@ class TimelineFragment :
             lazyLoadedViews.inviteView(false)?.isVisible = false
 
             if (mainState.tombstoneEvent == null) {
+                views.composerContainer.isVisible = messageComposerState.isComposerVisible
+
                 when (messageComposerState.canSendMessage) {
                     CanSendStatus.Allowed -> {
                         NotificationAreaView.State.Hidden

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
@@ -252,13 +252,6 @@ class MessageComposerFragment : VectorBaseFragment<FragmentComposerBinding>(), A
         messageComposerViewModel.endAllVoiceActions()
     }
 
-    override fun invalidate() = withState(timelineViewModel, messageComposerViewModel) { mainState, messageComposerState ->
-        if (mainState.tombstoneEvent != null) return@withState
-
-        composer.setInvisible(!messageComposerState.isComposerVisible)
-        composer.sendButton.isInvisible = !messageComposerState.isSendButtonVisible
-    }
-
     private fun setupComposer() {
         val composerEditText = composer.editText
         composerEditText.setHint(R.string.room_message_placeholder)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fix the way the composer is hidden when user has no permission to write in a room.

## Motivation and context

Fixes #7411.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|![Screenshot_1666594680](https://user-images.githubusercontent.com/480955/197466022-82ead508-d5d9-4ac9-aa3e-d05afcb7d7d5.png)|![Screenshot_1666594610](https://user-images.githubusercontent.com/480955/197466048-a962b281-13af-48cd-933d-0f9c21b600b0.png)|

## Tests

<!-- Explain how you tested your development -->

- Create a Room.
- Invite some other account, restrict their permissions to -1 or -2 (I don't know if there is a better way to do this).
- With the other account, enter the room with restricted permissions (you might have to join, then exit the room screen and come back because of a different bug).
- You should see the 'You do not have permissions...' text with just a little whitespace above it. Check the screenshot and see if it matches the 'after' screenshot.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
