### PR TITLE
Fix duplicated pills when pills contain other spans

### DIFF
--- a/changelog.d/7501.bugfix
+++ b/changelog.d/7501.bugfix
@@ -1,0 +1,1 @@
+Fix duplicated mention pills in some cases


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Remove spans conflicting within pill spans

## Motivation and context

- Duplicated pills if the mention contains an image: https://github.com/SchildiChat/SchildiChat-android/issues/148
- Duplicated pills if the mention contains underscores: https://github.com/SchildiChat/SchildiChat-android/issues/156

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|![device-2022-11-01-113714](https://user-images.githubusercontent.com/12481742/199254899-953140a9-8950-4b44-82ba-6982a4ec3e15.png)|![device-2022-11-01-151524](https://user-images.githubusercontent.com/12481742/199254926-58070b88-a7d2-46d8-9ba2-2f6b5586f23b.png)|



## Tests

<!-- Explain how you tested your development -->

- Send or receive events with mention-urls that contain another span, such as:
  - At least two underscores, which markdown will want to put italic (https://github.com/SchildiChat/SchildiChat-android/issues/156)
  - An inline image (https://github.com/SchildiChat/SchildiChat-android/issues/148)
- Observe the number of pills shown for each mention

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [x] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

## Sign-off


Signed-off-by: Tobias Büttner <dev@spiritcroc.de>