### PR TITLE
ANR on session start when sending client info is enabled

### DIFF
--- a/changelog.d/7604.bugfix
+++ b/changelog.d/7604.bugfix
@@ -1,0 +1,1 @@
+ANR on session start when sending client info is enabled

--- a/vector/src/main/java/im/vector/app/core/di/ActiveSessionHolder.kt
+++ b/vector/src/main/java/im/vector/app/core/di/ActiveSessionHolder.kt
@@ -111,9 +111,7 @@ class ActiveSessionHolder @Inject constructor(
                 }
                 ?: sessionInitializer.tryInitialize(readCurrentSession = { activeSessionReference.get() }) { session ->
                     setActiveSession(session)
-                    runBlocking {
-                        configureAndStartSessionUseCase.execute(session, startSyncing = startSync)
-                    }
+                    configureAndStartSessionUseCase.execute(session, startSyncing = startSync)
                 }
     }
 

--- a/vector/src/test/java/im/vector/app/core/session/ConfigureAndStartSessionUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/core/session/ConfigureAndStartSessionUseCaseTest.kt
@@ -18,6 +18,7 @@ package im.vector.app.core.session
 
 import im.vector.app.core.extensions.startSyncing
 import im.vector.app.core.session.clientinfo.UpdateMatrixClientInfoUseCase
+import im.vector.app.features.session.coroutineScope
 import im.vector.app.test.fakes.FakeContext
 import im.vector.app.test.fakes.FakeEnableNotificationsSettingUpdater
 import im.vector.app.test.fakes.FakeSession
@@ -32,6 +33,7 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkAll
 import io.mockk.verify
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -57,6 +59,7 @@ class ConfigureAndStartSessionUseCaseTest {
     @Before
     fun setup() {
         mockkStatic("im.vector.app.core.extensions.SessionKt")
+        mockkStatic("im.vector.app.features.session.SessionCoroutineScopesKt")
     }
 
     @After
@@ -68,6 +71,7 @@ class ConfigureAndStartSessionUseCaseTest {
     fun `given start sync needed and client info recording enabled when execute then it should be configured properly`() = runTest {
         // Given
         val fakeSession = givenASession()
+        every { fakeSession.coroutineScope } returns this
         fakeWebRtcCallManager.givenCheckForProtocolsSupportIfNeededSucceeds()
         coJustRun { fakeUpdateMatrixClientInfoUseCase.execute(any()) }
         fakeVectorPreferences.givenIsClientInfoRecordingEnabled(isEnabled = true)
@@ -75,6 +79,7 @@ class ConfigureAndStartSessionUseCaseTest {
 
         // When
         configureAndStartSessionUseCase.execute(fakeSession, startSyncing = true)
+        advanceUntilIdle()
 
         // Then
         verify { fakeSession.startSyncing(fakeContext.instance) }
@@ -88,6 +93,7 @@ class ConfigureAndStartSessionUseCaseTest {
     fun `given start sync needed and client info recording disabled when execute then it should be configured properly`() = runTest {
         // Given
         val fakeSession = givenASession()
+        every { fakeSession.coroutineScope } returns this
         fakeWebRtcCallManager.givenCheckForProtocolsSupportIfNeededSucceeds()
         coJustRun { fakeUpdateMatrixClientInfoUseCase.execute(any()) }
         fakeVectorPreferences.givenIsClientInfoRecordingEnabled(isEnabled = false)
@@ -95,6 +101,7 @@ class ConfigureAndStartSessionUseCaseTest {
 
         // When
         configureAndStartSessionUseCase.execute(fakeSession, startSyncing = true)
+        advanceUntilIdle()
 
         // Then
         verify { fakeSession.startSyncing(fakeContext.instance) }
@@ -108,6 +115,7 @@ class ConfigureAndStartSessionUseCaseTest {
     fun `given a session and no start sync needed when execute then it should be configured properly`() = runTest {
         // Given
         val fakeSession = givenASession()
+        every { fakeSession.coroutineScope } returns this
         fakeWebRtcCallManager.givenCheckForProtocolsSupportIfNeededSucceeds()
         coJustRun { fakeUpdateMatrixClientInfoUseCase.execute(any()) }
         fakeVectorPreferences.givenIsClientInfoRecordingEnabled(isEnabled = true)
@@ -115,6 +123,7 @@ class ConfigureAndStartSessionUseCaseTest {
 
         // When
         configureAndStartSessionUseCase.execute(fakeSession, startSyncing = false)
+        advanceUntilIdle()
 
         // Then
         verify(inverse = true) { fakeSession.startSyncing(fakeContext.instance) }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Launch the sending of client info in a dedicated coroutine so that it does not block the main thread on app startup and leads to ANR.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7604 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Enable the labs flag about "Client info recording" in a previous version of the app
- Update the app with this fix
- The app should not block on startup

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
