### PR TITLE
[Rich text editor] Fix design and spacing of rich text editor

### DIFF
--- a/7658.bugfix
+++ b/7658.bugfix
@@ -1,0 +1,1 @@
+[Rich text editor] Fix design and spacing of rich text editor

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
@@ -274,8 +274,8 @@ class RichTextComposerLayout @JvmOverloads constructor(
                 connect(R.id.composerEditTextOuterBorder, ConstraintSet.START, R.id.composerLayoutContent, ConstraintSet.START, dpToPx(12))
                 connect(R.id.composerEditTextOuterBorder, ConstraintSet.END, R.id.composerLayoutContent, ConstraintSet.END, dpToPx(12))
             } else {
-                connect(R.id.composerEditTextOuterBorder, ConstraintSet.TOP, R.id.composerLayoutContent, ConstraintSet.TOP, dpToPx(10))
-                connect(R.id.composerEditTextOuterBorder, ConstraintSet.BOTTOM, R.id.composerLayoutContent, ConstraintSet.BOTTOM, dpToPx(10))
+                connect(R.id.composerEditTextOuterBorder, ConstraintSet.TOP, R.id.composerLayoutContent, ConstraintSet.TOP, dpToPx(8))
+                connect(R.id.composerEditTextOuterBorder, ConstraintSet.BOTTOM, R.id.composerLayoutContent, ConstraintSet.BOTTOM, dpToPx(8))
                 connect(R.id.composerEditTextOuterBorder, ConstraintSet.START, R.id.attachmentButton, ConstraintSet.END, 0)
                 connect(R.id.composerEditTextOuterBorder, ConstraintSet.END, R.id.sendButton, ConstraintSet.START, 0)
             }

--- a/vector/src/main/res/layout/composer_rich_text_layout.xml
+++ b/vector/src/main/res/layout/composer_rich_text_layout.xml
@@ -32,26 +32,26 @@
 
         <ImageButton
             android:id="@+id/attachmentButton"
-            android:layout_width="56dp"
-            android:layout_height="60dp"
-            android:layout_margin="@dimen/composer_attachment_margin"
-            android:background="?android:attr/selectableItemBackground"
+            android:layout_width="60dp"
+            android:layout_height="56dp"
+            android:background="?android:attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/option_send_files"
             android:src="@drawable/ic_rich_composer_add"
-            android:paddingStart="4dp"
             app:layout_constraintVertical_bias="1"
-            app:layout_constraintBottom_toBottomOf="@id/sendButton"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/sendButton"
-            app:layout_goneMarginBottom="57dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_goneMarginBottom="56dp"
             tools:ignore="MissingPrefix,RtlSymmetry" />
 
+        <!-- Constraints are updated programmatically -->
         <FrameLayout
             android:id="@+id/composerEditTextOuterBorder"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:minHeight="40dp"
             android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
             android:layout_marginHorizontal="12dp"
             app:layout_constraintVertical_bias="0"
             app:layout_constraintTop_toTopOf="parent"
@@ -156,19 +156,19 @@
             app:layout_constraintBottom_toBottomOf="@id/composerEditTextOuterBorder"
             app:layout_constraintVertical_bias="0"
             android:src="@drawable/ic_composer_full_screen"
-            android:background="?android:attr/selectableItemBackground"
+            android:background="?android:attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/rich_text_editor_full_screen_toggle" />
 
         <ImageButton
             android:id="@+id/sendButton"
             android:layout_width="56dp"
-            android:layout_height="60dp"
+            android:layout_height="56dp"
             android:paddingEnd="4dp"
             android:contentDescription="@string/action_send"
             android:scaleType="center"
             android:src="@drawable/ic_rich_composer_send"
             android:visibility="invisible"
-            android:background="?android:selectableItemBackground"
+            android:background="?android:attr/selectableItemBackgroundBorderless"
             app:layout_constraintTop_toBottomOf="@id/composerEditTextOuterBorder"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Improve design and spacing of the rich text editor.

Minor changes to
- position of input field relative to buttons
- spacing around attachments button
- spacing around send button
- selectable backgrounds

## Motivation and context

https://element-io.atlassian.net/browse/PSU-994

## Screenshots / GIFs

| |Before|After|
|-|-|-|
|Empty input, formatting disabled|![rich-text-formatting-disabled-before](https://user-images.githubusercontent.com/4940864/204543837-23a2ccfa-1e0b-4c82-903b-b397bf53317f.png)|![rich-text-formatting-disabled](https://user-images.githubusercontent.com/4940864/204539450-d28db31c-afbb-4091-b90d-6c6811a63aef.png)|
|Empty input, formatting enabled|![rich-text-formatting-enabled-before](https://user-images.githubusercontent.com/4940864/204543891-61d9fd70-fe63-424e-a046-850026602aa5.png)|![rich-text-formatting-enabled](https://user-images.githubusercontent.com/4940864/204539510-a2971d6e-256a-4135-9d4a-42572bad1b2b.png)|
|Text in input, formatting disabled|![rich-text-formatting-disabled-send-before](https://user-images.githubusercontent.com/4940864/204543940-ef74ab7d-75f9-4bf9-a9a2-ea5fa5bb797b.png)|![rich-text-formatting-disabled-send](https://user-images.githubusercontent.com/4940864/204539614-5472a2e2-494a-461f-be63-94e85cb66c30.png)|
|Text in input, formatting enabled|![rich-text-formatting-enabled-send-before](https://user-images.githubusercontent.com/4940864/204544076-b6792fbb-a5bd-4807-acfe-be9bca3699c5.png)|![rich-text-formatting-enabled-send](https://user-images.githubusercontent.com/4940864/204539641-8d31d19d-b2e5-4614-a608-cfe0c25754b3.png)|

## Tests

1. Enable rich text editor (via labs)
2. Navigate to a room
3. Enable text formatting (via the attachment menu)
4. *Check design*
5. Disable text formatting (via the attachment menu)
6. *Check design*

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 13

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
