### PR TITLE
Fix usage of unknown shield in room summary (PSG-1019)

### DIFF
--- a/changelog.d/7710.bugfix
+++ b/changelog.d/7710.bugfix
@@ -1,0 +1,1 @@
+Fix usage of unknown shield in room summary

--- a/vector/src/main/java/im/vector/app/core/ui/views/ShieldImageView.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/views/ShieldImageView.kt
@@ -38,6 +38,25 @@ class ShieldImageView @JvmOverloads constructor(
         }
     }
 
+    /**
+     * Renders device shield with the support of unknown shields instead of black shields which is used for rooms.
+     * @param roomEncryptionTrustLevel trust level that is usally calculated with [im.vector.app.features.settings.devices.TrustUtils.shieldForTrust]
+     * @param borderLess if true then the shield icon with border around is used
+     */
+    fun renderDeviceShield(roomEncryptionTrustLevel: RoomEncryptionTrustLevel?, borderLess: Boolean = false) {
+        isVisible = roomEncryptionTrustLevel != null
+
+        if (roomEncryptionTrustLevel == RoomEncryptionTrustLevel.Default) {
+            contentDescription = context.getString(R.string.a11y_trust_level_default)
+            setImageResource(
+                    if (borderLess) R.drawable.ic_shield_unknown_no_border
+                    else R.drawable.ic_shield_unknown
+            )
+        } else {
+            render(roomEncryptionTrustLevel, borderLess)
+        }
+    }
+
     fun render(roomEncryptionTrustLevel: RoomEncryptionTrustLevel?, borderLess: Boolean = false) {
         isVisible = roomEncryptionTrustLevel != null
 
@@ -45,8 +64,8 @@ class ShieldImageView @JvmOverloads constructor(
             RoomEncryptionTrustLevel.Default -> {
                 contentDescription = context.getString(R.string.a11y_trust_level_default)
                 setImageResource(
-                        if (borderLess) R.drawable.ic_shield_unknown_no_border
-                        else R.drawable.ic_shield_unknown
+                        if (borderLess) R.drawable.ic_shield_black_no_border
+                        else R.drawable.ic_shield_black
                 )
             }
             RoomEncryptionTrustLevel.Warning -> {
@@ -137,7 +156,7 @@ class ShieldImageView @JvmOverloads constructor(
 @DrawableRes
 fun RoomEncryptionTrustLevel.toDrawableRes(): Int {
     return when (this) {
-        RoomEncryptionTrustLevel.Default -> R.drawable.ic_shield_unknown
+        RoomEncryptionTrustLevel.Default -> R.drawable.ic_shield_black
         RoomEncryptionTrustLevel.Warning -> R.drawable.ic_shield_warning
         RoomEncryptionTrustLevel.Trusted -> R.drawable.ic_shield_trusted
         RoomEncryptionTrustLevel.E2EWithUnsupportedAlgorithm -> R.drawable.ic_warning_badge

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DeviceItem.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DeviceItem.kt
@@ -85,9 +85,9 @@ abstract class DeviceItem : VectorEpoxyModel<DeviceItem.Holder>(R.layout.item_de
                     trusted
             )
 
-            holder.trustIcon.render(shield)
+            holder.trustIcon.renderDeviceShield(shield)
         } else {
-            holder.trustIcon.render(null)
+            holder.trustIcon.renderDeviceShield(null)
         }
 
         val detailedModeLabels = listOf(

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/OtherSessionItem.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/OtherSessionItem.kt
@@ -97,7 +97,7 @@ abstract class OtherSessionItem : VectorEpoxyModel<OtherSessionItem.Holder>(R.la
         } else {
             setDeviceTypeIconUseCase.execute(deviceType, holder.otherSessionDeviceTypeImageView, stringProvider)
         }
-        holder.otherSessionVerificationStatusImageView.render(roomEncryptionTrustLevel)
+        holder.otherSessionVerificationStatusImageView.renderDeviceShield(roomEncryptionTrustLevel)
         holder.otherSessionNameTextView.text = sessionName
         holder.otherSessionDescriptionTextView.text = sessionDescription
         sessionDescriptionColor?.let {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoView.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoView.kt
@@ -90,7 +90,7 @@ class SessionInfoView @JvmOverloads constructor(
             hasLearnMoreLink: Boolean,
             isVerifyButtonVisible: Boolean,
     ) {
-        views.sessionInfoVerificationStatusImageView.render(encryptionTrustLevel)
+        views.sessionInfoVerificationStatusImageView.renderDeviceShield(encryptionTrustLevel)
         when {
             encryptionTrustLevel == RoomEncryptionTrustLevel.Trusted -> renderCrossSigningVerified(isCurrentSession)
             encryptionTrustLevel == RoomEncryptionTrustLevel.Default && !isCurrentSession -> renderCrossSigningUnknown()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content
While we are developing new Session Management screens we introduced a new shield for devices which has an unknown e2e status. But this also accidentally effected the shield of rooms. This PR will revert these changes.

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Login with an unverified session
- Enable new session management in Labs settings
- Navigate to Settings > Security & Privacy > Show All Sessions
- See unknown shield ("?") for the current session 
- Navigate to an encrypted room details
- See black shield next to the room name instead of an unknown shield

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
