### PR TITLE
[RTE] Change layout based on plain text / rich text mode

### DIFF
--- a/changelog.d/7620.bugfix
+++ b/changelog.d/7620.bugfix
@@ -1,0 +1,1 @@
+Make the plain text mode layout of the RTE more compact.

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
@@ -45,6 +45,7 @@ import im.vector.app.R
 import im.vector.app.core.extensions.hideKeyboard
 import im.vector.app.core.extensions.setTextIfDifferent
 import im.vector.app.core.extensions.showKeyboard
+import im.vector.app.core.utils.DimensionConverter
 import im.vector.app.databinding.ComposerRichTextLayoutBinding
 import im.vector.app.databinding.ViewRichTextMenuButtonBinding
 import io.element.android.wysiwyg.EditorEditText
@@ -110,6 +111,8 @@ class RichTextComposerLayout @JvmOverloads constructor(
             setCornerSize(cornerSize.toFloat())
         }
     }
+
+    private val dimensionConverter = DimensionConverter(resources)
 
     fun setFullScreen(isFullScreen: Boolean) {
         editText.updateLayoutParams<ViewGroup.LayoutParams> {
@@ -258,7 +261,7 @@ class RichTextComposerLayout @JvmOverloads constructor(
         views.plainTextComposerEditText.isVisible = !isTextFormattingEnabled
 
         // The layouts for formatted text mode and plain text mode are different, so we need to update the constraints
-        val dp = { px: Int -> (px * resources.displayMetrics.density).toInt() }
+        val dpToPx = { dp: Int -> dimensionConverter.dpToPx(dp) }
         ConstraintSet().apply {
             clone(views.composerLayoutContent)
             clear(R.id.composerEditTextOuterBorder, ConstraintSet.TOP)
@@ -266,13 +269,13 @@ class RichTextComposerLayout @JvmOverloads constructor(
             clear(R.id.composerEditTextOuterBorder, ConstraintSet.START)
             clear(R.id.composerEditTextOuterBorder, ConstraintSet.END)
             if (isTextFormattingEnabled) {
-                connect(R.id.composerEditTextOuterBorder, ConstraintSet.TOP, R.id.composerLayoutContent, ConstraintSet.TOP, dp(8))
+                connect(R.id.composerEditTextOuterBorder, ConstraintSet.TOP, R.id.composerLayoutContent, ConstraintSet.TOP, dpToPx(8))
                 connect(R.id.composerEditTextOuterBorder, ConstraintSet.BOTTOM, R.id.sendButton, ConstraintSet.TOP, 0)
-                connect(R.id.composerEditTextOuterBorder, ConstraintSet.START, R.id.composerLayoutContent, ConstraintSet.START, dp(12))
-                connect(R.id.composerEditTextOuterBorder, ConstraintSet.END, R.id.composerLayoutContent, ConstraintSet.END, dp(12))
+                connect(R.id.composerEditTextOuterBorder, ConstraintSet.START, R.id.composerLayoutContent, ConstraintSet.START, dpToPx(12))
+                connect(R.id.composerEditTextOuterBorder, ConstraintSet.END, R.id.composerLayoutContent, ConstraintSet.END, dpToPx(12))
             } else {
-                connect(R.id.composerEditTextOuterBorder, ConstraintSet.TOP, R.id.composerLayoutContent, ConstraintSet.TOP, dp(10))
-                connect(R.id.composerEditTextOuterBorder, ConstraintSet.BOTTOM, R.id.composerLayoutContent, ConstraintSet.BOTTOM, dp(10))
+                connect(R.id.composerEditTextOuterBorder, ConstraintSet.TOP, R.id.composerLayoutContent, ConstraintSet.TOP, dpToPx(10))
+                connect(R.id.composerEditTextOuterBorder, ConstraintSet.BOTTOM, R.id.composerLayoutContent, ConstraintSet.BOTTOM, dpToPx(10))
                 connect(R.id.composerEditTextOuterBorder, ConstraintSet.START, R.id.attachmentButton, ConstraintSet.END, 0)
                 connect(R.id.composerEditTextOuterBorder, ConstraintSet.END, R.id.sendButton, ConstraintSet.START, 0)
             }
@@ -281,8 +284,10 @@ class RichTextComposerLayout @JvmOverloads constructor(
     }
 
     private fun updateFullScreenButtonVisibility() {
+        val isLargeScreenDevice = resources.configuration.isLayoutSizeAtLeast(Configuration.SCREENLAYOUT_SIZE_LARGE)
+        val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
         // There's no point in having full screen in landscape since there's almost no vertical space
-        views.composerFullScreenButton.isInvisible = !isTextFormattingEnabled || resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+        views.composerFullScreenButton.isInvisible = !isTextFormattingEnabled || (isLandscape && !isLargeScreenDevice)
     }
 
     /**

--- a/vector/src/main/res/layout/composer_rich_text_layout.xml
+++ b/vector/src/main/res/layout/composer_rich_text_layout.xml
@@ -26,6 +26,7 @@
     </FrameLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/composerLayoutContent"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Creates a ConstraintSet change when the rich text mode of the editor is enabled/disabled.
- Disables the full screen button when either the rich text mode is disabled or it's in landscape orientation, since there is almost no vertical space available.

## Motivation and context

Fixes #7620.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|![IMAGE 2022-11-21 09:31:59](https://user-images.githubusercontent.com/480955/203002602-4d880dbb-7ce4-4acd-86d3-800139f4c0f9.jpg)|![Screen](https://user-images.githubusercontent.com/480955/203002671-e9b2ed5a-a5eb-497d-9bfd-67317524b414.png)|

## Tests

<!-- Explain how you tested your development -->

- Enabled the Rich Text Editor in Labs.
- Enter a room, make sure your device is in portrait orientation (vertical).
- Enter full screen mode using the 'maximise' button.
- Tap on the "+" button, disable formatting. Check that the full screen mode was cancelled and there is no 'maximise' button anymore.
- Enable formatting again, the maximise button should be back.
- Enter full screen mode again.
- Rotate the screen to landscape. Check that the full screen mode was disabled and there is no maximise button again.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
