### PR TITLE
[Session manager] Hide push notification toggle when there is no server support (PSG-970)

### DIFF
--- a/changelog.d/7457.bugfix
+++ b/changelog.d/7457.bugfix
@@ -1,0 +1,1 @@
+[Session manager] Hide push notification toggle when there is no server support

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/homeserver/HomeServerCapabilities.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/homeserver/HomeServerCapabilities.kt
@@ -70,6 +70,11 @@ data class HomeServerCapabilities(
          * True if the home server supports threaded read receipts and unread notifications.
          */
         val canUseThreadReadReceiptsAndNotifications: Boolean = false,
+
+        /**
+         * True if the home server supports remote toggle of Pusher for a given device.
+         */
+        val canRemotelyTogglePushNotificationsOfDevices: Boolean = false,
 ) {
 
     enum class RoomCapabilitySupport {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/version/Versions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/version/Versions.kt
@@ -18,6 +18,7 @@ package org.matrix.android.sdk.internal.auth.version
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import org.matrix.android.sdk.api.extensions.orFalse
 
 /**
  * Model for https://matrix.org/docs/spec/client_server/latest#get-matrix-client-versions.
@@ -56,6 +57,7 @@ private const val FEATURE_THREADS_MSC3440_STABLE = "org.matrix.msc3440.stable"
 private const val FEATURE_QR_CODE_LOGIN = "org.matrix.msc3882"
 private const val FEATURE_THREADS_MSC3771 = "org.matrix.msc3771"
 private const val FEATURE_THREADS_MSC3773 = "org.matrix.msc3773"
+private const val FEATURE_PUSH_NOTIFICATIONS_MSC3881 = "org.matrix.msc3881"
 
 /**
  * Return true if the SDK supports this homeserver version.
@@ -141,4 +143,13 @@ private fun Versions.getMaxVersion(): HomeServerVersion {
             ?.mapNotNull { HomeServerVersion.parse(it) }
             ?.maxOrNull()
             ?: HomeServerVersion.r0_0_0
+}
+
+/**
+ * Indicate if the server supports MSC3881: https://github.com/matrix-org/matrix-spec-proposals/pull/3881.
+ *
+ * @return true if remote toggle of push notifications is supported
+ */
+internal fun Versions.doesServerSupportRemoteToggleOfPushNotifications(): Boolean {
+    return unstableFeatures?.get(FEATURE_PUSH_NOTIFICATIONS_MSC3881).orFalse()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/version/Versions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/version/Versions.kt
@@ -57,7 +57,7 @@ private const val FEATURE_THREADS_MSC3440_STABLE = "org.matrix.msc3440.stable"
 private const val FEATURE_QR_CODE_LOGIN = "org.matrix.msc3882"
 private const val FEATURE_THREADS_MSC3771 = "org.matrix.msc3771"
 private const val FEATURE_THREADS_MSC3773 = "org.matrix.msc3773"
-private const val FEATURE_PUSH_NOTIFICATIONS_MSC3881 = "org.matrix.msc3881"
+private const val FEATURE_REMOTE_TOGGLE_PUSH_NOTIFICATIONS_MSC3881 = "org.matrix.msc3881"
 
 /**
  * Return true if the SDK supports this homeserver version.
@@ -151,5 +151,5 @@ private fun Versions.getMaxVersion(): HomeServerVersion {
  * @return true if remote toggle of push notifications is supported
  */
 internal fun Versions.doesServerSupportRemoteToggleOfPushNotifications(): Boolean {
-    return unstableFeatures?.get(FEATURE_PUSH_NOTIFICATIONS_MSC3881).orFalse()
+    return unstableFeatures?.get(FEATURE_REMOTE_TOGGLE_PUSH_NOTIFICATIONS_MSC3881).orFalse()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/RealmSessionStoreMigration.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/RealmSessionStoreMigration.kt
@@ -58,6 +58,7 @@ import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo038
 import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo039
 import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo040
 import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo041
+import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo042
 import org.matrix.android.sdk.internal.util.Normalizer
 import org.matrix.android.sdk.internal.util.database.MatrixRealmMigration
 import javax.inject.Inject
@@ -66,7 +67,7 @@ internal class RealmSessionStoreMigration @Inject constructor(
         private val normalizer: Normalizer
 ) : MatrixRealmMigration(
         dbName = "Session",
-        schemaVersion = 41L,
+        schemaVersion = 42L,
 ) {
     /**
      * Forces all RealmSessionStoreMigration instances to be equal.
@@ -117,5 +118,6 @@ internal class RealmSessionStoreMigration @Inject constructor(
         if (oldVersion < 39) MigrateSessionTo039(realm).perform()
         if (oldVersion < 40) MigrateSessionTo040(realm).perform()
         if (oldVersion < 41) MigrateSessionTo041(realm).perform()
+        if (oldVersion < 42) MigrateSessionTo042(realm).perform()
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/HomeServerCapabilitiesMapper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/HomeServerCapabilitiesMapper.kt
@@ -45,7 +45,8 @@ internal object HomeServerCapabilitiesMapper {
                 canUseThreading = entity.canUseThreading,
                 canControlLogoutDevices = entity.canControlLogoutDevices,
                 canLoginWithQrCode = entity.canLoginWithQrCode,
-                canUseThreadReadReceiptsAndNotifications = entity.canUseThreadReadReceiptsAndNotifications
+                canUseThreadReadReceiptsAndNotifications = entity.canUseThreadReadReceiptsAndNotifications,
+                canRemotelyTogglePushNotificationsOfDevices = entity.canRemotelyTogglePushNotificationsOfDevices,
         )
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/migration/MigrateSessionTo042.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/migration/MigrateSessionTo042.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.database.migration
+
+import io.realm.DynamicRealm
+import org.matrix.android.sdk.internal.database.model.HomeServerCapabilitiesEntityFields
+import org.matrix.android.sdk.internal.extensions.forceRefreshOfHomeServerCapabilities
+import org.matrix.android.sdk.internal.util.database.RealmMigrator
+
+internal class MigrateSessionTo042(realm: DynamicRealm) : RealmMigrator(realm, 42) {
+
+    override fun doMigrate(realm: DynamicRealm) {
+        realm.schema.get("HomeServerCapabilitiesEntity")
+                ?.addField(HomeServerCapabilitiesEntityFields.CAN_REMOTELY_TOGGLE_PUSH_NOTIFICATIONS_OF_DEVICES, Boolean::class.java)
+                ?.forceRefreshOfHomeServerCapabilities()
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/HomeServerCapabilitiesEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/HomeServerCapabilitiesEntity.kt
@@ -33,6 +33,7 @@ internal open class HomeServerCapabilitiesEntity(
         var canControlLogoutDevices: Boolean = false,
         var canLoginWithQrCode: Boolean = false,
         var canUseThreadReadReceiptsAndNotifications: Boolean = false,
+        var canRemotelyTogglePushNotificationsOfDevices: Boolean = false,
 ) : RealmObject() {
 
     companion object

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetHomeServerCapabilitiesTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetHomeServerCapabilitiesTask.kt
@@ -25,6 +25,7 @@ import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilities
 import org.matrix.android.sdk.internal.auth.version.Versions
 import org.matrix.android.sdk.internal.auth.version.doesServerSupportLogoutDevices
 import org.matrix.android.sdk.internal.auth.version.doesServerSupportQrCodeLogin
+import org.matrix.android.sdk.internal.auth.version.doesServerSupportRemoteToggleOfPushNotifications
 import org.matrix.android.sdk.internal.auth.version.doesServerSupportThreadUnreadNotifications
 import org.matrix.android.sdk.internal.auth.version.doesServerSupportThreads
 import org.matrix.android.sdk.internal.auth.version.isLoginAndRegistrationSupportedBySdk
@@ -141,13 +142,18 @@ internal class DefaultGetHomeServerCapabilitiesTask @Inject constructor(
             }
 
             if (getVersionResult != null) {
-                homeServerCapabilitiesEntity.lastVersionIdentityServerSupported = getVersionResult.isLoginAndRegistrationSupportedBySdk()
-                homeServerCapabilitiesEntity.canControlLogoutDevices = getVersionResult.doesServerSupportLogoutDevices()
+                homeServerCapabilitiesEntity.lastVersionIdentityServerSupported =
+                        getVersionResult.isLoginAndRegistrationSupportedBySdk()
+                homeServerCapabilitiesEntity.canControlLogoutDevices =
+                        getVersionResult.doesServerSupportLogoutDevices()
                 homeServerCapabilitiesEntity.canUseThreading = /* capabilities?.threads?.enabled.orFalse() || */
                         getVersionResult.doesServerSupportThreads()
                 homeServerCapabilitiesEntity.canUseThreadReadReceiptsAndNotifications =
                         getVersionResult.doesServerSupportThreadUnreadNotifications()
-                homeServerCapabilitiesEntity.canLoginWithQrCode = getVersionResult.doesServerSupportQrCodeLogin()
+                homeServerCapabilitiesEntity.canLoginWithQrCode =
+                        getVersionResult.doesServerSupportQrCodeLogin()
+                homeServerCapabilitiesEntity.canRemotelyTogglePushNotificationsOfDevices =
+                        getVersionResult.doesServerSupportRemoteToggleOfPushNotifications()
             }
 
             if (getWellknownResult != null && getWellknownResult is WellknownResult.Prompt) {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaAccountDataUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaAccountDataUseCase.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices.v2.notification
+
+import im.vector.app.core.di.ActiveSessionHolder
+import org.matrix.android.sdk.api.session.accountdata.UserAccountDataTypes
+import javax.inject.Inject
+
+class CheckIfCanTogglePushNotificationsViaAccountDataUseCase @Inject constructor(
+        private val activeSessionHolder: ActiveSessionHolder,
+) {
+
+    fun execute(deviceId: String): Boolean {
+        return activeSessionHolder
+                .getSafeActiveSession()
+                ?.accountDataService()
+                ?.getUserAccountDataEvent(UserAccountDataTypes.TYPE_LOCAL_NOTIFICATION_SETTINGS + deviceId) != null
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaPusherUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaPusherUseCase.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices.v2.notification
+
+import im.vector.app.core.di.ActiveSessionHolder
+import org.matrix.android.sdk.api.extensions.orFalse
+import javax.inject.Inject
+
+class CheckIfCanTogglePushNotificationsViaPusherUseCase @Inject constructor(
+        private val activeSessionHolder: ActiveSessionHolder,
+) {
+
+    fun execute(): Boolean {
+        return activeSessionHolder
+                .getSafeActiveSession()
+                ?.homeServerCapabilitiesService()
+                ?.getHomeServerCapabilities()
+                ?.canRemotelyTogglePushNotificationsOfDevices
+                .orFalse()
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCase.kt
@@ -18,7 +18,6 @@ package im.vector.app.features.settings.devices.v2.notification
 
 import im.vector.app.core.di.ActiveSessionHolder
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import org.matrix.android.sdk.api.account.LocalNotificationSettingsContent
@@ -34,11 +33,10 @@ class GetNotificationsStatusUseCase @Inject constructor(
         private val checkIfCanTogglePushNotificationsViaAccountDataUseCase: CheckIfCanTogglePushNotificationsViaAccountDataUseCase,
 ) {
 
-    // TODO add unit tests
     fun execute(deviceId: String): Flow<NotificationsStatus> {
         val session = activeSessionHolder.getSafeActiveSession()
         return when {
-            session == null -> emptyFlow()
+            session == null -> flowOf(NotificationsStatus.NOT_SUPPORTED)
             checkIfCanTogglePushNotificationsViaPusherUseCase.execute() -> {
                 session.flow()
                         .livePushers()

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCase.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices.v2.notification
+
+import im.vector.app.core.di.ActiveSessionHolder
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import org.matrix.android.sdk.api.account.LocalNotificationSettingsContent
+import org.matrix.android.sdk.api.session.accountdata.UserAccountDataTypes
+import org.matrix.android.sdk.api.session.events.model.toModel
+import org.matrix.android.sdk.flow.flow
+import org.matrix.android.sdk.flow.unwrap
+import javax.inject.Inject
+
+class GetNotificationsStatusUseCase @Inject constructor(
+        private val activeSessionHolder: ActiveSessionHolder,
+        private val checkIfCanTogglePushNotificationsViaPusherUseCase: CheckIfCanTogglePushNotificationsViaPusherUseCase,
+        private val checkIfCanTogglePushNotificationsViaAccountDataUseCase: CheckIfCanTogglePushNotificationsViaAccountDataUseCase,
+) {
+
+    // TODO add unit tests
+    fun execute(deviceId: String): Flow<NotificationsStatus> {
+        val session = activeSessionHolder.getSafeActiveSession()
+        return when {
+            session == null -> emptyFlow()
+            checkIfCanTogglePushNotificationsViaPusherUseCase.execute() -> {
+                session.flow()
+                        .livePushers()
+                        .map { it.filter { pusher -> pusher.deviceId == deviceId } }
+                        .map { it.takeIf { it.isNotEmpty() }?.any { pusher -> pusher.enabled } }
+                        .map { if (it == true) NotificationsStatus.ENABLED else NotificationsStatus.DISABLED }
+            }
+            checkIfCanTogglePushNotificationsViaAccountDataUseCase.execute(deviceId) -> {
+                session.flow()
+                        .liveUserAccountData(UserAccountDataTypes.TYPE_LOCAL_NOTIFICATION_SETTINGS + deviceId)
+                        .unwrap()
+                        .map { it.content.toModel<LocalNotificationSettingsContent>()?.isSilenced?.not() }
+                        .map { if (it == true) NotificationsStatus.ENABLED else NotificationsStatus.DISABLED }
+            }
+            else -> flowOf(NotificationsStatus.NOT_SUPPORTED)
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCase.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.settings.devices.v2.notification
 
 import im.vector.app.core.di.ActiveSessionHolder
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import org.matrix.android.sdk.api.account.LocalNotificationSettingsContent
@@ -43,6 +44,7 @@ class GetNotificationsStatusUseCase @Inject constructor(
                         .map { it.filter { pusher -> pusher.deviceId == deviceId } }
                         .map { it.takeIf { it.isNotEmpty() }?.any { pusher -> pusher.enabled } }
                         .map { if (it == true) NotificationsStatus.ENABLED else NotificationsStatus.DISABLED }
+                        .distinctUntilChanged()
             }
             checkIfCanTogglePushNotificationsViaAccountDataUseCase.execute(deviceId) -> {
                 session.flow()
@@ -50,6 +52,7 @@ class GetNotificationsStatusUseCase @Inject constructor(
                         .unwrap()
                         .map { it.content.toModel<LocalNotificationSettingsContent>()?.isSilenced?.not() }
                         .map { if (it == true) NotificationsStatus.ENABLED else NotificationsStatus.DISABLED }
+                        .distinctUntilChanged()
             }
             else -> flowOf(NotificationsStatus.NOT_SUPPORTED)
         }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/NotificationsStatus.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/NotificationsStatus.kt
@@ -14,20 +14,10 @@
  * limitations under the License.
  */
 
-package im.vector.app.test.fakes
+package im.vector.app.features.settings.devices.v2.notification
 
-import im.vector.app.features.settings.devices.v2.notification.TogglePushNotificationUseCase
-import io.mockk.coJustRun
-import io.mockk.coVerify
-import io.mockk.mockk
-
-class FakeTogglePushNotificationUseCase {
-
-    val instance = mockk<TogglePushNotificationUseCase> {
-        coJustRun { execute(any(), any()) }
-    }
-
-    fun verifyExecute(deviceId: String, enabled: Boolean) {
-        coVerify { instance.execute(deviceId, enabled) }
-    }
+enum class NotificationsStatus {
+    ENABLED,
+    DISABLED,
+    NOT_SUPPORTED,
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
@@ -24,6 +24,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.fragmentViewModel
@@ -43,6 +44,7 @@ import im.vector.app.features.auth.ReAuthActivity
 import im.vector.app.features.crypto.recover.SetupMode
 import im.vector.app.features.settings.devices.v2.list.SessionInfoViewState
 import im.vector.app.features.settings.devices.v2.more.SessionLearnMoreBottomSheet
+import im.vector.app.features.settings.devices.v2.notification.NotificationsStatus
 import im.vector.app.features.workers.signout.SignOutUiWorker
 import org.matrix.android.sdk.api.auth.data.LoginFlowTypes
 import org.matrix.android.sdk.api.extensions.orFalse
@@ -177,7 +179,7 @@ class SessionOverviewFragment :
         updateEntryDetails(state.deviceId)
         updateSessionInfo(state)
         updateLoading(state.isLoading)
-        updatePushNotificationToggle(state.deviceId, state.notificationsEnabled)
+        updatePushNotificationToggle(state.deviceId, state.notificationsStatus)
     }
 
     private fun updateToolbar(viewState: SessionOverviewViewState) {
@@ -218,15 +220,19 @@ class SessionOverviewFragment :
         }
     }
 
-    private fun updatePushNotificationToggle(deviceId: String, enabled: Boolean) {
-        views.sessionOverviewPushNotifications.apply {
-            setOnCheckedChangeListener(null)
-            setChecked(enabled)
-            post {
-                setOnCheckedChangeListener { _, isChecked ->
-                    viewModel.handle(SessionOverviewAction.TogglePushNotifications(deviceId, isChecked))
+    private fun updatePushNotificationToggle(deviceId: String, notificationsStatus: NotificationsStatus) {
+        views.sessionOverviewPushNotifications.isGone = notificationsStatus == NotificationsStatus.NOT_SUPPORTED
+        when (notificationsStatus) {
+            NotificationsStatus.ENABLED, NotificationsStatus.DISABLED -> {
+                views.sessionOverviewPushNotifications.setOnCheckedChangeListener(null)
+                views.sessionOverviewPushNotifications.setChecked(notificationsStatus == NotificationsStatus.ENABLED)
+                views.sessionOverviewPushNotifications.post {
+                    views.sessionOverviewPushNotifications.setOnCheckedChangeListener { _, isChecked ->
+                        viewModel.handle(SessionOverviewAction.TogglePushNotifications(deviceId, isChecked))
+                    }
                 }
             }
+            else -> Unit
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
@@ -30,7 +30,6 @@ import im.vector.app.features.auth.PendingAuthHandler
 import im.vector.app.features.settings.devices.v2.RefreshDevicesUseCase
 import im.vector.app.features.settings.devices.v2.VectorSessionsListViewModel
 import im.vector.app.features.settings.devices.v2.notification.GetNotificationsStatusUseCase
-import im.vector.app.features.settings.devices.v2.notification.NotificationsStatus
 import im.vector.app.features.settings.devices.v2.notification.TogglePushNotificationUseCase
 import im.vector.app.features.settings.devices.v2.signout.InterceptSignoutFlowResponseUseCase
 import im.vector.app.features.settings.devices.v2.signout.SignoutSessionResult
@@ -220,9 +219,6 @@ class SessionOverviewViewModel @AssistedInject constructor(
     private fun handleTogglePusherAction(action: SessionOverviewAction.TogglePushNotifications) {
         viewModelScope.launch {
             togglePushNotificationUseCase.execute(action.deviceId, action.enabled)
-            // TODO should not be needed => test without
-            val status = if (action.enabled) NotificationsStatus.ENABLED else NotificationsStatus.DISABLED
-            setState { copy(notificationsStatus = status) }
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewState.kt
@@ -20,13 +20,14 @@ import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.Uninitialized
 import im.vector.app.features.settings.devices.v2.DeviceFullInfo
+import im.vector.app.features.settings.devices.v2.notification.NotificationsStatus
 
 data class SessionOverviewViewState(
         val deviceId: String,
         val isCurrentSessionTrusted: Boolean = false,
         val deviceInfo: Async<DeviceFullInfo> = Uninitialized,
         val isLoading: Boolean = false,
-        val notificationsEnabled: Boolean = false,
+        val notificationsStatus: NotificationsStatus = NotificationsStatus.NOT_SUPPORTED,
 ) : MavericksState {
     constructor(args: SessionOverviewArgs) : this(
             deviceId = args.deviceId

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaAccountDataUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaAccountDataUseCaseTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices.v2.notification
+
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.matrix.android.sdk.api.session.accountdata.UserAccountDataTypes
+
+private const val A_DEVICE_ID = "device-id"
+
+class CheckIfCanTogglePushNotificationsViaAccountDataUseCaseTest {
+
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+
+    private val checkIfCanTogglePushNotificationsViaAccountDataUseCase =
+            CheckIfCanTogglePushNotificationsViaAccountDataUseCase(
+                    activeSessionHolder = fakeActiveSessionHolder.instance,
+            )
+
+    @Test
+    fun `given current session and an account data for the device id when execute then result is true`() {
+        // Given
+        fakeActiveSessionHolder
+                .fakeSession
+                .accountDataService()
+                .givenGetUserAccountDataEventReturns(
+                        type = UserAccountDataTypes.TYPE_LOCAL_NOTIFICATION_SETTINGS + A_DEVICE_ID,
+                        content = mockk(),
+                )
+
+        // When
+        val result = checkIfCanTogglePushNotificationsViaAccountDataUseCase.execute(A_DEVICE_ID)
+
+        // Then
+        result shouldBeEqualTo true
+    }
+
+    @Test
+    fun `given current session and NO account data for the device id when execute then result is false`() {
+        // Given
+        fakeActiveSessionHolder
+                .fakeSession
+                .accountDataService()
+                .givenGetUserAccountDataEventReturns(
+                        type = UserAccountDataTypes.TYPE_LOCAL_NOTIFICATION_SETTINGS + A_DEVICE_ID,
+                        content = null,
+                )
+
+        // When
+        val result = checkIfCanTogglePushNotificationsViaAccountDataUseCase.execute(A_DEVICE_ID)
+
+        // Then
+        result shouldBeEqualTo false
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaPusherUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaPusherUseCaseTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices.v2.notification
+
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import im.vector.app.test.fixtures.aHomeServerCapabilities
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+private val A_HOMESERVER_CAPABILITIES = aHomeServerCapabilities(canRemotelyTogglePushNotificationsOfDevices = true)
+
+class CheckIfCanTogglePushNotificationsViaPusherUseCaseTest {
+
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+
+    private val checkIfCanTogglePushNotificationsViaPusherUseCase =
+            CheckIfCanTogglePushNotificationsViaPusherUseCase(
+                    activeSessionHolder = fakeActiveSessionHolder.instance,
+            )
+
+    @Test
+    fun `given current session when execute then toggle capability is returned`() {
+        // Given
+        fakeActiveSessionHolder
+                .fakeSession
+                .fakeHomeServerCapabilitiesService
+                .givenCapabilities(A_HOMESERVER_CAPABILITIES)
+
+        // When
+        val result = checkIfCanTogglePushNotificationsViaPusherUseCase.execute()
+
+        // Then
+        result shouldBeEqualTo A_HOMESERVER_CAPABILITIES.canRemotelyTogglePushNotificationsOfDevices
+    }
+
+    @Test
+    fun `given no current session when execute then false is returned`() {
+        // Given
+        fakeActiveSessionHolder.givenGetSafeActiveSessionReturns(null)
+
+        // When
+        val result = checkIfCanTogglePushNotificationsViaPusherUseCase.execute()
+
+        // Then
+        result shouldBeEqualTo false
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCaseTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices.v2.notification
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import im.vector.app.test.fixtures.PusherFixture
+import im.vector.app.test.testDispatcher
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.matrix.android.sdk.api.account.LocalNotificationSettingsContent
+import org.matrix.android.sdk.api.session.accountdata.UserAccountDataTypes
+import org.matrix.android.sdk.api.session.events.model.toContent
+
+private const val A_DEVICE_ID = "device-id"
+
+class GetNotificationsStatusUseCaseTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+    private val fakeCheckIfCanTogglePushNotificationsViaPusherUseCase =
+            mockk<CheckIfCanTogglePushNotificationsViaPusherUseCase>()
+    private val fakeCheckIfCanTogglePushNotificationsViaAccountDataUseCase =
+            mockk<CheckIfCanTogglePushNotificationsViaAccountDataUseCase>()
+
+    private val getNotificationsStatusUseCase =
+            GetNotificationsStatusUseCase(
+                    activeSessionHolder = fakeActiveSessionHolder.instance,
+                    checkIfCanTogglePushNotificationsViaPusherUseCase = fakeCheckIfCanTogglePushNotificationsViaPusherUseCase,
+                    checkIfCanTogglePushNotificationsViaAccountDataUseCase = fakeCheckIfCanTogglePushNotificationsViaAccountDataUseCase,
+            )
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `given NO current session when execute then resulting flow contains NOT_SUPPORTED value`() = runTest {
+        // Given
+        fakeActiveSessionHolder.givenGetSafeActiveSessionReturns(null)
+
+        // When
+        val result = getNotificationsStatusUseCase.execute(A_DEVICE_ID)
+
+        // Then
+        result.firstOrNull() shouldBeEqualTo NotificationsStatus.NOT_SUPPORTED
+    }
+
+    @Test
+    fun `given current session and toggle is not supported when execute then resulting flow contains NOT_SUPPORTED value`() = runTest {
+        // Given
+        every { fakeCheckIfCanTogglePushNotificationsViaPusherUseCase.execute() } returns false
+        every { fakeCheckIfCanTogglePushNotificationsViaAccountDataUseCase.execute(A_DEVICE_ID) } returns false
+
+        // When
+        val result = getNotificationsStatusUseCase.execute(A_DEVICE_ID)
+
+        // Then
+        result.firstOrNull() shouldBeEqualTo NotificationsStatus.NOT_SUPPORTED
+    }
+
+    @Test
+    fun `given current session and toggle via pusher is supported when execute then resulting flow contains status based on pusher value`() = runTest {
+        // Given
+        val pushers = listOf(
+                PusherFixture.aPusher(
+                        deviceId = A_DEVICE_ID,
+                        enabled = true,
+                )
+        )
+        fakeActiveSessionHolder.fakeSession.pushersService().givenPushersLive(pushers)
+        every { fakeCheckIfCanTogglePushNotificationsViaPusherUseCase.execute() } returns true
+        every { fakeCheckIfCanTogglePushNotificationsViaAccountDataUseCase.execute(A_DEVICE_ID) } returns false
+
+        // When
+        val result = getNotificationsStatusUseCase.execute(A_DEVICE_ID)
+
+        // Then
+        result.firstOrNull() shouldBeEqualTo NotificationsStatus.ENABLED
+    }
+
+    @Test
+    fun `given current session and toggle via account data is supported when execute then resulting flow contains status based on settings value`() = runTest {
+        // Given
+        fakeActiveSessionHolder
+                .fakeSession
+                .accountDataService()
+                .givenGetUserAccountDataEventReturns(
+                        type = UserAccountDataTypes.TYPE_LOCAL_NOTIFICATION_SETTINGS + A_DEVICE_ID,
+                        content = LocalNotificationSettingsContent(
+                                isSilenced = false
+                        ).toContent(),
+                )
+        every { fakeCheckIfCanTogglePushNotificationsViaPusherUseCase.execute() } returns false
+        every { fakeCheckIfCanTogglePushNotificationsViaAccountDataUseCase.execute(A_DEVICE_ID) } returns true
+
+        // When
+        val result = getNotificationsStatusUseCase.execute(A_DEVICE_ID)
+
+        // Then
+        result.firstOrNull() shouldBeEqualTo NotificationsStatus.ENABLED
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCaseTest.kt
@@ -22,6 +22,7 @@ import im.vector.app.test.fixtures.PusherFixture
 import im.vector.app.test.testDispatcher
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verifyOrder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.test.resetMain
@@ -89,6 +90,11 @@ class GetNotificationsStatusUseCaseTest {
 
         // Then
         result.firstOrNull() shouldBeEqualTo NotificationsStatus.NOT_SUPPORTED
+        verifyOrder {
+            // we should first check account data
+            fakeCheckIfCanTogglePushNotificationsViaAccountDataUseCase.execute(A_DEVICE_ID)
+            fakeCheckIfCanTogglePushNotificationsViaPusherUseCase.execute()
+        }
     }
 
     @Test

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeSessionAccountDataService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeSessionAccountDataService.kt
@@ -28,8 +28,8 @@ import org.matrix.android.sdk.api.session.events.model.Content
 
 class FakeSessionAccountDataService : SessionAccountDataService by mockk(relaxed = true) {
 
-    fun givenGetUserAccountDataEventReturns(type: String, content: Content) {
-        every { getUserAccountDataEvent(type) } returns UserAccountDataEvent(type, content)
+    fun givenGetUserAccountDataEventReturns(type: String, content: Content?) {
+        every { getUserAccountDataEvent(type) } returns content?.let { UserAccountDataEvent(type, it) }
     }
 
     fun givenUpdateUserAccountDataEventSucceeds() {

--- a/vector/src/test/java/im/vector/app/test/fixtures/HomeserverCapabilityFixture.kt
+++ b/vector/src/test/java/im/vector/app/test/fixtures/HomeserverCapabilityFixture.kt
@@ -27,14 +27,16 @@ fun aHomeServerCapabilities(
         maxUploadFileSize: Long = 100L,
         lastVersionIdentityServerSupported: Boolean = false,
         defaultIdentityServerUrl: String? = null,
-        roomVersions: RoomVersionCapabilities? = null
+        roomVersions: RoomVersionCapabilities? = null,
+        canRemotelyTogglePushNotificationsOfDevices: Boolean = true,
 ) = HomeServerCapabilities(
-        canChangePassword,
-        canChangeDisplayName,
-        canChangeAvatar,
-        canChange3pid,
-        maxUploadFileSize,
-        lastVersionIdentityServerSupported,
-        defaultIdentityServerUrl,
-        roomVersions
+        canChangePassword = canChangePassword,
+        canChangeDisplayName = canChangeDisplayName,
+        canChangeAvatar = canChangeAvatar,
+        canChange3pid = canChange3pid,
+        maxUploadFileSize = maxUploadFileSize,
+        lastVersionIdentityServerSupported = lastVersionIdentityServerSupported,
+        defaultIdentityServerUrl = defaultIdentityServerUrl,
+        roomVersions = roomVersions,
+        canRemotelyTogglePushNotificationsOfDevices = canRemotelyTogglePushNotificationsOfDevices,
 )


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Checking the support for MC3881 about new enabled field for Pusher to render the push notification toggle for a session in the overview screen.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7457 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Signin to matrix server
- Enable the new session manager labs flag
- Go to Settings -> Security & Privacy -> Show all sessions
- Go to a mobile session overview
- Check the push notification toggle is not displayed (matrix does not support the feature yet)
- Go to a web session overview
- Check the push notification toggle is displayed (since there should be an associated account data setting)
- Signin to a server which supports MCS3881
- Go to Settings -> Security & Privacy -> Show all sessions
- Go to a mobile session overview
- Check the push notification toggle is displayed

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
