### PR TITLE
Use the latest startForeground API

### DIFF
--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -72,7 +72,9 @@
     <application android:supportsRtl="true">
 
         <!-- Sentry auto-initialization disable -->
-        <meta-data android:name="io.sentry.auto-init" android:value="false" />
+        <meta-data
+            android:name="io.sentry.auto-init"
+            android:value="false" />
 
         <!-- No limit for screen ratio: avoid black strips -->
         <meta-data
@@ -330,6 +332,7 @@
 
         <service
             android:name=".core.services.CallAndroidService"
+            android:foregroundServiceType="phoneCall"
             android:exported="false">
             <!-- in order to get headset button events -->
             <intent-filter>
@@ -341,6 +344,7 @@
         <service
             android:name=".core.services.VectorSyncAndroidService"
             android:exported="false"
+            android:foregroundServiceType="dataSync"
             tools:ignore="Instantiatable" />
 
         <service

--- a/vector/src/main/java/im/vector/app/core/extensions/Service.kt
+++ b/vector/src/main/java/im/vector/app/core/extensions/Service.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.extensions
+
+import android.app.Notification
+import android.app.Service
+import android.content.pm.ServiceInfo
+import android.os.Build
+
+fun Service.startForegroundCompat(
+        id: Int,
+        notification: Notification,
+        provideForegroundServiceType: (() -> Int)? = null
+) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        startForeground(
+                id,
+                notification,
+                provideForegroundServiceType?.invoke() ?: ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST
+        )
+    } else {
+        startForeground(id, notification)
+    }
+}

--- a/vector/src/main/java/im/vector/app/core/services/CallAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/core/services/CallAndroidService.kt
@@ -28,6 +28,7 @@ import androidx.media.session.MediaButtonReceiver
 import com.airbnb.mvrx.Mavericks
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.core.extensions.singletonEntryPoint
+import im.vector.app.core.extensions.startForegroundCompat
 import im.vector.app.features.call.CallArgs
 import im.vector.app.features.call.VectorCallActivity
 import im.vector.app.features.call.telecom.CallConnection
@@ -181,7 +182,7 @@ class CallAndroidService : VectorAndroidService() {
                 fromBg = fromBg
         )
         if (knownCalls.isEmpty()) {
-            startForeground(callId.hashCode(), notification)
+            startForegroundCompat(callId.hashCode(), notification)
         } else {
             notificationManager.notify(callId.hashCode(), notification)
         }
@@ -201,7 +202,7 @@ class CallAndroidService : VectorAndroidService() {
         }
         val notification = notificationUtils.buildCallEndedNotification(false)
         val notificationId = callId.hashCode()
-        startForeground(notificationId, notification)
+        startForegroundCompat(notificationId, notification)
         if (knownCalls.isEmpty()) {
             Timber.tag(loggerTag.value).v("No more call, stop the service")
             stopForegroundCompat()
@@ -236,7 +237,7 @@ class CallAndroidService : VectorAndroidService() {
                 title = callInformation.opponentMatrixItem?.getBestName() ?: callInformation.opponentUserId
         )
         if (knownCalls.isEmpty()) {
-            startForeground(callId.hashCode(), notification)
+            startForegroundCompat(callId.hashCode(), notification)
         } else {
             notificationManager.notify(callId.hashCode(), notification)
         }
@@ -260,7 +261,7 @@ class CallAndroidService : VectorAndroidService() {
                 title = callInformation.opponentMatrixItem?.getBestName() ?: callInformation.opponentUserId
         )
         if (knownCalls.isEmpty()) {
-            startForeground(callId.hashCode(), notification)
+            startForegroundCompat(callId.hashCode(), notification)
         } else {
             notificationManager.notify(callId.hashCode(), notification)
         }
@@ -273,9 +274,9 @@ class CallAndroidService : VectorAndroidService() {
         callRingPlayerOutgoing?.stop()
         val notification = notificationUtils.buildCallEndedNotification(false)
         if (callId != null) {
-            startForeground(callId.hashCode(), notification)
+            startForegroundCompat(callId.hashCode(), notification)
         } else {
-            startForeground(DEFAULT_NOTIFICATION_ID, notification)
+            startForegroundCompat(DEFAULT_NOTIFICATION_ID, notification)
         }
         if (knownCalls.isEmpty()) {
             mediaSession?.isActive = false

--- a/vector/src/main/java/im/vector/app/core/services/VectorSyncAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/core/services/VectorSyncAndroidService.kt
@@ -32,6 +32,7 @@ import androidx.work.Worker
 import androidx.work.WorkerParameters
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
+import im.vector.app.core.extensions.startForegroundCompat
 import im.vector.app.core.platform.PendingIntentCompat
 import im.vector.app.core.time.Clock
 import im.vector.app.core.time.DefaultClock
@@ -98,7 +99,7 @@ class VectorSyncAndroidService : SyncAndroidService() {
             R.string.notification_listening_for_notifications
         }
         val notification = notificationUtils.buildForegroundServiceNotification(notificationSubtitleRes, false)
-        startForeground(NotificationUtils.NOTIFICATION_ID_FOREGROUND_SERVICE, notification)
+        startForegroundCompat(NotificationUtils.NOTIFICATION_ID_FOREGROUND_SERVICE, notification)
     }
 
     override fun onRescheduleAsked(

--- a/vector/src/main/java/im/vector/app/features/call/webrtc/ScreenCaptureAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/features/call/webrtc/ScreenCaptureAndroidService.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 import android.os.Binder
 import android.os.IBinder
 import dagger.hilt.android.AndroidEntryPoint
+import im.vector.app.core.extensions.startForegroundCompat
 import im.vector.app.core.services.VectorAndroidService
 import im.vector.app.core.time.Clock
 import im.vector.app.features.notifications.NotificationUtils
@@ -41,7 +42,7 @@ class ScreenCaptureAndroidService : VectorAndroidService() {
     private fun showStickyNotification() {
         val notificationId = clock.epochMillis().toInt()
         val notification = notificationUtils.buildScreenSharingNotification()
-        startForeground(notificationId, notification)
+        startForegroundCompat(notificationId, notification)
     }
 
     override fun onBind(intent: Intent?): IBinder {

--- a/vector/src/main/java/im/vector/app/features/location/live/tracking/LocationSharingAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/tracking/LocationSharingAndroidService.kt
@@ -22,6 +22,7 @@ import android.os.Parcelable
 import androidx.core.app.NotificationManagerCompat
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.core.extensions.startForegroundCompat
 import im.vector.app.core.services.VectorAndroidService
 import im.vector.app.features.location.LocationData
 import im.vector.app.features.location.LocationTracker
@@ -105,7 +106,7 @@ class LocationSharingAndroidService : VectorAndroidService(), LocationTracker.Ca
             if (foregroundModeStarted) {
                 NotificationManagerCompat.from(this).notify(FOREGROUND_SERVICE_NOTIFICATION_ID, notification)
             } else {
-                startForeground(FOREGROUND_SERVICE_NOTIFICATION_ID, notification)
+                startForegroundCompat(FOREGROUND_SERVICE_NOTIFICATION_ID, notification)
                 foregroundModeStarted = true
             }
 

--- a/vector/src/main/java/im/vector/app/features/start/StartAppAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/features/start/StartAppAndroidService.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.di.NamedGlobalScope
+import im.vector.app.core.extensions.startForegroundCompat
 import im.vector.app.core.services.VectorAndroidService
 import im.vector.app.features.notifications.NotificationUtils
 import kotlinx.coroutines.CoroutineScope
@@ -58,6 +59,6 @@ class StartAppAndroidService : VectorAndroidService() {
     private fun showStickyNotification() {
         val notificationId = Random.nextInt()
         val notification = notificationUtils.buildStartAppNotification()
-        startForeground(notificationId, notification)
+        startForegroundCompat(notificationId, notification)
     }
 }


### PR DESCRIPTION
Use the API `startForeground(int id, @NonNull Notification notification, @ForegroundServiceType int foregroundServiceType)` when available.

Add missing android:foregroundServiceType in the manifest

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

Using this API should give more information to the system

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Use the latest API

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Smoke test on services (sync/call/etc.)

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
