### PR TITLE
Push notifications toggle: align implementation for current session (PSG-971)

### DIFF
--- a/changelog.d/7512.feature
+++ b/changelog.d/7512.feature
@@ -1,0 +1,1 @@
+Push notifications toggle: align implementation for current session

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -1679,7 +1679,8 @@
     <string name="create_new_room">Create New Room</string>
     <string name="create_new_space">Create New Space</string>
     <string name="error_no_network">No network. Please check your Internet connection.</string>
-    <string name="error_check_network">Something went wrong. Please check your network connection and try again.</string>
+    <!-- TODO delete -->
+    <string name="error_check_network" tools:ignore="UnusedResources">Something went wrong. Please check your network connection and try again.</string>
     <string name="change_room_directory_network">"Change network"</string>
     <string name="please_wait">"Please wait…"</string>
     <string name="updating_your_data">Updating your data…</string>

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/homeserver/HomeServerCapabilitiesService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/homeserver/HomeServerCapabilitiesService.kt
@@ -16,6 +16,9 @@
 
 package org.matrix.android.sdk.api.session.homeserver
 
+import androidx.lifecycle.LiveData
+import org.matrix.android.sdk.api.util.Optional
+
 /**
  * This interface defines a method to retrieve the homeserver capabilities.
  */
@@ -30,4 +33,9 @@ interface HomeServerCapabilitiesService {
      * Get the HomeServer capabilities.
      */
     fun getHomeServerCapabilities(): HomeServerCapabilities
+
+    /**
+     * Get a LiveData on the HomeServer capabilities.
+     */
+    fun getHomeServerCapabilitiesLive(): LiveData<Optional<HomeServerCapabilities>>
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/DefaultHomeServerCapabilitiesService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/DefaultHomeServerCapabilitiesService.kt
@@ -16,8 +16,10 @@
 
 package org.matrix.android.sdk.internal.session.homeserver
 
+import androidx.lifecycle.LiveData
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilities
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilitiesService
+import org.matrix.android.sdk.api.util.Optional
 import javax.inject.Inject
 
 internal class DefaultHomeServerCapabilitiesService @Inject constructor(
@@ -32,5 +34,9 @@ internal class DefaultHomeServerCapabilitiesService @Inject constructor(
     override fun getHomeServerCapabilities(): HomeServerCapabilities {
         return homeServerCapabilitiesDataSource.getHomeServerCapabilities()
                 ?: HomeServerCapabilities()
+    }
+
+    override fun getHomeServerCapabilitiesLive(): LiveData<Optional<HomeServerCapabilities>> {
+        return homeServerCapabilitiesDataSource.getHomeServerCapabilitiesLive()
     }
 }

--- a/vector/src/main/java/im/vector/app/core/di/ActiveSessionHolder.kt
+++ b/vector/src/main/java/im/vector/app/core/di/ActiveSessionHolder.kt
@@ -19,6 +19,7 @@ package im.vector.app.core.di
 import android.content.Context
 import im.vector.app.ActiveSessionDataSource
 import im.vector.app.core.extensions.startSyncing
+import im.vector.app.core.notification.EnableNotificationsSettingUpdater
 import im.vector.app.core.pushers.UnifiedPushHelper
 import im.vector.app.core.services.GuardServiceStarter
 import im.vector.app.core.session.ConfigureAndStartSessionUseCase

--- a/vector/src/main/java/im/vector/app/core/di/ActiveSessionHolder.kt
+++ b/vector/src/main/java/im/vector/app/core/di/ActiveSessionHolder.kt
@@ -19,7 +19,6 @@ package im.vector.app.core.di
 import android.content.Context
 import im.vector.app.ActiveSessionDataSource
 import im.vector.app.core.extensions.startSyncing
-import im.vector.app.core.notification.EnableNotificationsSettingUpdater
 import im.vector.app.core.pushers.UnifiedPushHelper
 import im.vector.app.core.services.GuardServiceStarter
 import im.vector.app.core.session.ConfigureAndStartSessionUseCase

--- a/vector/src/main/java/im/vector/app/core/notification/UpdateEnableNotificationsSettingOnChangeUseCase.kt
+++ b/vector/src/main/java/im/vector/app/core/notification/UpdateEnableNotificationsSettingOnChangeUseCase.kt
@@ -22,7 +22,6 @@ import im.vector.app.features.settings.devices.v2.notification.NotificationsStat
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import org.matrix.android.sdk.api.session.Session
-import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -42,7 +41,6 @@ class UpdateEnableNotificationsSettingOnChangeUseCase @Inject constructor(
     }
 
     private fun updatePreference(notificationStatus: NotificationsStatus) {
-        Timber.d("updatePreference with status=$notificationStatus")
         when (notificationStatus) {
             NotificationsStatus.ENABLED -> vectorPreferences.setNotificationEnabledForDevice(true)
             NotificationsStatus.DISABLED -> vectorPreferences.setNotificationEnabledForDevice(false)

--- a/vector/src/main/java/im/vector/app/core/notification/UpdateEnableNotificationsSettingOnChangeUseCase.kt
+++ b/vector/src/main/java/im/vector/app/core/notification/UpdateEnableNotificationsSettingOnChangeUseCase.kt
@@ -19,8 +19,7 @@ package im.vector.app.core.notification
 import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.settings.devices.v2.notification.GetNotificationsStatusUseCase
 import im.vector.app.features.settings.devices.v2.notification.NotificationsStatus
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import org.matrix.android.sdk.api.session.Session
 import timber.log.Timber
@@ -35,11 +34,11 @@ class UpdateEnableNotificationsSettingOnChangeUseCase @Inject constructor(
         private val getNotificationsStatusUseCase: GetNotificationsStatusUseCase,
 ) {
 
-    // TODO add unit tests
-    fun execute(session: Session): Flow<NotificationsStatus> {
-        val deviceId = session.sessionParams.deviceId ?: return emptyFlow()
-        return getNotificationsStatusUseCase.execute(session, deviceId)
+    suspend fun execute(session: Session) {
+        val deviceId = session.sessionParams.deviceId ?: return
+        getNotificationsStatusUseCase.execute(session, deviceId)
                 .onEach(::updatePreference)
+                .collect()
     }
 
     private fun updatePreference(notificationStatus: NotificationsStatus) {

--- a/vector/src/main/java/im/vector/app/core/notification/UpdateEnableNotificationsSettingOnChangeUseCase.kt
+++ b/vector/src/main/java/im/vector/app/core/notification/UpdateEnableNotificationsSettingOnChangeUseCase.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.notification
+
+import im.vector.app.features.settings.VectorPreferences
+import im.vector.app.features.settings.devices.v2.notification.GetNotificationsStatusUseCase
+import im.vector.app.features.settings.devices.v2.notification.NotificationsStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.onEach
+import org.matrix.android.sdk.api.session.Session
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * Listen for changes in either Pusher or Account data to update the local enable notifications
+ * setting for the current device.
+ */
+class UpdateEnableNotificationsSettingOnChangeUseCase @Inject constructor(
+        private val vectorPreferences: VectorPreferences,
+        private val getNotificationsStatusUseCase: GetNotificationsStatusUseCase,
+) {
+
+    // TODO add unit tests
+    fun execute(session: Session): Flow<NotificationsStatus> {
+        val deviceId = session.sessionParams.deviceId ?: return emptyFlow()
+        return getNotificationsStatusUseCase.execute(session, deviceId)
+                .onEach(::updatePreference)
+    }
+
+    private fun updatePreference(notificationStatus: NotificationsStatus) {
+        Timber.d("updatePreference with status=$notificationStatus")
+        when (notificationStatus) {
+            NotificationsStatus.ENABLED -> vectorPreferences.setNotificationEnabledForDevice(true)
+            NotificationsStatus.DISABLED -> vectorPreferences.setNotificationEnabledForDevice(false)
+            else -> Unit
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/core/pushers/PushersManager.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/PushersManager.kt
@@ -97,12 +97,6 @@ class PushersManager @Inject constructor(
         return session.pushersService().getPushers().firstOrNull { it.deviceId == deviceId }
     }
 
-    suspend fun togglePusherForCurrentSession(enable: Boolean) {
-        val session = activeSessionHolder.getSafeActiveSession() ?: return
-        val pusher = getPusherForCurrentSession() ?: return
-        session.pushersService().togglePusher(pusher, enable)
-    }
-
     suspend fun unregisterEmailPusher(email: String) {
         val currentSession = activeSessionHolder.getSafeActiveSession() ?: return
         currentSession.pushersService().removeEmailPusher(email)

--- a/vector/src/main/java/im/vector/app/core/session/ConfigureAndStartSessionUseCase.kt
+++ b/vector/src/main/java/im/vector/app/core/session/ConfigureAndStartSessionUseCase.kt
@@ -19,6 +19,7 @@ package im.vector.app.core.session
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import im.vector.app.core.extensions.startSyncing
+import im.vector.app.core.notification.EnableNotificationsSettingUpdater
 import im.vector.app.core.session.clientinfo.UpdateMatrixClientInfoUseCase
 import im.vector.app.features.call.webrtc.WebRtcCallManager
 import im.vector.app.features.settings.VectorPreferences
@@ -32,8 +33,10 @@ class ConfigureAndStartSessionUseCase @Inject constructor(
         private val webRtcCallManager: WebRtcCallManager,
         private val updateMatrixClientInfoUseCase: UpdateMatrixClientInfoUseCase,
         private val vectorPreferences: VectorPreferences,
+        private val enableNotificationsSettingUpdater: EnableNotificationsSettingUpdater,
 ) {
 
+    // TODO update unit tests
     suspend fun execute(session: Session, startSyncing: Boolean = true) {
         Timber.i("Configure and start session for ${session.myUserId}. startSyncing: $startSyncing")
         session.open()
@@ -46,5 +49,6 @@ class ConfigureAndStartSessionUseCase @Inject constructor(
         if (vectorPreferences.isClientInfoRecordingEnabled()) {
             updateMatrixClientInfoUseCase.execute(session)
         }
+        enableNotificationsSettingUpdater.onSessionsStarted(session)
     }
 }

--- a/vector/src/main/java/im/vector/app/core/session/ConfigureAndStartSessionUseCase.kt
+++ b/vector/src/main/java/im/vector/app/core/session/ConfigureAndStartSessionUseCase.kt
@@ -36,7 +36,6 @@ class ConfigureAndStartSessionUseCase @Inject constructor(
         private val enableNotificationsSettingUpdater: EnableNotificationsSettingUpdater,
 ) {
 
-    // TODO update unit tests
     suspend fun execute(session: Session, startSyncing: Boolean = true) {
         Timber.i("Configure and start session for ${session.myUserId}. startSyncing: $startSyncing")
         session.open()

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CanTogglePushNotificationsViaPusherUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CanTogglePushNotificationsViaPusherUseCase.kt
@@ -25,7 +25,6 @@ import javax.inject.Inject
 
 class CanTogglePushNotificationsViaPusherUseCase @Inject constructor() {
 
-    // TODO add unit tests
     fun execute(session: Session): Flow<Boolean> {
         return session
                 .homeServerCapabilitiesService()

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CanTogglePushNotificationsViaPusherUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CanTogglePushNotificationsViaPusherUseCase.kt
@@ -25,6 +25,7 @@ import javax.inject.Inject
 
 class CanTogglePushNotificationsViaPusherUseCase @Inject constructor() {
 
+    // TODO add unit tests
     fun execute(session: Session): Flow<Boolean> {
         return session
                 .homeServerCapabilitiesService()

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CanTogglePushNotificationsViaPusherUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CanTogglePushNotificationsViaPusherUseCase.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.settings.devices.v2.notification
 
 import androidx.lifecycle.asFlow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.flow.unwrap
@@ -32,5 +33,6 @@ class CanTogglePushNotificationsViaPusherUseCase @Inject constructor() {
                 .asFlow()
                 .unwrap()
                 .map { it.canRemotelyTogglePushNotificationsOfDevices }
+                .distinctUntilChanged()
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CanTogglePushNotificationsViaPusherUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CanTogglePushNotificationsViaPusherUseCase.kt
@@ -16,15 +16,21 @@
 
 package im.vector.app.features.settings.devices.v2.notification
 
+import androidx.lifecycle.asFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import org.matrix.android.sdk.api.session.Session
-import org.matrix.android.sdk.api.session.accountdata.UserAccountDataTypes
+import org.matrix.android.sdk.flow.unwrap
 import javax.inject.Inject
 
-class CheckIfCanTogglePushNotificationsViaAccountDataUseCase @Inject constructor() {
+class CanTogglePushNotificationsViaPusherUseCase @Inject constructor() {
 
-    fun execute(session: Session, deviceId: String): Boolean {
+    fun execute(session: Session): Flow<Boolean> {
         return session
-                .accountDataService()
-                .getUserAccountDataEvent(UserAccountDataTypes.TYPE_LOCAL_NOTIFICATION_SETTINGS + deviceId) != null
+                .homeServerCapabilitiesService()
+                .getHomeServerCapabilitiesLive()
+                .asFlow()
+                .unwrap()
+                .map { it.canRemotelyTogglePushNotificationsOfDevices }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaAccountDataUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaAccountDataUseCase.kt
@@ -22,6 +22,7 @@ import javax.inject.Inject
 
 class CheckIfCanTogglePushNotificationsViaAccountDataUseCase @Inject constructor() {
 
+    // TODO update unit tests
     fun execute(session: Session, deviceId: String): Boolean {
         return session
                 .accountDataService()

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaPusherUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaPusherUseCase.kt
@@ -21,6 +21,7 @@ import javax.inject.Inject
 
 class CheckIfCanTogglePushNotificationsViaPusherUseCase @Inject constructor() {
 
+    // TODO update unit tests
     fun execute(session: Session): Boolean {
         return session
                 .homeServerCapabilitiesService()

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaPusherUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaPusherUseCase.kt
@@ -21,7 +21,6 @@ import javax.inject.Inject
 
 class CheckIfCanTogglePushNotificationsViaPusherUseCase @Inject constructor() {
 
-    // TODO update unit tests
     fun execute(session: Session): Boolean {
         return session
                 .homeServerCapabilitiesService()

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaPusherUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaPusherUseCase.kt
@@ -16,20 +16,15 @@
 
 package im.vector.app.features.settings.devices.v2.notification
 
-import im.vector.app.core.di.ActiveSessionHolder
-import org.matrix.android.sdk.api.extensions.orFalse
+import org.matrix.android.sdk.api.session.Session
 import javax.inject.Inject
 
-class CheckIfCanTogglePushNotificationsViaPusherUseCase @Inject constructor(
-        private val activeSessionHolder: ActiveSessionHolder,
-) {
+class CheckIfCanTogglePushNotificationsViaPusherUseCase @Inject constructor() {
 
-    fun execute(): Boolean {
-        return activeSessionHolder
-                .getSafeActiveSession()
-                ?.homeServerCapabilitiesService()
-                ?.getHomeServerCapabilities()
-                ?.canRemotelyTogglePushNotificationsOfDevices
-                .orFalse()
+    fun execute(session: Session): Boolean {
+        return session
+                .homeServerCapabilitiesService()
+                .getHomeServerCapabilities()
+                .canRemotelyTogglePushNotificationsOfDevices
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCase.kt
@@ -34,7 +34,6 @@ class GetNotificationsStatusUseCase @Inject constructor(
         private val checkIfCanTogglePushNotificationsViaAccountDataUseCase: CheckIfCanTogglePushNotificationsViaAccountDataUseCase,
 ) {
 
-    // TODO update unit tests
     fun execute(session: Session, deviceId: String): Flow<NotificationsStatus> {
         return when {
             checkIfCanTogglePushNotificationsViaAccountDataUseCase.execute(session, deviceId) -> {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/GetNotificationsStatusUseCase.kt
@@ -34,6 +34,7 @@ class GetNotificationsStatusUseCase @Inject constructor(
         private val checkIfCanTogglePushNotificationsViaAccountDataUseCase: CheckIfCanTogglePushNotificationsViaAccountDataUseCase,
 ) {
 
+    // TODO update unit tests
     fun execute(session: Session, deviceId: String): Flow<NotificationsStatus> {
         return when {
             checkIfCanTogglePushNotificationsViaAccountDataUseCase.execute(session, deviceId) -> {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/TogglePushNotificationUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/TogglePushNotificationUseCase.kt
@@ -28,7 +28,6 @@ class TogglePushNotificationUseCase @Inject constructor(
         private val checkIfCanTogglePushNotificationsViaAccountDataUseCase: CheckIfCanTogglePushNotificationsViaAccountDataUseCase,
 ) {
 
-    // TODO update unit tests
     suspend fun execute(deviceId: String, enabled: Boolean) {
         val session = activeSessionHolder.getSafeActiveSession() ?: return
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/TogglePushNotificationUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/TogglePushNotificationUseCase.kt
@@ -31,14 +31,14 @@ class TogglePushNotificationUseCase @Inject constructor(
     suspend fun execute(deviceId: String, enabled: Boolean) {
         val session = activeSessionHolder.getSafeActiveSession() ?: return
 
-        if (checkIfCanTogglePushNotificationsViaPusherUseCase.execute()) {
+        if (checkIfCanTogglePushNotificationsViaPusherUseCase.execute(session)) {
             val devicePusher = session.pushersService().getPushers().firstOrNull { it.deviceId == deviceId }
             devicePusher?.let { pusher ->
                 session.pushersService().togglePusher(pusher, enabled)
             }
         }
 
-        if (checkIfCanTogglePushNotificationsViaAccountDataUseCase.execute(deviceId)) {
+        if (checkIfCanTogglePushNotificationsViaAccountDataUseCase.execute(session, deviceId)) {
             val newNotificationSettingsContent = LocalNotificationSettingsContent(isSilenced = !enabled)
             session.accountDataService().updateUserAccountData(
                     UserAccountDataTypes.TYPE_LOCAL_NOTIFICATION_SETTINGS + deviceId,

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/TogglePushNotificationUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/notification/TogglePushNotificationUseCase.kt
@@ -28,6 +28,7 @@ class TogglePushNotificationUseCase @Inject constructor(
         private val checkIfCanTogglePushNotificationsViaAccountDataUseCase: CheckIfCanTogglePushNotificationsViaAccountDataUseCase,
 ) {
 
+    // TODO update unit tests
     suspend fun execute(deviceId: String, enabled: Boolean) {
         val session = activeSessionHolder.getSafeActiveSession() ?: return
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
@@ -96,9 +96,11 @@ class SessionOverviewViewModel @AssistedInject constructor(
     }
 
     private fun observeNotificationsStatus(deviceId: String) {
-        getNotificationsStatusUseCase.execute(deviceId)
-                .onEach { setState { copy(notificationsStatus = it) } }
-                .launchIn(viewModelScope)
+        activeSessionHolder.getSafeActiveSession()?.let { session ->
+            getNotificationsStatusUseCase.execute(session, deviceId)
+                    .onEach { setState { copy(notificationsStatus = it) } }
+                    .launchIn(viewModelScope)
+        }
     }
 
     override fun handle(action: SessionOverviewAction) {

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/DisableNotificationsForCurrentSessionUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/DisableNotificationsForCurrentSessionUseCase.kt
@@ -31,7 +31,6 @@ class DisableNotificationsForCurrentSessionUseCase @Inject constructor(
         private val togglePushNotificationUseCase: TogglePushNotificationUseCase,
 ) {
 
-    // TODO add unit tests
     suspend fun execute() {
         val session = activeSessionHolder.getSafeActiveSession() ?: return
         val deviceId = session.sessionParams.deviceId ?: return

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/DisableNotificationsForCurrentSessionUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/DisableNotificationsForCurrentSessionUseCase.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.notifications
+
+import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.core.pushers.PushersManager
+import im.vector.app.core.pushers.UnifiedPushHelper
+import im.vector.app.features.settings.devices.v2.notification.CheckIfCanTogglePushNotificationsViaPusherUseCase
+import im.vector.app.features.settings.devices.v2.notification.TogglePushNotificationUseCase
+import javax.inject.Inject
+
+class DisableNotificationsForCurrentSessionUseCase @Inject constructor(
+        private val activeSessionHolder: ActiveSessionHolder,
+        private val unifiedPushHelper: UnifiedPushHelper,
+        private val pushersManager: PushersManager,
+        private val checkIfCanTogglePushNotificationsViaPusherUseCase: CheckIfCanTogglePushNotificationsViaPusherUseCase,
+        private val togglePushNotificationUseCase: TogglePushNotificationUseCase,
+) {
+
+    // TODO add unit tests
+    suspend fun execute() {
+        val session = activeSessionHolder.getSafeActiveSession() ?: return
+        val deviceId = session.sessionParams.deviceId ?: return
+        if (checkIfCanTogglePushNotificationsViaPusherUseCase.execute()) {
+            togglePushNotificationUseCase.execute(deviceId, enabled = false)
+        } else {
+            unifiedPushHelper.unregister(pushersManager)
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/DisableNotificationsForCurrentSessionUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/DisableNotificationsForCurrentSessionUseCase.kt
@@ -35,7 +35,7 @@ class DisableNotificationsForCurrentSessionUseCase @Inject constructor(
     suspend fun execute() {
         val session = activeSessionHolder.getSafeActiveSession() ?: return
         val deviceId = session.sessionParams.deviceId ?: return
-        if (checkIfCanTogglePushNotificationsViaPusherUseCase.execute()) {
+        if (checkIfCanTogglePushNotificationsViaPusherUseCase.execute(session)) {
             togglePushNotificationUseCase.execute(deviceId, enabled = false)
         } else {
             unifiedPushHelper.unregister(pushersManager)

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/EnableNotificationsForCurrentSessionUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/EnableNotificationsForCurrentSessionUseCase.kt
@@ -37,7 +37,6 @@ class EnableNotificationsForCurrentSessionUseCase @Inject constructor(
         private val togglePushNotificationUseCase: TogglePushNotificationUseCase,
 ) {
 
-    // TODO add unit tests
     suspend fun execute(fragmentActivity: FragmentActivity) {
         val pusherForCurrentSession = pushersManager.getPusherForCurrentSession()
         if (pusherForCurrentSession == null) {

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/EnableNotificationsForCurrentSessionUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/EnableNotificationsForCurrentSessionUseCase.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.notifications
+
+import androidx.fragment.app.FragmentActivity
+import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.core.pushers.FcmHelper
+import im.vector.app.core.pushers.PushersManager
+import im.vector.app.core.pushers.UnifiedPushHelper
+import im.vector.app.features.settings.devices.v2.notification.CheckIfCanTogglePushNotificationsViaPusherUseCase
+import im.vector.app.features.settings.devices.v2.notification.TogglePushNotificationUseCase
+import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+class EnableNotificationsForCurrentSessionUseCase @Inject constructor(
+        private val activeSessionHolder: ActiveSessionHolder,
+        private val unifiedPushHelper: UnifiedPushHelper,
+        private val pushersManager: PushersManager,
+        private val fcmHelper: FcmHelper,
+        private val checkIfCanTogglePushNotificationsViaPusherUseCase: CheckIfCanTogglePushNotificationsViaPusherUseCase,
+        private val togglePushNotificationUseCase: TogglePushNotificationUseCase,
+) {
+
+    // TODO add unit tests
+    suspend fun execute(fragmentActivity: FragmentActivity) {
+        val pusherForCurrentSession = pushersManager.getPusherForCurrentSession()
+        if (pusherForCurrentSession == null) {
+            registerPusher(fragmentActivity)
+        }
+
+        if (checkIfCanTogglePushNotificationsViaPusherUseCase.execute()) {
+            val session = activeSessionHolder.getSafeActiveSession() ?: return
+            val deviceId = session.sessionParams.deviceId ?: return
+            togglePushNotificationUseCase.execute(deviceId, enabled = true)
+        }
+    }
+
+    private suspend fun registerPusher(fragmentActivity: FragmentActivity) {
+        suspendCoroutine { continuation ->
+            try {
+                unifiedPushHelper.register(fragmentActivity) {
+                    if (unifiedPushHelper.isEmbeddedDistributor()) {
+                        fcmHelper.ensureFcmTokenIsRetrieved(
+                                fragmentActivity,
+                                pushersManager,
+                                registerPusher = true
+                        )
+                    }
+                    continuation.resume(Unit)
+                }
+            } catch (error: Exception) {
+                continuation.resumeWithException(error)
+            }
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/EnableNotificationsForCurrentSessionUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/EnableNotificationsForCurrentSessionUseCase.kt
@@ -44,8 +44,8 @@ class EnableNotificationsForCurrentSessionUseCase @Inject constructor(
             registerPusher(fragmentActivity)
         }
 
-        if (checkIfCanTogglePushNotificationsViaPusherUseCase.execute()) {
-            val session = activeSessionHolder.getSafeActiveSession() ?: return
+        val session = activeSessionHolder.getSafeActiveSession() ?: return
+        if (checkIfCanTogglePushNotificationsViaPusherUseCase.execute(session)) {
             val deviceId = session.sessionParams.deviceId ?: return
             togglePushNotificationUseCase.execute(deviceId, enabled = true)
         }

--- a/vector/src/test/java/im/vector/app/core/notification/UpdateEnableNotificationsSettingOnChangeUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/core/notification/UpdateEnableNotificationsSettingOnChangeUseCaseTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.notification
+
+import im.vector.app.features.settings.devices.v2.notification.NotificationsStatus
+import im.vector.app.test.fakes.FakeGetNotificationsStatusUseCase
+import im.vector.app.test.fakes.FakeSession
+import im.vector.app.test.fakes.FakeVectorPreferences
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+private const val A_SESSION_ID = "session-id"
+
+class UpdateEnableNotificationsSettingOnChangeUseCaseTest {
+
+    private val fakeSession = FakeSession().also { it.givenSessionId(A_SESSION_ID) }
+    private val fakeVectorPreferences = FakeVectorPreferences()
+    private val fakeGetNotificationsStatusUseCase = FakeGetNotificationsStatusUseCase()
+
+    private val updateEnableNotificationsSettingOnChangeUseCase = UpdateEnableNotificationsSettingOnChangeUseCase(
+            vectorPreferences = fakeVectorPreferences.instance,
+            getNotificationsStatusUseCase = fakeGetNotificationsStatusUseCase.instance,
+    )
+
+    @Test
+    fun `given notifications are enabled when execute then setting is updated to true`() = runTest {
+        // Given
+        fakeGetNotificationsStatusUseCase.givenExecuteReturns(
+                fakeSession,
+                A_SESSION_ID,
+                NotificationsStatus.ENABLED,
+        )
+        fakeVectorPreferences.givenSetNotificationEnabledForDevice()
+
+        // When
+        updateEnableNotificationsSettingOnChangeUseCase.execute(fakeSession)
+
+        // Then
+        fakeVectorPreferences.verifySetNotificationEnabledForDevice(true)
+    }
+
+    @Test
+    fun `given notifications are disabled when execute then setting is updated to false`() = runTest {
+        // Given
+        fakeGetNotificationsStatusUseCase.givenExecuteReturns(
+                fakeSession,
+                A_SESSION_ID,
+                NotificationsStatus.DISABLED,
+        )
+        fakeVectorPreferences.givenSetNotificationEnabledForDevice()
+
+        // When
+        updateEnableNotificationsSettingOnChangeUseCase.execute(fakeSession)
+
+        // Then
+        fakeVectorPreferences.verifySetNotificationEnabledForDevice(false)
+    }
+
+    @Test
+    fun `given notifications toggle is not supported when execute then nothing is done`() = runTest {
+        // Given
+        fakeGetNotificationsStatusUseCase.givenExecuteReturns(
+                fakeSession,
+                A_SESSION_ID,
+                NotificationsStatus.NOT_SUPPORTED,
+        )
+        fakeVectorPreferences.givenSetNotificationEnabledForDevice()
+
+        // When
+        updateEnableNotificationsSettingOnChangeUseCase.execute(fakeSession)
+
+        // Then
+        fakeVectorPreferences.verifySetNotificationEnabledForDevice(true, inverse = true)
+        fakeVectorPreferences.verifySetNotificationEnabledForDevice(false, inverse = true)
+    }
+}

--- a/vector/src/test/java/im/vector/app/core/pushers/PushersManagerTest.kt
+++ b/vector/src/test/java/im/vector/app/core/pushers/PushersManagerTest.kt
@@ -29,7 +29,6 @@ import im.vector.app.test.fixtures.CryptoDeviceInfoFixture.aCryptoDeviceInfo
 import im.vector.app.test.fixtures.PusherFixture
 import im.vector.app.test.fixtures.SessionParamsFixture
 import io.mockk.mockk
-import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.matrix.android.sdk.api.session.crypto.model.UnsignedDeviceInfo
@@ -100,20 +99,5 @@ class PushersManagerTest {
         val pusher = pushersManager.getPusherForCurrentSession()
 
         pusher shouldBeEqualTo expectedPusher
-    }
-
-    @Test
-    fun `when togglePusherForCurrentSession, then do service toggle pusher`() = runTest {
-        val deviceId = "device_id"
-        val sessionParams = SessionParamsFixture.aSessionParams(
-                credentials = CredentialsFixture.aCredentials(deviceId = deviceId)
-        )
-        session.givenSessionParams(sessionParams)
-        val pusher = PusherFixture.aPusher(deviceId = deviceId)
-        pushersService.givenGetPushers(listOf(pusher))
-
-        pushersManager.togglePusherForCurrentSession(true)
-
-        pushersService.verifyTogglePusherCalled(pusher, true)
     }
 }

--- a/vector/src/test/java/im/vector/app/core/session/ConfigureAndStartSessionUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/core/session/ConfigureAndStartSessionUseCaseTest.kt
@@ -19,6 +19,7 @@ package im.vector.app.core.session
 import im.vector.app.core.extensions.startSyncing
 import im.vector.app.core.session.clientinfo.UpdateMatrixClientInfoUseCase
 import im.vector.app.test.fakes.FakeContext
+import im.vector.app.test.fakes.FakeEnableNotificationsSettingUpdater
 import im.vector.app.test.fakes.FakeSession
 import im.vector.app.test.fakes.FakeVectorPreferences
 import im.vector.app.test.fakes.FakeWebRtcCallManager
@@ -43,12 +44,14 @@ class ConfigureAndStartSessionUseCaseTest {
     private val fakeWebRtcCallManager = FakeWebRtcCallManager()
     private val fakeUpdateMatrixClientInfoUseCase = mockk<UpdateMatrixClientInfoUseCase>()
     private val fakeVectorPreferences = FakeVectorPreferences()
+    private val fakeEnableNotificationsSettingUpdater = FakeEnableNotificationsSettingUpdater()
 
     private val configureAndStartSessionUseCase = ConfigureAndStartSessionUseCase(
             context = fakeContext.instance,
             webRtcCallManager = fakeWebRtcCallManager.instance,
             updateMatrixClientInfoUseCase = fakeUpdateMatrixClientInfoUseCase,
             vectorPreferences = fakeVectorPreferences.instance,
+            enableNotificationsSettingUpdater = fakeEnableNotificationsSettingUpdater.instance,
     )
 
     @Before
@@ -68,6 +71,7 @@ class ConfigureAndStartSessionUseCaseTest {
         fakeWebRtcCallManager.givenCheckForProtocolsSupportIfNeededSucceeds()
         coJustRun { fakeUpdateMatrixClientInfoUseCase.execute(any()) }
         fakeVectorPreferences.givenIsClientInfoRecordingEnabled(isEnabled = true)
+        fakeEnableNotificationsSettingUpdater.givenOnSessionsStarted(fakeSession)
 
         // When
         configureAndStartSessionUseCase.execute(fakeSession, startSyncing = true)
@@ -87,6 +91,7 @@ class ConfigureAndStartSessionUseCaseTest {
         fakeWebRtcCallManager.givenCheckForProtocolsSupportIfNeededSucceeds()
         coJustRun { fakeUpdateMatrixClientInfoUseCase.execute(any()) }
         fakeVectorPreferences.givenIsClientInfoRecordingEnabled(isEnabled = false)
+        fakeEnableNotificationsSettingUpdater.givenOnSessionsStarted(fakeSession)
 
         // When
         configureAndStartSessionUseCase.execute(fakeSession, startSyncing = true)
@@ -106,6 +111,7 @@ class ConfigureAndStartSessionUseCaseTest {
         fakeWebRtcCallManager.givenCheckForProtocolsSupportIfNeededSucceeds()
         coJustRun { fakeUpdateMatrixClientInfoUseCase.execute(any()) }
         fakeVectorPreferences.givenIsClientInfoRecordingEnabled(isEnabled = true)
+        fakeEnableNotificationsSettingUpdater.givenOnSessionsStarted(fakeSession)
 
         // When
         configureAndStartSessionUseCase.execute(fakeSession, startSyncing = false)

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/CanTogglePushNotificationsViaPusherUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/CanTogglePushNotificationsViaPusherUseCaseTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.devices.v2.notification
+
+import im.vector.app.test.fakes.FakeFlowLiveDataConversions
+import im.vector.app.test.fakes.FakeSession
+import im.vector.app.test.fakes.givenAsFlow
+import im.vector.app.test.fixtures.aHomeServerCapabilities
+import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+private val A_HOMESERVER_CAPABILITIES = aHomeServerCapabilities(canRemotelyTogglePushNotificationsOfDevices = true)
+
+class CanTogglePushNotificationsViaPusherUseCaseTest {
+
+    private val fakeSession = FakeSession()
+    private val fakeFlowLiveDataConversions = FakeFlowLiveDataConversions()
+
+    private val canTogglePushNotificationsViaPusherUseCase =
+            CanTogglePushNotificationsViaPusherUseCase()
+
+    @Before
+    fun setUp() {
+        fakeFlowLiveDataConversions.setup()
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `given current session when execute then flow of the toggle capability is returned`() = runTest {
+        // Given
+        fakeSession
+                .fakeHomeServerCapabilitiesService
+                .givenCapabilitiesLiveReturns(A_HOMESERVER_CAPABILITIES)
+                .givenAsFlow()
+
+        // When
+        val result = canTogglePushNotificationsViaPusherUseCase.execute(fakeSession).firstOrNull()
+
+        // Then
+        result shouldBeEqualTo A_HOMESERVER_CAPABILITIES.canRemotelyTogglePushNotificationsOfDevices
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaAccountDataUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaAccountDataUseCaseTest.kt
@@ -16,7 +16,7 @@
 
 package im.vector.app.features.settings.devices.v2.notification
 
-import im.vector.app.test.fakes.FakeActiveSessionHolder
+import im.vector.app.test.fakes.FakeSession
 import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
@@ -26,18 +26,15 @@ private const val A_DEVICE_ID = "device-id"
 
 class CheckIfCanTogglePushNotificationsViaAccountDataUseCaseTest {
 
-    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+    private val fakeSession = FakeSession()
 
     private val checkIfCanTogglePushNotificationsViaAccountDataUseCase =
-            CheckIfCanTogglePushNotificationsViaAccountDataUseCase(
-                    activeSessionHolder = fakeActiveSessionHolder.instance,
-            )
+            CheckIfCanTogglePushNotificationsViaAccountDataUseCase()
 
     @Test
     fun `given current session and an account data for the device id when execute then result is true`() {
         // Given
-        fakeActiveSessionHolder
-                .fakeSession
+        fakeSession
                 .accountDataService()
                 .givenGetUserAccountDataEventReturns(
                         type = UserAccountDataTypes.TYPE_LOCAL_NOTIFICATION_SETTINGS + A_DEVICE_ID,
@@ -45,7 +42,7 @@ class CheckIfCanTogglePushNotificationsViaAccountDataUseCaseTest {
                 )
 
         // When
-        val result = checkIfCanTogglePushNotificationsViaAccountDataUseCase.execute(A_DEVICE_ID)
+        val result = checkIfCanTogglePushNotificationsViaAccountDataUseCase.execute(fakeSession, A_DEVICE_ID)
 
         // Then
         result shouldBeEqualTo true
@@ -54,8 +51,7 @@ class CheckIfCanTogglePushNotificationsViaAccountDataUseCaseTest {
     @Test
     fun `given current session and NO account data for the device id when execute then result is false`() {
         // Given
-        fakeActiveSessionHolder
-                .fakeSession
+        fakeSession
                 .accountDataService()
                 .givenGetUserAccountDataEventReturns(
                         type = UserAccountDataTypes.TYPE_LOCAL_NOTIFICATION_SETTINGS + A_DEVICE_ID,
@@ -63,7 +59,7 @@ class CheckIfCanTogglePushNotificationsViaAccountDataUseCaseTest {
                 )
 
         // When
-        val result = checkIfCanTogglePushNotificationsViaAccountDataUseCase.execute(A_DEVICE_ID)
+        val result = checkIfCanTogglePushNotificationsViaAccountDataUseCase.execute(fakeSession, A_DEVICE_ID)
 
         // Then
         result shouldBeEqualTo false

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaPusherUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/CheckIfCanTogglePushNotificationsViaPusherUseCaseTest.kt
@@ -16,7 +16,7 @@
 
 package im.vector.app.features.settings.devices.v2.notification
 
-import im.vector.app.test.fakes.FakeActiveSessionHolder
+import im.vector.app.test.fakes.FakeSession
 import im.vector.app.test.fixtures.aHomeServerCapabilities
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
@@ -25,37 +25,22 @@ private val A_HOMESERVER_CAPABILITIES = aHomeServerCapabilities(canRemotelyToggl
 
 class CheckIfCanTogglePushNotificationsViaPusherUseCaseTest {
 
-    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+    private val fakeSession = FakeSession()
 
     private val checkIfCanTogglePushNotificationsViaPusherUseCase =
-            CheckIfCanTogglePushNotificationsViaPusherUseCase(
-                    activeSessionHolder = fakeActiveSessionHolder.instance,
-            )
+            CheckIfCanTogglePushNotificationsViaPusherUseCase()
 
     @Test
     fun `given current session when execute then toggle capability is returned`() {
         // Given
-        fakeActiveSessionHolder
-                .fakeSession
+        fakeSession
                 .fakeHomeServerCapabilitiesService
                 .givenCapabilities(A_HOMESERVER_CAPABILITIES)
 
         // When
-        val result = checkIfCanTogglePushNotificationsViaPusherUseCase.execute()
+        val result = checkIfCanTogglePushNotificationsViaPusherUseCase.execute(fakeSession)
 
         // Then
         result shouldBeEqualTo A_HOMESERVER_CAPABILITIES.canRemotelyTogglePushNotificationsOfDevices
-    }
-
-    @Test
-    fun `given no current session when execute then false is returned`() {
-        // Given
-        fakeActiveSessionHolder.givenGetSafeActiveSessionReturns(null)
-
-        // When
-        val result = checkIfCanTogglePushNotificationsViaPusherUseCase.execute()
-
-        // Then
-        result shouldBeEqualTo false
     }
 }

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/TogglePushNotificationUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/notification/TogglePushNotificationUseCaseTest.kt
@@ -49,10 +49,11 @@ class TogglePushNotificationUseCaseTest {
                 PusherFixture.aPusher(deviceId = sessionId, enabled = false),
                 PusherFixture.aPusher(deviceId = "another id", enabled = false)
         )
-        activeSessionHolder.fakeSession.pushersService().givenPushersLive(pushers)
-        activeSessionHolder.fakeSession.pushersService().givenGetPushers(pushers)
-        every { fakeCheckIfCanTogglePushNotificationsViaPusherUseCase.execute() } returns true
-        every { fakeCheckIfCanTogglePushNotificationsViaAccountDataUseCase.execute(sessionId) } returns false
+        val fakeSession = activeSessionHolder.fakeSession
+        fakeSession.pushersService().givenPushersLive(pushers)
+        fakeSession.pushersService().givenGetPushers(pushers)
+        every { fakeCheckIfCanTogglePushNotificationsViaPusherUseCase.execute(fakeSession) } returns true
+        every { fakeCheckIfCanTogglePushNotificationsViaAccountDataUseCase.execute(fakeSession, sessionId) } returns false
 
         // When
         togglePushNotificationUseCase.execute(sessionId, true)
@@ -69,13 +70,14 @@ class TogglePushNotificationUseCaseTest {
                 PusherFixture.aPusher(deviceId = sessionId, enabled = false),
                 PusherFixture.aPusher(deviceId = "another id", enabled = false)
         )
-        activeSessionHolder.fakeSession.pushersService().givenPushersLive(pushers)
-        activeSessionHolder.fakeSession.accountDataService().givenGetUserAccountDataEventReturns(
+        val fakeSession = activeSessionHolder.fakeSession
+        fakeSession.pushersService().givenPushersLive(pushers)
+        fakeSession.accountDataService().givenGetUserAccountDataEventReturns(
                 UserAccountDataTypes.TYPE_LOCAL_NOTIFICATION_SETTINGS + sessionId,
                 LocalNotificationSettingsContent(isSilenced = true).toContent()
         )
-        every { fakeCheckIfCanTogglePushNotificationsViaPusherUseCase.execute() } returns false
-        every { fakeCheckIfCanTogglePushNotificationsViaAccountDataUseCase.execute(sessionId) } returns true
+        every { fakeCheckIfCanTogglePushNotificationsViaPusherUseCase.execute(fakeSession) } returns false
+        every { fakeCheckIfCanTogglePushNotificationsViaAccountDataUseCase.execute(fakeSession, sessionId) } returns true
 
         // When
         togglePushNotificationUseCase.execute(sessionId, true)

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
@@ -22,11 +22,11 @@ import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.test.MavericksTestRule
 import im.vector.app.features.settings.devices.v2.DeviceFullInfo
 import im.vector.app.features.settings.devices.v2.RefreshDevicesUseCase
-import im.vector.app.features.settings.devices.v2.notification.GetNotificationsStatusUseCase
 import im.vector.app.features.settings.devices.v2.notification.NotificationsStatus
 import im.vector.app.features.settings.devices.v2.signout.InterceptSignoutFlowResponseUseCase
 import im.vector.app.features.settings.devices.v2.verification.CheckIfCurrentSessionCanBeVerifiedUseCase
 import im.vector.app.test.fakes.FakeActiveSessionHolder
+import im.vector.app.test.fakes.FakeGetNotificationsStatusUseCase
 import im.vector.app.test.fakes.FakePendingAuthHandler
 import im.vector.app.test.fakes.FakeSignoutSessionsUseCase
 import im.vector.app.test.fakes.FakeTogglePushNotificationUseCase
@@ -77,7 +77,7 @@ class SessionOverviewViewModelTest {
     private val fakePendingAuthHandler = FakePendingAuthHandler()
     private val refreshDevicesUseCase = mockk<RefreshDevicesUseCase>(relaxed = true)
     private val togglePushNotificationUseCase = FakeTogglePushNotificationUseCase()
-    private val fakeGetNotificationsStatusUseCase = mockk<GetNotificationsStatusUseCase>()
+    private val fakeGetNotificationsStatusUseCase = FakeGetNotificationsStatusUseCase()
     private val notificationsStatus = NotificationsStatus.ENABLED
 
     private fun createViewModel() = SessionOverviewViewModel(
@@ -90,7 +90,7 @@ class SessionOverviewViewModelTest {
             activeSessionHolder = fakeActiveSessionHolder.instance,
             refreshDevicesUseCase = refreshDevicesUseCase,
             togglePushNotificationUseCase = togglePushNotificationUseCase.instance,
-            getNotificationsStatusUseCase = fakeGetNotificationsStatusUseCase,
+            getNotificationsStatusUseCase = fakeGetNotificationsStatusUseCase.instance,
     )
 
     @Before
@@ -100,7 +100,11 @@ class SessionOverviewViewModelTest {
         every { SystemClock.elapsedRealtime() } returns 1234
 
         givenVerificationService()
-        every { fakeGetNotificationsStatusUseCase.execute(fakeActiveSessionHolder.fakeSession, A_SESSION_ID_1) } returns flowOf(notificationsStatus)
+        fakeGetNotificationsStatusUseCase.givenExecuteReturns(
+                fakeActiveSessionHolder.fakeSession,
+                A_SESSION_ID_1,
+                notificationsStatus
+        )
     }
 
     private fun givenVerificationService(): FakeVerificationService {

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
@@ -37,6 +37,8 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
+import io.mockk.justRun
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
@@ -98,7 +100,7 @@ class SessionOverviewViewModelTest {
         every { SystemClock.elapsedRealtime() } returns 1234
 
         givenVerificationService()
-        every { fakeGetNotificationsStatusUseCase.execute(A_SESSION_ID_1) } returns flowOf(notificationsStatus)
+        every { fakeGetNotificationsStatusUseCase.execute(fakeActiveSessionHolder.fakeSession, A_SESSION_ID_1) } returns flowOf(notificationsStatus)
     }
 
     private fun givenVerificationService(): FakeVerificationService {
@@ -412,13 +414,10 @@ class SessionOverviewViewModelTest {
 
     @Test
     fun `when viewModel init, then observe pushers and emit to state`() {
-        val notificationStatus = NotificationsStatus.ENABLED
-        every { fakeGetNotificationsStatusUseCase.execute(A_SESSION_ID_1) } returns flowOf(notificationStatus)
-
         val viewModel = createViewModel()
 
         viewModel.test()
-                .assertLatestState { state -> state.notificationsStatus == notificationStatus }
+                .assertLatestState { state -> state.notificationsStatus == notificationsStatus }
                 .finish()
     }
 

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModelTest.kt
@@ -37,8 +37,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
-import io.mockk.justRun
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs

--- a/vector/src/test/java/im/vector/app/features/settings/notifications/DisableNotificationsForCurrentSessionUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/notifications/DisableNotificationsForCurrentSessionUseCaseTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.notifications
+
+import im.vector.app.features.settings.devices.v2.notification.CheckIfCanTogglePushNotificationsViaPusherUseCase
+import im.vector.app.features.settings.devices.v2.notification.TogglePushNotificationUseCase
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import im.vector.app.test.fakes.FakePushersManager
+import im.vector.app.test.fakes.FakeUnifiedPushHelper
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+private const val A_SESSION_ID = "session-id"
+
+class DisableNotificationsForCurrentSessionUseCaseTest {
+
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+    private val fakeUnifiedPushHelper = FakeUnifiedPushHelper()
+    private val fakePushersManager = FakePushersManager()
+    private val fakeCheckIfCanTogglePushNotificationsViaPusherUseCase = mockk<CheckIfCanTogglePushNotificationsViaPusherUseCase>()
+    private val fakeTogglePushNotificationUseCase = mockk<TogglePushNotificationUseCase>()
+
+    private val disableNotificationsForCurrentSessionUseCase = DisableNotificationsForCurrentSessionUseCase(
+            activeSessionHolder = fakeActiveSessionHolder.instance,
+            unifiedPushHelper = fakeUnifiedPushHelper.instance,
+            pushersManager = fakePushersManager.instance,
+            checkIfCanTogglePushNotificationsViaPusherUseCase = fakeCheckIfCanTogglePushNotificationsViaPusherUseCase,
+            togglePushNotificationUseCase = fakeTogglePushNotificationUseCase,
+    )
+
+    @Test
+    fun `given toggle via pusher is possible when execute then disable notification via toggle of existing pusher`() = runTest {
+        // Given
+        val fakeSession = fakeActiveSessionHolder.fakeSession
+        fakeSession.givenSessionId(A_SESSION_ID)
+        every { fakeCheckIfCanTogglePushNotificationsViaPusherUseCase.execute(fakeSession) } returns true
+        coJustRun { fakeTogglePushNotificationUseCase.execute(A_SESSION_ID, any()) }
+
+        // When
+        disableNotificationsForCurrentSessionUseCase.execute()
+
+        // Then
+        coVerify { fakeTogglePushNotificationUseCase.execute(A_SESSION_ID, false) }
+    }
+
+    @Test
+    fun `given toggle via pusher is NOT possible when execute then disable notification by unregistering the pusher`() = runTest {
+        // Given
+        val fakeSession = fakeActiveSessionHolder.fakeSession
+        fakeSession.givenSessionId(A_SESSION_ID)
+        every { fakeCheckIfCanTogglePushNotificationsViaPusherUseCase.execute(fakeSession) } returns false
+        fakeUnifiedPushHelper.givenUnregister(fakePushersManager.instance)
+
+        // When
+        disableNotificationsForCurrentSessionUseCase.execute()
+
+        // Then
+        fakeUnifiedPushHelper.verifyUnregister(fakePushersManager.instance)
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/settings/notifications/EnableNotificationsForCurrentSessionUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/notifications/EnableNotificationsForCurrentSessionUseCaseTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.notifications
+
+import androidx.fragment.app.FragmentActivity
+import im.vector.app.features.settings.devices.v2.notification.CheckIfCanTogglePushNotificationsViaPusherUseCase
+import im.vector.app.features.settings.devices.v2.notification.TogglePushNotificationUseCase
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import im.vector.app.test.fakes.FakeFcmHelper
+import im.vector.app.test.fakes.FakePushersManager
+import im.vector.app.test.fakes.FakeUnifiedPushHelper
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+private const val A_SESSION_ID = "session-id"
+
+class EnableNotificationsForCurrentSessionUseCaseTest {
+
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+    private val fakeUnifiedPushHelper = FakeUnifiedPushHelper()
+    private val fakePushersManager = FakePushersManager()
+    private val fakeFcmHelper = FakeFcmHelper()
+    private val fakeCheckIfCanTogglePushNotificationsViaPusherUseCase = mockk<CheckIfCanTogglePushNotificationsViaPusherUseCase>()
+    private val fakeTogglePushNotificationUseCase = mockk<TogglePushNotificationUseCase>()
+
+    private val enableNotificationsForCurrentSessionUseCase = EnableNotificationsForCurrentSessionUseCase(
+            activeSessionHolder = fakeActiveSessionHolder.instance,
+            unifiedPushHelper = fakeUnifiedPushHelper.instance,
+            pushersManager = fakePushersManager.instance,
+            fcmHelper = fakeFcmHelper.instance,
+            checkIfCanTogglePushNotificationsViaPusherUseCase = fakeCheckIfCanTogglePushNotificationsViaPusherUseCase,
+            togglePushNotificationUseCase = fakeTogglePushNotificationUseCase,
+    )
+
+    @Test
+    fun `given no existing pusher for current session when execute then a new pusher is registered`() = runTest {
+        // Given
+        val fragmentActivity = mockk<FragmentActivity>()
+        fakePushersManager.givenGetPusherForCurrentSessionReturns(null)
+        fakeUnifiedPushHelper.givenRegister(fragmentActivity)
+        fakeUnifiedPushHelper.givenIsEmbeddedDistributorReturns(true)
+        fakeFcmHelper.givenEnsureFcmTokenIsRetrieved(fragmentActivity, fakePushersManager.instance)
+        every { fakeCheckIfCanTogglePushNotificationsViaPusherUseCase.execute(fakeActiveSessionHolder.fakeSession) } returns false
+
+        // When
+        enableNotificationsForCurrentSessionUseCase.execute(fragmentActivity)
+
+        // Then
+        fakeUnifiedPushHelper.verifyRegister(fragmentActivity)
+        fakeFcmHelper.verifyEnsureFcmTokenIsRetrieved(fragmentActivity, fakePushersManager.instance, registerPusher = true)
+    }
+
+    @Test
+    fun `given toggle via Pusher is possible when execute then current pusher is toggled to true`() = runTest {
+        // Given
+        val fragmentActivity = mockk<FragmentActivity>()
+        fakePushersManager.givenGetPusherForCurrentSessionReturns(mockk())
+        val fakeSession = fakeActiveSessionHolder.fakeSession
+        fakeSession.givenSessionId(A_SESSION_ID)
+        every { fakeCheckIfCanTogglePushNotificationsViaPusherUseCase.execute(fakeActiveSessionHolder.fakeSession) } returns true
+        coJustRun { fakeTogglePushNotificationUseCase.execute(A_SESSION_ID, any()) }
+
+        // When
+        enableNotificationsForCurrentSessionUseCase.execute(fragmentActivity)
+
+        // Then
+        coVerify { fakeTogglePushNotificationUseCase.execute(A_SESSION_ID, true) }
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeEnableNotificationsSettingUpdater.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeEnableNotificationsSettingUpdater.kt
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.devices.v2.notification
+package im.vector.app.test.fakes
 
+import im.vector.app.core.notification.EnableNotificationsSettingUpdater
+import io.mockk.justRun
+import io.mockk.mockk
 import org.matrix.android.sdk.api.session.Session
-import org.matrix.android.sdk.api.session.accountdata.UserAccountDataTypes
-import javax.inject.Inject
 
-class CheckIfCanTogglePushNotificationsViaAccountDataUseCase @Inject constructor() {
+class FakeEnableNotificationsSettingUpdater {
 
-    fun execute(session: Session, deviceId: String): Boolean {
-        return session
-                .accountDataService()
-                .getUserAccountDataEvent(UserAccountDataTypes.TYPE_LOCAL_NOTIFICATION_SETTINGS + deviceId) != null
+    val instance = mockk<EnableNotificationsSettingUpdater>()
+
+    fun givenOnSessionsStarted(session: Session) {
+        justRun { instance.onSessionsStarted(session) }
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeFcmHelper.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeFcmHelper.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import androidx.fragment.app.FragmentActivity
+import im.vector.app.core.pushers.FcmHelper
+import im.vector.app.core.pushers.PushersManager
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+
+class FakeFcmHelper {
+
+    val instance = mockk<FcmHelper>()
+
+    fun givenEnsureFcmTokenIsRetrieved(
+            fragmentActivity: FragmentActivity,
+            pushersManager: PushersManager,
+    ) {
+        justRun { instance.ensureFcmTokenIsRetrieved(fragmentActivity, pushersManager, any()) }
+    }
+
+    fun verifyEnsureFcmTokenIsRetrieved(
+            fragmentActivity: FragmentActivity,
+            pushersManager: PushersManager,
+            registerPusher: Boolean,
+    ) {
+        verify { instance.ensureFcmTokenIsRetrieved(fragmentActivity, pushersManager, registerPusher) }
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeGetNotificationsStatusUseCase.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeGetNotificationsStatusUseCase.kt
@@ -14,26 +14,24 @@
  * limitations under the License.
  */
 
-package im.vector.app.core.notification
+package im.vector.app.test.fakes
 
-import im.vector.app.features.session.coroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
+import im.vector.app.features.settings.devices.v2.notification.GetNotificationsStatusUseCase
+import im.vector.app.features.settings.devices.v2.notification.NotificationsStatus
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
 import org.matrix.android.sdk.api.session.Session
-import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
-class EnableNotificationsSettingUpdater @Inject constructor(
-        private val updateEnableNotificationsSettingOnChangeUseCase: UpdateEnableNotificationsSettingOnChangeUseCase,
-) {
+class FakeGetNotificationsStatusUseCase {
 
-    private var job: Job? = null
+    val instance = mockk<GetNotificationsStatusUseCase>()
 
-    fun onSessionsStarted(session: Session) {
-        job?.cancel()
-        job = session.coroutineScope.launch {
-            updateEnableNotificationsSettingOnChangeUseCase.execute(session)
-        }
+    fun givenExecuteReturns(
+            session: Session,
+            sessionId: String,
+            notificationsStatus: NotificationsStatus
+    ) {
+        every { instance.execute(session, sessionId) } returns flowOf(notificationsStatus)
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeHomeServerCapabilitiesService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeHomeServerCapabilitiesService.kt
@@ -16,14 +16,24 @@
 
 package im.vector.app.test.fakes
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import io.mockk.every
 import io.mockk.mockk
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilities
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilitiesService
+import org.matrix.android.sdk.api.util.Optional
+import org.matrix.android.sdk.api.util.toOptional
 
 class FakeHomeServerCapabilitiesService : HomeServerCapabilitiesService by mockk() {
 
     fun givenCapabilities(homeServerCapabilities: HomeServerCapabilities) {
         every { getHomeServerCapabilities() } returns homeServerCapabilities
+    }
+
+    fun givenCapabilitiesLiveReturns(homeServerCapabilities: HomeServerCapabilities): LiveData<Optional<HomeServerCapabilities>> {
+        return MutableLiveData(homeServerCapabilities.toOptional()).also {
+            every { getHomeServerCapabilitiesLive() } returns it
+        }
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakePushersManager.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakePushersManager.kt
@@ -17,9 +17,15 @@
 package im.vector.app.test.fakes
 
 import im.vector.app.core.pushers.PushersManager
+import io.mockk.every
 import io.mockk.mockk
+import org.matrix.android.sdk.api.session.pushers.Pusher
 
 class FakePushersManager {
 
     val instance = mockk<PushersManager>()
+
+    fun givenGetPusherForCurrentSessionReturns(pusher: Pusher?) {
+        every { instance.getPusherForCurrentSession() } returns pusher
+    }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakePushersManager.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakePushersManager.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import im.vector.app.core.pushers.PushersManager
+import io.mockk.mockk
+
+class FakePushersManager {
+
+    val instance = mockk<PushersManager>()
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeUnifiedPushHelper.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeUnifiedPushHelper.kt
@@ -16,15 +16,28 @@
 
 package im.vector.app.test.fakes
 
+import androidx.fragment.app.FragmentActivity
 import im.vector.app.core.pushers.PushersManager
 import im.vector.app.core.pushers.UnifiedPushHelper
 import io.mockk.coJustRun
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 
 class FakeUnifiedPushHelper {
 
     val instance = mockk<UnifiedPushHelper>()
+
+    fun givenRegister(fragmentActivity: FragmentActivity) {
+        every { instance.register(fragmentActivity, any()) } answers {
+            secondArg<Runnable>().run()
+        }
+    }
+
+    fun verifyRegister(fragmentActivity: FragmentActivity) {
+        verify { instance.register(fragmentActivity, any()) }
+    }
 
     fun givenUnregister(pushersManager: PushersManager) {
         coJustRun { instance.unregister(pushersManager) }
@@ -32,5 +45,9 @@ class FakeUnifiedPushHelper {
 
     fun verifyUnregister(pushersManager: PushersManager) {
         coVerify { instance.unregister(pushersManager) }
+    }
+
+    fun givenIsEmbeddedDistributorReturns(isEmbedded: Boolean) {
+        every { instance.isEmbeddedDistributor() } returns isEmbedded
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeUnifiedPushHelper.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeUnifiedPushHelper.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fakes
+
+import im.vector.app.core.pushers.PushersManager
+import im.vector.app.core.pushers.UnifiedPushHelper
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.mockk
+
+class FakeUnifiedPushHelper {
+
+    val instance = mockk<UnifiedPushHelper>()
+
+    fun givenUnregister(pushersManager: PushersManager) {
+        coJustRun { instance.unregister(pushersManager) }
+    }
+
+    fun verifyUnregister(pushersManager: PushersManager) {
+        coVerify { instance.unregister(pushersManager) }
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorPreferences.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorPreferences.kt
@@ -18,6 +18,7 @@ package im.vector.app.test.fakes
 
 import im.vector.app.features.settings.VectorPreferences
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 
@@ -42,5 +43,13 @@ class FakeVectorPreferences {
     }
 
     fun givenTextFormatting(isEnabled: Boolean) =
-        every { instance.isTextFormattingEnabled() } returns isEnabled
+            every { instance.isTextFormattingEnabled() } returns isEnabled
+
+    fun givenSetNotificationEnabledForDevice() {
+        justRun { instance.setNotificationEnabledForDevice(any()) }
+    }
+
+    fun verifySetNotificationEnabledForDevice(enabled: Boolean, inverse: Boolean = false) {
+        verify(inverse = inverse) { instance.setNotificationEnabledForDevice(enabled) }
+    }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Simplifying and fixing the logic for the push notifications toggle for the current session in "Settings -> Notifications".
The main update is to only rely on the related local preference. This preference is now updated whenever the pusher or account data related to the current device is edited as it may be remotely updated from another device (see `EnableNotificationsSettingUpdater`).
Unit tests have been added to cover all this logic.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7512 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Signin to server "synapse-prefill.lab.element.dev"
- Enable the new session manager labs setting
- Go to Settings -> Notifications
- Check the notifications are enabled for the current session
- Check notifications are well received on the device in this case
- Disable the notifications for the session
- Check notifications are no more received on the device
- Go to Settings -> Security & Privacy -> Show all sessions
- Go to the current session overview
- Check the notifications are disabled for the current session
- Enable notifications
- Check notifications are well received on the device in this case
- Go to Settings -> Notifications
- Check the notifications are enabled for the current session  

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
