### PR TITLE
Rich Text Editor: fix several inset issues in room screen

### DIFF
--- a/changelog.d/7680.bugfix
+++ b/changelog.d/7680.bugfix
@@ -1,0 +1,3 @@
+Rich Text Editor: fix several issues related to insets:
+* Empty space displayed at the bottom when you don't have permissions to send messages into a room.
+* Wrong insets being kept when you exit the room screen and the keyboard is displayed, then come back to it.

--- a/vector/src/main/java/im/vector/app/core/utils/ExpandingBottomSheetBehavior.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/ExpandingBottomSheetBehavior.kt
@@ -608,26 +608,33 @@ class ExpandingBottomSheetBehavior<V : View> : CoordinatorLayout.Behavior<V> {
         initialPaddingBottom = view.paddingBottom
 
         // This should only be used to set initial insets and other edge cases where the insets can't be applied using an animation.
-        var applyInsetsFromAnimation = false
+        var isAnimating = false
 
-        // This will animated inset changes, making them look a lot better. However, it won't update initial insets.
+        // This will animate inset changes, making them look a lot better. However, it won't update initial insets.
         ViewCompat.setWindowInsetsAnimationCallback(view, object : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_STOP) {
+            override fun onPrepare(animation: WindowInsetsAnimationCompat) {
+                isAnimating = true
+            }
+
             override fun onProgress(insets: WindowInsetsCompat, runningAnimations: MutableList<WindowInsetsAnimationCompat>): WindowInsetsCompat {
-                return applyInsets(view, insets)
+                return if (isAnimating) {
+                    applyInsets(view, insets)
+                } else {
+                    insets
+                }
             }
 
             override fun onEnd(animation: WindowInsetsAnimationCompat) {
-                applyInsetsFromAnimation = false
+                isAnimating = false
                 view.requestApplyInsets()
             }
         })
 
         ViewCompat.setOnApplyWindowInsetsListener(view) { _: View, insets: WindowInsetsCompat ->
-            if (!applyInsetsFromAnimation) {
-                applyInsetsFromAnimation = true
-                applyInsets(view, insets)
-            } else {
+            if (isAnimating) {
                 insets
+            } else {
+                applyInsets(view, insets)
             }
         }
 

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
@@ -255,7 +255,7 @@ class MessageComposerFragment : VectorBaseFragment<FragmentComposerBinding>(), A
     ) { mainState, messageComposerState, attachmentState ->
         if (mainState.tombstoneEvent != null) return@withState
 
-        (composer as? View)?.isInvisible = !messageComposerState.isComposerVisible
+        (composer as? View)?.isVisible = messageComposerState.isComposerVisible
         composer.sendButton.isInvisible = !messageComposerState.isSendButtonVisible
         (composer as? RichTextComposerLayout)?.isTextFormattingEnabled = attachmentState.isTextFormattingEnabled
     }

--- a/vector/src/main/res/layout/fragment_timeline.xml
+++ b/vector/src/main/res/layout/fragment_timeline.xml
@@ -75,7 +75,7 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:overScrollMode="always"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/notificationAreaView"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/removeJitsiWidgetView"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

* Changes the way insets are applied in `ExpandingBottomSheetBehavior`.
* Hides the composer using `isVisible = false` instead of `isInvisible = true` in `MessageComposerFragment`.
* Also fixes a small issue with constraints in `fragment_timeline.xml`.

## Motivation and context

Fixes #7680 .

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

See the issue linked above.

## Tests

<!-- Explain how you tested your development -->

To test the issue with the blank space:
- Open a room where you have no permission to post messages.

To test the issue with insets not being applied when coming back to the chat screen.
- Open a room.
- Open the keyboard by tapping on the composer.
- Open the settings screen for the room.
- Come back.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
