### PR TITLE
Persist the playback state of voice messages across different screens

### DIFF
--- a/changelog.d/7582.feature
+++ b/changelog.d/7582.feature
@@ -1,0 +1,1 @@
+Voice messages - Persist the playback position across different screens

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/AudioMessageHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/AudioMessageHelper.kt
@@ -253,8 +253,8 @@ class AudioMessageHelper @Inject constructor(
         playbackTicker = null
     }
 
-    fun clearTracker() {
-        playbackTracker.clear()
+    fun stopTracking() {
+        playbackTracker.unregisterListeners()
     }
 
     fun stopAllVoiceActions(deleteRecord: Boolean = true): MultiPickerAudioType? {

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
@@ -960,7 +960,7 @@ class MessageComposerViewModel @AssistedInject constructor(
     }
 
     fun endAllVoiceActions(deleteRecord: Boolean = true) {
-        audioMessageHelper.clearTracker()
+        audioMessageHelper.stopTracking()
         audioMessageHelper.stopAllVoiceActions(deleteRecord)
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/AudioMessagePlaybackTracker.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/helper/AudioMessagePlaybackTracker.kt
@@ -136,12 +136,11 @@ class AudioMessagePlaybackTracker @Inject constructor() {
         }
     }
 
-    fun clear() {
+    fun unregisterListeners() {
         listeners.forEach {
             it.value.onUpdate(Listener.State.Idle)
         }
         listeners.clear()
-        states.clear()
     }
 
     companion object {


### PR DESCRIPTION
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

When pausing a voice message playback, the playback position is now persisted when closing the room timeline.
This also affects voice broadcast playbacks.

## Motivation and context

[Voice Broadcast](https://github.com/vector-im/element-android/issues/7127) feature requires to be able to listen to a voice broadcast when navigating across the app. For this need, we decided to not reset the playback position for voice messages when closing the room timeline.

The positions will be reset only after killing the application.

## Screenshots / GIFs

## Tests

- Have a room timeline with several voice broadcasts and voice messages
- Play/pause some of them or seek to a given position
- Navigate into the app
- Go back to the previous room
- Verify that the playback positions are not reset
- Verify that the position is correct when resuming the playback

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
