### PR TITLE
Fix search tests

### DIFF
--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/search/SearchMessagesTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/search/SearchMessagesTest.kt
@@ -43,7 +43,7 @@ class SearchMessagesTest : InstrumentedTest {
             cryptoTestData.firstSession
                     .searchService()
                     .search(
-                            searchTerm = "lore",
+                            searchTerm = "lorem",
                             limit = 10,
                             includeProfile = true,
                             afterLimit = 0,
@@ -61,7 +61,7 @@ class SearchMessagesTest : InstrumentedTest {
             cryptoTestData.firstSession
                     .searchService()
                     .search(
-                            searchTerm = "lore",
+                            searchTerm = "lorem",
                             roomId = cryptoTestData.roomId,
                             limit = 10,
                             includeProfile = true,

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/search/SearchMessagesTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/session/search/SearchMessagesTest.kt
@@ -16,6 +16,7 @@
 
 package org.matrix.android.sdk.session.search
 
+import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Assert.assertTrue
 import org.junit.FixMethodOrder
 import org.junit.Test
@@ -73,7 +74,28 @@ class SearchMessagesTest : InstrumentedTest {
         }
     }
 
-    private fun doTest(block: suspend (CryptoTestData) -> SearchResult) = runCryptoTest(context()) { cryptoTestHelper, commonTestHelper ->
+    @Test
+    fun sendTextMessageAndSearchPartOfItIncompleteWord() {
+        doTest(expectedNumberOfResult = 0) { cryptoTestData ->
+            cryptoTestData.firstSession
+                    .searchService()
+                    .search(
+                            searchTerm = "lore", /* incomplete word */
+                            roomId = cryptoTestData.roomId,
+                            limit = 10,
+                            includeProfile = true,
+                            afterLimit = 0,
+                            beforeLimit = 10,
+                            orderByRecent = true,
+                            nextBatch = null
+                    )
+        }
+    }
+
+    private fun doTest(
+            expectedNumberOfResult: Int = 2,
+            block: suspend (CryptoTestData) -> SearchResult,
+    ) = runCryptoTest(context()) { cryptoTestHelper, commonTestHelper ->
         val cryptoTestData = cryptoTestHelper.doE2ETestWithAliceInARoom(false)
         val aliceSession = cryptoTestData.firstSession
         val aliceRoomId = cryptoTestData.roomId
@@ -87,7 +109,7 @@ class SearchMessagesTest : InstrumentedTest {
 
         val data = block.invoke(cryptoTestData)
 
-        assertTrue(data.results?.size == 2)
+        data.results?.size shouldBeEqualTo expectedNumberOfResult
         assertTrue(
                 data.results
                         ?.all {


### PR DESCRIPTION
Synapse is not returning result for incomplete word anymore.

This PR take into account this change.

A new test is added to check this new behavior about incomplete word.

Maybe related to recent change on Synapse 1.71.0: https://github.com/matrix-org/synapse/releases/tag/v1.71.0 :

> Allow use of Postgres and SQLlite full-text search operators in search queries. (https://github.com/matrix-org/synapse/issues/11635, https://github.com/matrix-org/synapse/issues/14310, https://github.com/matrix-org/synapse/issues/14311)

No need for a changelog.