### PR TITLE
Remind unverified sessions with a banner once a week (PSG-892)

### DIFF
--- a/changelog.d/7694.feature
+++ b/changelog.d/7694.feature
@@ -1,0 +1,1 @@
+Remind unverified sessions with a banner once a week

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -2647,8 +2647,12 @@
     <string name="unencrypted">Unencrypted</string>
     <string name="encrypted_unverified">Encrypted by an unverified device</string>
     <string name="key_authenticity_not_guaranteed">The authenticity of this encrypted message can\'t be guaranteed on this device.</string>
+    <!-- TODO TO BE REMOVED -->
     <string name="review_logins">Review where you’re logged in</string>
+    <!-- TODO TO BE REMOVED -->
     <string name="verify_other_sessions">Verify all your sessions to ensure your account &amp; messages are safe</string>
+    <string name="review_unverified_sessions_title">You have unverified sessions</string>
+    <string name="review_unverified_sessions_description">Review to ensure your account is safe</string>
     <!-- Argument will be replaced by the other session name (e.g, Desktop, mobile) -->
     <string name="verify_this_session">Verify the new login accessing your account: %1$s</string>
 

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -2648,9 +2648,9 @@
     <string name="encrypted_unverified">Encrypted by an unverified device</string>
     <string name="key_authenticity_not_guaranteed">The authenticity of this encrypted message can\'t be guaranteed on this device.</string>
     <!-- TODO TO BE REMOVED -->
-    <string name="review_logins">Review where you’re logged in</string>
+    <string name="review_logins" tools:ignore="UnusedResources">Review where you’re logged in</string>
     <!-- TODO TO BE REMOVED -->
-    <string name="verify_other_sessions">Verify all your sessions to ensure your account &amp; messages are safe</string>
+    <string name="verify_other_sessions" tools:ignore="UnusedResources">Verify all your sessions to ensure your account &amp; messages are safe</string>
     <string name="review_unverified_sessions_title">You have unverified sessions</string>
     <string name="review_unverified_sessions_description">Review to ensure your account is safe</string>
     <!-- Argument will be replaced by the other session name (e.g, Desktop, mobile) -->

--- a/vector-app/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
+++ b/vector-app/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
@@ -88,6 +88,9 @@ class DebugVectorFeatures(
     override fun isVoiceBroadcastEnabled(): Boolean = read(DebugFeatureKeys.voiceBroadcastEnabled)
             ?: vectorFeatures.isVoiceBroadcastEnabled()
 
+    override fun isUnverifiedSessionsAlertEnabled(): Boolean = read(DebugFeatureKeys.unverifiedSessionsAlertEnabled)
+            ?: vectorFeatures.isUnverifiedSessionsAlertEnabled()
+
     fun <T> override(value: T?, key: Preferences.Key<T>) = updatePreferences {
         if (value == null) {
             it.remove(key)
@@ -151,4 +154,5 @@ object DebugFeatureKeys {
     val qrCodeLoginForAllServers = booleanPreferencesKey("qr-code-login-for-all-servers")
     val reciprocateQrCodeLogin = booleanPreferencesKey("reciprocate-qr-code-login")
     val voiceBroadcastEnabled = booleanPreferencesKey("voice-broadcast-enabled")
+    val unverifiedSessionsAlertEnabled = booleanPreferencesKey("unverified-sessions-alert-enabled")
 }

--- a/vector-config/src/main/java/im/vector/app/config/Config.kt
+++ b/vector-config/src/main/java/im/vector/app/config/Config.kt
@@ -16,6 +16,8 @@
 
 package im.vector.app.config
 
+import kotlin.time.Duration.Companion.days
+
 /**
  * Set of flags to configure the application.
  */
@@ -93,4 +95,6 @@ object Config {
      * Can be disabled by providing Analytics.Disabled
      */
     val NIGHTLY_ANALYTICS_CONFIG = RELEASE_ANALYTICS_CONFIG.copy(sentryEnvironment = "NIGHTLY")
+
+    val SHOW_UNVERIFIED_SESSIONS_ALERT_AFTER_MILLIS = 7.days.inWholeMilliseconds // 1 Week
 }

--- a/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
+++ b/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
@@ -64,5 +64,5 @@ class DefaultVectorFeatures : VectorFeatures {
     override fun isQrCodeLoginForAllServers(): Boolean = false
     override fun isReciprocateQrCodeLogin(): Boolean = false
     override fun isVoiceBroadcastEnabled(): Boolean = true
-    override fun isUnverifiedSessionsAlertEnabled(): Boolean = false
+    override fun isUnverifiedSessionsAlertEnabled(): Boolean = true
 }

--- a/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
+++ b/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
@@ -44,6 +44,7 @@ interface VectorFeatures {
     fun isQrCodeLoginForAllServers(): Boolean
     fun isReciprocateQrCodeLogin(): Boolean
     fun isVoiceBroadcastEnabled(): Boolean
+    fun isUnverifiedSessionsAlertEnabled(): Boolean
 }
 
 class DefaultVectorFeatures : VectorFeatures {
@@ -63,4 +64,5 @@ class DefaultVectorFeatures : VectorFeatures {
     override fun isQrCodeLoginForAllServers(): Boolean = false
     override fun isReciprocateQrCodeLogin(): Boolean = false
     override fun isVoiceBroadcastEnabled(): Boolean = true
+    override fun isUnverifiedSessionsAlertEnabled(): Boolean = false
 }

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
@@ -256,8 +256,8 @@ class HomeDetailFragment :
         alertManager.postVectorAlert(
                 VerificationVectorAlert(
                         uid = uid,
-                        title = getString(R.string.review_logins),
-                        description = getString(R.string.verify_other_sessions),
+                        title = getString(R.string.review_unverified_sessions_title),
+                        description = getString(R.string.review_unverified_sessions_description),
                         iconId = R.drawable.ic_shield_warning
                 ).apply {
                     viewBinder = VerificationVectorAlert.ViewBinder(user, avatarRenderer)

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
@@ -239,12 +239,12 @@ class HomeDetailFragment :
                                     .requestSessionVerification(vectorBaseActivity, newest.deviceId ?: "")
                         }
                         unknownDeviceDetectorSharedViewModel.handle(
-                                UnknownDeviceDetectorSharedViewModel.Action.IgnoreDevice(newest.deviceId?.let { listOf(it) }.orEmpty())
+                                UnknownDeviceDetectorSharedViewModel.Action.IgnoreNewLogin(newest.deviceId?.let { listOf(it) }.orEmpty())
                         )
                     }
                     dismissedAction = Runnable {
                         unknownDeviceDetectorSharedViewModel.handle(
-                                UnknownDeviceDetectorSharedViewModel.Action.IgnoreDevice(newest.deviceId?.let { listOf(it) }.orEmpty())
+                                UnknownDeviceDetectorSharedViewModel.Action.IgnoreNewLogin(newest.deviceId?.let { listOf(it) }.orEmpty())
                         )
                     }
                 }

--- a/vector/src/main/java/im/vector/app/features/home/IsNewLoginAlertShownUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/home/IsNewLoginAlertShownUseCase.kt
@@ -16,24 +16,16 @@
 
 package im.vector.app.features.home
 
-import im.vector.app.config.Config
-import im.vector.app.core.time.Clock
-import im.vector.app.features.VectorFeatures
 import im.vector.app.features.settings.VectorPreferences
 import javax.inject.Inject
 
-class ShouldShowUnverifiedSessionsAlertUseCase @Inject constructor(
-        private val vectorFeatures: VectorFeatures,
+class IsNewLoginAlertShownUseCase @Inject constructor(
         private val vectorPreferences: VectorPreferences,
-        private val clock: Clock,
 ) {
 
     fun execute(deviceId: String?): Boolean {
         deviceId ?: return false
 
-        val isUnverifiedSessionsAlertEnabled = vectorFeatures.isUnverifiedSessionsAlertEnabled()
-        val unverifiedSessionsAlertLastShownMillis = vectorPreferences.getUnverifiedSessionsAlertLastShownMillis(deviceId)
-        return isUnverifiedSessionsAlertEnabled &&
-                clock.epochMillis() - unverifiedSessionsAlertLastShownMillis >= Config.SHOW_UNVERIFIED_SESSIONS_ALERT_AFTER_MILLIS
+        return vectorPreferences.isNewLoginAlertShownForDevice(deviceId)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
@@ -270,8 +270,8 @@ class NewHomeDetailFragment :
         alertManager.postVectorAlert(
                 VerificationVectorAlert(
                         uid = uid,
-                        title = getString(R.string.review_logins),
-                        description = getString(R.string.verify_other_sessions),
+                        title = getString(R.string.review_unverified_sessions_title),
+                        description = getString(R.string.review_unverified_sessions_description),
                         iconId = R.drawable.ic_shield_warning
                 ).apply {
                     viewBinder = VerificationVectorAlert.ViewBinder(user, avatarRenderer)

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
@@ -253,12 +253,12 @@ class NewHomeDetailFragment :
                                     .requestSessionVerification(vectorBaseActivity, newest.deviceId ?: "")
                         }
                         unknownDeviceDetectorSharedViewModel.handle(
-                                UnknownDeviceDetectorSharedViewModel.Action.IgnoreDevice(newest.deviceId?.let { listOf(it) }.orEmpty())
+                                UnknownDeviceDetectorSharedViewModel.Action.IgnoreNewLogin(newest.deviceId?.let { listOf(it) }.orEmpty())
                         )
                     }
                     dismissedAction = Runnable {
                         unknownDeviceDetectorSharedViewModel.handle(
-                                UnknownDeviceDetectorSharedViewModel.Action.IgnoreDevice(newest.deviceId?.let { listOf(it) }.orEmpty())
+                                UnknownDeviceDetectorSharedViewModel.Action.IgnoreNewLogin(newest.deviceId?.let { listOf(it) }.orEmpty())
                         )
                     }
                 }

--- a/vector/src/main/java/im/vector/app/features/home/SetNewLoginAlertShownUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/home/SetNewLoginAlertShownUseCase.kt
@@ -16,24 +16,16 @@
 
 package im.vector.app.features.home
 
-import im.vector.app.config.Config
-import im.vector.app.core.time.Clock
-import im.vector.app.features.VectorFeatures
 import im.vector.app.features.settings.VectorPreferences
 import javax.inject.Inject
 
-class ShouldShowUnverifiedSessionsAlertUseCase @Inject constructor(
-        private val vectorFeatures: VectorFeatures,
+class SetNewLoginAlertShownUseCase @Inject constructor(
         private val vectorPreferences: VectorPreferences,
-        private val clock: Clock,
 ) {
 
-    fun execute(deviceId: String?): Boolean {
-        deviceId ?: return false
-
-        val isUnverifiedSessionsAlertEnabled = vectorFeatures.isUnverifiedSessionsAlertEnabled()
-        val unverifiedSessionsAlertLastShownMillis = vectorPreferences.getUnverifiedSessionsAlertLastShownMillis(deviceId)
-        return isUnverifiedSessionsAlertEnabled &&
-                clock.epochMillis() - unverifiedSessionsAlertLastShownMillis >= Config.SHOW_UNVERIFIED_SESSIONS_ALERT_AFTER_MILLIS
+    fun execute(deviceIds: List<String>) {
+        deviceIds.forEach {
+            vectorPreferences.setNewLoginAlertShownForDevice(it)
+        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/SetUnverifiedSessionsAlertShownUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/home/SetUnverifiedSessionsAlertShownUseCase.kt
@@ -16,24 +16,19 @@
 
 package im.vector.app.features.home
 
-import im.vector.app.config.Config
 import im.vector.app.core.time.Clock
-import im.vector.app.features.VectorFeatures
 import im.vector.app.features.settings.VectorPreferences
 import javax.inject.Inject
 
-class ShouldShowUnverifiedSessionsAlertUseCase @Inject constructor(
-        private val vectorFeatures: VectorFeatures,
+class SetUnverifiedSessionsAlertShownUseCase @Inject constructor(
         private val vectorPreferences: VectorPreferences,
         private val clock: Clock,
 ) {
 
-    fun execute(deviceId: String?): Boolean {
-        deviceId ?: return false
-
-        val isUnverifiedSessionsAlertEnabled = vectorFeatures.isUnverifiedSessionsAlertEnabled()
-        val unverifiedSessionsAlertLastShownMillis = vectorPreferences.getUnverifiedSessionsAlertLastShownMillis(deviceId)
-        return isUnverifiedSessionsAlertEnabled &&
-                clock.epochMillis() - unverifiedSessionsAlertLastShownMillis >= Config.SHOW_UNVERIFIED_SESSIONS_ALERT_AFTER_MILLIS
+    fun execute(deviceIds: List<String>) {
+        val epochMillis = clock.epochMillis()
+        deviceIds.forEach {
+            vectorPreferences.setUnverifiedSessionsAlertLastShownMillis(it, epochMillis)
+        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/ShouldShowUnverifiedSessionsAlertUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/home/ShouldShowUnverifiedSessionsAlertUseCase.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home
+
+import im.vector.app.config.Config
+import im.vector.app.core.time.Clock
+import im.vector.app.features.VectorFeatures
+import im.vector.app.features.settings.VectorPreferences
+import javax.inject.Inject
+
+class ShouldShowUnverifiedSessionsAlertUseCase @Inject constructor(
+        private val vectorFeatures: VectorFeatures,
+        private val vectorPreferences: VectorPreferences,
+        private val clock: Clock,
+) {
+
+    fun execute(): Boolean {
+        val isUnverifiedSessionsAlertEnabled = vectorFeatures.isUnverifiedSessionsAlertEnabled()
+        val unverifiedSessionsAlertLastShownMillis = vectorPreferences.getUnverifiedSessionsAlertLastShownMillis()
+        return isUnverifiedSessionsAlertEnabled &&
+                clock.epochMillis() - unverifiedSessionsAlertLastShownMillis >= Config.SHOW_UNVERIFIED_SESSIONS_ALERT_AFTER_MILLIS
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -245,6 +245,8 @@ class VectorPreferences @Inject constructor(
         // This key will be used to enable user for displaying live user info or not.
         const val SETTINGS_TIMELINE_SHOW_LIVE_SENDER_INFO = "SETTINGS_TIMELINE_SHOW_LIVE_SENDER_INFO"
 
+        const val SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS = "SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS"
+
         // Possible values for TAKE_PHOTO_VIDEO_MODE
         const val TAKE_PHOTO_VIDEO_MODE_ALWAYS_ASK = 0
         const val TAKE_PHOTO_VIDEO_MODE_PHOTO = 1
@@ -1238,7 +1240,17 @@ class VectorPreferences @Inject constructor(
 
     fun setIpAddressVisibilityInDeviceManagerScreens(isVisible: Boolean) {
         defaultPrefs.edit {
-            putBoolean(VectorPreferences.SETTINGS_SESSION_MANAGER_SHOW_IP_ADDRESS, isVisible)
+            putBoolean(SETTINGS_SESSION_MANAGER_SHOW_IP_ADDRESS, isVisible)
+        }
+    }
+
+    fun getUnverifiedSessionsAlertLastShownMillis(): Long {
+        return defaultPrefs.getLong(SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS, 0)
+    }
+
+    fun setUnverifiedSessionsAlertLastShownMillis(lastShownMillis: Long) {
+        defaultPrefs.edit {
+            putLong(SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS, lastShownMillis)
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -227,8 +227,6 @@ class VectorPreferences @Inject constructor(
         private const val MEDIA_SAVING_1_MONTH = 2
         private const val MEDIA_SAVING_FOREVER = 3
 
-        private const val SETTINGS_UNKNOWN_DEVICE_DISMISSED_LIST = "SETTINGS_UNKNWON_DEVICE_DISMISSED_LIST"
-
         private const val TAKE_PHOTO_VIDEO_MODE = "TAKE_PHOTO_VIDEO_MODE"
 
         private const val SETTINGS_LABS_ENABLE_LIVE_LOCATION = "SETTINGS_LABS_ENABLE_LIVE_LOCATION"
@@ -245,7 +243,8 @@ class VectorPreferences @Inject constructor(
         // This key will be used to enable user for displaying live user info or not.
         const val SETTINGS_TIMELINE_SHOW_LIVE_SENDER_INFO = "SETTINGS_TIMELINE_SHOW_LIVE_SENDER_INFO"
 
-        const val SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS = "SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS"
+        const val SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS = "SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS_"
+        const val SETTINGS_NEW_LOGIN_ALERT_SHOWN_FOR_DEVICE = "SETTINGS_NEW_LOGIN_ALERT_SHOWN_FOR_DEVICE_"
 
         // Possible values for TAKE_PHOTO_VIDEO_MODE
         const val TAKE_PHOTO_VIDEO_MODE_ALWAYS_ASK = 0
@@ -520,18 +519,6 @@ class VectorPreferences @Inject constructor(
      */
     fun useShutterSound(): Boolean {
         return defaultPrefs.getBoolean(SETTINGS_PLAY_SHUTTER_SOUND_KEY, true)
-    }
-
-    fun storeUnknownDeviceDismissedList(deviceIds: List<String>) {
-        defaultPrefs.edit(true) {
-            putStringSet(SETTINGS_UNKNOWN_DEVICE_DISMISSED_LIST, deviceIds.toSet())
-        }
-    }
-
-    fun getUnknownDeviceDismissedList(): List<String> {
-        return tryOrNull {
-            defaultPrefs.getStringSet(SETTINGS_UNKNOWN_DEVICE_DISMISSED_LIST, null)?.toList()
-        }.orEmpty()
     }
 
     /**
@@ -1244,13 +1231,23 @@ class VectorPreferences @Inject constructor(
         }
     }
 
-    fun getUnverifiedSessionsAlertLastShownMillis(): Long {
-        return defaultPrefs.getLong(SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS, 0)
+    fun getUnverifiedSessionsAlertLastShownMillis(deviceId: String): Long {
+        return defaultPrefs.getLong(SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS + deviceId, 0)
     }
 
-    fun setUnverifiedSessionsAlertLastShownMillis(lastShownMillis: Long) {
+    fun setUnverifiedSessionsAlertLastShownMillis(deviceId: String, lastShownMillis: Long) {
         defaultPrefs.edit {
-            putLong(SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS, lastShownMillis)
+            putLong(SETTINGS_UNVERIFIED_SESSIONS_ALERT_LAST_SHOWN_MILLIS + deviceId, lastShownMillis)
+        }
+    }
+
+    fun isNewLoginAlertShownForDevice(deviceId: String): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_NEW_LOGIN_ALERT_SHOWN_FOR_DEVICE + deviceId, false)
+    }
+
+    fun setNewLoginAlertShownForDevice(deviceId: String) {
+        defaultPrefs.edit {
+            putBoolean(SETTINGS_NEW_LOGIN_ALERT_SHOWN_FOR_DEVICE + deviceId, true)
         }
     }
 }

--- a/vector/src/test/java/im/vector/app/features/home/ShouldShowUnverifiedSessionsAlertUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/home/ShouldShowUnverifiedSessionsAlertUseCaseTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home
+
+import im.vector.app.config.Config
+import im.vector.app.test.fakes.FakeClock
+import im.vector.app.test.fakes.FakeVectorFeatures
+import im.vector.app.test.fakes.FakeVectorPreferences
+import org.amshove.kluent.shouldBe
+import org.junit.Test
+
+private val AN_EPOCH = Config.SHOW_UNVERIFIED_SESSIONS_ALERT_AFTER_MILLIS
+
+class ShouldShowUnverifiedSessionsAlertUseCaseTest {
+
+    private val fakeVectorFeatures = FakeVectorFeatures()
+    private val fakeVectorPreferences = FakeVectorPreferences()
+    private val fakeClock = FakeClock()
+
+    private val shouldShowUnverifiedSessionsAlertUseCase = ShouldShowUnverifiedSessionsAlertUseCase(
+            vectorFeatures = fakeVectorFeatures,
+            vectorPreferences = fakeVectorPreferences.instance,
+            clock = fakeClock,
+    )
+
+    @Test
+    fun `given the feature is disabled then the use case returns false`() {
+        fakeVectorFeatures.givenUnverifiedSessionsAlertEnabled(false)
+        fakeVectorPreferences.givenUnverifiedSessionsAlertLastShownMillis(0L)
+
+        shouldShowUnverifiedSessionsAlertUseCase.execute() shouldBe false
+    }
+
+    @Test
+    fun `given the feature in enabled and there is not a saved preference then the use case returns true`() {
+        fakeVectorFeatures.givenUnverifiedSessionsAlertEnabled(true)
+        fakeVectorPreferences.givenUnverifiedSessionsAlertLastShownMillis(0L)
+        fakeClock.givenEpoch(AN_EPOCH + 1)
+
+        shouldShowUnverifiedSessionsAlertUseCase.execute() shouldBe true
+    }
+
+    @Test
+    fun `given the feature in enabled and last shown is a long time ago then the use case returns true`() {
+        fakeVectorFeatures.givenUnverifiedSessionsAlertEnabled(true)
+        fakeVectorPreferences.givenUnverifiedSessionsAlertLastShownMillis(AN_EPOCH)
+        fakeClock.givenEpoch(AN_EPOCH * 2 + 1)
+
+        shouldShowUnverifiedSessionsAlertUseCase.execute() shouldBe true
+    }
+
+    @Test
+    fun `given the feature in enabled and last shown is not a long time ago then the use case returns false`() {
+        fakeVectorFeatures.givenUnverifiedSessionsAlertEnabled(true)
+        fakeVectorPreferences.givenUnverifiedSessionsAlertLastShownMillis(AN_EPOCH)
+        fakeClock.givenEpoch(AN_EPOCH + 1)
+
+        shouldShowUnverifiedSessionsAlertUseCase.execute() shouldBe false
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/home/ShouldShowUnverifiedSessionsAlertUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/home/ShouldShowUnverifiedSessionsAlertUseCaseTest.kt
@@ -23,7 +23,8 @@ import im.vector.app.test.fakes.FakeVectorPreferences
 import org.amshove.kluent.shouldBe
 import org.junit.Test
 
-private val AN_EPOCH = Config.SHOW_UNVERIFIED_SESSIONS_ALERT_AFTER_MILLIS
+private val AN_EPOCH = Config.SHOW_UNVERIFIED_SESSIONS_ALERT_AFTER_MILLIS.toLong()
+private const val A_DEVICE_ID = "A_DEVICE_ID"
 
 class ShouldShowUnverifiedSessionsAlertUseCaseTest {
 
@@ -42,7 +43,7 @@ class ShouldShowUnverifiedSessionsAlertUseCaseTest {
         fakeVectorFeatures.givenUnverifiedSessionsAlertEnabled(false)
         fakeVectorPreferences.givenUnverifiedSessionsAlertLastShownMillis(0L)
 
-        shouldShowUnverifiedSessionsAlertUseCase.execute() shouldBe false
+        shouldShowUnverifiedSessionsAlertUseCase.execute(A_DEVICE_ID) shouldBe false
     }
 
     @Test
@@ -51,7 +52,7 @@ class ShouldShowUnverifiedSessionsAlertUseCaseTest {
         fakeVectorPreferences.givenUnverifiedSessionsAlertLastShownMillis(0L)
         fakeClock.givenEpoch(AN_EPOCH + 1)
 
-        shouldShowUnverifiedSessionsAlertUseCase.execute() shouldBe true
+        shouldShowUnverifiedSessionsAlertUseCase.execute(A_DEVICE_ID) shouldBe true
     }
 
     @Test
@@ -60,7 +61,7 @@ class ShouldShowUnverifiedSessionsAlertUseCaseTest {
         fakeVectorPreferences.givenUnverifiedSessionsAlertLastShownMillis(AN_EPOCH)
         fakeClock.givenEpoch(AN_EPOCH * 2 + 1)
 
-        shouldShowUnverifiedSessionsAlertUseCase.execute() shouldBe true
+        shouldShowUnverifiedSessionsAlertUseCase.execute(A_DEVICE_ID) shouldBe true
     }
 
     @Test
@@ -69,6 +70,6 @@ class ShouldShowUnverifiedSessionsAlertUseCaseTest {
         fakeVectorPreferences.givenUnverifiedSessionsAlertLastShownMillis(AN_EPOCH)
         fakeClock.givenEpoch(AN_EPOCH + 1)
 
-        shouldShowUnverifiedSessionsAlertUseCase.execute() shouldBe false
+        shouldShowUnverifiedSessionsAlertUseCase.execute(A_DEVICE_ID) shouldBe false
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorFeatures.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorFeatures.kt
@@ -50,4 +50,8 @@ class FakeVectorFeatures : VectorFeatures by spyk<DefaultVectorFeatures>() {
     fun givenVoiceBroadcast(isEnabled: Boolean) {
         every { isVoiceBroadcastEnabled() } returns isEnabled
     }
+
+    fun givenUnverifiedSessionsAlertEnabled(isEnabled: Boolean) {
+        every { isUnverifiedSessionsAlertEnabled() } returns isEnabled
+    }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorPreferences.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorPreferences.kt
@@ -56,4 +56,8 @@ class FakeVectorPreferences {
     fun givenSessionManagerShowIpAddress(showIpAddress: Boolean) {
         every { instance.showIpAddressInSessionManagerScreens() } returns showIpAddress
     }
+
+    fun givenUnverifiedSessionsAlertLastShownMillis(lastShownMillis: Long) {
+        every { instance.getUnverifiedSessionsAlertLastShownMillis() } returns lastShownMillis
+    }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorPreferences.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorPreferences.kt
@@ -58,6 +58,6 @@ class FakeVectorPreferences {
     }
 
     fun givenUnverifiedSessionsAlertLastShownMillis(lastShownMillis: Long) {
-        every { instance.getUnverifiedSessionsAlertLastShownMillis() } returns lastShownMillis
+        every { instance.getUnverifiedSessionsAlertLastShownMillis(any()) } returns lastShownMillis
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content
Currently, we never remind users about their unverified sessions once the alert banner is dismissed. We want to remind users to review unverified sessions in a certain period.

<!-- Describe shortly what has been changed -->

## Motivation and context
When we detect a new login on another device, we are showing a "New Login" banner on verified devices. If the user dismisses it we need to show "Review your logins" banners to the user. If the user dismisses this banner too, then we don't show a banner for a while (1 week in current config).

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Set `Config.SHOW_UNVERIFIED_SESSIONS_ALERT_AFTER_MILLIS = 60_000` for test purposes
- Have a verified session
- Login from another session
- See "New login" banner appears in verified device
- Dismiss the banner
- See "Review your logins" banner
- Dismiss the banner
- Wait 1 minute and see the banner again

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
