### PR TITLE
Track send message tasks using Sentry

### DIFF
--- a/changelog.d/7602.sdk
+++ b/changelog.d/7602.sdk
@@ -1,0 +1,1 @@
+Add sentry tracking around send message task.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/extensions/MetricsExtensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/extensions/MetricsExtensions.kt
@@ -28,11 +28,11 @@ import kotlin.contracts.contract
  * @param block Action/Task to be executed within this span.
  */
 @OptIn(ExperimentalContracts::class)
-inline fun List<MetricPlugin>.measureMetric(block: () -> Unit) {
+inline fun <T> List<MetricPlugin>.measureTransaction(block: () -> T): T {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }
-    try {
+    return try {
         this.forEach { plugin -> plugin.startTransaction() } // Start the transaction.
         block()
     } catch (throwable: Throwable) {
@@ -51,11 +51,11 @@ inline fun List<MetricPlugin>.measureMetric(block: () -> Unit) {
  * @param block Action/Task to be executed within this span.
  */
 @OptIn(ExperimentalContracts::class)
-inline fun List<SpannableMetricPlugin>.measureSpan(operation: String, description: String, block: () -> Unit) {
+inline fun <T> List<SpannableMetricPlugin>.measureSpan(operation: String, description: String, block: () -> T): T {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }
-    try {
+    return try {
         this.forEach { plugin -> plugin.startSpan(operation, description) } // Start the transaction.
         block()
     } catch (throwable: Throwable) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/extensions/MetricsExtensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/extensions/MetricsExtensions.kt
@@ -25,9 +25,10 @@ import kotlin.contracts.contract
 /**
  * Executes the given [block] while measuring the transaction.
  *
+ * @param T type of the output from [block]
  * @param block Action/Task to be executed within this span.
  *
- * @returns Output of the [block()]
+ * @return Output of the [block()]
  */
 @OptIn(ExperimentalContracts::class)
 inline fun <T> List<MetricPlugin>.measureTransaction(block: () -> T): T {
@@ -48,11 +49,12 @@ inline fun <T> List<MetricPlugin>.measureTransaction(block: () -> T): T {
 /**
  * Executes the given [block] while measuring a span.
  *
+ * @param T type of the output from [block]
  * @param operation Name of the new span.
  * @param description Description of the new span.
  * @param block Action/Task to be executed within this span.
  *
- * @returns Output of the [block()]
+ * @return Output of the [block]
  */
 @OptIn(ExperimentalContracts::class)
 inline fun <T> List<SpannableMetricPlugin>.measureSpan(operation: String, description: String, block: () -> T): T {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/extensions/MetricsExtensions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/extensions/MetricsExtensions.kt
@@ -26,6 +26,8 @@ import kotlin.contracts.contract
  * Executes the given [block] while measuring the transaction.
  *
  * @param block Action/Task to be executed within this span.
+ *
+ * @returns Output of the [block()]
  */
 @OptIn(ExperimentalContracts::class)
 inline fun <T> List<MetricPlugin>.measureTransaction(block: () -> T): T {
@@ -49,6 +51,8 @@ inline fun <T> List<MetricPlugin>.measureTransaction(block: () -> T): T {
  * @param operation Name of the new span.
  * @param description Description of the new span.
  * @param block Action/Task to be executed within this span.
+ *
+ * @returns Output of the [block()]
  */
 @OptIn(ExperimentalContracts::class)
 inline fun <T> List<SpannableMetricPlugin>.measureSpan(operation: String, description: String, block: () -> T): T {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/metrics/SendServiceMetricPlugin.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/metrics/SendServiceMetricPlugin.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.api.metrics
+
+import org.matrix.android.sdk.api.logger.LoggerTag
+import timber.log.Timber
+
+private val loggerTag = LoggerTag("SendServiceMetricPlugin", LoggerTag.CRYPTO)
+
+/**
+ * An spannable metric plugin for tracking send message, events or command task.
+ */
+interface SendServiceMetricPlugin : SpannableMetricPlugin {
+
+    override fun logTransaction(message: String?) {
+        Timber.tag(loggerTag.value).v("## sendService() : $message")
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DeviceListManager.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DeviceListManager.kt
@@ -22,7 +22,7 @@ import org.matrix.android.sdk.api.MatrixConfiguration
 import org.matrix.android.sdk.api.MatrixCoroutineDispatchers
 import org.matrix.android.sdk.api.MatrixPatterns
 import org.matrix.android.sdk.api.auth.data.Credentials
-import org.matrix.android.sdk.api.extensions.measureMetric
+import org.matrix.android.sdk.api.extensions.measureTransaction
 import org.matrix.android.sdk.api.metrics.DownloadDeviceKeysMetricsPlugin
 import org.matrix.android.sdk.api.session.crypto.crosssigning.DeviceTrustLevel
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
@@ -355,7 +355,7 @@ internal class DeviceListManager @Inject constructor(
         val relevantPlugins = metricPlugins.filterIsInstance<DownloadDeviceKeysMetricsPlugin>()
 
         val response: KeysQueryResponse
-        relevantPlugins.measureMetric {
+        relevantPlugins.measureTransaction {
             response = try {
                 downloadKeysForUsersTask.execute(params)
             } catch (throwable: Throwable) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
@@ -19,8 +19,8 @@ package org.matrix.android.sdk.internal.session.sync
 import com.zhuinden.monarchy.Monarchy
 import io.realm.Realm
 import org.matrix.android.sdk.api.MatrixConfiguration
-import org.matrix.android.sdk.api.extensions.measureMetric
 import org.matrix.android.sdk.api.extensions.measureSpan
+import org.matrix.android.sdk.api.extensions.measureTransaction
 import org.matrix.android.sdk.api.metrics.SyncDurationMetricPlugin
 import org.matrix.android.sdk.api.session.pushrules.PushRuleService
 import org.matrix.android.sdk.api.session.pushrules.RuleScope
@@ -71,7 +71,7 @@ internal class SyncResponseHandler @Inject constructor(
         val isInitialSync = fromToken == null
         Timber.v("Start handling sync, is InitialSync: $isInitialSync")
 
-        relevantPlugins.measureMetric {
+        relevantPlugins.measureTransaction {
             startCryptoService(isInitialSync)
 
             // Handle the to device events before the room ones

--- a/vector/src/main/java/im/vector/app/features/analytics/metrics/VectorPlugins.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/metrics/VectorPlugins.kt
@@ -17,6 +17,7 @@
 package im.vector.app.features.analytics.metrics
 
 import im.vector.app.features.analytics.metrics.sentry.SentryDownloadDeviceKeysMetrics
+import im.vector.app.features.analytics.metrics.sentry.SentrySendServiceMetrics
 import im.vector.app.features.analytics.metrics.sentry.SentrySyncDurationMetrics
 import org.matrix.android.sdk.api.metrics.MetricPlugin
 import javax.inject.Inject
@@ -29,9 +30,10 @@ import javax.inject.Singleton
 data class VectorPlugins @Inject constructor(
         val sentryDownloadDeviceKeysMetrics: SentryDownloadDeviceKeysMetrics,
         val sentrySyncDurationMetrics: SentrySyncDurationMetrics,
+        val sentrySendServiceMetrics: SentrySendServiceMetrics
 ) {
     /**
      * Returns [List] of all [MetricPlugin] hold by this class.
      */
-    fun plugins(): List<MetricPlugin> = listOf(sentryDownloadDeviceKeysMetrics, sentrySyncDurationMetrics)
+    fun plugins(): List<MetricPlugin> = listOf(sentryDownloadDeviceKeysMetrics, sentrySyncDurationMetrics, sentrySendServiceMetrics)
 }

--- a/vector/src/main/java/im/vector/app/features/analytics/metrics/sentry/SentrySendServiceMetrics.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/metrics/sentry/SentrySendServiceMetrics.kt
@@ -20,7 +20,7 @@ import io.sentry.ISpan
 import io.sentry.ITransaction
 import io.sentry.Sentry
 import io.sentry.SpanStatus
-import org.matrix.android.sdk.api.metrics.SyncDurationMetricPlugin
+import org.matrix.android.sdk.api.metrics.SendServiceMetricPlugin
 import java.util.EmptyStackException
 import java.util.Stack
 import javax.inject.Inject
@@ -28,7 +28,7 @@ import javax.inject.Inject
 /**
  * Sentry based implementation of SyncDurationMetricPlugin.
  */
-class SentrySyncDurationMetrics @Inject constructor() : SyncDurationMetricPlugin {
+class SentrySendServiceMetrics @Inject constructor() : SendServiceMetricPlugin {
     private var transaction: ITransaction? = null
 
     // Stacks to keep spans in LIFO order.
@@ -44,7 +44,7 @@ class SentrySyncDurationMetrics @Inject constructor() : SyncDurationMetricPlugin
      */
     override fun startSpan(operation: String, description: String) {
         if (Sentry.isEnabled()) {
-            val span = Sentry.getSpan()
+            val span = Sentry.getSpan() ?: transaction
             span?.let {
                 val innerSpan = it.startChild(operation, description)
                 spans.push(innerSpan)
@@ -64,7 +64,7 @@ class SentrySyncDurationMetrics @Inject constructor() : SyncDurationMetricPlugin
 
     override fun startTransaction() {
         if (Sentry.isEnabled()) {
-            transaction = Sentry.startTransaction("sync_response_handler", "task", true)
+            transaction = Sentry.startTransaction("SendService", "action.handle", true)
             logTransaction("Sentry transaction started")
         }
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content
- A new plugin `SendServiceMetricPlugin` is added.
- Send event tasks is now tracked with spans.


## Motivation and context

- In order to improve the crypto layer, we need to have some metrics to track and improve. `SendService` is a transaction which tracks the process of sending an event in a room.

## Tests

<!-- Explain how you tested your development -->

- Enable analytics in Element-Android app.
- Try to open some conversations (rooms), especially the ones for which you don't have keys yet.
- You must see  `SendService` events being logged in  [here](https://sentry.tools.element.io/organizations/element/performance/summary/events/?breakdown=none&project=49&query=&showTransactions=p100&sort=-timestamp&statsPeriod=24h&transaction=SendService).
- Also make sure to test that messages of all type are being sent without any issues.

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): Android 11 and 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
