### PR TITLE
Add setting to allow disabling direct share

### DIFF
--- a/changelog.d/2725.feature
+++ b/changelog.d/2725.feature
@@ -1,0 +1,1 @@
+Add setting to allow disabling direct share

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -1032,6 +1032,8 @@
     <string name="settings_chat_effects_description">Use /confetti command or send a message containing ❄️ or 🎉</string>
     <string name="settings_autoplay_animated_images_title">Autoplay animated images</string>
     <string name="settings_autoplay_animated_images_summary">Play animated images in the timeline as soon as they are visible</string>
+    <string name="settings_enable_direct_share_title">Enable direct share</string>
+    <string name="settings_enable_direct_share_summary">Show recent chats in the system share menu</string>
     <string name="settings_show_join_leave_messages">Show join and leave events</string>
     <string name="settings_show_join_leave_messages_summary">Invites, removes, and bans are unaffected.</string>
     <string name="settings_show_avatar_display_name_changes_messages">Show account events</string>

--- a/vector/src/main/java/im/vector/app/features/home/ShortcutCreator.kt
+++ b/vector/src/main/java/im/vector/app/features/home/ShortcutCreator.kt
@@ -29,6 +29,7 @@ import im.vector.app.core.glide.GlideApp
 import im.vector.app.core.resources.BuildMeta
 import im.vector.app.core.utils.DimensionConverter
 import im.vector.app.features.MainActivity
+import im.vector.app.features.settings.VectorPreferences
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
 import org.matrix.android.sdk.api.util.toMatrixItem
 import javax.inject.Inject
@@ -55,6 +56,7 @@ class ShortcutCreator @Inject constructor(
             dimensionConverter.dpToPx(72)
         }
     }
+    @Inject lateinit var vectorPreferences: VectorPreferences
 
     fun canCreateShortcut(): Boolean {
         return ShortcutManagerCompat.isRequestPinShortcutSupported(context)
@@ -73,10 +75,12 @@ class ShortcutCreator @Inject constructor(
         } catch (failure: Throwable) {
             null
         }
-        val categories = if (Build.VERSION.SDK_INT >= 25) {
-            setOf(directShareCategory, ShortcutInfo.SHORTCUT_CATEGORY_CONVERSATION)
-        } else {
-            setOf(directShareCategory)
+        val categories = mutableSetOf<String>()
+        if (vectorPreferences.directShareEnabled()) {
+            categories.add(directShareCategory)
+        }
+        if (Build.VERSION.SDK_INT >= 25) {
+            categories.add(ShortcutInfo.SHORTCUT_CATEGORY_CONVERSATION)
         }
 
         return ShortcutInfoCompat.Builder(context, roomSummary.roomId)

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -123,6 +123,7 @@ class VectorPreferences @Inject constructor(
         private const val SETTINGS_LABS_ENABLE_LATEX_MATHS = "SETTINGS_LABS_ENABLE_LATEX_MATHS"
         const val SETTINGS_PRESENCE_USER_ALWAYS_APPEARS_OFFLINE = "SETTINGS_PRESENCE_USER_ALWAYS_APPEARS_OFFLINE"
         const val SETTINGS_AUTOPLAY_ANIMATED_IMAGES = "SETTINGS_AUTOPLAY_ANIMATED_IMAGES"
+        private const val SETTINGS_ENABLE_DIRECT_SHARE = "SETTINGS_ENABLE_DIRECT_SHARE"
 
         // Room directory
         private const val SETTINGS_ROOM_DIRECTORY_SHOW_ALL_PUBLIC_ROOMS = "SETTINGS_ROOM_DIRECTORY_SHOW_ALL_PUBLIC_ROOMS"
@@ -1002,6 +1003,10 @@ class VectorPreferences @Inject constructor(
 
     fun chatEffectsEnabled(): Boolean {
         return defaultPrefs.getBoolean(SETTINGS_ENABLE_CHAT_EFFECTS, true)
+    }
+
+    fun directShareEnabled(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_ENABLE_DIRECT_SHARE, true)
     }
 
     /**

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -147,6 +147,12 @@
             android:title="@string/settings_vibrate_on_mention"
             app:isPreferenceVisible="@bool/false_not_implemented" />
 
+        <im.vector.app.core.preference.VectorSwitchPreference
+            android:defaultValue="true"
+            android:key="SETTINGS_ENABLE_DIRECT_SHARE"
+            android:summary="@string/settings_enable_direct_share_summary"
+            android:title="@string/settings_enable_direct_share_title" />
+
     </im.vector.app.core.preference.VectorPreferenceCategory>
 
     <im.vector.app.core.preference.VectorPreferenceCategory


### PR DESCRIPTION
Direct share continues to be enabled by default.

As requested in #2725

Signed-off-by: Joaquín Aguirrezabalaga <kinote@kinote.org>

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Adds a new setting under preferences "Enable direct share" that allows enabling or disabling direct share.

Direct share support was added in #2029, this PR allows the user to disable it.

## Motivation and context

Closes #2725

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->


| Before | After |
|-|-|
| ![menu-no-option](https://user-images.githubusercontent.com/1480/198875056-0b951651-fe81-4983-9942-6991a3255776.png) | ![menu-option-on](https://user-images.githubusercontent.com/1480/198875063-ce9790c1-34ab-45dd-b276-33bd2751bd13.png) |

| Setting | Effect |
|-|-|
|![menu-option-on](https://user-images.githubusercontent.com/1480/198875214-a741d600-4ea4-465e-919a-ca460b04f351.png)|![share-on](https://user-images.githubusercontent.com/1480/198875221-b5c48ffa-0d94-46ec-95d9-006a5d5543eb.png)|
|![menu-option-off](https://user-images.githubusercontent.com/1480/198875077-42d2b417-8ce3-42d2-a5cb-c653493b3827.png)|![share-off](https://user-images.githubusercontent.com/1480/198875438-04cd7e6b-a950-42ca-a7a4-ea971e6c984c.png)|



## Tests

<!-- Explain how you tested your development -->

- Open element
- Share content from another app and check that it shows the direct share chat rooms

- Open preferences in element
- Check that "Enable direct share" is enabled
- Disable "Enable direct share"
- Restart element
- Share content from another app and check that it does not show the element chat rooms in the direct share row

- Open preferences in element
- Disable "Enable direct share"
- Restart element
- Share content from another app and check that it shows the direct share chat rooms

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): Physical in Android 12, emulator in lollipop API 21

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
