### PR TITLE
[Rich text editor] Add plain text mode

### DIFF
--- a/changelog.d/7452.feature
+++ b/changelog.d/7452.feature
@@ -1,0 +1,1 @@
+[Rich text editor] Add plain text mode

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -98,7 +98,7 @@ ext.libs = [
         ],
         element     : [
                 'opusencoder'             : "io.element.android:opusencoder:1.1.0",
-                'wysiwyg'                 : "io.element.android:wysiwyg:0.3.1"
+                'wysiwyg'                 : "io.element.android:wysiwyg:0.4.0"
         ],
         squareup    : [
                 'moshi'                  : "com.squareup.moshi:moshi:$moshi",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -98,7 +98,7 @@ ext.libs = [
         ],
         element     : [
                 'opusencoder'             : "io.element.android:opusencoder:1.1.0",
-                'wysiwyg'                 : "io.element.android:wysiwyg:0.2.1"
+                'wysiwyg'                 : "io.element.android:wysiwyg:0.3.1"
         ],
         squareup    : [
                 'moshi'                  : "com.squareup.moshi:moshi:$moshi",

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -3213,6 +3213,7 @@
     <string name="attachment_type_selector_location">Location</string>
     <string name="attachment_type_selector_camera">Camera</string>
     <string name="attachment_type_selector_contact">Contact</string>
+    <string name="attachment_type_selector_rich_text">Toggle rich text</string>
 
     <string name="message_reaction_show_less">Show less</string>
     <plurals name="message_reaction_show_more">

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -3213,7 +3213,7 @@
     <string name="attachment_type_selector_location">Location</string>
     <string name="attachment_type_selector_camera">Camera</string>
     <string name="attachment_type_selector_contact">Contact</string>
-    <string name="attachment_type_selector_rich_text">Toggle rich text</string>
+    <string name="attachment_type_selector_text_formatting">Text formatting</string>
 
     <string name="message_reaction_show_less">Show less</string>
     <plurals name="message_reaction_show_more">

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorBottomSheet.kt
@@ -23,10 +23,10 @@ import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
-import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.parentFragmentViewModel
 import com.airbnb.mvrx.withState
 import dagger.hilt.android.AndroidEntryPoint
+import im.vector.app.R
 import im.vector.app.core.platform.VectorBaseBottomSheetDialogFragment
 import im.vector.app.databinding.BottomSheetAttachmentTypeSelectorBinding
 import im.vector.app.features.home.room.detail.TimelineViewModel
@@ -34,7 +34,7 @@ import im.vector.app.features.home.room.detail.TimelineViewModel
 @AndroidEntryPoint
 class AttachmentTypeSelectorBottomSheet : VectorBaseBottomSheetDialogFragment<BottomSheetAttachmentTypeSelectorBinding>() {
 
-    private val viewModel: AttachmentTypeSelectorViewModel by fragmentViewModel()
+    private val viewModel: AttachmentTypeSelectorViewModel by parentFragmentViewModel()
     private val timelineViewModel: TimelineViewModel by parentFragmentViewModel()
     private val sharedActionViewModel: AttachmentTypeSelectorSharedActionViewModel by viewModels(
             ownerProducer = { requireParentFragment() }
@@ -51,6 +51,14 @@ class AttachmentTypeSelectorBottomSheet : VectorBaseBottomSheetDialogFragment<Bo
         views.location.isVisible = viewState.isLocationVisible
         views.voiceBroadcast.isVisible = viewState.isVoiceBroadcastVisible
         views.poll.isVisible = !timelineState.isThreadTimeline()
+        views.textFormatting.isChecked = viewState.isTextFormattingEnabled
+        views.textFormatting.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                if (viewState.isTextFormattingEnabled) {
+                    R.drawable.ic_text_formatting
+                } else {
+                    R.drawable.ic_text_formatting_disabled
+                }, 0, 0, 0
+        )
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -63,7 +71,7 @@ class AttachmentTypeSelectorBottomSheet : VectorBaseBottomSheetDialogFragment<Bo
         views.location.debouncedClicks { onAttachmentSelected(AttachmentType.LOCATION) }
         views.camera.debouncedClicks { onAttachmentSelected(AttachmentType.CAMERA) }
         views.contact.debouncedClicks { onAttachmentSelected(AttachmentType.CONTACT) }
-        views.textFormatting.debouncedClicks { onTextFormattingToggled() }
+        views.textFormatting.setOnCheckedChangeListener { _, isChecked -> onTextFormattingToggled(isChecked) }
     }
 
     private fun onAttachmentSelected(attachmentType: AttachmentType) {
@@ -72,11 +80,8 @@ class AttachmentTypeSelectorBottomSheet : VectorBaseBottomSheetDialogFragment<Bo
         dismiss()
     }
 
-    private fun onTextFormattingToggled() {
-        val action = AttachmentTypeSelectorSharedAction.ToggleTextFormatting
-        sharedActionViewModel.post(action)
-        dismiss()
-    }
+    private fun onTextFormattingToggled(isEnabled: Boolean) =
+            viewModel.handle(AttachmentTypeSelectorAction.ToggleTextFormatting(isEnabled))
 
     companion object {
         fun show(fragmentManager: FragmentManager) {

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorBottomSheet.kt
@@ -63,10 +63,17 @@ class AttachmentTypeSelectorBottomSheet : VectorBaseBottomSheetDialogFragment<Bo
         views.location.debouncedClicks { onAttachmentSelected(AttachmentType.LOCATION) }
         views.camera.debouncedClicks { onAttachmentSelected(AttachmentType.CAMERA) }
         views.contact.debouncedClicks { onAttachmentSelected(AttachmentType.CONTACT) }
+        views.textFormatting.debouncedClicks { onTextFormattingToggled() }
     }
 
     private fun onAttachmentSelected(attachmentType: AttachmentType) {
         val action = AttachmentTypeSelectorSharedAction.SelectAttachmentTypeAction(attachmentType)
+        sharedActionViewModel.post(action)
+        dismiss()
+    }
+
+    private fun onTextFormattingToggled() {
+        val action = AttachmentTypeSelectorSharedAction.ToggleTextFormatting
         sharedActionViewModel.post(action)
         dismiss()
     }

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorSharedActionViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorSharedActionViewModel.kt
@@ -27,4 +27,6 @@ sealed interface AttachmentTypeSelectorSharedAction : VectorSharedAction {
     data class SelectAttachmentTypeAction(
             val attachmentType: AttachmentType
     ) : AttachmentTypeSelectorSharedAction
+
+    object ToggleTextFormatting : AttachmentTypeSelectorSharedAction
 }

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorSharedActionViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorSharedActionViewModel.kt
@@ -27,6 +27,4 @@ sealed interface AttachmentTypeSelectorSharedAction : VectorSharedAction {
     data class SelectAttachmentTypeAction(
             val attachmentType: AttachmentType
     ) : AttachmentTypeSelectorSharedAction
-
-    object ToggleTextFormatting : AttachmentTypeSelectorSharedAction
 }

--- a/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/attachments/AttachmentTypeSelectorViewModel.kt
@@ -23,15 +23,17 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
-import im.vector.app.core.platform.EmptyAction
 import im.vector.app.core.platform.EmptyViewEvents
 import im.vector.app.core.platform.VectorViewModel
+import im.vector.app.core.platform.VectorViewModelAction
 import im.vector.app.features.VectorFeatures
+import im.vector.app.features.settings.VectorPreferences
 
 class AttachmentTypeSelectorViewModel @AssistedInject constructor(
         @Assisted initialState: AttachmentTypeSelectorViewState,
         private val vectorFeatures: VectorFeatures,
-) : VectorViewModel<AttachmentTypeSelectorViewState, EmptyAction, EmptyViewEvents>(initialState) {
+        private val vectorPreferences: VectorPreferences,
+) : VectorViewModel<AttachmentTypeSelectorViewState, AttachmentTypeSelectorAction, EmptyViewEvents>(initialState) {
     @AssistedFactory
     interface Factory : MavericksAssistedViewModelFactory<AttachmentTypeSelectorViewModel, AttachmentTypeSelectorViewState> {
         override fun create(initialState: AttachmentTypeSelectorViewState): AttachmentTypeSelectorViewModel
@@ -39,8 +41,8 @@ class AttachmentTypeSelectorViewModel @AssistedInject constructor(
 
     companion object : MavericksViewModelFactory<AttachmentTypeSelectorViewModel, AttachmentTypeSelectorViewState> by hiltMavericksViewModelFactory()
 
-    override fun handle(action: EmptyAction) {
-        // do nothing
+    override fun handle(action: AttachmentTypeSelectorAction) = when (action) {
+        is AttachmentTypeSelectorAction.ToggleTextFormatting -> setTextFormattingEnabled(action.isEnabled)
     }
 
     init {
@@ -48,6 +50,16 @@ class AttachmentTypeSelectorViewModel @AssistedInject constructor(
             copy(
                     isLocationVisible = vectorFeatures.isLocationSharingEnabled(),
                     isVoiceBroadcastVisible = vectorFeatures.isVoiceBroadcastEnabled(),
+                    isTextFormattingEnabled = vectorPreferences.isTextFormattingEnabled(),
+            )
+        }
+    }
+
+    private fun setTextFormattingEnabled(isEnabled: Boolean) {
+        vectorPreferences.setTextFormattingEnabled(isEnabled)
+        setState {
+            copy(
+                    isTextFormattingEnabled = isEnabled
             )
         }
     }
@@ -56,4 +68,9 @@ class AttachmentTypeSelectorViewModel @AssistedInject constructor(
 data class AttachmentTypeSelectorViewState(
         val isLocationVisible: Boolean = false,
         val isVoiceBroadcastVisible: Boolean = false,
+        val isTextFormattingEnabled: Boolean = false,
 ) : MavericksState
+
+sealed interface AttachmentTypeSelectorAction : VectorViewModelAction {
+    data class ToggleTextFormatting(val isEnabled: Boolean) : AttachmentTypeSelectorAction
+}

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
@@ -231,6 +231,11 @@ class MessageComposerFragment : VectorBaseFragment<FragmentComposerBinding>(), A
                 .onEach { onTypeSelected(it.attachmentType) }
                 .launchIn(lifecycleScope)
 
+        attachmentViewModel.stream()
+                .filterIsInstance<AttachmentTypeSelectorSharedAction.ToggleTextFormatting>()
+                .onEach { toggleTextFormatting() }
+                .launchIn(lifecycleScope)
+
         if (savedInstanceState != null) {
             handleShareData()
         }
@@ -711,6 +716,11 @@ class MessageComposerFragment : VectorBaseFragment<FragmentComposerBinding>(), A
         } else {
             attachmentsHelper.pendingType = type
         }
+    }
+
+    private fun toggleTextFormatting() {
+        val richTextComposer = composer as? RichTextComposerLayout ?: return
+         richTextComposer.isTextFormattingEnabled = !richTextComposer.isTextFormattingEnabled
     }
 
     private val attachmentFileActivityResultLauncher = registerStartForActivityResult {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
@@ -62,12 +62,24 @@ class RichTextComposerLayout @JvmOverloads constructor(
 
     private val animationDuration = 100L
 
+    var isTextFormattingEnabled = true
+        set(value) {
+            if (field == value) return
+            syncEditTexts()
+            field = value
+            updateEditTextVisibility()
+        }
+
     override val text: Editable?
-        get() = views.composerEditText.text
+        get() = editText.text
     override val formattedText: String?
-        get() = views.composerEditText.getHtmlOutput()
+        get() = (editText as? EditorEditText)?.getHtmlOutput()
     override val editText: EditText
-        get() = views.composerEditText
+        get() = if (isTextFormattingEnabled) {
+            views.richTextComposerEditText
+        } else {
+            views.plainTextComposerEditText
+        }
     override val emojiButton: ImageButton?
         get() = null
     override val sendButton: ImageButton
@@ -94,21 +106,12 @@ class RichTextComposerLayout @JvmOverloads constructor(
 
         collapse(false)
 
-        views.composerEditText.addTextChangedListener(object : TextWatcher {
-            private var previousTextWasExpanded = false
-
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-            override fun afterTextChanged(s: Editable) {
-                callback?.onTextChanged(s)
-
-                val isExpanded = s.lines().count() > 1
-                if (previousTextWasExpanded != isExpanded) {
-                    updateTextFieldBorder(isExpanded)
-                }
-                previousTextWasExpanded = isExpanded
-            }
-        })
+        views.richTextComposerEditText.addTextChangedListener(
+                TextChangeListener({ callback?.onTextChanged(it) }, ::updateTextFieldBorder)
+        )
+        views.plainTextComposerEditText.addTextChangedListener(
+                TextChangeListener({ callback?.onTextChanged(it) }, ::updateTextFieldBorder)
+        )
 
         views.composerRelatedMessageCloseButton.setOnClickListener {
             collapse()
@@ -129,23 +132,23 @@ class RichTextComposerLayout @JvmOverloads constructor(
 
     private fun setupRichTextMenu() {
         addRichTextMenuItem(R.drawable.ic_composer_bold, R.string.rich_text_editor_format_bold, ComposerAction.Bold) {
-            views.composerEditText.toggleInlineFormat(InlineFormat.Bold)
+            views.richTextComposerEditText.toggleInlineFormat(InlineFormat.Bold)
         }
         addRichTextMenuItem(R.drawable.ic_composer_italic, R.string.rich_text_editor_format_italic, ComposerAction.Italic) {
-            views.composerEditText.toggleInlineFormat(InlineFormat.Italic)
+            views.richTextComposerEditText.toggleInlineFormat(InlineFormat.Italic)
         }
         addRichTextMenuItem(R.drawable.ic_composer_underlined, R.string.rich_text_editor_format_underline, ComposerAction.Underline) {
-            views.composerEditText.toggleInlineFormat(InlineFormat.Underline)
+            views.richTextComposerEditText.toggleInlineFormat(InlineFormat.Underline)
         }
         addRichTextMenuItem(R.drawable.ic_composer_strikethrough, R.string.rich_text_editor_format_strikethrough, ComposerAction.StrikeThrough) {
-            views.composerEditText.toggleInlineFormat(InlineFormat.StrikeThrough)
+            views.richTextComposerEditText.toggleInlineFormat(InlineFormat.StrikeThrough)
         }
     }
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
-        views.composerEditText.menuStateChangedListener = EditorEditText.OnMenuStateChangedListener { state ->
+        views.richTextComposerEditText.menuStateChangedListener = EditorEditText.OnMenuStateChangedListener { state ->
             if (state is MenuState.Update) {
                 updateMenuStateFor(ComposerAction.Bold, state)
                 updateMenuStateFor(ComposerAction.Italic, state)
@@ -153,7 +156,25 @@ class RichTextComposerLayout @JvmOverloads constructor(
                 updateMenuStateFor(ComposerAction.StrikeThrough, state)
             }
         }
+
+        updateEditTextVisibility()
     }
+
+    private fun updateEditTextVisibility() {
+        views.richTextComposerEditText.isVisible = isTextFormattingEnabled
+        views.richTextMenu.isVisible = isTextFormattingEnabled
+        views.plainTextComposerEditText.isVisible = !isTextFormattingEnabled
+    }
+
+    /**
+     * Updates the non-active input with the contents of the active input.
+     */
+    private fun syncEditTexts() =
+        if (isTextFormattingEnabled) {
+            views.plainTextComposerEditText.setText(views.richTextComposerEditText.getPlainText())
+        } else {
+            views.richTextComposerEditText.setText(views.plainTextComposerEditText.text.toString())
+        }
 
     private fun addRichTextMenuItem(@DrawableRes iconId: Int, @StringRes description: Int, action: ComposerAction, onClick: () -> Unit) {
         val inflater = LayoutInflater.from(context)
@@ -184,7 +205,7 @@ class RichTextComposerLayout @JvmOverloads constructor(
     }
 
     override fun replaceFormattedContent(text: CharSequence) {
-        views.composerEditText.setHtml(text.toString())
+        views.richTextComposerEditText.setHtml(text.toString())
     }
 
     override fun collapse(animate: Boolean, transitionComplete: (() -> Unit)?) {
@@ -206,7 +227,7 @@ class RichTextComposerLayout @JvmOverloads constructor(
     }
 
     override fun setTextIfDifferent(text: CharSequence?): Boolean {
-        return views.composerEditText.setTextIfDifferent(text)
+        return editText.setTextIfDifferent(text)
     }
 
     private fun applyNewConstraintSet(animate: Boolean, transitionComplete: (() -> Unit)?) {
@@ -239,5 +260,24 @@ class RichTextComposerLayout @JvmOverloads constructor(
 
     override fun setInvisible(isInvisible: Boolean) {
         this.isInvisible = isInvisible
+    }
+
+    private class TextChangeListener(
+            private val onTextChanged: (s: Editable) -> Unit,
+            private val onExpandedChanged: (isExpanded: Boolean) -> Unit,
+    ) : TextWatcher {
+        private var previousTextWasExpanded = false
+
+        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+        override fun afterTextChanged(s: Editable) {
+            onTextChanged.invoke(s)
+
+            val isExpanded = s.lines().count() > 1
+            if (previousTextWasExpanded != isExpanded) {
+                onExpandedChanged(isExpanded)
+            }
+            previousTextWasExpanded = isExpanded
+        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
@@ -44,7 +44,7 @@ import im.vector.app.core.extensions.setTextIfDifferent
 import im.vector.app.databinding.ComposerRichTextLayoutBinding
 import im.vector.app.databinding.ViewRichTextMenuButtonBinding
 import io.element.android.wysiwyg.EditorEditText
-import io.element.android.wysiwyg.InlineFormat
+import io.element.android.wysiwyg.inputhandlers.models.InlineFormat
 import uniffi.wysiwyg_composer.ComposerAction
 import uniffi.wysiwyg_composer.MenuState
 
@@ -140,6 +140,10 @@ class RichTextComposerLayout @JvmOverloads constructor(
         addRichTextMenuItem(R.drawable.ic_composer_strikethrough, R.string.rich_text_editor_format_strikethrough, ComposerAction.StrikeThrough) {
             views.composerEditText.toggleInlineFormat(InlineFormat.StrikeThrough)
         }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
 
         views.composerEditText.menuStateChangedListener = EditorEditText.OnMenuStateChangedListener { state ->
             if (state is MenuState.Update) {

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -109,6 +109,7 @@ class VectorPreferences @Inject constructor(
         const val SETTINGS_SHOW_URL_PREVIEW_KEY = "SETTINGS_SHOW_URL_PREVIEW_KEY"
         private const val SETTINGS_SEND_TYPING_NOTIF_KEY = "SETTINGS_SEND_TYPING_NOTIF_KEY"
         private const val SETTINGS_ENABLE_MARKDOWN_KEY = "SETTINGS_ENABLE_MARKDOWN_KEY"
+        private const val SETTINGS_ENABLE_RICH_TEXT_FORMATTING_KEY = "SETTINGS_ENABLE_RICH_TEXT_FORMATTING_KEY"
         private const val SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY = "SETTINGS_ALWAYS_SHOW_TIMESTAMPS_KEY"
         private const val SETTINGS_12_24_TIMESTAMPS_KEY = "SETTINGS_12_24_TIMESTAMPS_KEY"
         private const val SETTINGS_SHOW_READ_RECEIPTS_KEY = "SETTINGS_SHOW_READ_RECEIPTS_KEY"
@@ -758,6 +759,24 @@ class VectorPreferences @Inject constructor(
             putBoolean(SETTINGS_ENABLE_MARKDOWN_KEY, isEnabled)
         }
     }
+
+    /**
+     * Tells if text formatting is enabled within the rich text editor.
+     *
+     * @return true if the text formatting is enabled
+     */
+    fun isTextFormattingEnabled(): Boolean =
+        defaultPrefs.getBoolean(SETTINGS_ENABLE_RICH_TEXT_FORMATTING_KEY, true)
+
+    /**
+     * Update whether text formatting is enabled within the rich text editor.
+     *
+     * @param isEnabled true to enable the text formatting
+     */
+    fun setTextFormattingEnabled(isEnabled: Boolean) =
+        defaultPrefs.edit {
+            putBoolean(SETTINGS_ENABLE_RICH_TEXT_FORMATTING_KEY, isEnabled)
+        }
 
     /**
      * Tells if a confirmation dialog should be displayed before staring a call.

--- a/vector/src/main/res/drawable/ic_text_formatting.xml
+++ b/vector/src/main/res/drawable/ic_text_formatting.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,0h24v24h-24z"/>
+    <path
+        android:pathData="M3,20.667C3,21.4 3.6,22 4.333,22H20.333C21.067,22 21.667,21.4 21.667,20.667C21.667,19.933 21.067,19.333 20.333,19.333H4.333C3.6,19.333 3,19.933 3,20.667ZM9,13.733H15.667L16.547,15.867C16.747,16.347 17.213,16.667 17.733,16.667C18.653,16.667 19.267,15.72 18.907,14.88L13.733,2.92C13.493,2.36 12.947,2 12.333,2C11.72,2 11.173,2.36 10.933,2.92L5.76,14.88C5.4,15.72 6.027,16.667 6.947,16.667C7.467,16.667 7.933,16.347 8.133,15.867L9,13.733ZM12.333,4.64L14.827,11.333H9.84L12.333,4.64Z"
+        android:fillColor="#0DBD8B"/>
+  </group>
+</vector>

--- a/vector/src/main/res/drawable/ic_text_formatting_disabled.xml
+++ b/vector/src/main/res/drawable/ic_text_formatting_disabled.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,0h24v24h-24z"/>
+    <path
+        android:pathData="M9,15.733H15.667L16.547,17.867C16.747,18.347 17.213,18.667 17.733,18.667C18.653,18.667 19.267,17.72 18.907,16.88L13.733,4.92C13.493,4.36 12.947,4 12.333,4C11.72,4 11.173,4.36 10.933,4.92L5.76,16.88C5.4,17.72 6.027,18.667 6.947,18.667C7.467,18.667 7.933,18.347 8.133,17.867L9,15.733ZM12.333,6.64L14.827,13.333H9.84L12.333,6.64Z"
+        android:fillColor="#0DBD8B"/>
+    <path
+        android:strokeWidth="1"
+        android:pathData="M2.5,11.667C2.5,12.676 3.324,13.5 4.333,13.5H20.333C21.343,13.5 22.167,12.676 22.167,11.667C22.167,10.657 21.343,9.833 20.333,9.833H4.333C3.324,9.833 2.5,10.657 2.5,11.667Z"
+        android:fillColor="#0DBD8B"
+        android:strokeColor="#ffffff"/>
+  </group>
+</vector>

--- a/vector/src/main/res/layout/bottom_sheet_attachment_type_selector.xml
+++ b/vector/src/main/res/layout/bottom_sheet_attachment_type_selector.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?colorSurface">
@@ -82,13 +83,24 @@
             app:tint="?colorPrimary"
             app:titleTextColor="?vctr_content_primary" />
 
-        <im.vector.app.core.ui.views.BottomSheetActionButton
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="?vctr_list_separator" />
+
+        <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/textFormatting"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:actionTitle="@string/attachment_type_selector_rich_text"
-            app:tint="?colorPrimary"
-            app:titleTextColor="?vctr_content_primary" />
+            android:drawableStart="@drawable/ic_text_formatting"
+            android:drawablePadding="20dp"
+            android:padding="20dp"
+            android:paddingStart="28dp"
+            android:text="@string/attachment_type_selector_text_formatting"
+            android:textAppearance="@style/TextAppearance.Vector.Subtitle"
+            android:textColor="?vctr_content_primary"
+            app:drawableTint="?colorPrimary"
+            tools:ignore="RtlSymmetry" />
 
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/vector/src/main/res/layout/bottom_sheet_attachment_type_selector.xml
+++ b/vector/src/main/res/layout/bottom_sheet_attachment_type_selector.xml
@@ -82,5 +82,13 @@
             app:tint="?colorPrimary"
             app:titleTextColor="?vctr_content_primary" />
 
+        <im.vector.app.core.ui.views.BottomSheetActionButton
+            android:id="@+id/textFormatting"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:actionTitle="@string/attachment_type_selector_rich_text"
+            app:tint="?colorPrimary"
+            app:titleTextColor="?vctr_content_primary" />
+
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/vector/src/main/res/layout/composer_rich_text_layout.xml
+++ b/vector/src/main/res/layout/composer_rich_text_layout.xml
@@ -104,12 +104,24 @@
         android:background="@drawable/bg_composer_rich_edit_text_single_line" />
 
     <io.element.android.wysiwyg.EditorEditText
-        android:id="@+id/composerEditText"
+        android:id="@+id/richTextComposerEditText"
         style="@style/Widget.Vector.EditText.RichTextComposer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:nextFocusLeft="@id/composerEditText"
-        android:nextFocusUp="@id/composerEditText"
+        android:nextFocusLeft="@id/richTextComposerEditText"
+        android:nextFocusUp="@id/richTextComposerEditText"
+        tools:hint="@string/room_message_placeholder"
+        tools:text="@tools:sample/lorem/random"
+        tools:ignore="MissingConstraints" />
+
+    <!-- Use a separate EditText for plain text editing while the rich text editor doesn't support this mode -->
+    <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/plainTextComposerEditText"
+        style="@style/Widget.Vector.EditText.RichTextComposer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:nextFocusLeft="@id/plainTextComposerEditText"
+        android:nextFocusUp="@id/plainTextComposerEditText"
         tools:hint="@string/room_message_placeholder"
         tools:text="@tools:sample/lorem/random"
         tools:ignore="MissingConstraints" />

--- a/vector/src/main/res/layout/composer_rich_text_layout_constraint_set_compact.xml
+++ b/vector/src/main/res/layout/composer_rich_text_layout_constraint_set_compact.xml
@@ -135,7 +135,23 @@
         app:layout_constraintEnd_toEndOf="parent" />
 
     <io.element.android.wysiwyg.EditorEditText
-        android:id="@+id/composerEditText"
+        android:id="@+id/richTextComposerEditText"
+        style="@style/Widget.Vector.EditText.RichTextComposer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="@string/room_message_placeholder"
+        android:nextFocusLeft="@id/richTextComposerEditText"
+        android:nextFocusUp="@id/richTextComposerEditText"
+        android:layout_marginHorizontal="12dp"
+        android:layout_marginVertical="10dp"
+        app:layout_constraintBottom_toBottomOf="@id/composerEditTextOuterBorder"
+        app:layout_constraintEnd_toEndOf="@id/composerEditTextOuterBorder"
+        app:layout_constraintStart_toStartOf="@id/composerEditTextOuterBorder"
+        app:layout_constraintTop_toTopOf="@id/composerEditTextOuterBorder"
+        tools:text="@tools:sample/lorem/random" />
+
+    <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/plainTextComposerEditText"
         style="@style/Widget.Vector.EditText.RichTextComposer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/vector/src/main/res/layout/composer_rich_text_layout_constraint_set_expanded.xml
+++ b/vector/src/main/res/layout/composer_rich_text_layout_constraint_set_expanded.xml
@@ -149,13 +149,29 @@
         app:layout_constraintEnd_toEndOf="parent" />
 
     <io.element.android.wysiwyg.EditorEditText
-        android:id="@+id/composerEditText"
+        android:id="@+id/richTextComposerEditText"
         style="@style/Widget.Vector.EditText.RichTextComposer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:hint="@string/room_message_placeholder"
-        android:nextFocusLeft="@id/composerEditText"
-        android:nextFocusUp="@id/composerEditText"
+        android:nextFocusLeft="@id/richTextComposerEditText"
+        android:nextFocusUp="@id/richTextComposerEditText"
+        android:layout_marginHorizontal="12dp"
+        android:layout_marginVertical="10dp"
+        app:layout_constraintBottom_toBottomOf="@id/composerEditTextOuterBorder"
+        app:layout_constraintEnd_toEndOf="@id/composerEditTextOuterBorder"
+        app:layout_constraintStart_toStartOf="@id/composerEditTextOuterBorder"
+        app:layout_constraintTop_toTopOf="@id/composerEditTextOuterBorder"
+        tools:text="@tools:sample/lorem/random" />
+
+    <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/plainTextComposerEditText"
+        style="@style/Widget.Vector.EditText.RichTextComposer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="@string/room_message_placeholder"
+        android:nextFocusLeft="@id/plainTextComposerEditText"
+        android:nextFocusUp="@id/plainTextComposerEditText"
         android:layout_marginHorizontal="12dp"
         android:layout_marginVertical="10dp"
         app:layout_constraintBottom_toBottomOf="@id/composerEditTextOuterBorder"

--- a/vector/src/test/java/im/vector/app/features/attachments/AttachmentTypeSelectorViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/attachments/AttachmentTypeSelectorViewModelTest.kt
@@ -18,7 +18,9 @@ package im.vector.app.features.attachments
 
 import com.airbnb.mvrx.test.MavericksTestRule
 import im.vector.app.test.fakes.FakeVectorFeatures
+import im.vector.app.test.fakes.FakeVectorPreferences
 import im.vector.app.test.test
+import io.mockk.verifyOrder
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -29,6 +31,7 @@ internal class AttachmentTypeSelectorViewModelTest {
     val mavericksTestRule = MavericksTestRule()
 
     private val fakeVectorFeatures = FakeVectorFeatures()
+    private val fakeVectorPreferences = FakeVectorPreferences()
     private val initialState = AttachmentTypeSelectorViewState()
 
     @Before
@@ -36,6 +39,7 @@ internal class AttachmentTypeSelectorViewModelTest {
         // Disable all features by default
         fakeVectorFeatures.givenLocationSharing(isEnabled = false)
         fakeVectorFeatures.givenVoiceBroadcast(isEnabled = false)
+        fakeVectorPreferences.givenTextFormatting(isEnabled = false)
     }
 
     @Test
@@ -82,10 +86,57 @@ internal class AttachmentTypeSelectorViewModelTest {
                 .finish()
     }
 
+    @Test
+    fun `given text formatting is enabled, then text formatting option is checked`() {
+        fakeVectorPreferences.givenTextFormatting(isEnabled = true)
+
+        createViewModel()
+                .test()
+                .assertStates(
+                        listOf(
+                                initialState.copy(
+                                        isTextFormattingEnabled = true
+                                ),
+                        )
+                )
+                .finish()
+    }
+
+    @Test
+    fun `when text formatting is changed, then it updates the UI`() {
+        createViewModel()
+                .apply {
+                    handle(AttachmentTypeSelectorAction.ToggleTextFormatting(isEnabled = true))
+                }
+                .test()
+                .assertStates(
+                        listOf(
+                                initialState.copy(
+                                        isTextFormattingEnabled = true
+                                ),
+                        )
+                )
+                .finish()
+    }
+
+    @Test
+    fun `when text formatting is changed, then it persists the change`() {
+        createViewModel()
+                .apply {
+                    handle(AttachmentTypeSelectorAction.ToggleTextFormatting(isEnabled = true))
+                    handle(AttachmentTypeSelectorAction.ToggleTextFormatting(isEnabled = false))
+                }
+        verifyOrder {
+            fakeVectorPreferences.instance.setTextFormattingEnabled(true)
+            fakeVectorPreferences.instance.setTextFormattingEnabled(false)
+        }
+    }
+
     private fun createViewModel(): AttachmentTypeSelectorViewModel {
         return AttachmentTypeSelectorViewModel(
                 initialState,
                 vectorFeatures = fakeVectorFeatures,
+                vectorPreferences = fakeVectorPreferences.instance,
         )
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorPreferences.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorPreferences.kt
@@ -40,4 +40,7 @@ class FakeVectorPreferences {
     fun givenIsClientInfoRecordingEnabled(isEnabled: Boolean) {
         every { instance.isClientInfoRecordingEnabled() } returns isEnabled
     }
+
+    fun givenTextFormatting(isEnabled: Boolean) =
+        every { instance.isTextFormattingEnabled() } returns isEnabled
 }


### PR DESCRIPTION
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Add a toggle to disable rich text editing and enter plain text mode.

## Motivation and context

The plain text mode is a fallback for the rich text editor bypassing it completely.

Note that the plain text mode does not yet support markdown.

[`PSU-780`](https://element-io.atlassian.net/browse/PSU-780)

## Screenshots / GIFs

||Before|After|
|-|-|-|
|Toggle|![before-light](https://user-images.githubusercontent.com/4940864/197997663-f263dd0e-c91a-4030-b994-194317e8a8b4.png)|![after-light-on](https://user-images.githubusercontent.com/4940864/197997827-efbe1f59-a999-4eab-b0ca-5c1cd06325a2.png)|
|Toggle |![before-dark](https://user-images.githubusercontent.com/4940864/197997732-c7fad9d7-32ed-4e3f-b6ea-e2012def047e.png)|![after-dark](https://user-images.githubusercontent.com/4940864/197998118-6079f392-56b9-4059-b284-2cb9fd4687e2.png)|
|Toggle off ||![after-light-off](https://user-images.githubusercontent.com/4940864/197997905-8cd36a69-0610-468c-9477-f5e497dd8f86.png)|
| Plain text mode || ![image](https://user-images.githubusercontent.com/4940864/198025714-26448ca8-227a-47cb-8873-138526a72b2c.png)|
## Tests
### UI
- Change the text formatting setting
- Note the new setting is reflected in the UI

### Message format
- Switch the text formatting setting on
- Note that messages are sent in HTML
- Switch the text formatting setting off
- Note that messages are sent as plain text

### Editor
- Type a message
- Toggle the setting
- Note that the message is not cleared from the editor

### Persistence
- Change the text formatting setting
- Restart the app
- View the text formatting setting
- Note the new setting is persisted

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 33, 21

## Checklist

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
