### PR TITLE
Fixes Ignored User Visible in Threads

### DIFF
--- a/changelog.d/7451.bugfix
+++ b/changelog.d/7451.bugfix
@@ -1,0 +1,1 @@
+Fixes empty thread message from ignored user in timeline

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageItem.kt
@@ -111,7 +111,7 @@ abstract class AbsMessageItem<H : AbsMessageItem.Holder>(
         if (attributes.areThreadMessagesEnabled) {
             holder.threadSummaryConstraintLayout.onClick(_threadClickListener)
             attributes.threadDetails?.let { threadDetails ->
-                holder.threadSummaryConstraintLayout.isVisible = threadDetails.isRootThread
+                holder.threadSummaryConstraintLayout.isVisible = threadDetails.isRootThread && threadDetails.threadSummarySenderInfo != null
                 holder.threadSummaryCounterTextView.text = threadDetails.numberOfThreads.toString()
                 holder.threadSummaryInfoTextView.text = attributes.threadSummaryFormatted ?: attributes.decryptionErrorMessage
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fixes issue where you could get an "empty" thread message after ignoring a user

## Motivation and context

Closes https://github.com/vector-im/element-android/issues/7050

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- See a threaded message from a user
- Ignore the user
- See that the threaded message is no longer there

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
