### PR TITLE
[Rich text editor] Fix keyboard closing after collapsing rich text editor

### DIFF
--- a/changelog.d/7659.bugfix
+++ b/changelog.d/7659.bugfix
@@ -1,0 +1,1 @@
+[Rich text editor] Fix keyboard closing after collapsing editor

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
@@ -42,7 +42,6 @@ import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import com.google.android.material.shape.MaterialShapeDrawable
 import im.vector.app.R
-import im.vector.app.core.extensions.hideKeyboard
 import im.vector.app.core.extensions.setTextIfDifferent
 import im.vector.app.core.extensions.showKeyboard
 import im.vector.app.core.utils.DimensionConverter
@@ -132,8 +131,6 @@ class RichTextComposerLayout @JvmOverloads constructor(
         views.bottomSheetHandle.isVisible = isFullScreen
         if (isFullScreen) {
             editText.showKeyboard(true)
-        } else {
-            editText.hideKeyboard()
         }
         this.isFullScreen = isFullScreen
     }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fix keyboard closing after collapsing rich text editor.

## Motivation and context

https://element-io.atlassian.net/browse/PSU-994

When enabling the full-screen mode of the rich text editor, the keyboard should be opened. However, when collapsing, the keyboard should not be closed if it is already open.

## Screenshots / GIFs
[expand-collapse-keyboard.webm](https://user-images.githubusercontent.com/4940864/204552865-3c8b12f9-4f45-40eb-8c1d-f59996d07450.webm)


## Tests

1. Enable the rich text editor via labs
2. Navigate to a room
3. Expand the text input
4. *Check the keyboard is opened*
5. Collapse the text input
6. *Check the keyboard is closed*

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 13

## Checklist


- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
