### PR TITLE
[Session manager] Add actions to rename and signout current session (PSG-885)

### DIFF
--- a/changelog.d/7697.feature
+++ b/changelog.d/7697.feature
@@ -1,0 +1,1 @@
+[Session manager] Add actions to rename and signout current session

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
@@ -102,7 +102,7 @@ class VectorSettingsDevicesFragment :
 
         initWaitingView()
         initCurrentSessionHeaderView()
-        initCurrentSessionListView()
+        initCurrentSessionView()
         initOtherSessionsHeaderView()
         initOtherSessionsView()
         initSecurityRecommendationsView()
@@ -177,7 +177,7 @@ class VectorSettingsDevicesFragment :
         activity?.let { SignOutUiWorker(it).perform() }
     }
 
-    private fun initCurrentSessionListView() {
+    private fun initCurrentSessionView() {
         views.deviceListCurrentSession.viewVerifyButton.debouncedClicks {
             viewModel.handle(DevicesAction.VerifyCurrentSession)
         }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
@@ -145,12 +145,26 @@ class VectorSettingsDevicesFragment :
     private fun initCurrentSessionHeaderView() {
         views.deviceListHeaderCurrentSession.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
+                R.id.currentSessionHeaderRename -> {
+                    navigateToRenameCurrentSession()
+                    true
+                }
                 R.id.currentSessionHeaderSignoutOtherSessions -> {
                     confirmMultiSignoutOtherSessions()
                     true
                 }
                 else -> false
             }
+        }
+    }
+
+    private fun navigateToRenameCurrentSession() = withState(viewModel) { state ->
+        val currentDeviceId = state.currentSessionCrossSigningInfo.deviceId
+        if (currentDeviceId.isNotEmpty()) {
+            viewNavigator.navigateToRenameSession(
+                    context = requireActivity(),
+                    deviceId = currentDeviceId,
+            )
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
@@ -52,6 +52,7 @@ import im.vector.app.features.settings.devices.v2.list.SecurityRecommendationVie
 import im.vector.app.features.settings.devices.v2.list.SecurityRecommendationViewState
 import im.vector.app.features.settings.devices.v2.list.SessionInfoViewState
 import im.vector.app.features.settings.devices.v2.signout.BuildConfirmSignoutDialogUseCase
+import im.vector.app.features.workers.signout.SignOutUiWorker
 import org.matrix.android.sdk.api.auth.data.LoginFlowTypes
 import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel
@@ -149,6 +150,10 @@ class VectorSettingsDevicesFragment :
                     navigateToRenameCurrentSession()
                     true
                 }
+                R.id.currentSessionHeaderSignout -> {
+                    confirmSignoutCurrentSession()
+                    true
+                }
                 R.id.currentSessionHeaderSignoutOtherSessions -> {
                     confirmMultiSignoutOtherSessions()
                     true
@@ -166,6 +171,10 @@ class VectorSettingsDevicesFragment :
                     deviceId = currentDeviceId,
             )
         }
+    }
+
+    private fun confirmSignoutCurrentSession() {
+        activity?.let { SignOutUiWorker(it).perform() }
     }
 
     private fun initCurrentSessionListView() {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
@@ -101,6 +101,7 @@ class VectorSettingsDevicesFragment :
 
         initWaitingView()
         initCurrentSessionHeaderView()
+        initCurrentSessionListView()
         initOtherSessionsHeaderView()
         initOtherSessionsView()
         initSecurityRecommendationsView()
@@ -150,6 +151,12 @@ class VectorSettingsDevicesFragment :
                 }
                 else -> false
             }
+        }
+    }
+
+    private fun initCurrentSessionListView() {
+        views.deviceListCurrentSession.viewVerifyButton.debouncedClicks {
+            viewModel.handle(DevicesAction.VerifyCurrentSession)
         }
     }
 
@@ -351,28 +358,35 @@ class VectorSettingsDevicesFragment :
 
     private fun renderCurrentSessionView(currentDeviceInfo: DeviceFullInfo?, hasOtherDevices: Boolean) {
         currentDeviceInfo?.let {
-            views.deviceListHeaderCurrentSession.isVisible = true
-            val colorDestructive = colorProvider.getColorFromAttribute(R.attr.colorError)
-            val signoutOtherSessionsItem = views.deviceListHeaderCurrentSession.menu.findItem(R.id.currentSessionHeaderSignoutOtherSessions)
-            signoutOtherSessionsItem.setTextColor(colorDestructive)
-            signoutOtherSessionsItem.isVisible = hasOtherDevices
-            views.deviceListCurrentSession.isVisible = true
-            val viewState = SessionInfoViewState(
-                    isCurrentSession = true,
-                    deviceFullInfo = it
-            )
-            views.deviceListCurrentSession.render(viewState, dateFormatter, drawableProvider, colorProvider, stringProvider)
-            views.deviceListCurrentSession.debouncedClicks {
-                currentDeviceInfo.deviceInfo.deviceId?.let { deviceId -> navigateToSessionOverview(deviceId) }
-            }
-            views.deviceListCurrentSession.viewDetailsButton.debouncedClicks {
-                currentDeviceInfo.deviceInfo.deviceId?.let { deviceId -> navigateToSessionOverview(deviceId) }
-            }
-            views.deviceListCurrentSession.viewVerifyButton.debouncedClicks {
-                viewModel.handle(DevicesAction.VerifyCurrentSession)
-            }
+            renderCurrentSessionHeaderView(hasOtherDevices)
+            renderCurrentSessionListView(it)
         } ?: run {
             hideCurrentSessionView()
+        }
+    }
+
+    private fun renderCurrentSessionHeaderView(hasOtherDevices: Boolean) {
+        views.deviceListHeaderCurrentSession.isVisible = true
+        val colorDestructive = colorProvider.getColorFromAttribute(R.attr.colorError)
+        val signoutSessionItem = views.deviceListHeaderCurrentSession.menu.findItem(R.id.currentSessionHeaderSignout)
+        signoutSessionItem.setTextColor(colorDestructive)
+        val signoutOtherSessionsItem = views.deviceListHeaderCurrentSession.menu.findItem(R.id.currentSessionHeaderSignoutOtherSessions)
+        signoutOtherSessionsItem.setTextColor(colorDestructive)
+        signoutOtherSessionsItem.isVisible = hasOtherDevices
+    }
+
+    private fun renderCurrentSessionListView(currentDeviceInfo: DeviceFullInfo) {
+        views.deviceListCurrentSession.isVisible = true
+        val viewState = SessionInfoViewState(
+                isCurrentSession = true,
+                deviceFullInfo = currentDeviceInfo
+        )
+        views.deviceListCurrentSession.render(viewState, dateFormatter, drawableProvider, colorProvider, stringProvider)
+        views.deviceListCurrentSession.debouncedClicks {
+            currentDeviceInfo.deviceInfo.deviceId?.let { deviceId -> navigateToSessionOverview(deviceId) }
+        }
+        views.deviceListCurrentSession.viewDetailsButton.debouncedClicks {
+            currentDeviceInfo.deviceInfo.deviceId?.let { deviceId -> navigateToSessionOverview(deviceId) }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesViewNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesViewNavigator.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import im.vector.app.features.settings.devices.v2.filter.DeviceManagerFilterType
 import im.vector.app.features.settings.devices.v2.othersessions.OtherSessionsActivity
 import im.vector.app.features.settings.devices.v2.overview.SessionOverviewActivity
+import im.vector.app.features.settings.devices.v2.rename.RenameSessionActivity
 import javax.inject.Inject
 
 class VectorSettingsDevicesViewNavigator @Inject constructor() {
@@ -37,5 +38,9 @@ class VectorSettingsDevicesViewNavigator @Inject constructor() {
         context.startActivity(
                 OtherSessionsActivity.newIntent(context, titleResourceId, defaultFilter, excludeCurrentDevice)
         )
+    }
+
+    fun navigateToRenameSession(context: Context, deviceId: String) {
+        context.startActivity(RenameSessionActivity.newIntent(context, deviceId))
     }
 }

--- a/vector/src/main/res/menu/menu_current_session_header.xml
+++ b/vector/src/main/res/menu/menu_current_session_header.xml
@@ -5,6 +5,16 @@
     tools:ignore="AlwaysShowAction">
 
     <item
+        android:id="@+id/currentSessionHeaderRename"
+        android:title="@string/device_manager_session_rename"
+        app:showAsAction="withText|never" />
+
+    <item
+        android:id="@+id/currentSessionHeaderSignout"
+        android:title="@string/logout"
+        app:showAsAction="withText|never" />
+
+    <item
         android:id="@+id/currentSessionHeaderSignoutOtherSessions"
         android:title="@string/device_manager_signout_all_other_sessions"
         app:showAsAction="withText|never" />

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesViewNavigatorTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesViewNavigatorTest.kt
@@ -26,7 +26,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
-import io.mockk.verify
 import org.junit.After
 import org.junit.Before
 import org.junit.Test

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesViewNavigatorTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesViewNavigatorTest.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 import im.vector.app.features.settings.devices.v2.filter.DeviceManagerFilterType
 import im.vector.app.features.settings.devices.v2.othersessions.OtherSessionsActivity
 import im.vector.app.features.settings.devices.v2.overview.SessionOverviewActivity
+import im.vector.app.features.settings.devices.v2.rename.RenameSessionActivity
 import im.vector.app.test.fakes.FakeContext
 import io.mockk.every
 import io.mockk.mockk
@@ -43,6 +44,7 @@ class VectorSettingsDevicesViewNavigatorTest {
     fun setUp() {
         mockkObject(SessionOverviewActivity.Companion)
         mockkObject(OtherSessionsActivity.Companion)
+        mockkObject(RenameSessionActivity.Companion)
     }
 
     @After
@@ -52,26 +54,41 @@ class VectorSettingsDevicesViewNavigatorTest {
 
     @Test
     fun `given a session id when navigating to overview then it starts the correct activity`() {
+        // Given
         val intent = givenIntentForSessionOverview(A_SESSION_ID)
         context.givenStartActivity(intent)
 
+        // When
         vectorSettingsDevicesViewNavigator.navigateToSessionOverview(context.instance, A_SESSION_ID)
 
-        verify {
-            context.instance.startActivity(intent)
-        }
+        // Then
+        context.verifyStartActivity(intent)
     }
 
     @Test
     fun `given an intent when navigating to other sessions list then it starts the correct activity`() {
+        // Given
         val intent = givenIntentForOtherSessions(A_TITLE_RESOURCE_ID, A_DEFAULT_FILTER, true)
         context.givenStartActivity(intent)
 
+        // When
         vectorSettingsDevicesViewNavigator.navigateToOtherSessions(context.instance, A_TITLE_RESOURCE_ID, A_DEFAULT_FILTER, true)
 
-        verify {
-            context.instance.startActivity(intent)
-        }
+        // Then
+        context.verifyStartActivity(intent)
+    }
+
+    @Test
+    fun `given an intent when navigating to rename session screen then it starts the correct activity`() {
+        // Given
+        val intent = givenIntentForRenameSession(A_SESSION_ID)
+        context.givenStartActivity(intent)
+
+        // When
+        vectorSettingsDevicesViewNavigator.navigateToRenameSession(context.instance, A_SESSION_ID)
+
+        // Then
+        context.verifyStartActivity(intent)
     }
 
     private fun givenIntentForSessionOverview(sessionId: String): Intent {
@@ -83,6 +100,12 @@ class VectorSettingsDevicesViewNavigatorTest {
     private fun givenIntentForOtherSessions(titleResourceId: Int, defaultFilter: DeviceManagerFilterType, excludeCurrentDevice: Boolean): Intent {
         val intent = mockk<Intent>()
         every { OtherSessionsActivity.newIntent(context.instance, titleResourceId, defaultFilter, excludeCurrentDevice) } returns intent
+        return intent
+    }
+
+    private fun givenIntentForRenameSession(sessionId: String): Intent {
+        val intent = mockk<Intent>()
+        every { RenameSessionActivity.newIntent(context.instance, sessionId) } returns intent
         return intent
     }
 }

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsViewNavigatorTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsViewNavigatorTest.kt
@@ -23,7 +23,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
-import io.mockk.verify
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -47,14 +46,15 @@ class OtherSessionsViewNavigatorTest {
 
     @Test
     fun `given a device id when navigating to overview then it starts the correct activity`() {
+        // Given
         val intent = givenIntentForDeviceOverview(A_DEVICE_ID)
         context.givenStartActivity(intent)
 
+        // When
         otherSessionsViewNavigator.navigateToSessionOverview(context.instance, A_DEVICE_ID)
 
-        verify {
-            context.instance.startActivity(intent)
-        }
+        // Then
+        context.verifyStartActivity(intent)
     }
 
     private fun givenIntentForDeviceOverview(deviceId: String): Intent {

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewNavigatorTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewNavigatorTest.kt
@@ -60,9 +60,7 @@ class SessionOverviewViewNavigatorTest {
         sessionOverviewViewNavigator.goToSessionDetails(context.instance, A_SESSION_ID)
 
         // Then
-        verify {
-            context.instance.startActivity(intent)
-        }
+        context.verifyStartActivity(intent)
     }
 
     @Test
@@ -75,9 +73,7 @@ class SessionOverviewViewNavigatorTest {
         sessionOverviewViewNavigator.goToRenameSession(context.instance, A_SESSION_ID)
 
         // Then
-        verify {
-            context.instance.startActivity(intent)
-        }
+        context.verifyStartActivity(intent)
     }
 
     @Test

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeContext.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeContext.kt
@@ -24,9 +24,9 @@ import android.net.ConnectivityManager
 import android.net.Uri
 import android.os.ParcelFileDescriptor
 import io.mockk.every
-import io.mockk.just
+import io.mockk.justRun
 import io.mockk.mockk
-import io.mockk.runs
+import io.mockk.verify
 import java.io.OutputStream
 
 class FakeContext(
@@ -73,7 +73,11 @@ class FakeContext(
     }
 
     fun givenStartActivity(intent: Intent) {
-        every { instance.startActivity(intent) } just runs
+        justRun { instance.startActivity(intent) }
+    }
+
+    fun verifyStartActivity(intent: Intent) {
+        verify { instance.startActivity(intent) }
     }
 
     fun givenClipboardManager(): FakeClipboardManager {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Adding 2 actions in the overflow menu of the current session card view in the new main session manager screen:
- rename current session
- signout current session

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7697 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

<img src="https://user-images.githubusercontent.com/46314705/205648429-fc93bdd8-9fc5-4573-b7f6-b79d696cbea1.gif" width=300 />

## Tests

<!-- Explain how you tested your development -->

- Enable the new Session manager in labs settings
- Go to Settings -> Security & Privacy -> Show all sessions
- Press the menu in the current session card view
- Check actions to rename and sign out the session are present
- Press the rename item
- Check the rename screen is opened for the current session
- Rename the session
- Check it updates the name of the session
- Press the menu in the current session card view
- Press the sign out item
- Check a confirm dialog is displayed
- Confirm
- Check the current session is signed out 

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
