### PR TITLE
Improve question about opening PR in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -76,9 +76,9 @@ body:
   - type: dropdown
     id: pr
     attributes:
-      label: Are you willing to provide a PR?
+      label: (Optional) Will you be opening a PR for this?
       description:  |
-        Providing a PR can drastically speed up the process of fixing this bug. Don't worry, it's still OK to answer 'No' :).
+        It can considerably speed up the process of fixing the bug.
       options:
         - 'Yes'
         - 'No'

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -37,9 +37,9 @@ body:
   - type: dropdown
     id: pr
     attributes:
-      label: Are you willing to provide a PR?
+      label: (Optional) Will you be opening a PR for this?
       description:  |
-        Don't worry, it's still OK to answer 'No' :).
+        It can considerably speed up the process of making the enhancement.
       options:
         - 'Yes'
         - 'No'

--- a/changelog.d/7595.misc
+++ b/changelog.d/7595.misc
@@ -1,0 +1,1 @@
+Improve question about opening a PR in issue templates. Contributed by [@opusforlife2](https://github.com/opusforlife2) in #7595


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Other : improvement to issue templates

## Content

<!-- Describe shortly what has been changed -->

Changed the wording of the question and description of whether the issue reporter will be opening a PR.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

The current wording is a bit... intimidating? ("I guess I'm willing to help, but I have no idea how!") And just a teensy bit condescending? ("Don't worry. _Pats head_. It's okay if you can't be useful.")

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR