### PR TITLE
Enable reset all and skip options

### DIFF
--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -410,7 +410,8 @@
     <string name="action_disconnect">Disconnect</string>
     <string name="action_play">Play</string>
     <string name="action_dismiss">Dismiss</string>
-    <string name="action_reset">Proceed to Reset</string>
+    <string name="action_reset">Reset</string>
+    <string name="action_proceed_to_reset">Proceed to reset</string>
     <string name="action_learn_more">Learn more</string>
     <string name="action_next">Next</string>
     <string name="action_got_it">Got it</string>
@@ -2634,7 +2635,8 @@
     <string name="failed_to_access_secure_storage">Failed to access secure storage</string>
     <string name="bad_passphrase_key_reset_all_action">Forgot or lost all recovery options? Reset everything</string>
     <string name="secure_backup_reset_all">Reset everything</string>
-    <string name="secure_backup_reset_all_no_other_devices">Resetting your verification keys cannot be undone. After resetting, you won't have access to old encrypted messages, and any friends who have previously verified you will see security warnings until you re-verify with them.</string>
+    <string name="secure_backup_reset_all_no_other_devices">Only do this if you have no other device you can verify this device with.</string>
+    <string name="secure_backup_reset_all_no_other_devices_long">Resetting your verification keys cannot be undone. After resetting, you won\'t have access to old encrypted messages, and any friends who have previously verified you will see security warnings until you re-verify with them.</string>
     <string name="secure_backup_reset_if_you_reset_all">If you reset everything</string>
     <string name="secure_backup_reset_no_history">You will restart with no history, no messages, trusted devices or trusted users</string>
     <string name="secure_backup_reset_danger_warning">Please only proceed if you\'re sure you\'ve lost all of your other devices and your security key.</string>

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -410,7 +410,7 @@
     <string name="action_disconnect">Disconnect</string>
     <string name="action_play">Play</string>
     <string name="action_dismiss">Dismiss</string>
-    <string name="action_reset">Reset</string>
+    <string name="action_reset">Proceed to Reset</string>
     <string name="action_learn_more">Learn more</string>
     <string name="action_next">Next</string>
     <string name="action_got_it">Got it</string>
@@ -2634,9 +2634,10 @@
     <string name="failed_to_access_secure_storage">Failed to access secure storage</string>
     <string name="bad_passphrase_key_reset_all_action">Forgot or lost all recovery options? Reset everything</string>
     <string name="secure_backup_reset_all">Reset everything</string>
-    <string name="secure_backup_reset_all_no_other_devices">Only do this if you have no other device you can verify this device with.</string>
+    <string name="secure_backup_reset_all_no_other_devices">Resetting your verification keys cannot be undone. After resetting, you won't have access to old encrypted messages, and any friends who have previously verified you will see security warnings until you re-verify with them.</string>
     <string name="secure_backup_reset_if_you_reset_all">If you reset everything</string>
     <string name="secure_backup_reset_no_history">You will restart with no history, no messages, trusted devices or trusted users</string>
+    <string name="secure_backup_reset_danger_warning">Please only proceed if you\'re sure you\'ve lost all of your other devices and your security key.</string>
     <plurals name="secure_backup_reset_devices_you_can_verify">
         <item quantity="one">Show the device you can verify with now</item>
         <item quantity="other">Show %d devices you can verify with now</item>

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/summary/RoomSummaryUpdater.kt
@@ -18,9 +18,7 @@ package org.matrix.android.sdk.internal.session.room.summary
 
 import io.realm.Realm
 import io.realm.kotlin.createObject
-import kotlinx.coroutines.runBlocking
 import org.matrix.android.sdk.api.extensions.orFalse
-import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.content.EncryptionEventContent
 import org.matrix.android.sdk.api.session.events.model.toModel
@@ -41,7 +39,6 @@ import org.matrix.android.sdk.api.session.room.send.SendState
 import org.matrix.android.sdk.api.session.sync.model.RoomSyncSummary
 import org.matrix.android.sdk.api.session.sync.model.RoomSyncUnreadNotifications
 import org.matrix.android.sdk.api.session.sync.model.RoomSyncUnreadThreadNotifications
-import org.matrix.android.sdk.internal.crypto.EventDecryptor
 import org.matrix.android.sdk.internal.database.mapper.ContentMapper
 import org.matrix.android.sdk.internal.database.mapper.asDomain
 import org.matrix.android.sdk.internal.database.model.CurrentStateEventEntity

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/RoomSummaryEventDecryptor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/RoomSummaryEventDecryptor.kt
@@ -50,9 +50,9 @@ internal class RoomSummaryEventDecryptor @Inject constructor(
     }
 
     private val scope: CoroutineScope = CoroutineScope(
-            cryptoCoroutineScope.coroutineContext
-                    + SupervisorJob()
-                    + CoroutineName("RoomSummaryDecryptor")
+            cryptoCoroutineScope.coroutineContext +
+                    SupervisorJob() +
+                    CoroutineName("RoomSummaryDecryptor")
     )
 
     private val channel = Channel<Message>(capacity = 300)
@@ -116,8 +116,8 @@ internal class RoomSummaryEventDecryptor @Inject constructor(
                             }
                 }
 
-                if (failure.errorType == MXCryptoError.ErrorType.UNKNOWN_INBOUND_SESSION_ID
-                        || failure.errorType == MXCryptoError.ErrorType.UNKNOWN_MESSAGE_INDEX) {
+                if (failure.errorType == MXCryptoError.ErrorType.UNKNOWN_INBOUND_SESSION_ID ||
+                        failure.errorType == MXCryptoError.ErrorType.UNKNOWN_MESSAGE_INDEX) {
                     (event.content["session_id"] as? String)?.let { sessionId ->
                         unknownSessionsFailure.getOrPut(sessionId) { mutableSetOf() }
                                 .add(event)

--- a/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/api/session/crypto/keysbackup/BackupUtils.kt
+++ b/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/api/session/crypto/keysbackup/BackupUtils.kt
@@ -16,8 +16,6 @@
 
 package org.matrix.android.sdk.api.session.crypto.keysbackup
 
-import org.matrix.android.sdk.api.session.securestorage.SsssPassphrase
-
 object BackupUtils {
     fun recoveryKeyFromBase58(key: String): IBackupRecoveryKey? = BackupRecoveryKey.fromBase58(key)
     fun recoveryKeyFromPassphrase(passphrase: String): IBackupRecoveryKey? = BackupRecoveryKey.newFromPassphrase(passphrase)

--- a/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
+++ b/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
@@ -36,7 +36,6 @@ import org.matrix.android.sdk.api.session.crypto.crosssigning.DeviceTrustLevel
 import org.matrix.android.sdk.api.session.crypto.crosssigning.MXCrossSigningInfo
 import org.matrix.android.sdk.api.session.crypto.crosssigning.PrivateKeysInfo
 import org.matrix.android.sdk.api.session.crypto.crosssigning.UserTrustResult
-import org.matrix.android.sdk.api.session.crypto.keysbackup.MegolmBackupAuthData
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
 import org.matrix.android.sdk.api.session.crypto.model.ImportRoomKeysResult
 import org.matrix.android.sdk.api.session.crypto.model.MXEventDecryptionResult
@@ -52,7 +51,6 @@ import org.matrix.android.sdk.api.util.JsonDict
 import org.matrix.android.sdk.api.util.Optional
 import org.matrix.android.sdk.api.util.toOptional
 import org.matrix.android.sdk.internal.coroutines.builder.safeInvokeOnClose
-import org.matrix.android.sdk.internal.crypto.keysbackup.model.rest.CreateKeysBackupVersionBody
 import org.matrix.android.sdk.internal.crypto.keysbackup.model.rest.DefaultKeysAlgorithmAndData
 import org.matrix.android.sdk.internal.crypto.keysbackup.model.rest.KeysAlgorithmAndData
 import org.matrix.android.sdk.internal.crypto.network.RequestSender

--- a/vector/src/main/java/im/vector/app/features/crypto/quads/SharedSecureStorageActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/quads/SharedSecureStorageActivity.kt
@@ -49,6 +49,7 @@ class SharedSecureStorageActivity :
             val requestedSecrets: List<String> = emptyList(),
             val resultKeyStoreAlias: String,
             val writeSecrets: List<Pair<String, String>> = emptyList(),
+            val currentStep: SharedSecureStorageViewState.Step = SharedSecureStorageViewState.Step.EnterPassphrase,
     ) : Parcelable
 
     private val viewModel: SharedSecureStorageViewModel by viewModel()
@@ -150,7 +151,8 @@ class SharedSecureStorageActivity :
                 context: Context,
                 keyId: String? = null,
                 requestedSecrets: List<String>,
-                resultKeyStoreAlias: String = DEFAULT_RESULT_KEYSTORE_ALIAS
+                resultKeyStoreAlias: String = DEFAULT_RESULT_KEYSTORE_ALIAS,
+                initialStep: SharedSecureStorageViewState.Step = SharedSecureStorageViewState.Step.EnterPassphrase
         ): Intent {
             require(requestedSecrets.isNotEmpty())
             return Intent(context, SharedSecureStorageActivity::class.java).also {
@@ -159,7 +161,8 @@ class SharedSecureStorageActivity :
                         Args(
                                 keyId = keyId,
                                 requestedSecrets = requestedSecrets,
-                                resultKeyStoreAlias = resultKeyStoreAlias
+                                resultKeyStoreAlias = resultKeyStoreAlias,
+                                currentStep = initialStep
                         )
                 )
             }
@@ -169,7 +172,8 @@ class SharedSecureStorageActivity :
                 context: Context,
                 keyId: String? = null,
                 writeSecrets: List<Pair<String, String>>,
-                resultKeyStoreAlias: String = DEFAULT_RESULT_KEYSTORE_ALIAS
+                resultKeyStoreAlias: String = DEFAULT_RESULT_KEYSTORE_ALIAS,
+                initialStep: SharedSecureStorageViewState.Step = SharedSecureStorageViewState.Step.EnterPassphrase
         ): Intent {
             require(writeSecrets.isNotEmpty())
             return Intent(context, SharedSecureStorageActivity::class.java).also {
@@ -178,7 +182,8 @@ class SharedSecureStorageActivity :
                         Args(
                                 keyId = keyId,
                                 writeSecrets = writeSecrets,
-                                resultKeyStoreAlias = resultKeyStoreAlias
+                                resultKeyStoreAlias = resultKeyStoreAlias,
+                                currentStep = initialStep,
                         )
                 )
             }

--- a/vector/src/main/java/im/vector/app/features/crypto/quads/SharedSecureStorageViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/quads/SharedSecureStorageViewModel.kt
@@ -58,7 +58,7 @@ data class SharedSecureStorageViewState(
         val ready: Boolean = false,
         val hasPassphrase: Boolean = true,
         val checkingSSSSAction: Async<Unit> = Uninitialized,
-        val step: Step = Step.EnterPassphrase,
+        val step: Step = Step.ResetAll,
         val activeDeviceCount: Int = 0,
         val showResetAllAction: Boolean = false,
         val userId: String = "",
@@ -74,7 +74,8 @@ data class SharedSecureStorageViewState(
             } else {
                 RequestType.ReadSecrets(args.requestedSecrets)
             },
-            resultKeyStoreAlias = args.resultKeyStoreAlias
+            resultKeyStoreAlias = args.resultKeyStoreAlias,
+            step = args.currentStep,
     )
 
     enum class Step {
@@ -125,7 +126,8 @@ class SharedSecureStorageViewModel @AssistedInject constructor(
                     copy(
                             hasPassphrase = true,
                             ready = true,
-                            step = SharedSecureStorageViewState.Step.EnterPassphrase
+                            step = if (initialState.step == SharedSecureStorageViewState.Step.ResetAll) SharedSecureStorageViewState.Step.ResetAll
+                            else SharedSecureStorageViewState.Step.EnterPassphrase
                     )
                 }
             } else {
@@ -133,7 +135,8 @@ class SharedSecureStorageViewModel @AssistedInject constructor(
                     copy(
                             hasPassphrase = false,
                             ready = true,
-                            step = SharedSecureStorageViewState.Step.EnterKey
+                            step = if (initialState.step == SharedSecureStorageViewState.Step.ResetAll) SharedSecureStorageViewState.Step.ResetAll
+                            else SharedSecureStorageViewState.Step.EnterKey
                     )
                 }
             }
@@ -203,6 +206,7 @@ class SharedSecureStorageViewModel @AssistedInject constructor(
                     _viewEvents.post(SharedSecureStorageViewEvent.Dismiss)
                 }
             }
+            /*
             SharedSecureStorageViewState.Step.ResetAll -> {
                 setState {
                     copy(
@@ -211,6 +215,7 @@ class SharedSecureStorageViewModel @AssistedInject constructor(
                     )
                 }
             }
+            */
             else -> {
                 _viewEvents.post(SharedSecureStorageViewEvent.Dismiss)
             }

--- a/vector/src/main/java/im/vector/app/features/crypto/quads/SharedSecureStorageViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/quads/SharedSecureStorageViewModel.kt
@@ -114,32 +114,35 @@ class SharedSecureStorageViewModel @AssistedInject constructor(
                 )
             }
         }
-        val keyResult = initialState.keyId?.let { session.sharedSecretStorageService().getKey(it) }
-                ?: session.sharedSecretStorageService().getDefaultKey()
 
-        if (!keyResult.isSuccess()) {
-            _viewEvents.post(SharedSecureStorageViewEvent.Dismiss)
-        } else {
-            val info = (keyResult as KeyInfoResult.Success).keyInfo
-            if (info.content.passphrase != null) {
-                setState {
-                    copy(
-                            hasPassphrase = true,
-                            ready = true,
-                            step = if (initialState.step == SharedSecureStorageViewState.Step.ResetAll) SharedSecureStorageViewState.Step.ResetAll
-                            else SharedSecureStorageViewState.Step.EnterPassphrase
-                    )
-                }
+        if (initialState.step != SharedSecureStorageViewState.Step.ResetAll) {
+            val keyResult = initialState.keyId?.let { session.sharedSecretStorageService().getKey(it) }
+                    ?: session.sharedSecretStorageService().getDefaultKey()
+
+            if (!keyResult.isSuccess()) {
+                _viewEvents.post(SharedSecureStorageViewEvent.Dismiss)
             } else {
-                setState {
-                    copy(
-                            hasPassphrase = false,
-                            ready = true,
-                            step = if (initialState.step == SharedSecureStorageViewState.Step.ResetAll) SharedSecureStorageViewState.Step.ResetAll
-                            else SharedSecureStorageViewState.Step.EnterKey
-                    )
+                val info = (keyResult as KeyInfoResult.Success).keyInfo
+                if (info.content.passphrase != null) {
+                    setState {
+                        copy(
+                                hasPassphrase = true,
+                                ready = true,
+                                step = SharedSecureStorageViewState.Step.EnterPassphrase
+                        )
+                    }
+                } else {
+                    setState {
+                        copy(
+                                hasPassphrase = false,
+                                ready = true,
+                                step = SharedSecureStorageViewState.Step.EnterKey
+                        )
+                    }
                 }
             }
+        } else {
+            setState { copy(ready = true) }
         }
 
         session.flow()
@@ -215,7 +218,7 @@ class SharedSecureStorageViewModel @AssistedInject constructor(
                     )
                 }
             }
-            */
+             */
             else -> {
                 _viewEvents.post(SharedSecureStorageViewEvent.Dismiss)
             }

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationAction.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationAction.kt
@@ -31,7 +31,7 @@ sealed class VerificationAction : VectorViewModelAction {
     data class GotItConclusion(val verified: Boolean) : VerificationAction()
     object FailedToGetKeysFrom4S : VerificationAction()
     object SkipVerification : VerificationAction()
-    object ForgotResetAll: VerificationAction()
+    object ForgotResetAll : VerificationAction()
     object VerifyFromPassphrase : VerificationAction()
     object ReadyPendingVerification : VerificationAction()
     object CancelPendingVerification : VerificationAction()

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationAction.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationAction.kt
@@ -31,6 +31,7 @@ sealed class VerificationAction : VectorViewModelAction {
     data class GotItConclusion(val verified: Boolean) : VerificationAction()
     object FailedToGetKeysFrom4S : VerificationAction()
     object SkipVerification : VerificationAction()
+    object ForgotResetAll: VerificationAction()
     object VerifyFromPassphrase : VerificationAction()
     object ReadyPendingVerification : VerificationAction()
     object CancelPendingVerification : VerificationAction()

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationBottomSheetViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationBottomSheetViewEvents.kt
@@ -24,7 +24,7 @@ import im.vector.app.core.platform.VectorViewEvents
 sealed class VerificationBottomSheetViewEvents : VectorViewEvents {
     object Dismiss : VerificationBottomSheetViewEvents()
     object AccessSecretStore : VerificationBottomSheetViewEvents()
-    object ResetAll: VerificationBottomSheetViewEvents()
+    object ResetAll : VerificationBottomSheetViewEvents()
     object GoToSettings : VerificationBottomSheetViewEvents()
     data class ModalError(val errorMessage: CharSequence) : VerificationBottomSheetViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationBottomSheetViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationBottomSheetViewEvents.kt
@@ -24,6 +24,7 @@ import im.vector.app.core.platform.VectorViewEvents
 sealed class VerificationBottomSheetViewEvents : VectorViewEvents {
     object Dismiss : VerificationBottomSheetViewEvents()
     object AccessSecretStore : VerificationBottomSheetViewEvents()
+    object ResetAll: VerificationBottomSheetViewEvents()
     object GoToSettings : VerificationBottomSheetViewEvents()
     data class ModalError(val errorMessage: CharSequence) : VerificationBottomSheetViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationBottomSheet.kt
@@ -34,6 +34,7 @@ import im.vector.app.core.extensions.toMvRxBundle
 import im.vector.app.core.platform.VectorBaseBottomSheetDialogFragment
 import im.vector.app.databinding.BottomSheetVerificationBinding
 import im.vector.app.features.crypto.quads.SharedSecureStorageActivity
+import im.vector.app.features.crypto.quads.SharedSecureStorageViewState
 import im.vector.app.features.crypto.verification.VerificationAction
 import im.vector.app.features.crypto.verification.VerificationBottomSheetViewEvents
 import kotlinx.parcelize.Parcelize
@@ -92,7 +93,18 @@ class SelfVerificationBottomSheet : VectorBaseBottomSheetDialogFragment<BottomSh
                                     requireContext(),
                                     null, // use default key
                                     listOf(MASTER_KEY_SSSS_NAME, USER_SIGNING_KEY_SSSS_NAME, SELF_SIGNING_KEY_SSSS_NAME, KEYBACKUP_SECRET_SSSS_NAME),
-                                    SharedSecureStorageActivity.DEFAULT_RESULT_KEYSTORE_ALIAS
+                                    SharedSecureStorageActivity.DEFAULT_RESULT_KEYSTORE_ALIAS,
+                            )
+                    )
+                }
+                VerificationBottomSheetViewEvents.ResetAll -> {
+                    secretStartForActivityResult.launch(
+                            SharedSecureStorageActivity.newReadIntent(
+                                    requireContext(),
+                                    null, // use default key
+                                    listOf(MASTER_KEY_SSSS_NAME, USER_SIGNING_KEY_SSSS_NAME, SELF_SIGNING_KEY_SSSS_NAME, KEYBACKUP_SECRET_SSSS_NAME),
+                                    SharedSecureStorageActivity.DEFAULT_RESULT_KEYSTORE_ALIAS,
+                                    SharedSecureStorageViewState.Step.ResetAll
                             )
                     )
                 }

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationController.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationController.kt
@@ -254,8 +254,8 @@ class SelfVerificationController @Inject constructor(
                 }
             }
             is Success -> {
-                val invoke = action.invoke()
-                if (invoke) {
+                val value = action.invoke()
+                if (value) {
                     verifiedSuccessTile()
                     bottomDone { (host.listener as? InteractionListener)?.onDoneFrom4S() }
                 } else {

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationFragment.kt
@@ -77,11 +77,11 @@ class SelfVerificationFragment  : VectorBaseFragment<BottomSheetVerificationChil
     }
 
     override fun onClickSkip() {
-        TODO("Not yet implemented")
+        viewModel.handle(VerificationAction.SkipVerification)
     }
 
     override fun onClickResetSecurity() {
-        TODO("Not yet implemented")
+
     }
 
     override fun onDoneFrom4S() {

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationFragment.kt
@@ -81,7 +81,7 @@ class SelfVerificationFragment  : VectorBaseFragment<BottomSheetVerificationChil
     }
 
     override fun onClickResetSecurity() {
-
+        viewModel.handle(VerificationAction.ForgotResetAll)
     }
 
     override fun onDoneFrom4S() {

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationViewModel.kt
@@ -287,7 +287,9 @@ class SelfVerificationViewModel @AssistedInject constructor(
                 }
             }
             VerificationAction.SecuredStorageHasBeenReset -> TODO()
-            VerificationAction.SkipVerification -> TODO()
+            VerificationAction.SkipVerification -> {
+                _viewEvents.post(VerificationBottomSheetViewEvents.Dismiss)
+            }
             VerificationAction.StartSASVerification -> {
                 withState { state ->
                     val request = state.pendingRequest.invoke() ?: return@withState

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationViewModel.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.features.crypto.verification.self
 
+import android.util.Log
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
@@ -286,9 +287,16 @@ class SelfVerificationViewModel @AssistedInject constructor(
                     }
                 }
             }
-            VerificationAction.SecuredStorageHasBeenReset -> TODO()
+            VerificationAction.SecuredStorageHasBeenReset -> {
+                if (session.cryptoService().crossSigningService().allPrivateKeysKnown()) {
+                    _viewEvents.post(VerificationBottomSheetViewEvents.Dismiss)
+                }
+            }
             VerificationAction.SkipVerification -> {
                 _viewEvents.post(VerificationBottomSheetViewEvents.Dismiss)
+            }
+            VerificationAction.ForgotResetAll -> {
+                _viewEvents.post(VerificationBottomSheetViewEvents.ResetAll)
             }
             VerificationAction.StartSASVerification -> {
                 withState { state ->

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/self/SelfVerificationViewModel.kt
@@ -16,7 +16,6 @@
 
 package im.vector.app.features.crypto.verification.self
 
-import android.util.Log
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/user/UserVerificationBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/user/UserVerificationBottomSheet.kt
@@ -90,6 +90,7 @@ class UserVerificationBottomSheet : VectorBaseBottomSheetDialogFragment<BottomSh
                             .setPositiveButton(R.string.ok, null)
                             .show()
                 }
+                VerificationBottomSheetViewEvents.ResetAll -> TODO()
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/user/UserVerificationBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/user/UserVerificationBottomSheet.kt
@@ -90,7 +90,9 @@ class UserVerificationBottomSheet : VectorBaseBottomSheetDialogFragment<BottomSh
                             .setPositiveButton(R.string.ok, null)
                             .show()
                 }
-                VerificationBottomSheetViewEvents.ResetAll -> TODO()
+                VerificationBottomSheetViewEvents.ResetAll -> {
+                    // no-op for user verification
+                }
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/user/UserVerificationViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/user/UserVerificationViewModel.kt
@@ -385,6 +385,9 @@ class UserVerificationViewModel @AssistedInject constructor(
                 // Not applicable for user verification
             }
             VerificationAction.RequestSelfVerification -> TODO()
+            VerificationAction.ForgotResetAll -> {
+                // Not applicable for user verification
+            }
         }
     }
 

--- a/vector/src/main/res/layout/fragment_ssss_reset_all.xml
+++ b/vector/src/main/res/layout/fragment_ssss_reset_all.xml
@@ -37,7 +37,7 @@
             android:layout_marginTop="16dp"
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="16dp"
-            android:text="@string/secure_backup_reset_all_no_other_devices"
+            android:text="@string/secure_backup_reset_all_no_other_devices_long"
             android:textColor="?vctr_content_primary"
             app:layout_constraintBottom_toTopOf="@id/ssss_reset_other_devices"
             app:layout_constraintTop_toBottomOf="@id/reset_title" />
@@ -87,7 +87,7 @@
             style="@style/Widget.Vector.Button.Text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/action_reset"
+            android:text="@string/action_proceed_to_reset"
             tools:ignore="MissingConstraints" />
 
         <androidx.constraintlayout.helper.widget.Flow

--- a/vector/src/main/res/layout/fragment_ssss_reset_all.xml
+++ b/vector/src/main/res/layout/fragment_ssss_reset_all.xml
@@ -61,19 +61,6 @@
             tools:visibility="visible" />
 
         <TextView
-            android:id="@+id/ssss_reset_text3"
-            style="@style/Widget.Vector.TextView.Subtitle"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:text="@string/secure_backup_reset_if_you_reset_all"
-            android:textColor="?colorError"
-            android:textStyle="bold"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/ssss_reset_other_devices" />
-
-        <TextView
             android:id="@+id/ssss_reset_text4"
             style="@style/Widget.Vector.TextView.Body"
             android:layout_width="match_parent"
@@ -82,9 +69,10 @@
             android:layout_marginTop="16dp"
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="16dp"
-            android:text="@string/secure_backup_reset_no_history"
+            android:text="@string/secure_backup_reset_danger_warning"
             android:textColor="?vctr_content_primary"
-            app:layout_constraintTop_toBottomOf="@id/ssss_reset_text3" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ssss_reset_other_devices" />
 
         <Button
             android:id="@+id/ssss_reset_button_cancel"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content
- Implemented ResetAll for self verification.
- Skip option is enabled for self verification.
- Fixed back navigation with SharedSecureStorage.


## Motivation and context

Part of element-r refactor alignment with web.

## Tests

<!-- Explain how you tested your development -->

- Login to an account in Element-android
- Start self verification, Click on "Forgot or lost all recovery options".
- It should work as before.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
