### PR TITLE
Fix bad content types when sending unencrypted media event with additional content data

### DIFF
--- a/changelog.d/7519.bugfix
+++ b/changelog.d/7519.bugfix
@@ -1,0 +1,1 @@
+Voice Broadcast - Fix error on voice messages in unencrypted rooms

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/UploadContentWorker.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/UploadContentWorker.kt
@@ -408,7 +408,7 @@ internal class UploadContentWorker(val context: Context, params: WorkerParameter
             newAttachmentAttributes: NewAttachmentAttributes
     ) {
         localEchoRepository.updateEcho(eventId) { _, event ->
-            val content: Content? = event.asDomain().content
+            val content: Content? = event.asDomain(castJsonNumbers = true).content
             val messageContent: MessageContent? = content.toModel()
             // Retrieve potential additional content from the original event
             val additionalContent = content.orEmpty() - messageContent?.toContent().orEmpty().keys


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fix incorrect type of event content entries when sending unencrypted events related to media files

## Motivation and context

After uploading a media file (eg. voice message), the local event related to the media is updated with some metadata (eg. size). The event entity was retrieved from the database and mapped to the Event model without casting the json numbers to their original type.

Here is the issue, after retrieving some additional data, the entity was updated with the new metadata plus the additional data, with the wrong number types, causing an error when sending the event to the server.

This PR forces the cast of the json number before updating the event in the database.

Note: the issue is only visible on voice broadcast because additional data are added to the voice message events triggering a specific code to retrieve the additional data after uploading the voice message file.

## Screenshots / GIFs

Before:
`Event(type=m.room.message, eventId=$xxx, content={msgtype=m.audio, body=Voice Broadcast Part (2).mp4, info={mimetype=video/mp4, size=11275.0, duration=3413.0}, url=xxx, m.relates_to={rel_type=m.reference, event_id=$xxx}, org.matrix.msc1767.audio={duration=3413.0}, org.matrix.msc3245.voice={}, io.element.voice_broadcast_chunk={sequence=2.0}}, prevContent=null, originServerTs=1667415437377, senderId=@xxx:matrix.org, stateKey=null, roomId=!xxx:matrix.org, unsignedData=UnsignedData(age=null, redactedEvent=null, transactionId=$xxx, prevContent=null, relations=null, replacesState=null), redacts=null)`
After:
`Event(type=m.room.message, eventId=$xxx, content={msgtype=m.audio, body=Voice Broadcast Part (2).mp4, info={mimetype=video/mp4, size=11275, duration=3413}, url=xxx, m.relates_to={rel_type=m.reference, event_id=$xxx}, org.matrix.msc1767.audio={duration=3413}, org.matrix.msc3245.voice={}, io.element.voice_broadcast_chunk={sequence=2}}, prevContent=null, originServerTs=1667415437377, senderId=@xxx:matrix.org, stateKey=null, roomId=!xxx:matrix.org, unsignedData=UnsignedData(age=null, redactedEvent=null, transactionId=$xxx, prevContent=null, relations=null, replacesState=null), redacts=null)`

## Tests

- Start a voice broadcast in an unencrypted room
- Pause or stop the voice broadcast to send a voice message (or wait at least 120s)
- Verify that there is no "failed to send" error

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
