### PR TITLE
Move TypingView into the timeline as another item

### DIFF
--- a/changelog.d/7496.feature
+++ b/changelog.d/7496.feature
@@ -1,0 +1,1 @@
+Move TypingView inside the timeline items.

--- a/vector/src/main/java/im/vector/app/core/ui/views/TypingMessageView.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/views/TypingMessageView.kt
@@ -48,9 +48,4 @@ class TypingMessageView @JvmOverloads constructor(
         views.typingUserText.text = typingHelper.getNotificationTypingMessage(typingUsers)
         views.typingUserAvatars.render(typingUsers, avatarRenderer)
     }
-
-    override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
-        removeAllViews()
-    }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -1154,7 +1154,6 @@ class TimelineFragment :
         }
         val summary = mainState.asyncRoomSummary()
         renderToolbar(summary)
-        renderTypingMessageNotification(summary, mainState)
         views.removeJitsiWidgetView.render(mainState)
         if (mainState.hasFailedSending) {
             lazyLoadedViews.failedMessagesWarningView(inflateIfNeeded = true, createFailedMessagesWarningCallback())?.isVisible = true
@@ -1228,17 +1227,6 @@ class TimelineFragment :
     private fun FragmentTimelineBinding.hideComposerViews() {
         composerContainer.isVisible = false
         voiceMessageRecorderContainer.isVisible = false
-    }
-
-    private fun renderTypingMessageNotification(roomSummary: RoomSummary?, state: RoomDetailViewState) {
-        if (!isThreadTimeLine() && roomSummary != null) {
-            views.typingMessageView.isInvisible = state.typingUsers.isNullOrEmpty()
-            state.typingUsers
-                    ?.take(MAX_TYPING_MESSAGE_USERS_COUNT)
-                    ?.let { senders -> views.typingMessageView.render(senders, avatarRenderer) }
-        } else {
-            views.typingMessageView.isInvisible = true
-        }
     }
 
     private fun renderToolbar(roomSummary: RoomSummary?) {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/TimelineEventController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/TimelineEventController.kt
@@ -32,6 +32,7 @@ import im.vector.app.core.extensions.localDateTime
 import im.vector.app.core.extensions.nextOrNull
 import im.vector.app.core.extensions.prevOrNull
 import im.vector.app.core.time.Clock
+import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.detail.JitsiState
 import im.vector.app.features.home.room.detail.RoomDetailAction
 import im.vector.app.features.home.room.detail.RoomDetailViewState
@@ -57,6 +58,7 @@ import im.vector.app.features.home.room.detail.timeline.item.MessageInformationD
 import im.vector.app.features.home.room.detail.timeline.item.ReactionsSummaryEvents
 import im.vector.app.features.home.room.detail.timeline.item.ReadReceiptData
 import im.vector.app.features.home.room.detail.timeline.item.ReadReceiptsItem
+import im.vector.app.features.home.room.detail.timeline.item.TypingItem_
 import im.vector.app.features.home.room.detail.timeline.url.PreviewUrlRetriever
 import im.vector.app.features.media.AttachmentData
 import im.vector.app.features.media.ImageContentRenderer
@@ -94,6 +96,7 @@ class TimelineEventController @Inject constructor(
         private val readReceiptsItemFactory: ReadReceiptsItemFactory,
         private val reactionListFactory: ReactionsSummaryFactory,
         private val clock: Clock,
+        private val avatarRenderer: AvatarRenderer,
 ) : EpoxyController(backgroundHandler, backgroundHandler), Timeline.Listener, EpoxyController.Interceptor {
 
     /**
@@ -104,7 +107,7 @@ class TimelineEventController @Inject constructor(
             val highlightedEventId: String? = null,
             val jitsiState: JitsiState = JitsiState(),
             val roomSummary: RoomSummary? = null,
-            val rootThreadEventId: String? = null
+            val rootThreadEventId: String? = null,
     ) {
 
         constructor(state: RoomDetailViewState) : this(
@@ -112,7 +115,7 @@ class TimelineEventController @Inject constructor(
                 highlightedEventId = state.highlightedEventId,
                 jitsiState = state.jitsiState,
                 roomSummary = state.asyncRoomSummary(),
-                rootThreadEventId = state.rootThreadEventId
+                rootThreadEventId = state.rootThreadEventId,
         )
 
         fun isFromThreadTimeline(): Boolean = rootThreadEventId != null
@@ -286,7 +289,7 @@ class TimelineEventController @Inject constructor(
 
     private val interceptorHelper = TimelineControllerInterceptorHelper(
             ::positionOfReadMarker,
-            adapterPositionMapping
+            adapterPositionMapping,
     )
 
     init {
@@ -333,6 +336,10 @@ class TimelineEventController @Inject constructor(
                 .id("forward_loading_item_$timestamp")
                 .setVisibilityStateChangedListener(Timeline.Direction.FORWARDS)
                 .addWhenLoading(Timeline.Direction.FORWARDS)
+
+        val typingUsers = partialState.roomSummary?.typingUsers.orEmpty()
+        val typingItem = TypingItem_().id("typing_view").avatarRenderer(avatarRenderer).users(typingUsers)
+        add(typingItem)
 
         val timelineModels = getModels()
         add(timelineModels)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/TimelineEventController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/TimelineEventController.kt
@@ -337,9 +337,11 @@ class TimelineEventController @Inject constructor(
                 .setVisibilityStateChangedListener(Timeline.Direction.FORWARDS)
                 .addWhenLoading(Timeline.Direction.FORWARDS)
 
-        val typingUsers = partialState.roomSummary?.typingUsers.orEmpty()
-        val typingItem = TypingItem_().id("typing_view").avatarRenderer(avatarRenderer).users(typingUsers)
-        add(typingItem)
+        if (!showingForwardLoader) {
+            val typingUsers = partialState.roomSummary?.typingUsers.orEmpty()
+            val typingItem = TypingItem_().id("typing_view").avatarRenderer(avatarRenderer).users(typingUsers)
+            add(typingItem)
+        }
 
         val timelineModels = getModels()
         add(timelineModels)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/TypingItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/TypingItem.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home.room.detail.timeline.item
+
+import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
+import com.airbnb.epoxy.EpoxyAttribute
+import com.airbnb.epoxy.EpoxyModelClass
+import com.airbnb.epoxy.EpoxyModelWithHolder
+import im.vector.app.R
+import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.ui.views.TypingMessageView
+import im.vector.app.features.home.AvatarRenderer
+import org.matrix.android.sdk.api.session.room.sender.SenderInfo
+
+@EpoxyModelClass
+abstract class TypingItem : EpoxyModelWithHolder<TypingItem.TypingHolder>() {
+
+    companion object {
+        private const val MAX_TYPING_MESSAGE_USERS_COUNT = 4
+    }
+
+    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
+    lateinit var avatarRenderer: AvatarRenderer
+
+    @EpoxyAttribute
+    var users: List<SenderInfo> = emptyList()
+
+    override fun getDefaultLayout(): Int = R.layout.item_typing_users
+
+    override fun bind(holder: TypingHolder) {
+        super.bind(holder)
+
+        val typingUsers = users.take(MAX_TYPING_MESSAGE_USERS_COUNT)
+        holder.typingView.apply {
+            animate().cancel()
+            val duration = 100L
+            if (typingUsers.isEmpty()) {
+                animate().translationY(height.toFloat())
+                        .alpha(0f)
+                        .setDuration(duration)
+                        .withEndAction {
+                            isInvisible = true
+                        }.start()
+            } else {
+                isVisible = true
+
+                translationY = height.toFloat()
+                alpha = 0f
+                render(typingUsers, avatarRenderer)
+                animate().translationY(0f)
+                        .alpha(1f)
+                        .setDuration(duration)
+                        .start()
+            }
+        }
+    }
+
+    class TypingHolder : VectorEpoxyHolder() {
+        val typingView by bind<TypingMessageView>(R.id.typingMessageView)
+    }
+}

--- a/vector/src/main/res/layout/fragment_timeline.xml
+++ b/vector/src/main/res/layout/fragment_timeline.xml
@@ -85,7 +85,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:overScrollMode="always"
-        app:layout_constraintBottom_toTopOf="@id/typingMessageView"
+        app:layout_constraintBottom_toTopOf="@id/bottomBarrier"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/removeJitsiWidgetView"
@@ -106,18 +106,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/removeJitsiWidgetView" />
-
-    <im.vector.app.core.ui.views.TypingMessageView
-        android:id="@+id/typingMessageView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:paddingStart="20dp"
-        android:paddingEnd="20dp"
-        android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@id/bottomBarrier"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/timelineRecyclerView" />
 
     <im.vector.app.core.ui.views.NotificationAreaView
         android:id="@+id/notificationAreaView"

--- a/vector/src/main/res/layout/item_typing_users.xml
+++ b/vector/src/main/res/layout/item_typing_users.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<im.vector.app.core.ui.views.TypingMessageView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/typingMessageView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="20dp"
+    android:visibility="invisible" />


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Creates a new `TypingItem` that contains a `TypingView` so it's not part of the timeline.

## Motivation and context

Closes #7564 .

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|[old_typing_view.webm](https://user-images.githubusercontent.com/480955/201083798-678abb55-982e-4bd7-982c-690eb1d668e1.webm)|[new_typing_item.webm](https://user-images.githubusercontent.com/480955/201089117-8eb10ec2-7f1a-4113-a8ff-325e46c952a5.webm)|

## Tests

<!-- Explain how you tested your development -->

- Open a room shared with another account you can sign in into.
- Write from that other account.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 9

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
