### PR TITLE
Voice Broadcast - Do not display the recording tile on the other sessions

### DIFF
--- a/changelog.d/7431.bugfix
+++ b/changelog.d/7431.bugfix
@@ -1,0 +1,1 @@
+ [Voice Broadcast] Do not display the recorder view for a live broadcast started from another session

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/VoiceBroadcastItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/VoiceBroadcastItemFactory.kt
@@ -60,7 +60,9 @@ class VoiceBroadcastItemFactory @Inject constructor(
         val voiceBroadcastContent = voiceBroadcastEvent.content ?: return null
         val voiceBroadcastId = voiceBroadcastEventsGroup.voiceBroadcastId
 
-        val isRecording = voiceBroadcastContent.voiceBroadcastState != VoiceBroadcastState.STOPPED && voiceBroadcastEvent.root.stateKey == session.myUserId
+        val isRecording = voiceBroadcastContent.voiceBroadcastState != VoiceBroadcastState.STOPPED &&
+                voiceBroadcastEvent.root.stateKey == session.myUserId &&
+                messageContent.deviceId == session.sessionParams.deviceId
 
         val voiceBroadcastAttributes = AbsMessageVoiceBroadcastItem.Attributes(
                 voiceBroadcastId = voiceBroadcastId,


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Add a check on the recorder device id before showing the recording or listening tile in the timeline

## Motivation and context

Fix https://github.com/vector-im/element-android/issues/7431

## Screenshots / GIFs

## Tests

- Record a voice broadcast on a sessionA in a room
- Open the room with a sessionB while the voice broadcast is live
- Verify that the sessionB is in a listening state (can start/pause listening to the VB but cannot pause or stop the recording)

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the <del>develop</del> resilience-rc branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
