### PR TITLE
add to device tracing id

### DIFF
--- a/changelog.d/7708.misc
+++ b/changelog.d/7708.misc
@@ -1,0 +1,1 @@
+Add tracing Id for to device messages

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/EventType.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/EventType.kt
@@ -16,6 +16,8 @@
 
 package org.matrix.android.sdk.api.session.events.model
 
+import org.matrix.android.sdk.api.session.room.model.message.MessageType.MSGTYPE_VERIFICATION_REQUEST
+
 /**
  * Constants defining known event types from Matrix specifications.
  */
@@ -126,6 +128,7 @@ object EventType {
 
     fun isVerificationEvent(type: String): Boolean {
         return when (type) {
+            MSGTYPE_VERIFICATION_REQUEST,
             KEY_VERIFICATION_START,
             KEY_VERIFICATION_ACCEPT,
             KEY_VERIFICATION_KEY,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/SendToDeviceTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/tasks/SendToDeviceTask.kt
@@ -17,13 +17,20 @@
 package org.matrix.android.sdk.internal.crypto.tasks
 
 import org.matrix.android.sdk.api.session.crypto.model.MXUsersDevicesMap
+import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.internal.crypto.api.CryptoApi
 import org.matrix.android.sdk.internal.crypto.model.rest.SendToDeviceBody
 import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 import org.matrix.android.sdk.internal.network.executeRequest
 import org.matrix.android.sdk.internal.task.Task
+import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
+
+const val TO_DEVICE_TRACING_ID_KEY = "org.matrix.msgid"
+
+fun Event.toDeviceTracingId(): String? = content?.get(TO_DEVICE_TRACING_ID_KEY) as? String
 
 internal interface SendToDeviceTask : Task<SendToDeviceTask.Params, Unit> {
     data class Params(
@@ -42,14 +49,16 @@ internal class DefaultSendToDeviceTask @Inject constructor(
 ) : SendToDeviceTask {
 
     override suspend fun execute(params: SendToDeviceTask.Params) {
-        val sendToDeviceBody = SendToDeviceBody(
-                messages = params.contentMap.map
-        )
-
         // If params.transactionId is not provided, we create a unique txnId.
         // It's important to do that outside the requestBlock parameter of executeRequest()
         // to use the same value if the request is retried
         val txnId = params.transactionId ?: createUniqueTxnId()
+
+        // add id tracing to debug
+        val decorated = decorateWithToDeviceTracingIds(params)
+        val sendToDeviceBody = SendToDeviceBody(
+                messages = decorated.first
+        )
 
         return executeRequest(
                 globalErrorReceiver,
@@ -61,7 +70,34 @@ internal class DefaultSendToDeviceTask @Inject constructor(
                     transactionId = txnId,
                     body = sendToDeviceBody
             )
+            Timber.i("Sent to device type=${params.eventType} txnid=$txnId [${decorated.second.joinToString(",")}]")
         }
+    }
+
+    /**
+     * To make it easier to track down where to-device messages are getting lost,
+     * add a custom property to each one, and that will be logged after sent and on reception. Synapse will also log
+     * this property.
+     * @return A pair, first is the decorated content, and second info to log out after sending
+     */
+    private fun decorateWithToDeviceTracingIds(params: SendToDeviceTask.Params): Pair<Map<String, Map<String, Any>>, List<String>> {
+        val tracingInfo = mutableListOf<String>()
+        val decoratedContent = params.contentMap.map.map { userToDeviceMap ->
+            val userId = userToDeviceMap.key
+            userId to userToDeviceMap.value.map {
+                val deviceId = it.key
+                deviceId to it.value.toContent().toMutableMap().apply {
+                    put(
+                            TO_DEVICE_TRACING_ID_KEY,
+                            UUID.randomUUID().toString().also {
+                                tracingInfo.add("$userId/$deviceId (msgid $it)")
+                            }
+                    )
+                }
+            }.toMap()
+        }.toMap()
+
+        return decoratedContent to tracingInfo
     }
 }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/CryptoSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/CryptoSyncHandler.kt
@@ -49,14 +49,14 @@ internal class CryptoSyncHandler @Inject constructor(
                 ?.forEachIndexed { index, event ->
                     progressReporter?.reportProgress(index * 100F / total)
                     // Decrypt event if necessary
-                    Timber.tag(loggerTag.value).d("To device event tracingId:${event.toDeviceTracingId()}")
+                    Timber.tag(loggerTag.value).d("To device event msgid:${event.toDeviceTracingId()}")
                     decryptToDeviceEvent(event, null)
 
                     if (event.getClearType() == EventType.MESSAGE &&
                             event.getClearContent()?.toModel<MessageContent>()?.msgType == "m.bad.encrypted") {
                         Timber.tag(loggerTag.value).e("handleToDeviceEvent() : Warning: Unable to decrypt to-device event : ${event.content}")
                     } else {
-                        Timber.tag(loggerTag.value).d("received to-device ${event.getClearType()} from:${event.senderId} id:${event.toDeviceTracingId()}")
+                        Timber.tag(loggerTag.value).d("received to-device ${event.getClearType()} from:${event.senderId} msgid:${event.toDeviceTracingId()}")
                         verificationService.onToDeviceEvent(event)
                         cryptoService.onToDeviceEvent(event)
                     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/CryptoSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/CryptoSyncHandler.kt
@@ -29,6 +29,7 @@ import org.matrix.android.sdk.api.session.room.model.message.MessageContent
 import org.matrix.android.sdk.api.session.sync.model.SyncResponse
 import org.matrix.android.sdk.api.session.sync.model.ToDeviceSyncResponse
 import org.matrix.android.sdk.internal.crypto.DefaultCryptoService
+import org.matrix.android.sdk.internal.crypto.tasks.toDeviceTracingId
 import org.matrix.android.sdk.internal.crypto.verification.DefaultVerificationService
 import org.matrix.android.sdk.internal.session.sync.ProgressReporter
 import timber.log.Timber
@@ -48,12 +49,14 @@ internal class CryptoSyncHandler @Inject constructor(
                 ?.forEachIndexed { index, event ->
                     progressReporter?.reportProgress(index * 100F / total)
                     // Decrypt event if necessary
-                    Timber.tag(loggerTag.value).i("To device event from ${event.senderId} of type:${event.type}")
+                    Timber.tag(loggerTag.value).d("To device event tracingId:${event.toDeviceTracingId()}")
                     decryptToDeviceEvent(event, null)
+
                     if (event.getClearType() == EventType.MESSAGE &&
                             event.getClearContent()?.toModel<MessageContent>()?.msgType == "m.bad.encrypted") {
                         Timber.tag(loggerTag.value).e("handleToDeviceEvent() : Warning: Unable to decrypt to-device event : ${event.content}")
                     } else {
+                        Timber.tag(loggerTag.value).d("received to-device ${event.getClearType()} from:${event.senderId} id:${event.toDeviceTracingId()}")
                         verificationService.onToDeviceEvent(event)
                         cryptoService.onToDeviceEvent(event)
                     }

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/crypto/DefaultSendToDeviceTaskTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/crypto/DefaultSendToDeviceTaskTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright 2022 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/crypto/DefaultSendToDeviceTaskTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/crypto/DefaultSendToDeviceTaskTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.crypto
+
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.internal.assertEquals
+import org.junit.Assert
+import org.junit.Test
+import org.matrix.android.sdk.api.session.crypto.model.DeviceInfo
+import org.matrix.android.sdk.api.session.crypto.model.DevicesListResponse
+import org.matrix.android.sdk.api.session.crypto.model.MXUsersDevicesMap
+import org.matrix.android.sdk.api.session.events.model.EventType
+import org.matrix.android.sdk.internal.crypto.api.CryptoApi
+import org.matrix.android.sdk.internal.crypto.model.rest.DeleteDeviceParams
+import org.matrix.android.sdk.internal.crypto.model.rest.DeleteDevicesParams
+import org.matrix.android.sdk.internal.crypto.model.rest.KeyChangesResponse
+import org.matrix.android.sdk.internal.crypto.model.rest.KeysClaimBody
+import org.matrix.android.sdk.internal.crypto.model.rest.KeysClaimResponse
+import org.matrix.android.sdk.internal.crypto.model.rest.KeysQueryBody
+import org.matrix.android.sdk.internal.crypto.model.rest.KeysQueryResponse
+import org.matrix.android.sdk.internal.crypto.model.rest.KeysUploadBody
+import org.matrix.android.sdk.internal.crypto.model.rest.KeysUploadResponse
+import org.matrix.android.sdk.internal.crypto.model.rest.SendToDeviceBody
+import org.matrix.android.sdk.internal.crypto.model.rest.SignatureUploadResponse
+import org.matrix.android.sdk.internal.crypto.model.rest.UpdateDeviceInfoBody
+import org.matrix.android.sdk.internal.crypto.model.rest.UploadSigningKeysBody
+import org.matrix.android.sdk.internal.crypto.tasks.DefaultSendToDeviceTask
+import org.matrix.android.sdk.internal.crypto.tasks.SendToDeviceTask
+import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
+
+class DefaultSendToDeviceTaskTest {
+
+    val users = listOf(
+            "@alice:example.com" to listOf("D0", "D1"),
+            "bob@example.com" to listOf("D2", "D3")
+    )
+
+    val fakeEncryptedContent = mapOf(
+            "algorithm" to "m.olm.v1.curve25519-aes-sha2",
+            "sender_key" to "gMObR+/4dqL5T4DisRRRYBJpn+OjzFnkyCFOktP6Eyw",
+            "ciphertext" to mapOf(
+                    "tdwXf7006FDgzmufMCVI4rDdVPO51ecRTTT6HkRxUwE" to mapOf(
+                            "type" to 0,
+                            "body" to "AwogCA1ULEc0abGIFxMDIC9iv7ul3jqJSnapTHQ+8JJx"
+                    )
+            )
+    )
+
+    @Test
+    fun `tracing id should be added to all to_device contents`() {
+        val fakeCryptoAPi = FakeCryptoApi()
+
+        val sendToDeviceTask = DefaultSendToDeviceTask(
+                cryptoApi = fakeCryptoAPi,
+                globalErrorReceiver = mockk<GlobalErrorReceiver>(relaxed = true)
+        )
+
+        val contentMap = MXUsersDevicesMap<Any>()
+
+        users.forEach {
+            val userId = it.first
+            it.second.forEach {
+                contentMap.setObject(userId, it, fakeEncryptedContent)
+            }
+        }
+
+        val params = SendToDeviceTask.Params(
+                eventType = EventType.ENCRYPTED,
+                contentMap = contentMap
+        )
+
+        runBlocking {
+            sendToDeviceTask.execute(params)
+        }
+
+        val generatedIds = mutableListOf<String>()
+        users.forEach {
+            val userId = it.first
+            it.second.forEach {
+                val modifiedContent = fakeCryptoAPi.body!!.messages!![userId]!![it] as Map<String, *>
+                Assert.assertNotNull("Tracing id should have been added", modifiedContent["org.matrix.msgid"])
+                generatedIds.add(modifiedContent["org.matrix.msgid"] as String)
+
+                assertEquals(
+                        "The rest of the content should be the same",
+                        fakeEncryptedContent.keys,
+                        modifiedContent.toMutableMap().apply { remove("org.matrix.msgid") }.keys
+                )
+            }
+        }
+
+        assertEquals("Id should be unique per content", generatedIds.size, generatedIds.toSet().size)
+        println("modified content ${fakeCryptoAPi.body}")
+    }
+
+    internal class FakeCryptoApi : CryptoApi {
+        override suspend fun getDevices(): DevicesListResponse {
+            throw java.lang.AssertionError("Should not be called")
+        }
+
+        override suspend fun getDeviceInfo(deviceId: String): DeviceInfo {
+            throw java.lang.AssertionError("Should not be called")
+        }
+
+        override suspend fun uploadKeys(body: KeysUploadBody): KeysUploadResponse {
+            throw java.lang.AssertionError("Should not be called")
+        }
+
+        override suspend fun downloadKeysForUsers(params: KeysQueryBody): KeysQueryResponse {
+            throw java.lang.AssertionError("Should not be called")
+        }
+
+        override suspend fun uploadSigningKeys(params: UploadSigningKeysBody): KeysQueryResponse {
+            throw java.lang.AssertionError("Should not be called")
+        }
+
+        override suspend fun uploadSignatures(params: Map<String, Any>?): SignatureUploadResponse {
+            throw java.lang.AssertionError("Should not be called")
+        }
+
+        override suspend fun claimOneTimeKeysForUsersDevices(body: KeysClaimBody): KeysClaimResponse {
+            throw java.lang.AssertionError("Should not be called")
+        }
+
+        var body: SendToDeviceBody? = null
+        override suspend fun sendToDevice(eventType: String, transactionId: String, body: SendToDeviceBody) {
+            this.body = body
+        }
+
+        override suspend fun deleteDevice(deviceId: String, params: DeleteDeviceParams) {
+            throw java.lang.AssertionError("Should not be called")
+        }
+
+        override suspend fun deleteDevices(params: DeleteDevicesParams) {
+            throw java.lang.AssertionError("Should not be called")
+        }
+
+        override suspend fun updateDeviceInfo(deviceId: String, params: UpdateDeviceInfoBody) {
+            throw java.lang.AssertionError("Should not be called")
+        }
+
+        override suspend fun getKeyChanges(oldToken: String, newToken: String): KeyChangesResponse {
+            throw java.lang.AssertionError("Should not be called")
+        }
+    }
+}

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/crypto/DefaultSendToDeviceTaskTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/crypto/DefaultSendToDeviceTaskTest.kt
@@ -41,16 +41,15 @@ import org.matrix.android.sdk.internal.crypto.model.rest.UpdateDeviceInfoBody
 import org.matrix.android.sdk.internal.crypto.model.rest.UploadSigningKeysBody
 import org.matrix.android.sdk.internal.crypto.tasks.DefaultSendToDeviceTask
 import org.matrix.android.sdk.internal.crypto.tasks.SendToDeviceTask
-import org.matrix.android.sdk.internal.network.GlobalErrorReceiver
 
 class DefaultSendToDeviceTaskTest {
 
-    val users = listOf(
+    private val users = listOf(
             "@alice:example.com" to listOf("D0", "D1"),
             "bob@example.com" to listOf("D2", "D3")
     )
 
-    val fakeEncryptedContent = mapOf(
+    private val fakeEncryptedContent = mapOf(
             "algorithm" to "m.olm.v1.curve25519-aes-sha2",
             "sender_key" to "gMObR+/4dqL5T4DisRRRYBJpn+OjzFnkyCFOktP6Eyw",
             "ciphertext" to mapOf(
@@ -67,14 +66,14 @@ class DefaultSendToDeviceTaskTest {
 
         val sendToDeviceTask = DefaultSendToDeviceTask(
                 cryptoApi = fakeCryptoAPi,
-                globalErrorReceiver = mockk<GlobalErrorReceiver>(relaxed = true)
+                globalErrorReceiver = mockk(relaxed = true)
         )
 
         val contentMap = MXUsersDevicesMap<Any>()
 
-        users.forEach {
-            val userId = it.first
-            it.second.forEach {
+        users.forEach { pairOfUserDevices ->
+            val userId = pairOfUserDevices.first
+            pairOfUserDevices.second.forEach {
                 contentMap.setObject(userId, it, fakeEncryptedContent)
             }
         }
@@ -89,10 +88,10 @@ class DefaultSendToDeviceTaskTest {
         }
 
         val generatedIds = mutableListOf<String>()
-        users.forEach {
-            val userId = it.first
-            it.second.forEach {
-                val modifiedContent = fakeCryptoAPi.body!!.messages!![userId]!![it] as Map<String, *>
+        users.forEach { pairOfUserDevices ->
+            val userId = pairOfUserDevices.first
+            pairOfUserDevices.second.forEach {
+                val modifiedContent = fakeCryptoAPi.body!!.messages!![userId]!![it] as Map<*, *>
                 Assert.assertNotNull("Tracing id should have been added", modifiedContent["org.matrix.msgid"])
                 generatedIds.add(modifiedContent["org.matrix.msgid"] as String)
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Technical

## Content

<!-- Describe shortly what has been changed -->
Fixes #7708

Adding a tracing id to to-device messages that can be tracked synapse side in order to debug to-device delivery problems.

EA logs on reception updated to match web
```
received to-device m.room_key from:@sample:localhost:8480 id:b62c9f76-880d-4fbe-b9d7-f9b13c957d8d
```

EA logs on sending updated to match web
```
I  Sent to device  type=m.room.encrypted txnid=d99afdf1-b244-478b-bd72-eba892419893 [@eve:localhost:8480/YJQWVBZUWC (msgid 21ba49f2-8be0-440f-9c22-ba6e41a0d83c),@eve:localhost:8480/PMFTXZAUTL (msgid 58cd9624-137a-4c05-b5da-1a9e587364ef),@web:localhost:8481/FJQUOWZCIX (msgid f854cc8e-603f-48d5-953c-1ed1864b91cd)]
I  shareUserDevicesKey() : sendToDevice succeeds after 158 ms
```

Decorated content from sync:
```
{
  "content": {
    "algorithm": "m.olm.v1.curve25519-aes-sha2",
    "ciphertext": {
      "gMObR+/4dqL5T4DisRRRYBJpn+OjzFnkyCFOktP6Eyw": {
        "body": "AwogrdbTbG8VCW....slqU",
        "type": 0
      }
    },
    "org.matrix.msgid": "6390a372-fd3c-4f56-b0d5-2f2ce39f2d56",
    "sender_key": "EWnYTm/yIQ1lStSIqO6fdVYvS69OfU2DzrX+q+1d+w8"
  },
  "type": "m.room.encrypted",
  "sender": "@sample:localhost:8480"
}
```

## Exception

Verification to-device events will not be decorated, as they might use content signature that could break other clients (the hash in key.verification.start)

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

See https://github.com/vector-im/element-meta/issues/558#issuecomment-1337306861

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [x] Emulator

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] You've made a self review of your PR
