### PR TITLE
Voice Broadcast - Update seek bar position while playing

### DIFF
--- a/changelog.d/7496.wip
+++ b/changelog.d/7496.wip
@@ -1,0 +1,1 @@
+[Voice Broadcast] Add seekbar in listening tile

--- a/library/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/VideoViewHolder.kt
+++ b/library/attachment-viewer/src/main/java/im/vector/lib/attachmentviewer/VideoViewHolder.kt
@@ -103,14 +103,12 @@ class VideoViewHolder constructor(itemView: View) :
         views.videoView.setOnPreparedListener {
             stopTimer()
             countUpTimer = CountUpTimer(100).also {
-                it.tickListener = object : CountUpTimer.TickListener {
-                    override fun onTick(milliseconds: Long) {
-                        val duration = views.videoView.duration
-                        val progress = views.videoView.currentPosition
-                        val isPlaying = views.videoView.isPlaying
-//                        Log.v("FOO", "isPlaying $isPlaying $progress/$duration")
-                        eventListener?.get()?.onEvent(AttachmentEvents.VideoEvent(isPlaying, progress, duration))
-                    }
+                it.tickListener = CountUpTimer.TickListener {
+                    val duration = views.videoView.duration
+                    val progress = views.videoView.currentPosition
+                    val isPlaying = views.videoView.isPlaying
+                    //                        Log.v("FOO", "isPlaying $isPlaying $progress/$duration")
+                    eventListener?.get()?.onEvent(AttachmentEvents.VideoEvent(isPlaying, progress, duration))
                 }
                 it.resume()
             }

--- a/library/core-utils/src/main/java/im/vector/lib/core/utils/timer/CountUpTimer.kt
+++ b/library/core-utils/src/main/java/im/vector/lib/core/utils/timer/CountUpTimer.kt
@@ -66,7 +66,7 @@ class CountUpTimer(private val intervalInMs: Long = 1_000) {
         coroutineScope.cancel()
     }
 
-    interface TickListener {
+    fun interface TickListener {
         fun onTick(milliseconds: Long)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCall.kt
+++ b/vector/src/main/java/im/vector/app/features/call/webrtc/WebRtcCall.kt
@@ -167,12 +167,10 @@ class WebRtcCall(
     private var screenSender: RtpSender? = null
 
     private val timer = CountUpTimer(1000L).apply {
-        tickListener = object : CountUpTimer.TickListener {
-            override fun onTick(milliseconds: Long) {
-                val formattedDuration = formatDuration(Duration.ofMillis(milliseconds))
-                listeners.forEach {
-                    tryOrNull { it.onTick(formattedDuration) }
-                }
+        tickListener = CountUpTimer.TickListener { milliseconds ->
+            val formattedDuration = formatDuration(Duration.ofMillis(milliseconds))
+            listeners.forEach {
+                tryOrNull { it.onTick(formattedDuration) }
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
@@ -20,6 +20,7 @@ import android.net.Uri
 import android.view.View
 import im.vector.app.core.platform.VectorViewModelAction
 import im.vector.app.features.call.conference.ConferenceEvent
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcast
 import org.matrix.android.sdk.api.session.content.ContentAttachmentData
 import org.matrix.android.sdk.api.session.room.model.message.MessageStickerContent
 import org.matrix.android.sdk.api.session.room.model.message.MessageWithAttachmentContent
@@ -129,10 +130,10 @@ sealed class RoomDetailAction : VectorViewModelAction {
         }
 
         sealed class Listening : VoiceBroadcastAction() {
-            data class PlayOrResume(val voiceBroadcastId: String) : Listening()
+            data class PlayOrResume(val voiceBroadcast: VoiceBroadcast) : Listening()
             object Pause : Listening()
             object Stop : Listening()
-            data class SeekTo(val voiceBroadcastId: String, val positionMillis: Int) : Listening()
+            data class SeekTo(val voiceBroadcast: VoiceBroadcast, val positionMillis: Int) : Listening()
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/RoomDetailAction.kt
@@ -133,7 +133,7 @@ sealed class RoomDetailAction : VectorViewModelAction {
             data class PlayOrResume(val voiceBroadcast: VoiceBroadcast) : Listening()
             object Pause : Listening()
             object Stop : Listening()
-            data class SeekTo(val voiceBroadcast: VoiceBroadcast, val positionMillis: Int) : Listening()
+            data class SeekTo(val voiceBroadcast: VoiceBroadcast, val positionMillis: Int, val duration: Int) : Listening()
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -637,7 +637,7 @@ class TimelineViewModel @AssistedInject constructor(
                 is VoiceBroadcastAction.Listening.PlayOrResume -> voiceBroadcastHelper.playOrResumePlayback(action.voiceBroadcast)
                 VoiceBroadcastAction.Listening.Pause -> voiceBroadcastHelper.pausePlayback()
                 VoiceBroadcastAction.Listening.Stop -> voiceBroadcastHelper.stopPlayback()
-                is VoiceBroadcastAction.Listening.SeekTo -> voiceBroadcastHelper.seekTo(action.voiceBroadcast, action.positionMillis)
+                is VoiceBroadcastAction.Listening.SeekTo -> voiceBroadcastHelper.seekTo(action.voiceBroadcast, action.positionMillis, action.duration)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -634,10 +634,10 @@ class TimelineViewModel @AssistedInject constructor(
                 VoiceBroadcastAction.Recording.Pause -> voiceBroadcastHelper.pauseVoiceBroadcast(room.roomId)
                 VoiceBroadcastAction.Recording.Resume -> voiceBroadcastHelper.resumeVoiceBroadcast(room.roomId)
                 VoiceBroadcastAction.Recording.Stop -> voiceBroadcastHelper.stopVoiceBroadcast(room.roomId)
-                is VoiceBroadcastAction.Listening.PlayOrResume -> voiceBroadcastHelper.playOrResumePlayback(room.roomId, action.voiceBroadcastId)
+                is VoiceBroadcastAction.Listening.PlayOrResume -> voiceBroadcastHelper.playOrResumePlayback(action.voiceBroadcast)
                 VoiceBroadcastAction.Listening.Pause -> voiceBroadcastHelper.pausePlayback()
                 VoiceBroadcastAction.Listening.Stop -> voiceBroadcastHelper.stopPlayback()
-                is VoiceBroadcastAction.Listening.SeekTo -> voiceBroadcastHelper.seekTo(action.voiceBroadcastId, action.positionMillis)
+                is VoiceBroadcastAction.Listening.SeekTo -> voiceBroadcastHelper.seekTo(action.voiceBroadcast, action.positionMillis)
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/AudioMessageHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/AudioMessageHelper.kt
@@ -199,11 +199,7 @@ class AudioMessageHelper @Inject constructor(
     private fun startRecordingAmplitudes() {
         amplitudeTicker?.stop()
         amplitudeTicker = CountUpTimer(50).apply {
-            tickListener = object : CountUpTimer.TickListener {
-                override fun onTick(milliseconds: Long) {
-                    onAmplitudeTick()
-                }
-            }
+            tickListener = CountUpTimer.TickListener { onAmplitudeTick() }
             resume()
         }
     }
@@ -234,11 +230,7 @@ class AudioMessageHelper @Inject constructor(
     private fun startPlaybackTicker(id: String) {
         playbackTicker?.stop()
         playbackTicker = CountUpTimer().apply {
-            tickListener = object : CountUpTimer.TickListener {
-                override fun onTick(milliseconds: Long) {
-                    onPlaybackTick(id)
-                }
-            }
+            tickListener = CountUpTimer.TickListener { onPlaybackTick(id) }
             resume()
         }
         onPlaybackTick(id)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/voice/VoiceMessageRecorderView.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/voice/VoiceMessageRecorderView.kt
@@ -189,11 +189,9 @@ class VoiceMessageRecorderView @JvmOverloads constructor(
         val startMs = ((clock.epochMillis() - startAt)).coerceAtLeast(0)
         recordingTicker?.stop()
         recordingTicker = CountUpTimer().apply {
-            tickListener = object : CountUpTimer.TickListener {
-                override fun onTick(milliseconds: Long) {
-                    val isLocked = startFromLocked || lastKnownState is RecordingUiState.Locked
-                    onRecordingTick(isLocked, milliseconds + startMs)
-                }
+            tickListener = CountUpTimer.TickListener { milliseconds ->
+                val isLocked = startFromLocked || lastKnownState is RecordingUiState.Locked
+                onRecordingTick(isLocked, milliseconds + startMs)
             }
             resume()
         }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/VoiceBroadcastItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/VoiceBroadcastItemFactory.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.home.room.detail.timeline.factory
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.DrawableProvider
 import im.vector.app.features.displayname.getBestName
+import im.vector.app.features.home.room.detail.timeline.helper.AudioMessagePlaybackTracker
 import im.vector.app.features.home.room.detail.timeline.helper.AvatarSizeProvider
 import im.vector.app.features.home.room.detail.timeline.helper.VoiceBroadcastEventsGroup
 import im.vector.app.features.home.room.detail.timeline.item.AbsMessageItem
@@ -44,6 +45,7 @@ class VoiceBroadcastItemFactory @Inject constructor(
         private val drawableProvider: DrawableProvider,
         private val voiceBroadcastRecorder: VoiceBroadcastRecorder?,
         private val voiceBroadcastPlayer: VoiceBroadcastPlayer,
+        private val playbackTracker: AudioMessagePlaybackTracker,
 ) {
 
     fun create(
@@ -71,6 +73,7 @@ class VoiceBroadcastItemFactory @Inject constructor(
                 recorderName = params.event.root.stateKey?.let { session.getUserOrDefault(it) }?.toMatrixItem()?.getBestName().orEmpty(),
                 recorder = voiceBroadcastRecorder,
                 player = voiceBroadcastPlayer,
+                playbackTracker = playbackTracker,
                 roomItem = session.getRoom(params.event.roomId)?.roomSummary()?.toMatrixItem(),
                 colorProvider = colorProvider,
                 drawableProvider = drawableProvider,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/VoiceBroadcastItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/VoiceBroadcastItemFactory.kt
@@ -29,6 +29,7 @@ import im.vector.app.features.home.room.detail.timeline.item.MessageVoiceBroadca
 import im.vector.app.features.home.room.detail.timeline.item.MessageVoiceBroadcastRecordingItem_
 import im.vector.app.features.voicebroadcast.listening.VoiceBroadcastPlayer
 import im.vector.app.features.voicebroadcast.model.MessageVoiceBroadcastInfoContent
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcast
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
 import im.vector.app.features.voicebroadcast.model.asVoiceBroadcastEvent
 import im.vector.app.features.voicebroadcast.recording.VoiceBroadcastRecorder
@@ -60,14 +61,14 @@ class VoiceBroadcastItemFactory @Inject constructor(
         val voiceBroadcastEventsGroup = params.eventsGroup?.let { VoiceBroadcastEventsGroup(it) } ?: return null
         val voiceBroadcastEvent = voiceBroadcastEventsGroup.getLastDisplayableEvent().root.asVoiceBroadcastEvent() ?: return null
         val voiceBroadcastContent = voiceBroadcastEvent.content ?: return null
-        val voiceBroadcastId = voiceBroadcastEventsGroup.voiceBroadcastId
+        val voiceBroadcast = VoiceBroadcast(voiceBroadcastId = voiceBroadcastEventsGroup.voiceBroadcastId, roomId = params.event.roomId)
 
         val isRecording = voiceBroadcastContent.voiceBroadcastState != VoiceBroadcastState.STOPPED &&
                 voiceBroadcastEvent.root.stateKey == session.myUserId &&
                 messageContent.deviceId == session.sessionParams.deviceId
 
         val voiceBroadcastAttributes = AbsMessageVoiceBroadcastItem.Attributes(
-                voiceBroadcastId = voiceBroadcastId,
+                voiceBroadcast = voiceBroadcast,
                 voiceBroadcastState = voiceBroadcastContent.voiceBroadcastState,
                 duration = voiceBroadcastEventsGroup.getDuration(),
                 recorderName = params.event.root.stateKey?.let { session.getUserOrDefault(it) }?.toMatrixItem()?.getBestName().orEmpty(),
@@ -92,7 +93,7 @@ class VoiceBroadcastItemFactory @Inject constructor(
             voiceBroadcastAttributes: AbsMessageVoiceBroadcastItem.Attributes,
     ): MessageVoiceBroadcastRecordingItem {
         return MessageVoiceBroadcastRecordingItem_()
-                .id("voice_broadcast_${voiceBroadcastAttributes.voiceBroadcastId}")
+                .id("voice_broadcast_${voiceBroadcastAttributes.voiceBroadcast.voiceBroadcastId}")
                 .attributes(attributes)
                 .voiceBroadcastAttributes(voiceBroadcastAttributes)
                 .highlighted(highlight)
@@ -105,7 +106,7 @@ class VoiceBroadcastItemFactory @Inject constructor(
             voiceBroadcastAttributes: AbsMessageVoiceBroadcastItem.Attributes,
     ): MessageVoiceBroadcastListeningItem {
         return MessageVoiceBroadcastListeningItem_()
-                .id("voice_broadcast_${voiceBroadcastAttributes.voiceBroadcastId}")
+                .id("voice_broadcast_${voiceBroadcastAttributes.voiceBroadcast.voiceBroadcastId}")
                 .attributes(attributes)
                 .voiceBroadcastAttributes(voiceBroadcastAttributes)
                 .highlighted(highlight)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/AudioMessagePlaybackTracker.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/AudioMessagePlaybackTracker.kt
@@ -148,7 +148,7 @@ class AudioMessagePlaybackTracker @Inject constructor() {
         const val RECORDING_ID = "RECORDING_ID"
     }
 
-    interface Listener {
+    fun interface Listener {
 
         fun onUpdate(state: State)
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/AudioMessagePlaybackTracker.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/AudioMessagePlaybackTracker.kt
@@ -127,7 +127,7 @@ class AudioMessagePlaybackTracker @Inject constructor() {
         }
     }
 
-    private fun getPercentage(id: String): Float {
+    fun getPercentage(id: String): Float {
         return when (val state = states[id]) {
             is Listener.State.Playing -> state.percentage
             is Listener.State.Paused -> state.percentage

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageVoiceBroadcastItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageVoiceBroadcastItem.kt
@@ -25,6 +25,7 @@ import im.vector.app.R
 import im.vector.app.core.extensions.tintBackground
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.DrawableProvider
+import im.vector.app.features.home.room.detail.timeline.helper.AudioMessagePlaybackTracker
 import im.vector.app.features.voicebroadcast.listening.VoiceBroadcastPlayer
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
 import im.vector.app.features.voicebroadcast.recording.VoiceBroadcastRecorder
@@ -40,6 +41,8 @@ abstract class AbsMessageVoiceBroadcastItem<H : AbsMessageVoiceBroadcastItem.Hol
     protected val recorderName get() = voiceBroadcastAttributes.recorderName
     protected val recorder get() = voiceBroadcastAttributes.recorder
     protected val player get() = voiceBroadcastAttributes.player
+    protected val playbackTracker get() = voiceBroadcastAttributes.playbackTracker
+    protected val duration get() = voiceBroadcastAttributes.duration
     protected val roomItem get() = voiceBroadcastAttributes.roomItem
     protected val colorProvider get() = voiceBroadcastAttributes.colorProvider
     protected val drawableProvider get() = voiceBroadcastAttributes.drawableProvider
@@ -98,6 +101,7 @@ abstract class AbsMessageVoiceBroadcastItem<H : AbsMessageVoiceBroadcastItem.Hol
             val recorderName: String,
             val recorder: VoiceBroadcastRecorder?,
             val player: VoiceBroadcastPlayer,
+            val playbackTracker: AudioMessagePlaybackTracker,
             val roomItem: MatrixItem?,
             val colorProvider: ColorProvider,
             val drawableProvider: DrawableProvider,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageVoiceBroadcastItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/AbsMessageVoiceBroadcastItem.kt
@@ -27,6 +27,7 @@ import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.DrawableProvider
 import im.vector.app.features.home.room.detail.timeline.helper.AudioMessagePlaybackTracker
 import im.vector.app.features.voicebroadcast.listening.VoiceBroadcastPlayer
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcast
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
 import im.vector.app.features.voicebroadcast.recording.VoiceBroadcastRecorder
 import org.matrix.android.sdk.api.util.MatrixItem
@@ -36,7 +37,7 @@ abstract class AbsMessageVoiceBroadcastItem<H : AbsMessageVoiceBroadcastItem.Hol
     @EpoxyAttribute
     lateinit var voiceBroadcastAttributes: Attributes
 
-    protected val voiceBroadcastId get() = voiceBroadcastAttributes.voiceBroadcastId
+    protected val voiceBroadcast get() = voiceBroadcastAttributes.voiceBroadcast
     protected val voiceBroadcastState get() = voiceBroadcastAttributes.voiceBroadcastState
     protected val recorderName get() = voiceBroadcastAttributes.recorderName
     protected val recorder get() = voiceBroadcastAttributes.recorder
@@ -95,7 +96,7 @@ abstract class AbsMessageVoiceBroadcastItem<H : AbsMessageVoiceBroadcastItem.Hol
     }
 
     data class Attributes(
-            val voiceBroadcastId: String,
+            val voiceBroadcast: VoiceBroadcast,
             val voiceBroadcastState: VoiceBroadcastState?,
             val duration: Int,
             val recorderName: String,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageAudioItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageAudioItem.kt
@@ -140,16 +140,14 @@ abstract class MessageAudioItem : AbsMessageItem<MessageAudioItem.Holder>() {
     }
 
     private fun renderStateBasedOnAudioPlayback(holder: Holder) {
-        audioMessagePlaybackTracker.track(attributes.informationData.eventId, object : AudioMessagePlaybackTracker.Listener {
-            override fun onUpdate(state: AudioMessagePlaybackTracker.Listener.State) {
-                when (state) {
-                    is AudioMessagePlaybackTracker.Listener.State.Idle -> renderIdleState(holder)
-                    is AudioMessagePlaybackTracker.Listener.State.Playing -> renderPlayingState(holder, state)
-                    is AudioMessagePlaybackTracker.Listener.State.Paused -> renderPausedState(holder, state)
-                    is AudioMessagePlaybackTracker.Listener.State.Recording -> Unit
-                }
+        audioMessagePlaybackTracker.track(attributes.informationData.eventId) { state ->
+            when (state) {
+                is AudioMessagePlaybackTracker.Listener.State.Idle -> renderIdleState(holder)
+                is AudioMessagePlaybackTracker.Listener.State.Playing -> renderPlayingState(holder, state)
+                is AudioMessagePlaybackTracker.Listener.State.Paused -> renderPausedState(holder, state)
+                is AudioMessagePlaybackTracker.Listener.State.Recording -> Unit
             }
-        })
+        }
     }
 
     private fun renderIdleState(holder: Holder) {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
@@ -94,7 +94,7 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
             }
 
             override fun onStopTrackingTouch(seekBar: SeekBar) {
-                callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.SeekTo(voiceBroadcast, seekBar.progress))
+                callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.SeekTo(voiceBroadcast, seekBar.progress, duration))
                 isUserSeeking = false
             }
         })

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
@@ -44,9 +44,7 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
     }
 
     private fun bindVoiceBroadcastItem(holder: Holder) {
-        playerListener = VoiceBroadcastPlayer.Listener { state ->
-            renderPlayingState(holder, state)
-        }
+        playerListener = VoiceBroadcastPlayer.Listener { renderPlayingState(holder, it) }
         player.addListener(voiceBroadcast, playerListener)
         bindSeekBar(holder)
         bindButtons(holder)
@@ -56,13 +54,9 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
         with(holder) {
             playPauseButton.onClick {
                 when (player.playingState) {
-                    VoiceBroadcastPlayer.State.PLAYING -> {
-                        callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.Pause)
-                    }
+                    VoiceBroadcastPlayer.State.PLAYING -> callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.Pause)
                     VoiceBroadcastPlayer.State.PAUSED,
-                    VoiceBroadcastPlayer.State.IDLE -> {
-                        callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.PlayOrResume(voiceBroadcast))
-                    }
+                    VoiceBroadcastPlayer.State.IDLE -> callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.PlayOrResume(voiceBroadcast))
                     VoiceBroadcastPlayer.State.BUFFERING -> Unit
                 }
             }
@@ -106,20 +100,22 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
     }
 
     private fun bindSeekBar(holder: Holder) {
-        holder.durationView.text = formatPlaybackTime(duration)
-        holder.seekBar.max = duration
-        holder.seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
-            override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) = Unit
+        with(holder) {
+            durationView.text = formatPlaybackTime(duration)
+            seekBar.max = duration
+            seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+                override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) = Unit
 
-            override fun onStartTrackingTouch(seekBar: SeekBar) {
-                isUserSeeking = true
-            }
+                override fun onStartTrackingTouch(seekBar: SeekBar) {
+                    isUserSeeking = true
+                }
 
-            override fun onStopTrackingTouch(seekBar: SeekBar) {
-                callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.SeekTo(voiceBroadcast, seekBar.progress, duration))
-                isUserSeeking = false
-            }
-        })
+                override fun onStopTrackingTouch(seekBar: SeekBar) {
+                    callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.SeekTo(voiceBroadcast, seekBar.progress, duration))
+                    isUserSeeking = false
+                }
+            })
+        }
         playbackTracker.track(voiceBroadcast.voiceBroadcastId, object : AudioMessagePlaybackTracker.Listener {
             override fun onUpdate(state: State) {
                 renderBackwardForwardButtons(holder, state)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
@@ -71,18 +71,14 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
                     playPauseButton.setImageResource(R.drawable.ic_play_pause_pause)
                     playPauseButton.contentDescription = view.resources.getString(R.string.a11y_pause_voice_broadcast)
                     playPauseButton.onClick { callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.Pause) }
-                    seekBar.isEnabled = true
                 }
                 VoiceBroadcastPlayer.State.IDLE,
                 VoiceBroadcastPlayer.State.PAUSED -> {
                     playPauseButton.setImageResource(R.drawable.ic_play_pause_play)
                     playPauseButton.contentDescription = view.resources.getString(R.string.a11y_play_voice_broadcast)
                     playPauseButton.onClick { callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.PlayOrResume(voiceBroadcast)) }
-                    seekBar.isEnabled = false
                 }
-                VoiceBroadcastPlayer.State.BUFFERING -> {
-                    seekBar.isEnabled = true
-                }
+                VoiceBroadcastPlayer.State.BUFFERING -> Unit
             }
         }
     }
@@ -112,6 +108,7 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
                     }
                     is AudioMessagePlaybackTracker.Listener.State.Playing -> {
                         if (!isUserSeeking) {
+//                            Timber.d("Voice Broadcast | AudioMessagePlaybackTracker.Listener.onUpdate - duration: $duration, playbackTime: ${state.playbackTime}")
                             holder.seekBar.progress = state.playbackTime
                         }
                     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
@@ -108,7 +108,6 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
                     }
                     is AudioMessagePlaybackTracker.Listener.State.Playing -> {
                         if (!isUserSeeking) {
-//                            Timber.d("Voice Broadcast | AudioMessagePlaybackTracker.Listener.onUpdate - duration: $duration, playbackTime: ${state.playbackTime}")
                             holder.seekBar.progress = state.playbackTime
                         }
                     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
@@ -116,14 +116,12 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
                 }
             })
         }
-        playbackTracker.track(voiceBroadcast.voiceBroadcastId, object : AudioMessagePlaybackTracker.Listener {
-            override fun onUpdate(state: State) {
-                renderBackwardForwardButtons(holder, state)
-                if (!isUserSeeking) {
-                    holder.seekBar.progress = playbackTracker.getPlaybackTime(voiceBroadcast.voiceBroadcastId)
-                }
+        playbackTracker.track(voiceBroadcast.voiceBroadcastId) { playbackState ->
+            renderBackwardForwardButtons(holder, playbackState)
+            if (!isUserSeeking) {
+                holder.seekBar.progress = playbackTracker.getPlaybackTime(voiceBroadcast.voiceBroadcastId)
             }
-        })
+        }
     }
 
     private fun renderBackwardForwardButtons(holder: Holder, playbackState: State) {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
@@ -46,7 +46,7 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
         playerListener = VoiceBroadcastPlayer.Listener { state ->
             renderPlayingState(holder, state)
         }
-        player.addListener(voiceBroadcastId, playerListener)
+        player.addListener(voiceBroadcast, playerListener)
         bindSeekBar(holder)
     }
 
@@ -77,7 +77,7 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
                 VoiceBroadcastPlayer.State.PAUSED -> {
                     playPauseButton.setImageResource(R.drawable.ic_play_pause_play)
                     playPauseButton.contentDescription = view.resources.getString(R.string.a11y_play_voice_broadcast)
-                    playPauseButton.onClick { callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.PlayOrResume(voiceBroadcastId)) }
+                    playPauseButton.onClick { callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.PlayOrResume(voiceBroadcast)) }
                     seekBar.isEnabled = false
                 }
                 VoiceBroadcastPlayer.State.BUFFERING -> {
@@ -98,11 +98,11 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
             }
 
             override fun onStopTrackingTouch(seekBar: SeekBar) {
-                callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.SeekTo(voiceBroadcastId, seekBar.progress))
+                callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.SeekTo(voiceBroadcast, seekBar.progress))
                 isUserSeeking = false
             }
         })
-        playbackTracker.track(voiceBroadcastId, object : AudioMessagePlaybackTracker.Listener {
+        playbackTracker.track(voiceBroadcast.voiceBroadcastId, object : AudioMessagePlaybackTracker.Listener {
             override fun onUpdate(state: AudioMessagePlaybackTracker.Listener.State) {
                 when (state) {
                     is AudioMessagePlaybackTracker.Listener.State.Paused -> {
@@ -126,9 +126,9 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
 
     override fun unbind(holder: Holder) {
         super.unbind(holder)
-        player.removeListener(voiceBroadcastId, playerListener)
+        player.removeListener(voiceBroadcast, playerListener)
         holder.seekBar.setOnSeekBarChangeListener(null)
-        playbackTracker.untrack(voiceBroadcastId)
+        playbackTracker.untrack(voiceBroadcast.voiceBroadcastId)
     }
 
     override fun getViewStubId() = STUB_ID

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
@@ -27,7 +27,6 @@ import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
 import im.vector.app.core.epoxy.onClick
 import im.vector.app.features.home.room.detail.RoomDetailAction.VoiceBroadcastAction
-import im.vector.app.features.home.room.detail.timeline.helper.AudioMessagePlaybackTracker
 import im.vector.app.features.home.room.detail.timeline.helper.AudioMessagePlaybackTracker.Listener.State
 import im.vector.app.features.voicebroadcast.listening.VoiceBroadcastPlayer
 import im.vector.app.features.voicebroadcast.views.VoiceBroadcastMetadataView
@@ -53,11 +52,15 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
     private fun bindButtons(holder: Holder) {
         with(holder) {
             playPauseButton.onClick {
-                when (player.playingState) {
-                    VoiceBroadcastPlayer.State.PLAYING -> callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.Pause)
-                    VoiceBroadcastPlayer.State.PAUSED,
-                    VoiceBroadcastPlayer.State.IDLE -> callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.PlayOrResume(voiceBroadcast))
-                    VoiceBroadcastPlayer.State.BUFFERING -> Unit
+                if (player.currentVoiceBroadcast == voiceBroadcast) {
+                    when (player.playingState) {
+                        VoiceBroadcastPlayer.State.PLAYING -> callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.Pause)
+                        VoiceBroadcastPlayer.State.PAUSED,
+                        VoiceBroadcastPlayer.State.IDLE -> callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.PlayOrResume(voiceBroadcast))
+                        VoiceBroadcastPlayer.State.BUFFERING -> Unit
+                    }
+                } else {
+                    callback?.onTimelineItemAction(VoiceBroadcastAction.Listening.PlayOrResume(voiceBroadcast))
                 }
             }
             fastBackwardButton.onClick {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastListeningItem.kt
@@ -140,8 +140,13 @@ abstract class MessageVoiceBroadcastListeningItem : AbsMessageVoiceBroadcastItem
     override fun unbind(holder: Holder) {
         super.unbind(holder)
         player.removeListener(voiceBroadcast, playerListener)
-        holder.seekBar.setOnSeekBarChangeListener(null)
         playbackTracker.untrack(voiceBroadcast.voiceBroadcastId)
+        with(holder) {
+            seekBar.onClick(null)
+            playPauseButton.onClick(null)
+            fastForwardButton.onClick(null)
+            fastBackwardButton.onClick(null)
+        }
     }
 
     override fun getViewStubId() = STUB_ID

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceItem.kt
@@ -122,16 +122,14 @@ abstract class MessageVoiceItem : AbsMessageItem<MessageVoiceItem.Holder>() {
             true
         }
 
-        audioMessagePlaybackTracker.track(attributes.informationData.eventId, object : AudioMessagePlaybackTracker.Listener {
-            override fun onUpdate(state: AudioMessagePlaybackTracker.Listener.State) {
-                when (state) {
-                    is AudioMessagePlaybackTracker.Listener.State.Idle -> renderIdleState(holder, waveformColorIdle, waveformColorPlayed)
-                    is AudioMessagePlaybackTracker.Listener.State.Playing -> renderPlayingState(holder, state, waveformColorIdle, waveformColorPlayed)
-                    is AudioMessagePlaybackTracker.Listener.State.Paused -> renderPausedState(holder, state, waveformColorIdle, waveformColorPlayed)
-                    is AudioMessagePlaybackTracker.Listener.State.Recording -> Unit
-                }
+        audioMessagePlaybackTracker.track(attributes.informationData.eventId) { state ->
+            when (state) {
+                is AudioMessagePlaybackTracker.Listener.State.Idle -> renderIdleState(holder, waveformColorIdle, waveformColorPlayed)
+                is AudioMessagePlaybackTracker.Listener.State.Playing -> renderPlayingState(holder, state, waveformColorIdle, waveformColorPlayed)
+                is AudioMessagePlaybackTracker.Listener.State.Paused -> renderPausedState(holder, state, waveformColorIdle, waveformColorPlayed)
+                is AudioMessagePlaybackTracker.Listener.State.Recording -> Unit
             }
-        })
+        }
     }
 
     private fun getTouchedPositionPercentage(motionEvent: MotionEvent, view: View) = (motionEvent.x / view.width).coerceIn(0f, 1f)

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationUserItem.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationUserItem.kt
@@ -79,10 +79,8 @@ abstract class LiveLocationUserItem : VectorEpoxyModel<LiveLocationUserItem.Hold
             }
         }
 
-        holder.timer.tickListener = object : CountUpTimer.TickListener {
-            override fun onTick(milliseconds: Long) {
-                holder.itemLastUpdatedAtTextView.text = getFormattedLastUpdatedAt(locationUpdateTimeMillis)
-            }
+        holder.timer.tickListener = CountUpTimer.TickListener {
+            holder.itemLastUpdatedAtTextView.text = getFormattedLastUpdatedAt(locationUpdateTimeMillis)
         }
         holder.timer.resume()
 

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastExtensions.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastExtensions.kt
@@ -17,6 +17,8 @@
 package im.vector.app.features.voicebroadcast
 
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastChunk
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcastEvent
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
 import org.matrix.android.sdk.api.session.events.model.Content
 import org.matrix.android.sdk.api.session.events.model.getRelationContent
 import org.matrix.android.sdk.api.session.events.model.toModel
@@ -34,3 +36,6 @@ fun MessageAudioEvent.getVoiceBroadcastChunk(): VoiceBroadcastChunk? {
 val MessageAudioEvent.sequence: Int? get() = getVoiceBroadcastChunk()?.sequence
 
 val MessageAudioEvent.duration get() = content.audioInfo?.duration ?: content.audioWaveformInfo?.duration ?: 0
+
+val VoiceBroadcastEvent.isLive
+    get() = content?.voiceBroadcastState != null && content?.voiceBroadcastState != VoiceBroadcastState.STOPPED

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastExtensions.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastExtensions.kt
@@ -16,9 +16,11 @@
 
 package im.vector.app.features.voicebroadcast
 
+import im.vector.app.features.voicebroadcast.model.MessageVoiceBroadcastInfoContent
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastChunk
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastEvent
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
+import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.events.model.Content
 import org.matrix.android.sdk.api.session.events.model.getRelationContent
 import org.matrix.android.sdk.api.session.events.model.toModel
@@ -38,4 +40,7 @@ val MessageAudioEvent.sequence: Int? get() = getVoiceBroadcastChunk()?.sequence
 val MessageAudioEvent.duration get() = content.audioInfo?.duration ?: content.audioWaveformInfo?.duration ?: 0
 
 val VoiceBroadcastEvent.isLive
-    get() = content?.voiceBroadcastState != null && content?.voiceBroadcastState != VoiceBroadcastState.STOPPED
+    get() = content?.isLive.orFalse()
+
+val MessageVoiceBroadcastInfoContent.isLive
+    get() = voiceBroadcastState != null && voiceBroadcastState != VoiceBroadcastState.STOPPED

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastHelper.kt
@@ -49,8 +49,6 @@ class VoiceBroadcastHelper @Inject constructor(
     fun stopPlayback() = voiceBroadcastPlayer.stop()
 
     fun seekTo(voiceBroadcast: VoiceBroadcast, positionMillis: Int) {
-        if (voiceBroadcastPlayer.currentVoiceBroadcast == voiceBroadcast) {
-            voiceBroadcastPlayer.seekTo(positionMillis)
-        }
+        voiceBroadcastPlayer.seekTo(voiceBroadcast, positionMillis)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastHelper.kt
@@ -17,6 +17,7 @@
 package im.vector.app.features.voicebroadcast
 
 import im.vector.app.features.voicebroadcast.listening.VoiceBroadcastPlayer
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcast
 import im.vector.app.features.voicebroadcast.recording.usecase.PauseVoiceBroadcastUseCase
 import im.vector.app.features.voicebroadcast.recording.usecase.ResumeVoiceBroadcastUseCase
 import im.vector.app.features.voicebroadcast.recording.usecase.StartVoiceBroadcastUseCase
@@ -41,14 +42,14 @@ class VoiceBroadcastHelper @Inject constructor(
 
     suspend fun stopVoiceBroadcast(roomId: String) = stopVoiceBroadcastUseCase.execute(roomId)
 
-    fun playOrResumePlayback(roomId: String, voiceBroadcastId: String) = voiceBroadcastPlayer.playOrResume(roomId, voiceBroadcastId)
+    fun playOrResumePlayback(voiceBroadcast: VoiceBroadcast) = voiceBroadcastPlayer.playOrResume(voiceBroadcast)
 
     fun pausePlayback() = voiceBroadcastPlayer.pause()
 
     fun stopPlayback() = voiceBroadcastPlayer.stop()
 
-    fun seekTo(voiceBroadcastId: String, positionMillis: Int) {
-        if (voiceBroadcastPlayer.currentVoiceBroadcastId == voiceBroadcastId) {
+    fun seekTo(voiceBroadcast: VoiceBroadcast, positionMillis: Int) {
+        if (voiceBroadcastPlayer.currentVoiceBroadcast == voiceBroadcast) {
             voiceBroadcastPlayer.seekTo(positionMillis)
         }
     }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastHelper.kt
@@ -48,7 +48,7 @@ class VoiceBroadcastHelper @Inject constructor(
 
     fun stopPlayback() = voiceBroadcastPlayer.stop()
 
-    fun seekTo(voiceBroadcast: VoiceBroadcast, positionMillis: Int) {
-        voiceBroadcastPlayer.seekTo(voiceBroadcast, positionMillis)
+    fun seekTo(voiceBroadcast: VoiceBroadcast, positionMillis: Int, duration: Int) {
+        voiceBroadcastPlayer.seekTo(voiceBroadcast, positionMillis, duration)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayer.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayer.kt
@@ -48,7 +48,7 @@ interface VoiceBroadcastPlayer {
     /**
      * Seek the given voice broadcast playback to the given position, is milliseconds.
      */
-    fun seekTo(voiceBroadcast: VoiceBroadcast, positionMillis: Int)
+    fun seekTo(voiceBroadcast: VoiceBroadcast, positionMillis: Int, duration: Int)
 
     /**
      * Add a [Listener] to the given voice broadcast.

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayer.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayer.kt
@@ -16,12 +16,14 @@
 
 package im.vector.app.features.voicebroadcast.listening
 
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcast
+
 interface VoiceBroadcastPlayer {
 
     /**
-     * The current playing voice broadcast identifier, if any.
+     * The current playing voice broadcast, if any.
      */
-    val currentVoiceBroadcastId: String?
+    val currentVoiceBroadcast: VoiceBroadcast?
 
     /**
      * The current playing [State], [State.IDLE] by default.
@@ -31,7 +33,7 @@ interface VoiceBroadcastPlayer {
     /**
      * Start playback of the given voice broadcast.
      */
-    fun playOrResume(roomId: String, voiceBroadcastId: String)
+    fun playOrResume(voiceBroadcast: VoiceBroadcast)
 
     /**
      * Pause playback of the current voice broadcast, if any.
@@ -49,14 +51,14 @@ interface VoiceBroadcastPlayer {
     fun seekTo(positionMillis: Int)
 
     /**
-     * Add a [Listener] to the given voice broadcast id.
+     * Add a [Listener] to the given voice broadcast.
      */
-    fun addListener(voiceBroadcastId: String, listener: Listener)
+    fun addListener(voiceBroadcast: VoiceBroadcast, listener: Listener)
 
     /**
-     * Remove a [Listener] from the given voice broadcast id.
+     * Remove a [Listener] from the given voice broadcast.
      */
-    fun removeListener(voiceBroadcastId: String, listener: Listener)
+    fun removeListener(voiceBroadcast: VoiceBroadcast, listener: Listener)
 
     /**
      * Player states.

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayer.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayer.kt
@@ -46,9 +46,9 @@ interface VoiceBroadcastPlayer {
     fun stop()
 
     /**
-     * Seek to the given playback position, is milliseconds.
+     * Seek the given voice broadcast playback to the given position, is milliseconds.
      */
-    fun seekTo(positionMillis: Int)
+    fun seekTo(voiceBroadcast: VoiceBroadcast, positionMillis: Int)
 
     /**
      * Add a [Listener] to the given voice broadcast.

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -375,7 +375,6 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
             when (playingState) {
                 State.PLAYING,
                 State.PAUSED -> {
-                    Timber.d("Voice Broadcast | VoiceBroadcastPlayerImpl - sequence: ${playlist.currentSequence}, itemStartTime $itemStartTime, currentMediaPlayer=$currentMediaPlayer, currentMediaPlayer?.currentPosition: ${currentMediaPlayer?.currentPosition}")
                     val position = itemStartTime + (currentMediaPlayer?.currentPosition ?: 0)
                     val percentage = position.toFloat() / playlist.duration
                     if (playingState == State.PLAYING) {

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -296,7 +296,7 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
         override fun onInfo(mp: MediaPlayer, what: Int, extra: Int): Boolean {
             when (what) {
                 MediaPlayer.MEDIA_INFO_STARTED_AS_NEXT -> {
-                    playlist.currentSequence++
+                    playlist.currentSequence = playlist.currentSequence?.inc()
                     currentMediaPlayer = mp
                     nextMediaPlayer = null
                     prepareNextMediaPlayer()

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -166,8 +166,8 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
                 }
             }
             State.BUFFERING -> {
-                val newMediaContent = getNextAudioContent()
-                if (newMediaContent != null) {
+                val nextItem = playlist.getNextItem()
+                if (nextItem != null) {
                     val savedPosition = currentVoiceBroadcast?.let { playbackTracker.getPlaybackTime(it.voiceBroadcastId) }
                     startPlayback(savedPosition)
                 }
@@ -222,14 +222,10 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
         }
     }
 
-    private fun getNextAudioContent(): MessageAudioContent? {
-        return playlist.getNextItem()?.audioEvent?.content
-    }
-
     private fun prepareNextMediaPlayer() {
         nextMediaPlayer = null
-        val nextContent = getNextAudioContent()
-        if (nextContent != null) {
+        val nextItem = playlist.getNextItem()
+        if (nextItem != null) {
             sessionScope.launch {
                 prepareMediaPlayer(nextContent) { mp ->
                     if (nextMediaPlayer == null) {

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -358,12 +358,14 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
             playbackTicker = null
 
             val totalDuration = playlist.duration
-            val playbackTime = playbackTracker.getPlaybackTime(id)
-            val remainingTime = totalDuration - playbackTime
-            if (remainingTime < 1000) {
-                playbackTracker.updatePausedAtPlaybackTime(id, 0, 0f)
-            } else {
-                playbackTracker.pausePlayback(id)
+            if (totalDuration > 0) {
+                val playbackTime = playbackTracker.getPlaybackTime(id)
+                val remainingTime = totalDuration - playbackTime
+                if (remainingTime < 1000) {
+                    playbackTracker.updatePausedAtPlaybackTime(id, 0, 0f)
+                } else {
+                    playbackTracker.pausePlayback(id)
+                }
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -74,9 +74,11 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
     override var playingState = State.IDLE
         @MainThread
         set(value) {
-            Timber.w("## VoiceBroadcastPlayer state: $field -> $value")
-            field = value
-            onPlayingStateChanged(value)
+            if (field != value) {
+                Timber.w("## VoiceBroadcastPlayer state: $field -> $value")
+                field = value
+                onPlayingStateChanged(value)
+            }
         }
 
     /** Map voiceBroadcastId to listeners.*/
@@ -299,6 +301,7 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
                     playlist.currentSequence = playlist.currentSequence?.inc()
                     currentMediaPlayer = mp
                     nextMediaPlayer = null
+                    playingState = State.PLAYING
                     prepareNextMediaPlayer()
                 }
             }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -402,7 +402,7 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
                     }
                 }
                 State.IDLE -> {
-                    if (playbackTime == null || percentage == null || playbackTime == playlist.duration) {
+                    if (playbackTime == null || percentage == null || (playlist.duration - playbackTime) < 50) {
                         playbackTracker.stopPlayback(id)
                     } else {
                         playbackTracker.updatePausedAtPlaybackTime(id, playbackTime, percentage)

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -298,6 +298,7 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
                 MediaPlayer.MEDIA_INFO_STARTED_AS_NEXT -> {
                     playlist.currentSequence++
                     currentMediaPlayer = mp
+                    nextMediaPlayer = null
                     prepareNextMediaPlayer()
                 }
             }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -362,11 +362,7 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
         fun startPlaybackTicker(id: String) {
             playbackTicker?.stop()
             playbackTicker = CountUpTimer().apply {
-                tickListener = object : CountUpTimer.TickListener {
-                    override fun onTick(milliseconds: Long) {
-                        onPlaybackTick(id)
-                    }
-                }
+                tickListener = CountUpTimer.TickListener { onPlaybackTick(id) }
                 resume()
             }
             onPlaybackTick(id)

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -171,12 +171,12 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
                 val nextItem = playlist.getNextItem()
                 if (nextItem != null) {
                     val savedPosition = currentVoiceBroadcast?.let { playbackTracker.getPlaybackTime(it.voiceBroadcastId) }
-                    startPlayback(savedPosition)
+                    startPlayback(savedPosition?.takeIf { it > 0 })
                 }
             }
             State.IDLE -> {
                 val savedPosition = currentVoiceBroadcast?.let { playbackTracker.getPlaybackTime(it.voiceBroadcastId) }
-                startPlayback(savedPosition)
+                startPlayback(savedPosition?.takeIf { it > 0 })
             }
         }
     }
@@ -389,7 +389,7 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
                     val playbackTime = playbackTracker.getPlaybackTime(id)
                     val percentage = playbackTracker.getPercentage(id)
                     if (playingState == State.IDLE && duration > 0 && (duration - playbackTime) < 100) {
-                        playbackTracker.updatePausedAtPlaybackTime(id, 0, 0f)
+                        playbackTracker.stopPlayback(id)
                     } else {
                         playbackTracker.updatePausedAtPlaybackTime(id, playbackTime, percentage)
                     }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -371,7 +371,6 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
         private fun onPlaybackTick(id: String) {
             val currentItem = playlist.currentItem ?: return
             val itemStartTime = currentItem.startTime
-            val duration = playlist.duration
             when (playingState) {
                 State.PLAYING,
                 State.PAUSED -> {
@@ -383,15 +382,13 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
                         playbackTracker.updatePausedAtPlaybackTime(id, position, percentage)
                     }
                 }
-                State.BUFFERING,
-                State.IDLE -> {
+                State.BUFFERING -> {
                     val playbackTime = playbackTracker.getPlaybackTime(id)
                     val percentage = playbackTracker.getPercentage(id)
-                    if (playingState == State.IDLE && duration > 0 && (duration - playbackTime) < 100) {
-                        playbackTracker.stopPlayback(id)
-                    } else {
-                        playbackTracker.updatePausedAtPlaybackTime(id, playbackTime, percentage)
-                    }
+                    playbackTracker.updatePausedAtPlaybackTime(id, playbackTime, percentage)
+                }
+                State.IDLE -> {
+                    playbackTracker.stopPlayback(id)
                 }
             }
         }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -355,7 +355,7 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
 
         fun startPlaybackTicker(id: String) {
             playbackTicker?.stop()
-            playbackTicker = CountUpTimer().apply {
+            playbackTicker = CountUpTimer(50L).apply {
                 tickListener = CountUpTimer.TickListener { onPlaybackTick(id) }
                 resume()
             }
@@ -388,7 +388,7 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
                 State.IDLE -> {
                     val playbackTime = playbackTracker.getPlaybackTime(id)
                     val percentage = playbackTracker.getPercentage(id)
-                    if (playingState == State.IDLE && duration > 0 && (duration - playbackTime) < 1000) {
+                    if (playingState == State.IDLE && duration > 0 && (duration - playbackTime) < 100) {
                         playbackTracker.updatePausedAtPlaybackTime(id, 0, 0f)
                     } else {
                         playbackTracker.updatePausedAtPlaybackTime(id, playbackTime, percentage)

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlaylist.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlaylist.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.voicebroadcast.listening
+
+import im.vector.app.features.voicebroadcast.duration
+import im.vector.app.features.voicebroadcast.sequence
+import org.matrix.android.sdk.api.session.room.model.message.MessageAudioEvent
+
+class VoiceBroadcastPlaylist(
+        private val items: MutableList<PlaylistItem> = mutableListOf(),
+) : List<PlaylistItem> by items {
+
+    var currentSequence = 1
+    val currentItem get() = findBySequence(currentSequence)
+
+    val duration
+        get() = items.lastOrNull()?.let { it.startTime + it.audioEvent.duration } ?: 0
+
+    fun setItems(audioEvents: List<MessageAudioEvent>) {
+        items.clear()
+        val sorted = audioEvents.sortedBy { it.sequence?.toLong() ?: it.root.originServerTs }
+        val chunkPositions = sorted
+                .map { it.duration }
+                .runningFold(0) { acc, i -> acc + i }
+                .dropLast(1)
+        val newItems = sorted.mapIndexed { index, messageAudioEvent ->
+            PlaylistItem(
+                    audioEvent = messageAudioEvent,
+                    startTime = chunkPositions.getOrNull(index) ?: 0
+            )
+        }
+        items.addAll(newItems)
+    }
+
+    fun reset() {
+        currentSequence = 1
+        items.clear()
+    }
+
+    fun findByPosition(positionMillis: Int): PlaylistItem? {
+        return items.lastOrNull { it.startTime <= positionMillis }
+    }
+
+    fun findBySequence(sequenceNumber: Int): PlaylistItem? {
+        return items.find { it.audioEvent.sequence == sequenceNumber }
+    }
+
+    fun getNextItem() = findBySequence(currentSequence.plus(1))
+
+    fun firstOrNull() = findBySequence(1)
+}
+
+data class PlaylistItem(val audioEvent: MessageAudioEvent, val startTime: Int)

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlaylist.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlaylist.kt
@@ -24,8 +24,8 @@ class VoiceBroadcastPlaylist(
         private val items: MutableList<PlaylistItem> = mutableListOf(),
 ) : List<PlaylistItem> by items {
 
-    var currentSequence = 1
-    val currentItem get() = findBySequence(currentSequence)
+    var currentSequence: Int? = null
+    val currentItem get() = currentSequence?.let { findBySequence(it) }
 
     val duration
         get() = items.lastOrNull()?.let { it.startTime + it.audioEvent.duration } ?: 0
@@ -47,7 +47,7 @@ class VoiceBroadcastPlaylist(
     }
 
     fun reset() {
-        currentSequence = 1
+        currentSequence = null
         items.clear()
     }
 
@@ -59,7 +59,7 @@ class VoiceBroadcastPlaylist(
         return items.find { it.audioEvent.sequence == sequenceNumber }
     }
 
-    fun getNextItem() = findBySequence(currentSequence.plus(1))
+    fun getNextItem() = findBySequence(currentSequence?.plus(1) ?: 1)
 
     fun firstOrNull() = findBySequence(1)
 }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/usecase/GetLiveVoiceBroadcastChunksUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/usecase/GetLiveVoiceBroadcastChunksUseCase.kt
@@ -29,9 +29,12 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.lastOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.runningReduce
+import kotlinx.coroutines.runBlocking
 import org.matrix.android.sdk.api.session.events.model.RelationType
 import org.matrix.android.sdk.api.session.room.model.message.MessageAudioEvent
 import org.matrix.android.sdk.api.session.room.model.message.asMessageAudioEvent
@@ -57,7 +60,7 @@ class GetLiveVoiceBroadcastChunksUseCase @Inject constructor(
         val existingChunks = room.timelineService().getTimelineEventsRelatedTo(RelationType.REFERENCE, voiceBroadcast.voiceBroadcastId)
                 .mapNotNull { timelineEvent -> timelineEvent.root.asMessageAudioEvent().takeIf { it.isVoiceBroadcast() } }
 
-        val voiceBroadcastEvent = getVoiceBroadcastEventUseCase.execute(voiceBroadcast)
+        val voiceBroadcastEvent = runBlocking { getVoiceBroadcastEventUseCase.execute(voiceBroadcast).firstOrNull()?.getOrNull() }
         val voiceBroadcastState = voiceBroadcastEvent?.content?.voiceBroadcastState
 
         return if (voiceBroadcastState == null || voiceBroadcastState == VoiceBroadcastState.STOPPED) {

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/usecase/GetLiveVoiceBroadcastChunksUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/usecase/GetLiveVoiceBroadcastChunksUseCase.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.lastOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.runningReduce
 import kotlinx.coroutines.runBlocking

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/usecase/GetLiveVoiceBroadcastChunksUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/usecase/GetLiveVoiceBroadcastChunksUseCase.kt
@@ -19,11 +19,12 @@ package im.vector.app.features.voicebroadcast.listening.usecase
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.features.voicebroadcast.getVoiceBroadcastEventId
 import im.vector.app.features.voicebroadcast.isVoiceBroadcast
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcast
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastEvent
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
 import im.vector.app.features.voicebroadcast.model.asVoiceBroadcastEvent
 import im.vector.app.features.voicebroadcast.sequence
-import im.vector.app.features.voicebroadcast.usecase.GetVoiceBroadcastUseCase
+import im.vector.app.features.voicebroadcast.usecase.GetVoiceBroadcastEventUseCase
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -44,19 +45,19 @@ import javax.inject.Inject
  */
 class GetLiveVoiceBroadcastChunksUseCase @Inject constructor(
         private val activeSessionHolder: ActiveSessionHolder,
-        private val getVoiceBroadcastUseCase: GetVoiceBroadcastUseCase,
+        private val getVoiceBroadcastEventUseCase: GetVoiceBroadcastEventUseCase,
 ) {
 
-    fun execute(roomId: String, voiceBroadcastId: String): Flow<List<MessageAudioEvent>> {
+    fun execute(voiceBroadcast: VoiceBroadcast): Flow<List<MessageAudioEvent>> {
         val session = activeSessionHolder.getSafeActiveSession() ?: return emptyFlow()
-        val room = session.roomService().getRoom(roomId) ?: return emptyFlow()
+        val room = session.roomService().getRoom(voiceBroadcast.roomId) ?: return emptyFlow()
         val timeline = room.timelineService().createTimeline(null, TimelineSettings(5))
 
         // Get initial chunks
-        val existingChunks = room.timelineService().getTimelineEventsRelatedTo(RelationType.REFERENCE, voiceBroadcastId)
+        val existingChunks = room.timelineService().getTimelineEventsRelatedTo(RelationType.REFERENCE, voiceBroadcast.voiceBroadcastId)
                 .mapNotNull { timelineEvent -> timelineEvent.root.asMessageAudioEvent().takeIf { it.isVoiceBroadcast() } }
 
-        val voiceBroadcastEvent = getVoiceBroadcastUseCase.execute(roomId, voiceBroadcastId)
+        val voiceBroadcastEvent = getVoiceBroadcastEventUseCase.execute(voiceBroadcast)
         val voiceBroadcastState = voiceBroadcastEvent?.content?.voiceBroadcastState
 
         return if (voiceBroadcastState == null || voiceBroadcastState == VoiceBroadcastState.STOPPED) {
@@ -82,7 +83,7 @@ class GetLiveVoiceBroadcastChunksUseCase @Inject constructor(
                             lastSequence = stopEvent.content?.lastChunkSequence
                         }
 
-                        val newChunks = newEvents.mapToChunkEvents(voiceBroadcastId, voiceBroadcastEvent.root.senderId)
+                        val newChunks = newEvents.mapToChunkEvents(voiceBroadcast.voiceBroadcastId, voiceBroadcastEvent.root.senderId)
 
                         // Notify about new chunks
                         if (newChunks.isNotEmpty()) {

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/model/VoiceBroadcast.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/model/VoiceBroadcast.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.voicebroadcast.model
+
+data class VoiceBroadcast(
+        val voiceBroadcastId: String,
+        val roomId: String,
+)

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/GetVoiceBroadcastEventUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/GetVoiceBroadcastEventUseCase.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.features.voicebroadcast.usecase
 
+import im.vector.app.features.voicebroadcast.model.VoiceBroadcast
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastEvent
 import im.vector.app.features.voicebroadcast.model.asVoiceBroadcastEvent
 import org.matrix.android.sdk.api.session.Session
@@ -24,17 +25,18 @@ import org.matrix.android.sdk.api.session.getRoom
 import timber.log.Timber
 import javax.inject.Inject
 
-class GetVoiceBroadcastUseCase @Inject constructor(
+class GetVoiceBroadcastEventUseCase @Inject constructor(
         private val session: Session,
 ) {
 
-    fun execute(roomId: String, eventId: String): VoiceBroadcastEvent? {
-        val room = session.getRoom(roomId) ?: error("Unknown roomId: $roomId")
+    fun execute(voiceBroadcast: VoiceBroadcast): VoiceBroadcastEvent? {
+        val room = session.getRoom(voiceBroadcast.roomId) ?: error("Unknown roomId: ${voiceBroadcast.roomId}")
 
-        Timber.d("## GetVoiceBroadcastUseCase: get voice broadcast $eventId")
+        Timber.d("## GetVoiceBroadcastUseCase: get voice broadcast $voiceBroadcast")
 
-        val initialEvent = room.timelineService().getTimelineEvent(eventId)?.root?.asVoiceBroadcastEvent() // Fallback to initial event
-        val relatedEvents = room.timelineService().getTimelineEventsRelatedTo(RelationType.REFERENCE, eventId).sortedBy { it.root.originServerTs }
+        val initialEvent = room.timelineService().getTimelineEvent(voiceBroadcast.voiceBroadcastId)?.root?.asVoiceBroadcastEvent()
+        val relatedEvents = room.timelineService().getTimelineEventsRelatedTo(RelationType.REFERENCE, voiceBroadcast.voiceBroadcastId)
+                .sortedBy { it.root.originServerTs }
         return relatedEvents.mapNotNull { it.root.asVoiceBroadcastEvent() }.lastOrNull() ?: initialEvent
     }
 }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/GetVoiceBroadcastEventUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/usecase/GetVoiceBroadcastEventUseCase.kt
@@ -22,9 +22,7 @@ import im.vector.app.features.voicebroadcast.model.VoiceBroadcastEvent
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
 import im.vector.app.features.voicebroadcast.model.asVoiceBroadcastEvent
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
@@ -56,7 +54,7 @@ class GetVoiceBroadcastEventUseCase @Inject constructor(
 
         return when (latestEvent?.content?.voiceBroadcastState) {
             null, VoiceBroadcastState.STOPPED -> flowOf(latestEvent.toOptional())
-            else     -> {
+            else -> {
                 room.flow()
                         .liveStateEvent(VoiceBroadcastConstants.STATE_ROOM_VOICE_BROADCAST_INFO, QueryStringValue.Equals(latestEvent.root.stateKey.orEmpty()))
                         .unwrap()

--- a/vector/src/main/res/layout/item_timeline_event_voice_broadcast_listening_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_voice_broadcast_listening_stub.xml
@@ -100,7 +100,7 @@
         android:id="@+id/fastBackwardButton"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:background="@android:color/transparent"
+        android:background="@drawable/bg_rounded_button"
         android:contentDescription="@string/a11y_voice_broadcast_fast_backward"
         android:src="@drawable/ic_player_backward_30"
         app:tint="?vctr_content_secondary" />
@@ -127,7 +127,7 @@
         android:id="@+id/fastForwardButton"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:background="@android:color/transparent"
+        android:background="@drawable/bg_rounded_button"
         android:contentDescription="@string/a11y_voice_broadcast_fast_forward"
         android:src="@drawable/ic_player_forward_30"
         app:tint="?vctr_content_secondary" />

--- a/vector/src/main/res/layout/item_timeline_event_voice_broadcast_listening_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_voice_broadcast_listening_stub.xml
@@ -103,7 +103,9 @@
         android:background="@drawable/bg_rounded_button"
         android:contentDescription="@string/a11y_voice_broadcast_fast_backward"
         android:src="@drawable/ic_player_backward_30"
-        app:tint="?vctr_content_secondary" />
+        android:visibility="invisible"
+        app:tint="?vctr_content_secondary"
+        tools:visibility="visible" />
 
     <ImageButton
         android:id="@+id/playPauseButton"
@@ -121,7 +123,9 @@
         android:layout_height="@dimen/voice_broadcast_player_button_size"
         android:contentDescription="@string/a11y_voice_broadcast_buffering"
         android:indeterminate="true"
-        android:indeterminateTint="?vctr_content_secondary" />
+        android:indeterminateTint="?vctr_content_secondary"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <ImageButton
         android:id="@+id/fastForwardButton"
@@ -130,7 +134,9 @@
         android:background="@drawable/bg_rounded_button"
         android:contentDescription="@string/a11y_voice_broadcast_fast_forward"
         android:src="@drawable/ic_player_forward_30"
-        app:tint="?vctr_content_secondary" />
+        android:visibility="invisible"
+        app:tint="?vctr_content_secondary"
+        tools:visibility="visible" />
 
     <SeekBar
         android:id="@+id/seekBar"


### PR DESCRIPTION
## Type of change

- [x] WIP Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Update the live position of the playback when the voice broadcast is in a playing state.
Plus some improvements on the voice broadcast player.

## Motivation and context

Continue #7127 and improve #7494 

## Screenshots / GIFs

|Ended VB | Live VB|
|-|-|
|https://user-images.githubusercontent.com/11990514/200355744-69dea59f-3b0a-48ab-9c41-ca4ced2fbc52.mp4|https://user-images.githubusercontent.com/11990514/200355809-5139985f-b764-48ee-bc7a-9c605f971ef7.mp4 (the duration of the chunks has been set to 5 sec for this demo) |

## Tests

Play an ended / live voice broadcast and observe the seekbar behaviour

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
