### PR TITLE
temporary workaround for a failing sync due to unexpected `enableUnre…

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/filter/FilterFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/filter/FilterFactory.kt
@@ -67,7 +67,9 @@ internal object FilterFactory {
     }
 
     private fun createElementTimelineFilter(): RoomEventFilter? {
-        return RoomEventFilter(enableUnreadThreadNotifications = true)
+//        we need to check if homeserver supports thread notifications before setting this param
+//        return RoomEventFilter(enableUnreadThreadNotifications = true)
+        return null
     }
 
     private fun createElementStateFilter(): RoomEventFilter {


### PR DESCRIPTION
…adThreadNotifications` param

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

passing `unread_thread_notifications` for a sync filter cause sync to fail if synapse doesn't support 1.4 spec

## Motivation and context

related issue: https://github.com/vector-im/element-android/issues/7516

this PR won't close issue since it's temporary fix to unblock relase
