### PR TITLE
Missing translations on "replyTo" messages (PSG-978)

### DIFF
--- a/changelog.d/7555.bugfix
+++ b/changelog.d/7555.bugfix
@@ -1,0 +1,1 @@
+Missing translations on "replyTo" messages

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -3458,4 +3458,13 @@
     <string name="rich_text_editor_format_underline">Apply underline format</string>
     <string name="rich_text_editor_full_screen_toggle">Toggle full screen mode</string>
 
+    <!-- ReplyTo events -->
+    <string name="message_reply_to_prefix">In reply to</string>
+    <string name="message_reply_to_sender_sent_file">sent a file.</string>
+    <string name="message_reply_to_sender_sent_audio_file">sent an audio file.</string>
+    <string name="message_reply_to_sender_sent_voice_message">sent a voice message.</string>
+    <string name="message_reply_to_sender_sent_image">sent an image.</string>
+    <string name="message_reply_to_sender_sent_video">sent a video.</string>
+    <string name="message_reply_to_sender_sent_sticker">sent a sticker.</string>
+    <string name="message_reply_to_sender_created_poll">created a poll.</string>
 </resources>

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
@@ -33,6 +33,7 @@ import org.matrix.android.sdk.api.session.room.model.message.MessageStickerConte
 import org.matrix.android.sdk.api.session.room.model.message.MessageType
 import org.matrix.android.sdk.api.session.room.model.message.asMessageAudioEvent
 import org.matrix.android.sdk.api.session.room.model.relation.RelationDefaultContent
+import org.matrix.android.sdk.api.session.room.model.relation.isReply
 import org.matrix.android.sdk.api.session.room.model.relation.shouldRenderInThread
 import org.matrix.android.sdk.api.session.room.send.SendState
 import org.matrix.android.sdk.api.session.threads.ThreadDetails
@@ -420,7 +421,7 @@ fun Event.getRelationContentForType(type: String): RelationDefaultContent? =
         getRelationContent()?.takeIf { it.type == type }
 
 fun Event.isReply(): Boolean {
-    return getRelationContent()?.inReplyTo?.eventId != null
+    return getRelationContent().isReply()
 }
 
 fun Event.isReplyRenderedInThread(): Boolean {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
@@ -229,11 +229,14 @@ data class Event(
         return when {
             isReplyRenderedInThread() || isQuote() -> ContentUtils.extractUsefulTextFromReply(text)
             isFileMessage() -> "sent a file."
+            isVoiceMessage() -> "sent a voice message."
             isAudioMessage() -> "sent an audio file."
             isImageMessage() -> "sent an image."
             isVideoMessage() -> "sent a video."
-            isSticker() -> "sent a sticker"
+            isSticker() -> "sent a sticker."
             isPoll() -> getPollQuestion() ?: "created a poll."
+            isLiveLocation() -> "Live location."
+            isLocationMessage() -> "has shared their location."
             else -> text
         }
     }
@@ -444,7 +447,7 @@ fun Event.isInvitation(): Boolean = type == EventType.STATE_ROOM_MEMBER &&
         content?.toModel<RoomMemberContent>()?.membership == Membership.INVITE
 
 fun Event.getPollContent(): MessagePollContent? {
-    return content.toModel<MessagePollContent>()
+    return getDecryptedContent().toModel<MessagePollContent>()
 }
 
 fun Event.supportsNotification() =

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/Event.kt
@@ -447,7 +447,7 @@ fun Event.isInvitation(): Boolean = type == EventType.STATE_ROOM_MEMBER &&
         content?.toModel<RoomMemberContent>()?.membership == Membership.INVITE
 
 fun Event.getPollContent(): MessagePollContent? {
-    return getDecryptedContent().toModel<MessagePollContent>()
+    return getClearContent().toModel<MessagePollContent>()
 }
 
 fun Event.supportsNotification() =

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/location/LocationSharingService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/location/LocationSharingService.kt
@@ -47,10 +47,9 @@ interface LocationSharingService {
     /**
      * Starts sharing live location in the room.
      * @param timeoutMillis timeout of the live in milliseconds
-     * @param description description of the live for text fallback
      * @return the result of the update of the live
      */
-    suspend fun startLiveLocationShare(timeoutMillis: Long, description: String): UpdateLiveLocationShareResult
+    suspend fun startLiveLocationShare(timeoutMillis: Long): UpdateLiveLocationShareResult
 
     /**
      * Stops sharing live location in the room.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/relation/RelationDefaultContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/relation/RelationDefaultContent.kt
@@ -28,3 +28,5 @@ data class RelationDefaultContent(
 ) : RelationContent
 
 fun RelationDefaultContent.shouldRenderInThread(): Boolean = isFallingBack == false
+
+fun RelationDefaultContent?.isReply(): Boolean = this?.inReplyTo?.eventId != null

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingService.kt
@@ -73,7 +73,7 @@ internal class DefaultLocationSharingService @AssistedInject constructor(
         return sendLiveLocationTask.execute(params)
     }
 
-    override suspend fun startLiveLocationShare(timeoutMillis: Long, description: String): UpdateLiveLocationShareResult {
+    override suspend fun startLiveLocationShare(timeoutMillis: Long): UpdateLiveLocationShareResult {
         // Ensure to stop any active live before starting a new one
         if (checkIfExistingActiveLive()) {
             val result = stopLiveLocationShare()
@@ -84,7 +84,6 @@ internal class DefaultLocationSharingService @AssistedInject constructor(
         val params = StartLiveLocationShareTask.Params(
                 roomId = roomId,
                 timeoutMillis = timeoutMillis,
-                description = description
         )
         return startLiveLocationShareTask.execute(params)
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/StartLiveLocationShareTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/location/StartLiveLocationShareTask.kt
@@ -30,7 +30,6 @@ internal interface StartLiveLocationShareTask : Task<StartLiveLocationShareTask.
     data class Params(
             val roomId: String,
             val timeoutMillis: Long,
-            val description: String,
     )
 }
 
@@ -42,7 +41,7 @@ internal class DefaultStartLiveLocationShareTask @Inject constructor(
 
     override suspend fun execute(params: StartLiveLocationShareTask.Params): UpdateLiveLocationShareResult {
         val beaconContent = MessageBeaconInfoContent(
-                body = params.description,
+                body = "Live location",
                 timeout = params.timeoutMillis,
                 isLive = true,
                 unstableTimestampMillis = clock.epochMillis()

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingServiceTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultLocationSharingServiceTest.kt
@@ -53,7 +53,6 @@ private const val A_LATITUDE = 1.4
 private const val A_LONGITUDE = 40.0
 private const val AN_UNCERTAINTY = 5.0
 private const val A_TIMEOUT = 15_000L
-private const val A_DESCRIPTION = "description"
 private const val A_REASON = "reason"
 
 @ExperimentalCoroutinesApi
@@ -143,7 +142,7 @@ internal class DefaultLocationSharingServiceTest {
         coEvery { stopLiveLocationShareTask.execute(any()) } returns UpdateLiveLocationShareResult.Success("stopped-event-id")
         coEvery { startLiveLocationShareTask.execute(any()) } returns UpdateLiveLocationShareResult.Success(AN_EVENT_ID)
 
-        val result = defaultLocationSharingService.startLiveLocationShare(A_TIMEOUT, A_DESCRIPTION)
+        val result = defaultLocationSharingService.startLiveLocationShare(A_TIMEOUT)
 
         result shouldBeEqualTo UpdateLiveLocationShareResult.Success(AN_EVENT_ID)
         val expectedCheckExistingParams = CheckIfExistingActiveLiveTask.Params(
@@ -157,7 +156,6 @@ internal class DefaultLocationSharingServiceTest {
         val expectedStartParams = StartLiveLocationShareTask.Params(
                 roomId = A_ROOM_ID,
                 timeoutMillis = A_TIMEOUT,
-                description = A_DESCRIPTION
         )
         coVerify { startLiveLocationShareTask.execute(expectedStartParams) }
     }
@@ -168,7 +166,7 @@ internal class DefaultLocationSharingServiceTest {
         val error = Throwable()
         coEvery { stopLiveLocationShareTask.execute(any()) } returns UpdateLiveLocationShareResult.Failure(error)
 
-        val result = defaultLocationSharingService.startLiveLocationShare(A_TIMEOUT, A_DESCRIPTION)
+        val result = defaultLocationSharingService.startLiveLocationShare(A_TIMEOUT)
 
         result shouldBeEqualTo UpdateLiveLocationShareResult.Failure(error)
         val expectedCheckExistingParams = CheckIfExistingActiveLiveTask.Params(
@@ -186,7 +184,7 @@ internal class DefaultLocationSharingServiceTest {
         coEvery { checkIfExistingActiveLiveTask.execute(any()) } returns false
         coEvery { startLiveLocationShareTask.execute(any()) } returns UpdateLiveLocationShareResult.Success(AN_EVENT_ID)
 
-        val result = defaultLocationSharingService.startLiveLocationShare(A_TIMEOUT, A_DESCRIPTION)
+        val result = defaultLocationSharingService.startLiveLocationShare(A_TIMEOUT)
 
         result shouldBeEqualTo UpdateLiveLocationShareResult.Success(AN_EVENT_ID)
         val expectedCheckExistingParams = CheckIfExistingActiveLiveTask.Params(
@@ -196,7 +194,6 @@ internal class DefaultLocationSharingServiceTest {
         val expectedStartParams = StartLiveLocationShareTask.Params(
                 roomId = A_ROOM_ID,
                 timeoutMillis = A_TIMEOUT,
-                description = A_DESCRIPTION
         )
         coVerify { startLiveLocationShareTask.execute(expectedStartParams) }
     }

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultStartLiveLocationShareTaskTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/location/DefaultStartLiveLocationShareTaskTest.kt
@@ -34,7 +34,6 @@ import org.matrix.android.sdk.test.fakes.FakeSendStateTask
 private const val A_USER_ID = "user-id"
 private const val A_ROOM_ID = "room-id"
 private const val AN_EVENT_ID = "event-id"
-private const val A_DESCRIPTION = "description"
 private const val A_TIMEOUT = 15_000L
 private const val AN_EPOCH = 1655210176L
 
@@ -60,7 +59,6 @@ internal class DefaultStartLiveLocationShareTaskTest {
         val params = StartLiveLocationShareTask.Params(
                 roomId = A_ROOM_ID,
                 timeoutMillis = A_TIMEOUT,
-                description = A_DESCRIPTION
         )
         fakeClock.givenEpoch(AN_EPOCH)
         fakeSendStateTask.givenExecuteRetryReturns(AN_EVENT_ID)
@@ -69,7 +67,7 @@ internal class DefaultStartLiveLocationShareTaskTest {
 
         result shouldBeEqualTo UpdateLiveLocationShareResult.Success(AN_EVENT_ID)
         val expectedBeaconContent = MessageBeaconInfoContent(
-                body = A_DESCRIPTION,
+                body = "Live location",
                 timeout = params.timeoutMillis,
                 isLive = true,
                 unstableTimestampMillis = AN_EPOCH
@@ -91,7 +89,6 @@ internal class DefaultStartLiveLocationShareTaskTest {
         val params = StartLiveLocationShareTask.Params(
                 roomId = A_ROOM_ID,
                 timeoutMillis = A_TIMEOUT,
-                description = A_DESCRIPTION
         )
         fakeClock.givenEpoch(AN_EPOCH)
         fakeSendStateTask.givenExecuteRetryReturns("")
@@ -106,7 +103,6 @@ internal class DefaultStartLiveLocationShareTaskTest {
         val params = StartLiveLocationShareTask.Params(
                 roomId = A_ROOM_ID,
                 timeoutMillis = A_TIMEOUT,
-                description = A_DESCRIPTION
         )
         fakeClock.givenEpoch(AN_EPOCH)
         val error = Throwable()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -65,6 +65,7 @@ import im.vector.app.features.home.room.detail.timeline.item.RedactedMessageItem
 import im.vector.app.features.home.room.detail.timeline.item.VerificationRequestItem
 import im.vector.app.features.home.room.detail.timeline.item.VerificationRequestItem_
 import im.vector.app.features.home.room.detail.timeline.render.EventTextRenderer
+import im.vector.app.features.home.room.detail.timeline.render.ProcessBodyOfReplyToEventUseCase
 import im.vector.app.features.home.room.detail.timeline.tools.createLinkMovementMethod
 import im.vector.app.features.home.room.detail.timeline.tools.linkify
 import im.vector.app.features.html.EventHtmlRenderer
@@ -106,6 +107,7 @@ import org.matrix.android.sdk.api.session.room.model.message.MessageVideoContent
 import org.matrix.android.sdk.api.session.room.model.message.asMessageAudioEvent
 import org.matrix.android.sdk.api.session.room.model.message.getFileUrl
 import org.matrix.android.sdk.api.session.room.model.message.getThumbnailUrl
+import org.matrix.android.sdk.api.session.room.model.relation.ReplyToContent
 import org.matrix.android.sdk.api.settings.LightweightSettingsStorage
 import org.matrix.android.sdk.api.util.MimeTypes
 import javax.inject.Inject
@@ -139,6 +141,7 @@ class MessageItemFactory @Inject constructor(
         private val liveLocationShareMessageItemFactory: LiveLocationShareMessageItemFactory,
         private val pollItemViewStateFactory: PollItemViewStateFactory,
         private val voiceBroadcastItemFactory: VoiceBroadcastItemFactory,
+        private val processBodyOfReplyToEventUseCase: ProcessBodyOfReplyToEventUseCase,
 ) {
 
     // TODO inject this properly?
@@ -200,7 +203,7 @@ class MessageItemFactory @Inject constructor(
             is MessageVerificationRequestContent -> buildVerificationRequestMessageItem(messageContent, informationData, highlight, callback, attributes)
             is MessagePollContent -> buildPollItem(messageContent, informationData, highlight, callback, attributes)
             is MessageLocationContent -> buildLocationItem(messageContent, informationData, highlight, attributes)
-            is MessageBeaconInfoContent -> liveLocationShareMessageItemFactory.create(params.event, highlight, attributes)
+            is MessageBeaconInfoContent -> liveLocationShareMessageItemFactory.create(event, highlight, attributes)
             is MessageVoiceBroadcastInfoContent -> voiceBroadcastItemFactory.create(params, messageContent, highlight, attributes)
             else -> buildNotHandledMessageItem(messageContent, informationData, highlight, callback, attributes)
         }
@@ -437,7 +440,14 @@ class MessageItemFactory @Inject constructor(
             attributes: AbsMessageItem.Attributes
     ): MessageTextItem? {
         // For compatibility reason we should display the body
-        return buildMessageTextItem(messageContent.body, false, informationData, highlight, callback, attributes)
+        return buildMessageTextItem(
+                messageContent.body,
+                false,
+                informationData,
+                highlight,
+                callback,
+                attributes,
+        )
     }
 
     private fun buildImageMessageItem(
@@ -540,7 +550,8 @@ class MessageItemFactory @Inject constructor(
     ): VectorEpoxyModel<*>? {
         val matrixFormattedBody = messageContent.matrixFormattedBody
         return if (matrixFormattedBody != null) {
-            buildFormattedTextItem(matrixFormattedBody, informationData, highlight, callback, attributes)
+            val replyToContent = messageContent.relatesTo?.inReplyTo
+            buildFormattedTextItem(matrixFormattedBody, informationData, highlight, callback, attributes, replyToContent)
         } else {
             buildMessageTextItem(messageContent.body, false, informationData, highlight, callback, attributes)
         }
@@ -552,10 +563,21 @@ class MessageItemFactory @Inject constructor(
             highlight: Boolean,
             callback: TimelineEventController.Callback?,
             attributes: AbsMessageItem.Attributes,
+            replyToContent: ReplyToContent?,
     ): MessageTextItem? {
-        val compressed = htmlCompressor.compress(matrixFormattedBody)
+        val processedBody = replyToContent
+                ?.let { processBodyOfReplyToEventUseCase.execute(roomId, matrixFormattedBody, it) }
+                ?: matrixFormattedBody
+        val compressed = htmlCompressor.compress(processedBody)
         val renderedFormattedBody = htmlRenderer.get().render(compressed, pillsPostProcessor) as Spanned
-        return buildMessageTextItem(renderedFormattedBody, true, informationData, highlight, callback, attributes)
+        return buildMessageTextItem(
+                renderedFormattedBody,
+                true,
+                informationData,
+                highlight,
+                callback,
+                attributes,
+        )
     }
 
     private fun buildMessageTextItem(

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/render/EventTextRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/render/EventTextRenderer.kt
@@ -34,12 +34,8 @@ class EventTextRenderer @AssistedInject constructor(
         @Assisted private val roomId: String?,
         private val context: Context,
         private val avatarRenderer: AvatarRenderer,
-        private val sessionHolder: ActiveSessionHolder
+        private val activeSessionHolder: ActiveSessionHolder,
 ) {
-
-    /* ==========================================================================================
-     * Public api
-     * ========================================================================================== */
 
     @AssistedFactory
     interface Factory {
@@ -47,9 +43,13 @@ class EventTextRenderer @AssistedInject constructor(
     }
 
     /**
-     * @param text the text you want to render
+     * @param text the text to be rendered
      */
     fun render(text: CharSequence): CharSequence {
+        return renderNotifyEveryone(text)
+    }
+
+    private fun renderNotifyEveryone(text: CharSequence): CharSequence {
         return if (roomId != null && text.contains(MatrixItem.NOTIFY_EVERYONE)) {
             SpannableStringBuilder(text).apply {
                 addNotifyEveryoneSpans(this, roomId)
@@ -59,12 +59,8 @@ class EventTextRenderer @AssistedInject constructor(
         }
     }
 
-    /* ==========================================================================================
-     * Helper methods
-     * ========================================================================================== */
-
     private fun addNotifyEveryoneSpans(text: Spannable, roomId: String) {
-        val room: RoomSummary? = sessionHolder.getSafeActiveSession()?.roomService()?.getRoomSummary(roomId)
+        val room: RoomSummary? = activeSessionHolder.getSafeActiveSession()?.roomService()?.getRoomSummary(roomId)
         val matrixItem = MatrixItem.EveryoneInRoomItem(
                 id = roomId,
                 avatarUrl = room?.avatarUrl,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/render/ProcessBodyOfReplyToEventUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/render/ProcessBodyOfReplyToEventUseCase.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home.room.detail.timeline.render
+
+import im.vector.app.R
+import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.core.resources.StringProvider
+import org.matrix.android.sdk.api.session.events.model.getPollQuestion
+import org.matrix.android.sdk.api.session.events.model.isAudioMessage
+import org.matrix.android.sdk.api.session.events.model.isFileMessage
+import org.matrix.android.sdk.api.session.events.model.isImageMessage
+import org.matrix.android.sdk.api.session.events.model.isLiveLocation
+import org.matrix.android.sdk.api.session.events.model.isPoll
+import org.matrix.android.sdk.api.session.events.model.isSticker
+import org.matrix.android.sdk.api.session.events.model.isVideoMessage
+import org.matrix.android.sdk.api.session.events.model.isVoiceMessage
+import org.matrix.android.sdk.api.session.getRoom
+import org.matrix.android.sdk.api.session.room.getTimelineEvent
+import org.matrix.android.sdk.api.session.room.model.relation.ReplyToContent
+import javax.inject.Inject
+
+private const val IN_REPLY_TO = "In reply to"
+private const val BREAKING_LINE = "<br />"
+private const val ENDING_BLOCK_QUOTE = "</blockquote>"
+
+// TODO add unit tests
+class ProcessBodyOfReplyToEventUseCase @Inject constructor(
+        private val activeSessionHolder: ActiveSessionHolder,
+        private val stringProvider: StringProvider,
+) {
+
+    fun execute(roomId: String, matrixFormattedBody: String, replyToContent: ReplyToContent): String {
+        val repliedToEvent = replyToContent.eventId?.let { getEvent(it, roomId) }
+        val breakingLineIndex = matrixFormattedBody.lastIndexOf(BREAKING_LINE)
+        val endOfBlockQuoteIndex = matrixFormattedBody.lastIndexOf(ENDING_BLOCK_QUOTE)
+
+        // TODO check in other platform how is handled the case of no repliedToEvent fetched
+        val withTranslatedContent = if (repliedToEvent != null && breakingLineIndex != -1 && endOfBlockQuoteIndex != -1) {
+            val afterBreakingLineIndex = breakingLineIndex + BREAKING_LINE.length
+            when {
+                repliedToEvent.isFileMessage() -> {
+                    matrixFormattedBody.replaceRange(
+                            afterBreakingLineIndex,
+                            endOfBlockQuoteIndex,
+                            stringProvider.getString(R.string.message_reply_to_sender_sent_file)
+                    )
+                }
+                repliedToEvent.isVoiceMessage() -> {
+                    matrixFormattedBody.replaceRange(
+                            afterBreakingLineIndex,
+                            endOfBlockQuoteIndex,
+                            stringProvider.getString(R.string.message_reply_to_sender_sent_voice_message)
+                    )
+                }
+                repliedToEvent.isAudioMessage() -> {
+                    matrixFormattedBody.replaceRange(
+                            afterBreakingLineIndex,
+                            endOfBlockQuoteIndex,
+                            stringProvider.getString(R.string.message_reply_to_sender_sent_audio_file)
+                    )
+                }
+                repliedToEvent.isImageMessage() -> {
+                    matrixFormattedBody.replaceRange(
+                            afterBreakingLineIndex,
+                            endOfBlockQuoteIndex,
+                            stringProvider.getString(R.string.message_reply_to_sender_sent_image)
+                    )
+                }
+                repliedToEvent.isVideoMessage() -> {
+                    matrixFormattedBody.replaceRange(
+                            afterBreakingLineIndex,
+                            endOfBlockQuoteIndex,
+                            stringProvider.getString(R.string.message_reply_to_sender_sent_video)
+                    )
+                }
+                repliedToEvent.isSticker() -> {
+                    matrixFormattedBody.replaceRange(
+                            afterBreakingLineIndex,
+                            endOfBlockQuoteIndex,
+                            stringProvider.getString(R.string.message_reply_to_sender_sent_sticker)
+                    )
+                }
+                repliedToEvent.isPoll() -> {
+                    matrixFormattedBody.replaceRange(
+                            afterBreakingLineIndex,
+                            endOfBlockQuoteIndex,
+                            repliedToEvent.getPollQuestion() ?: stringProvider.getString(R.string.message_reply_to_sender_created_poll)
+                    )
+                }
+                repliedToEvent.isLiveLocation() -> {
+                    matrixFormattedBody.replaceRange(
+                            afterBreakingLineIndex,
+                            endOfBlockQuoteIndex,
+                            stringProvider.getString(R.string.live_location_description)
+                    )
+                }
+                else -> matrixFormattedBody
+            }
+        } else {
+            matrixFormattedBody
+        }
+
+        return withTranslatedContent.replace(
+                IN_REPLY_TO,
+                stringProvider.getString(R.string.message_reply_to_prefix)
+        )
+    }
+
+    private fun getEvent(eventId: String, roomId: String) =
+            activeSessionHolder.getSafeActiveSession()
+                    ?.getRoom(roomId)
+                    ?.getTimelineEvent(eventId)
+                    ?.root
+}

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/render/ProcessBodyOfReplyToEventUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/render/ProcessBodyOfReplyToEventUseCase.kt
@@ -44,7 +44,7 @@ class ProcessBodyOfReplyToEventUseCase @Inject constructor(
 
     fun execute(roomId: String, matrixFormattedBody: String, replyToContent: ReplyToContent): String {
         val repliedToEvent = replyToContent.eventId?.let { getEvent(it, roomId) }
-        val breakingLineIndex = matrixFormattedBody.lastIndexOf(BREAKING_LINE)
+        val breakingLineIndex = matrixFormattedBody.indexOf(BREAKING_LINE)
         val endOfBlockQuoteIndex = matrixFormattedBody.lastIndexOf(ENDING_BLOCK_QUOTE)
 
         val withTranslatedContent = if (repliedToEvent != null && breakingLineIndex != -1 && endOfBlockQuoteIndex != -1) {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/render/ProcessBodyOfReplyToEventUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/render/ProcessBodyOfReplyToEventUseCase.kt
@@ -37,7 +37,6 @@ private const val IN_REPLY_TO = "In reply to"
 private const val BREAKING_LINE = "<br />"
 private const val ENDING_BLOCK_QUOTE = "</blockquote>"
 
-// TODO add unit tests
 class ProcessBodyOfReplyToEventUseCase @Inject constructor(
         private val activeSessionHolder: ActiveSessionHolder,
         private val stringProvider: StringProvider,
@@ -48,7 +47,6 @@ class ProcessBodyOfReplyToEventUseCase @Inject constructor(
         val breakingLineIndex = matrixFormattedBody.lastIndexOf(BREAKING_LINE)
         val endOfBlockQuoteIndex = matrixFormattedBody.lastIndexOf(ENDING_BLOCK_QUOTE)
 
-        // TODO check in other platform how is handled the case of no repliedToEvent fetched
         val withTranslatedContent = if (repliedToEvent != null && breakingLineIndex != -1 && endOfBlockQuoteIndex != -1) {
             val afterBreakingLineIndex = breakingLineIndex + BREAKING_LINE.length
             when {

--- a/vector/src/main/java/im/vector/app/features/location/live/tracking/LocationSharingAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/tracking/LocationSharingAndroidService.kt
@@ -21,7 +21,6 @@ import android.os.IBinder
 import android.os.Parcelable
 import androidx.core.app.NotificationManagerCompat
 import dagger.hilt.android.AndroidEntryPoint
-import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.services.VectorAndroidService
 import im.vector.app.features.location.LocationData
@@ -125,10 +124,7 @@ class LocationSharingAndroidService : VectorAndroidService(), LocationTracker.Ca
         val updateLiveResult = session
                 .getRoom(roomArgs.roomId)
                 ?.locationSharingService()
-                ?.startLiveLocationShare(
-                        timeoutMillis = roomArgs.durationMillis,
-                        description = getString(R.string.live_location_description)
-                )
+                ?.startLiveLocationShare(roomArgs.durationMillis)
 
         updateLiveResult
                 ?.let { result ->

--- a/vector/src/test/java/im/vector/app/features/home/room/detail/timeline/render/ProcessBodyOfReplyToEventUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/home/room/detail/timeline/render/ProcessBodyOfReplyToEventUseCaseTest.kt
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home.room.detail.timeline.render
+
+import android.annotation.StringRes
+import im.vector.app.R
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import im.vector.app.test.fakes.FakeStringProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.api.session.events.model.getPollQuestion
+import org.matrix.android.sdk.api.session.events.model.isAudioMessage
+import org.matrix.android.sdk.api.session.events.model.isFileMessage
+import org.matrix.android.sdk.api.session.events.model.isImageMessage
+import org.matrix.android.sdk.api.session.events.model.isLiveLocation
+import org.matrix.android.sdk.api.session.events.model.isPoll
+import org.matrix.android.sdk.api.session.events.model.isSticker
+import org.matrix.android.sdk.api.session.events.model.isVideoMessage
+import org.matrix.android.sdk.api.session.events.model.isVoiceMessage
+import org.matrix.android.sdk.api.session.room.model.relation.ReplyToContent
+import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
+
+private const val A_ROOM_ID = "room-id"
+private const val AN_EVENT_ID = "event-id"
+private const val A_REPLY_TO_EVENT_MATRIX_FORMATTED_BODY =
+        "<mx-reply>" +
+                "<blockquote>" +
+                "<a href=\"matrixToLink\">In reply to</a> " +
+                "<a href=\"matrixToLink\">@user:matrix.org</a>" +
+                "<br />" +
+                "Message content" +
+                "</blockquote>" +
+                "</mx-reply>" +
+                "Reply text"
+private const val A_NEW_PREFIX = "new-prefix"
+private const val A_NEW_CONTENT = "new-content"
+private const val PREFIX_PROCESSED_ONLY_REPLY_TO_EVENT_MATRIX_FORMATTED_BODY =
+        "<mx-reply>" +
+                "<blockquote>" +
+                "<a href=\"matrixToLink\">$A_NEW_PREFIX</a> " +
+                "<a href=\"matrixToLink\">@user:matrix.org</a>" +
+                "<br />" +
+                "Message content" +
+                "</blockquote>" +
+                "</mx-reply>" +
+                "Reply text"
+private const val FULLY_PROCESSED_REPLY_TO_EVENT_MATRIX_FORMATTED_BODY =
+        "<mx-reply>" +
+                "<blockquote>" +
+                "<a href=\"matrixToLink\">$A_NEW_PREFIX</a> " +
+                "<a href=\"matrixToLink\">@user:matrix.org</a>" +
+                "<br />" +
+                A_NEW_CONTENT +
+                "</blockquote>" +
+                "</mx-reply>" +
+                "Reply text"
+
+class ProcessBodyOfReplyToEventUseCaseTest {
+
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+    private val fakeStringProvider = FakeStringProvider()
+    private val fakeReplyToContent = ReplyToContent(eventId = AN_EVENT_ID)
+    private val fakeRepliedEvent = givenARepliedEvent()
+
+    private val processBodyOfReplyToEventUseCase = ProcessBodyOfReplyToEventUseCase(
+            activeSessionHolder = fakeActiveSessionHolder.instance,
+            stringProvider = fakeStringProvider.instance,
+    )
+
+    @Before
+    fun setup() {
+        givenNewPrefix()
+        mockkStatic("org.matrix.android.sdk.api.session.events.model.EventKt")
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `given a replied event of type file message when process the formatted body then content is replaced by correct string`() {
+        // Given
+        givenTypeOfRepliedEvent(isFileMessage = true)
+        givenNewContentForId(R.string.message_reply_to_sender_sent_file)
+
+        executeAndAssertResult()
+    }
+
+    @Test
+    fun `given a replied event of type voice message when process the formatted body then content is replaced by correct string`() {
+        // Given
+        givenTypeOfRepliedEvent(isVoiceMessage = true)
+        givenNewContentForId(R.string.message_reply_to_sender_sent_voice_message)
+
+        executeAndAssertResult()
+    }
+
+    @Test
+    fun `given a replied event of type audio message when process the formatted body then content is replaced by correct string`() {
+        // Given
+        givenTypeOfRepliedEvent(isAudioMessage = true)
+        givenNewContentForId(R.string.message_reply_to_sender_sent_audio_file)
+
+        executeAndAssertResult()
+    }
+
+    @Test
+    fun `given a replied event of type image message when process the formatted body then content is replaced by correct string`() {
+        // Given
+        givenTypeOfRepliedEvent(isImageMessage = true)
+        givenNewContentForId(R.string.message_reply_to_sender_sent_image)
+
+        executeAndAssertResult()
+    }
+
+    @Test
+    fun `given a replied event of type video message when process the formatted body then content is replaced by correct string`() {
+        // Given
+        givenTypeOfRepliedEvent(isVideoMessage = true)
+        givenNewContentForId(R.string.message_reply_to_sender_sent_video)
+
+        executeAndAssertResult()
+    }
+
+    @Test
+    fun `given a replied event of type sticker message when process the formatted body then content is replaced by correct string`() {
+        // Given
+        givenTypeOfRepliedEvent(isStickerMessage = true)
+        givenNewContentForId(R.string.message_reply_to_sender_sent_sticker)
+
+        executeAndAssertResult()
+    }
+
+    @Test
+    fun `given a replied event of type poll message with null question when process the formatted body then content is replaced by correct string`() {
+        // Given
+        givenTypeOfRepliedEvent(isPollMessage = true)
+        givenNewContentForId(R.string.message_reply_to_sender_created_poll)
+        every { fakeRepliedEvent.getPollQuestion() } returns null
+
+        executeAndAssertResult()
+    }
+
+    @Test
+    fun `given a replied event of type poll message with existing question when process the formatted body then content is replaced by correct string`() {
+        // Given
+        givenTypeOfRepliedEvent(isPollMessage = true)
+        givenNewContentForId(R.string.message_reply_to_sender_created_poll)
+        every { fakeRepliedEvent.getPollQuestion() } returns A_NEW_CONTENT
+
+        executeAndAssertResult()
+    }
+
+    @Test
+    fun `given a replied event of type live location message when process the formatted body then content is replaced by correct string`() {
+        // Given
+        givenTypeOfRepliedEvent(isLiveLocationMessage = true)
+        givenNewContentForId(R.string.live_location_description)
+
+        executeAndAssertResult()
+    }
+
+    @Test
+    fun `given a replied event of type not handled when process the formatted body only prefix is replaced by correct string`() {
+        // Given
+        givenTypeOfRepliedEvent()
+
+        // When
+        val result = processBodyOfReplyToEventUseCase.execute(
+                roomId = A_ROOM_ID,
+                matrixFormattedBody = A_REPLY_TO_EVENT_MATRIX_FORMATTED_BODY,
+                replyToContent = fakeReplyToContent,
+        )
+
+        // Then
+        result shouldBeEqualTo PREFIX_PROCESSED_ONLY_REPLY_TO_EVENT_MATRIX_FORMATTED_BODY
+    }
+
+    @Test
+    fun `given no replied event found when process the formatted body then only prefix is replaced by correct string`() {
+        // Given
+        givenARepliedEvent(timelineEvent = null)
+
+        // When
+        val result = processBodyOfReplyToEventUseCase.execute(
+                roomId = A_ROOM_ID,
+                matrixFormattedBody = A_REPLY_TO_EVENT_MATRIX_FORMATTED_BODY,
+                replyToContent = fakeReplyToContent,
+        )
+
+        // Then
+        result shouldBeEqualTo PREFIX_PROCESSED_ONLY_REPLY_TO_EVENT_MATRIX_FORMATTED_BODY
+    }
+
+    private fun executeAndAssertResult() {
+        // When
+        val result = processBodyOfReplyToEventUseCase.execute(
+                roomId = A_ROOM_ID,
+                matrixFormattedBody = A_REPLY_TO_EVENT_MATRIX_FORMATTED_BODY,
+                replyToContent = fakeReplyToContent,
+        )
+
+        // Then
+        result shouldBeEqualTo FULLY_PROCESSED_REPLY_TO_EVENT_MATRIX_FORMATTED_BODY
+    }
+
+    private fun givenARepliedEvent(timelineEvent: TimelineEvent? = mockk()): Event {
+        val event = mockk<Event>()
+        timelineEvent?.let { every { it.root } returns event }
+        fakeActiveSessionHolder
+                .fakeSession
+                .roomService()
+                .getRoom(A_ROOM_ID)
+                .timelineService()
+                .givenTimelineEvent(timelineEvent)
+        return event
+    }
+
+    private fun givenTypeOfRepliedEvent(
+            isFileMessage: Boolean = false,
+            isVoiceMessage: Boolean = false,
+            isAudioMessage: Boolean = false,
+            isImageMessage: Boolean = false,
+            isVideoMessage: Boolean = false,
+            isStickerMessage: Boolean = false,
+            isPollMessage: Boolean = false,
+            isLiveLocationMessage: Boolean = false,
+    ) {
+        every { fakeRepliedEvent.isFileMessage() } returns isFileMessage
+        every { fakeRepliedEvent.isVoiceMessage() } returns isVoiceMessage
+        every { fakeRepliedEvent.isAudioMessage() } returns isAudioMessage
+        every { fakeRepliedEvent.isImageMessage() } returns isImageMessage
+        every { fakeRepliedEvent.isVideoMessage() } returns isVideoMessage
+        every { fakeRepliedEvent.isSticker() } returns isStickerMessage
+        every { fakeRepliedEvent.isPoll() } returns isPollMessage
+        every { fakeRepliedEvent.isLiveLocation() } returns isLiveLocationMessage
+    }
+
+    private fun givenNewPrefix() {
+        fakeStringProvider.given(R.string.message_reply_to_prefix, A_NEW_PREFIX)
+    }
+
+    private fun givenNewContentForId(@StringRes resId: Int) {
+        fakeStringProvider.given(resId, A_NEW_CONTENT)
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeTimelineService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeTimelineService.kt
@@ -23,7 +23,7 @@ import org.matrix.android.sdk.api.session.room.timeline.TimelineService
 
 class FakeTimelineService : TimelineService by mockk() {
 
-    fun givenTimelineEvent(event: TimelineEvent) {
+    fun givenTimelineEvent(event: TimelineEvent?) {
         every { getTimelineEvent(any()) } returns event
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Adding translations for "replyTo" events message on application side.
The description parameter exposed in SDK API for the start of a live location has also been removed to avoid introducing translated text in Matrix events.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7555 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

<img src="https://user-images.githubusercontent.com/46314705/201154879-52b7c71f-38f1-4cff-b74a-f1e070da3632.png" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/201154897-700e3b31-8d06-4edc-9cdd-cf11a8c10f33.png" width=300 />
<img src="https://user-images.githubusercontent.com/46314705/201155018-5440b012-85ce-4b1f-9326-a5fc779c19b3.png" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/201155037-5160c999-f68d-47c9-9144-df5d0f302565.png" width=300 />

## Tests

<!-- Explain how you tested your development -->

- Go to a room (encrypted or not)
- Send different type of messages
- Reply to these messages
- Check the replies are well rendered (right now they are not translated: we should wait for Weblate sync to see the changes)

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
