### PR TITLE
Replace org.apache.sanselan:sanselan by org.apache.commons:commons-imaging

### DIFF
--- a/changelog.d/7454.misc
+++ b/changelog.d/7454.misc
@@ -1,0 +1,1 @@
+Replace org.apache.sanselan:sanselan by org.apache.commons:commons-imaging

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -160,7 +160,7 @@ ext.libs = [
                 'emojiGoogle'            : "com.vanniktech:emoji-google:$vanniktechEmoji"
         ],
         apache      : [
-                'commonsImaging'         : "org.apache.sanselan:sanselan:0.97-incubator"
+                'commonsImaging'         : "org.apache.commons:commons-imaging:1.0-alpha3"
         ],
         sentry: [
                 'sentryAndroid'         : "io.sentry:sentry-android:$sentry"

--- a/dependencies_groups.gradle
+++ b/dependencies_groups.gradle
@@ -176,7 +176,6 @@ ext.groups = [
                         'org.apache.ant',
                         'org.apache.commons',
                         'org.apache.httpcomponents',
-                        'org.apache.sanselan',
                         'org.bouncycastle',
                         'org.ccil.cowan.tagsoup',
                         'org.checkerframework',

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/ImageExifTagRemover.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/ImageExifTagRemover.kt
@@ -50,10 +50,7 @@ internal class ImageExifTagRemover @Inject constructor(
         } ?: return@withContext jpegImageFile
 
         tryOrNull("Unable to remove ExifData") {
-            outputSet.removeField(ExifTagConstants.EXIF_TAG_GPSINFO)
-            outputSet.removeField(ExifTagConstants.EXIF_TAG_SUBJECT_LOCATION)
-            outputSet.removeField(ExifTagConstants.EXIF_TAG_USER_COMMENT)
-            GpsTagConstants.ALL_GPS_TAGS.forEach { tagInfo ->
+            tagsToRemove.forEach { tagInfo ->
                 outputSet.removeField(tagInfo)
             }
         } ?: return@withContext jpegImageFile
@@ -74,4 +71,12 @@ internal class ImageExifTagRemover @Inject constructor(
                 }
         )
     }
+
+    private val tagsToRemove
+        get() = GpsTagConstants.ALL_GPS_TAGS +
+                listOf(
+                        ExifTagConstants.EXIF_TAG_GPSINFO,
+                        ExifTagConstants.EXIF_TAG_SUBJECT_LOCATION,
+                        ExifTagConstants.EXIF_TAG_USER_COMMENT,
+                )
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/ImageExifTagRemover.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/ImageExifTagRemover.kt
@@ -53,16 +53,9 @@ internal class ImageExifTagRemover @Inject constructor(
             outputSet.removeField(ExifTagConstants.EXIF_TAG_GPSINFO)
             outputSet.removeField(ExifTagConstants.EXIF_TAG_SUBJECT_LOCATION)
             outputSet.removeField(ExifTagConstants.EXIF_TAG_USER_COMMENT)
-            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_ALTITUDE)
-            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_ALTITUDE_REF)
-            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_LONGITUDE)
-            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_LONGITUDE_REF)
-            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_DEST_LONGITUDE)
-            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_DEST_LONGITUDE_REF)
-            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_LATITUDE)
-            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_LATITUDE_REF)
-            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_DEST_LATITUDE)
-            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_DEST_LATITUDE_REF)
+            GpsTagConstants.ALL_GPS_TAGS.forEach { tagInfo ->
+                outputSet.removeField(tagInfo)
+            }
         } ?: return@withContext jpegImageFile
 
         val scrubbedFile = temporaryFileCreator.create()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/ImageExifTagRemover.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/ImageExifTagRemover.kt
@@ -17,11 +17,11 @@
 package org.matrix.android.sdk.internal.session.content
 
 import kotlinx.coroutines.withContext
-import org.apache.sanselan.Sanselan
-import org.apache.sanselan.formats.jpeg.JpegImageMetadata
-import org.apache.sanselan.formats.jpeg.exifRewrite.ExifRewriter
-import org.apache.sanselan.formats.tiff.constants.ExifTagConstants
-import org.apache.sanselan.formats.tiff.constants.GPSTagConstants
+import org.apache.commons.imaging.Imaging
+import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata
+import org.apache.commons.imaging.formats.jpeg.exif.ExifRewriter
+import org.apache.commons.imaging.formats.tiff.constants.ExifTagConstants
+import org.apache.commons.imaging.formats.tiff.constants.GpsTagConstants
 import org.matrix.android.sdk.api.MatrixCoroutineDispatchers
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.internal.util.TemporaryFileCreator
@@ -46,24 +46,23 @@ internal class ImageExifTagRemover @Inject constructor(
      */
     suspend fun removeSensitiveJpegExifTags(jpegImageFile: File): File = withContext(coroutineDispatchers.io) {
         val outputSet = tryOrNull("Unable to read JpegImageMetadata") {
-            (Sanselan.getMetadata(jpegImageFile) as? JpegImageMetadata)?.exif?.outputSet
+            (Imaging.getMetadata(jpegImageFile) as? JpegImageMetadata)?.exif?.outputSet
         } ?: return@withContext jpegImageFile
 
         tryOrNull("Unable to remove ExifData") {
             outputSet.removeField(ExifTagConstants.EXIF_TAG_GPSINFO)
-            outputSet.removeField(ExifTagConstants.EXIF_TAG_SUBJECT_LOCATION_1)
-            outputSet.removeField(ExifTagConstants.EXIF_TAG_SUBJECT_LOCATION_2)
+            outputSet.removeField(ExifTagConstants.EXIF_TAG_SUBJECT_LOCATION)
             outputSet.removeField(ExifTagConstants.EXIF_TAG_USER_COMMENT)
-            outputSet.removeField(GPSTagConstants.GPS_TAG_GPS_ALTITUDE)
-            outputSet.removeField(GPSTagConstants.GPS_TAG_GPS_ALTITUDE_REF)
-            outputSet.removeField(GPSTagConstants.GPS_TAG_GPS_LONGITUDE)
-            outputSet.removeField(GPSTagConstants.GPS_TAG_GPS_LONGITUDE_REF)
-            outputSet.removeField(GPSTagConstants.GPS_TAG_GPS_DEST_LONGITUDE)
-            outputSet.removeField(GPSTagConstants.GPS_TAG_GPS_DEST_LONGITUDE_REF)
-            outputSet.removeField(GPSTagConstants.GPS_TAG_GPS_LATITUDE)
-            outputSet.removeField(GPSTagConstants.GPS_TAG_GPS_LATITUDE_REF)
-            outputSet.removeField(GPSTagConstants.GPS_TAG_GPS_DEST_LATITUDE)
-            outputSet.removeField(GPSTagConstants.GPS_TAG_GPS_DEST_LATITUDE_REF)
+            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_ALTITUDE)
+            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_ALTITUDE_REF)
+            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_LONGITUDE)
+            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_LONGITUDE_REF)
+            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_DEST_LONGITUDE)
+            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_DEST_LONGITUDE_REF)
+            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_LATITUDE)
+            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_LATITUDE_REF)
+            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_DEST_LATITUDE)
+            outputSet.removeField(GpsTagConstants.GPS_TAG_GPS_DEST_LATITUDE_REF)
         } ?: return@withContext jpegImageFile
 
         val scrubbedFile = temporaryFileCreator.create()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Replace outdated dependency. Not sure why sanselan was used at the beginning.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fixes #7453

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Send an image with GPS data, without compressing
- Check that the sent image does not contains GPS data

Available info after sending (so visible by everyone in the room):

<img width="466" alt="image" src="https://user-images.githubusercontent.com/3940906/198008087-d242f2f4-ecb5-495d-8f86-ea38d02bbd29.png">

We could strip more data, but this is maybe out of scope of this PR.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
