### PR TITLE
Rich text editor: improve performance when changing composer mode

### DIFF
--- a/changelog.d/7691.bugfix
+++ b/changelog.d/7691.bugfix
@@ -1,0 +1,1 @@
+Rich Text Editor: improve performance when entering reply/edit/quote mode.

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerFragment.kt
@@ -285,7 +285,7 @@ class MessageComposerFragment : VectorBaseFragment<FragmentComposerBinding>(), A
                         else -> return
                     }
 
-                    (composer as? RichTextComposerLayout)?.setFullScreen(setFullScreen)
+                    (composer as? RichTextComposerLayout)?.setFullScreen(setFullScreen, true)
 
                     messageComposerViewModel.handle(MessageComposerAction.SetFullScreen(setFullScreen))
                 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerMode.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerMode.kt
@@ -23,6 +23,6 @@ sealed interface MessageComposerMode {
 
     sealed class Special(open val event: TimelineEvent, open val defaultContent: CharSequence) : MessageComposerMode
     data class Edit(override val event: TimelineEvent, override val defaultContent: CharSequence) : Special(event, defaultContent)
-    class Quote(override val event: TimelineEvent, override val defaultContent: CharSequence) : Special(event, defaultContent)
-    class Reply(override val event: TimelineEvent, override val defaultContent: CharSequence) : Special(event, defaultContent)
+    data class Quote(override val event: TimelineEvent, override val defaultContent: CharSequence) : Special(event, defaultContent)
+    data class Reply(override val event: TimelineEvent, override val defaultContent: CharSequence) : Special(event, defaultContent)
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
@@ -66,6 +66,7 @@ internal class RichTextComposerLayout @JvmOverloads constructor(
     // There is no need to persist these values since they're always updated by the parent fragment
     private var isFullScreen = false
     private var hasRelatedMessage = false
+    private var composerMode: MessageComposerMode? = null
 
     var isTextFormattingEnabled = true
         set(value) {
@@ -114,9 +115,15 @@ internal class RichTextComposerLayout @JvmOverloads constructor(
 
     private val dimensionConverter = DimensionConverter(resources)
 
-    fun setFullScreen(isFullScreen: Boolean) {
+    fun setFullScreen(isFullScreen: Boolean, animated: Boolean) {
+        if (!animated && views.composerLayout.layoutParams != null) {
+            views.composerLayout.updateLayoutParams<ViewGroup.LayoutParams> {
+                height =
+                        if (isFullScreen) ViewGroup.LayoutParams.MATCH_PARENT else ViewGroup.LayoutParams.WRAP_CONTENT
+            }
+        }
         editText.updateLayoutParams<ViewGroup.LayoutParams> {
-            height = if (isFullScreen) 0 else ViewGroup.LayoutParams.WRAP_CONTENT
+            height = if (isFullScreen) ViewGroup.LayoutParams.MATCH_PARENT else ViewGroup.LayoutParams.WRAP_CONTENT
         }
 
         updateTextFieldBorder(isFullScreen)
@@ -369,6 +376,9 @@ internal class RichTextComposerLayout @JvmOverloads constructor(
     }
 
     override fun renderComposerMode(mode: MessageComposerMode) {
+        if (this.composerMode == mode) return
+        this.composerMode = mode
+
         if (mode is MessageComposerMode.Special) {
             views.composerModeGroup.isVisible = true
             replaceFormattedContent(mode.defaultContent)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/RichTextComposerLayout.kt
@@ -376,12 +376,13 @@ internal class RichTextComposerLayout @JvmOverloads constructor(
     }
 
     override fun renderComposerMode(mode: MessageComposerMode) {
-        if (this.composerMode == mode) return
-        this.composerMode = mode
-
         if (mode is MessageComposerMode.Special) {
             views.composerModeGroup.isVisible = true
-            replaceFormattedContent(mode.defaultContent)
+            if (isTextFormattingEnabled) {
+                replaceFormattedContent(mode.defaultContent)
+            } else {
+                views.plainTextComposerEditText.setText(mode.defaultContent)
+            }
             hasRelatedMessage = true
             editText.showKeyboard(andRequestFocus = true)
         } else {
@@ -393,9 +394,13 @@ internal class RichTextComposerLayout @JvmOverloads constructor(
                     views.plainTextComposerEditText.setText(text)
                 }
             }
-            views.sendButton.contentDescription = resources.getString(R.string.action_send)
             hasRelatedMessage = false
         }
+
+        updateTextFieldBorder(isFullScreen)
+
+        if (this.composerMode == mode) return
+        this.composerMode = mode
 
         views.sendButton.apply {
             if (mode is MessageComposerMode.Edit) {
@@ -406,8 +411,6 @@ internal class RichTextComposerLayout @JvmOverloads constructor(
                 setImageResource(R.drawable.ic_rich_composer_send)
             }
         }
-
-        updateTextFieldBorder(isFullScreen)
 
         when (mode) {
             is MessageComposerMode.Edit -> {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Store the current `MessageComposerMode` so we can diff and avoid unnecessary updates. 

Also, only change some layout params for the editor if we don't want to animate the full screen change (keeps compatibility with both Element Android and Element X).

## Motivation and context

Element X stopped properly responding to input as the `renderComposerMode` method was being triggered for each change (on Element Android this is not so noticeable). It also had some issues with resizing the editor properly.

As both apps share most of this code, it's better to also handle it properly here.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

It's quite difficult to test, as it wasn't a noticeable issue in Element Android.

- Enable the Rich Text Editor in Labs.
- Open a room.
- Select a message and edit or quote it, or reply to it.
- Exit the editing/replying/quoting mode.

There should be no issues when writing or 'flashes'.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
