### PR TITLE
Fix italic text is truncated when bubble mode and markdown is enabled (PSG-1006)

### DIFF
--- a/changelog.d/5679.bugfix
+++ b/changelog.d/5679.bugfix
@@ -1,0 +1,1 @@
+Fix italic text is truncated when bubble mode and markdown is enabled

--- a/vector/src/androidTest/java/im/vector/app/core/utils/TestSpan.kt
+++ b/vector/src/androidTest/java/im/vector/app/core/utils/TestSpan.kt
@@ -29,6 +29,7 @@ import io.mockk.verify
 import io.noties.markwon.core.spans.EmphasisSpan
 import io.noties.markwon.core.spans.OrderedListItemSpan
 import io.noties.markwon.core.spans.StrongEmphasisSpan
+import me.gujun.android.span.style.CustomTypefaceSpan
 
 fun Spannable.toTestSpan(): String {
     var output = toString()
@@ -54,7 +55,7 @@ private fun Any.readTags(): SpanTags {
         OrderedListItemSpan::class -> SpanTags("[list item]", "[/list item]")
         HtmlCodeSpan::class -> SpanTags("[code]", "[/code]")
         StrongEmphasisSpan::class -> SpanTags("[bold]", "[/bold]")
-        EmphasisSpan::class -> SpanTags("[italic]", "[/italic]")
+        EmphasisSpan::class, CustomTypefaceSpan::class -> SpanTags("[italic]", "[/italic]")
         else -> throw IllegalArgumentException("Unknown ${this::class}")
     }
 }

--- a/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
@@ -98,12 +98,6 @@ class EventHtmlRenderer @Inject constructor(
         // It needs to be in this specific format: https://noties.io/Markwon/docs/v4/ext-latex
         builder
                 .usePlugin(object : AbstractMarkwonPlugin() {
-                    override fun configureSpansFactory(builder: MarkwonSpansFactory.Builder) {
-                        builder.setFactory(
-                                Emphasis::class.java
-                        ) { _, _ -> CustomTypefaceSpan(Typeface.create(Typeface.DEFAULT, Typeface.ITALIC)) }
-                    }
-
                     override fun processMarkdown(markdown: String): String {
                         return markdown
                                 .replace(Regex("""<span\s+data-mx-maths="([^"]*)">.*?</span>""")) { matchResult ->
@@ -133,6 +127,12 @@ class EventHtmlRenderer @Inject constructor(
                     )
             )
             .usePlugin(object : AbstractMarkwonPlugin() {
+                override fun configureSpansFactory(builder: MarkwonSpansFactory.Builder) {
+                    builder.setFactory(
+                            Emphasis::class.java
+                    ) { _, _ -> CustomTypefaceSpan(Typeface.create(Typeface.DEFAULT, Typeface.ITALIC)) }
+                }
+
                 override fun configureParser(builder: Parser.Builder) {
                     /* Configuring the Markwon block formatting processor.
                      * Default settings are all Markdown blocks. Turn those off.

--- a/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/html/EventHtmlRenderer.kt
@@ -27,6 +27,7 @@ package im.vector.app.features.html
 
 import android.content.Context
 import android.content.res.Resources
+import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.text.Spannable
 import androidx.core.text.toSpannable
@@ -40,6 +41,7 @@ import im.vector.app.features.settings.VectorPreferences
 import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
 import io.noties.markwon.MarkwonPlugin
+import io.noties.markwon.MarkwonSpansFactory
 import io.noties.markwon.PrecomputedFutureTextSetterCompat
 import io.noties.markwon.ext.latex.JLatexMathPlugin
 import io.noties.markwon.ext.latex.JLatexMathTheme
@@ -50,6 +52,8 @@ import io.noties.markwon.inlineparser.EntityInlineProcessor
 import io.noties.markwon.inlineparser.HtmlInlineProcessor
 import io.noties.markwon.inlineparser.MarkwonInlineParser
 import io.noties.markwon.inlineparser.MarkwonInlineParserPlugin
+import me.gujun.android.span.style.CustomTypefaceSpan
+import org.commonmark.node.Emphasis
 import org.commonmark.node.Node
 import org.commonmark.parser.Parser
 import org.matrix.android.sdk.api.MatrixUrls.isMxcUrl
@@ -94,6 +98,12 @@ class EventHtmlRenderer @Inject constructor(
         // It needs to be in this specific format: https://noties.io/Markwon/docs/v4/ext-latex
         builder
                 .usePlugin(object : AbstractMarkwonPlugin() {
+                    override fun configureSpansFactory(builder: MarkwonSpansFactory.Builder) {
+                        builder.setFactory(
+                                Emphasis::class.java
+                        ) { _, _ -> CustomTypefaceSpan(Typeface.create(Typeface.DEFAULT, Typeface.ITALIC)) }
+                    }
+
                     override fun processMarkdown(markdown: String): String {
                         return markdown
                                 .replace(Regex("""<span\s+data-mx-maths="([^"]*)">.*?</span>""")) { matchResult ->


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
When bubble mode and markdown are enabled, then italic texts are truncated at the end.
This is a known [issue](https://github.com/noties/Markwon/issues/101) both for the library we use and the Android OS. The root cause is that it is not actually using an italic font instead it is just skewing the view of text.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fixes #5679.

## Screenshots / GIFs

|Before|After|
|-|-|
|![italic_before](https://user-images.githubusercontent.com/1254401/202451860-9c58dbb1-fe4b-4f20-978f-ce88d1927dd9.jpeg)|![italic_after](https://user-images.githubusercontent.com/1254401/202451888-b087bded-d1b6-4390-a834-2773b2e39ee4.jpeg)|



<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Enable markdown formatting and bubble mode in settings
- Send an italic message by using * message * (without spaces)

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
