### PR TITLE
Disable nightly popup

### DIFF
--- a/changelog.d/7723.misc
+++ b/changelog.d/7723.misc
@@ -1,0 +1,1 @@
+Disable nightly popup and add an entry point in the advanced settings instead.

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -2487,6 +2487,9 @@
     <string name="settings_key_requests">Key Requests</string>
     <string name="settings_export_trail">Export Audit</string>
 
+    <string name="settings_nightly_build">Nightly build</string>
+    <string name="settings_nightly_build_update">Get the latest build (note: you may have trouble to sign in)</string>
+
     <string name="e2e_use_keybackup">Unlock encrypted messages history</string>
 
     <string name="refresh">Refresh</string>

--- a/vector-app/build.gradle
+++ b/vector-app/build.gradle
@@ -374,7 +374,7 @@ dependencies {
     // API-only library
     gplayImplementation libs.google.appdistributionApi
     // Full SDK implementation
-    gplayImplementation libs.google.appdistribution
+    nightlyImplementation libs.google.appdistribution
 
     // OSS License, gplay flavor only
     gplayImplementation 'com.google.android.gms:play-services-oss-licenses:17.0.0'

--- a/vector-app/src/fdroid/java/im/vector/app/di/FlavorModule.kt
+++ b/vector-app/src/fdroid/java/im/vector/app/di/FlavorModule.kt
@@ -46,9 +46,9 @@ abstract class FlavorModule {
 
         @Provides
         fun provideNightlyProxy() = object : NightlyProxy {
-            override fun onHomeResumed() {
-                // no op
-            }
+            override fun canDisplayPopup() = false
+            override fun isNightlyBuild() = false
+            override fun updateApplication() = Unit
         }
 
         @Provides

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -580,7 +580,9 @@ class HomeActivity :
         serverBackupStatusViewModel.refreshRemoteStateIfNeeded()
 
         // Check nightly
-        nightlyProxy.onHomeResumed()
+        if (nightlyProxy.canDisplayPopup()) {
+            nightlyProxy.updateApplication()
+        }
 
         checkNewAppLayoutFlagChange()
     }

--- a/vector/src/main/java/im/vector/app/features/home/NightlyProxy.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NightlyProxy.kt
@@ -17,5 +17,18 @@
 package im.vector.app.features.home
 
 interface NightlyProxy {
-    fun onHomeResumed()
+    /**
+     * Return true if this is a nightly build (checking the package of the app), and only once a day.
+     */
+    fun canDisplayPopup(): Boolean
+
+    /**
+     * Return true if this is a nightly build (checking the package of the app).
+     */
+    fun isNightlyBuild(): Boolean
+
+    /**
+     * Try to update the application, if update is available. Will also take care of the user sign in.
+     */
+    fun updateApplication()
 }

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsAdvancedSettingsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsAdvancedSettingsFragment.kt
@@ -22,10 +22,13 @@ import androidx.preference.SeekBarPreference
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
 import im.vector.app.core.platform.VectorBaseActivity
+import im.vector.app.core.preference.VectorPreference
 import im.vector.app.core.preference.VectorPreferenceCategory
 import im.vector.app.core.preference.VectorSwitchPreference
 import im.vector.app.features.analytics.plan.MobileScreen
+import im.vector.app.features.home.NightlyProxy
 import im.vector.app.features.rageshake.RageShake
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class VectorSettingsAdvancedSettingsFragment :
@@ -33,6 +36,8 @@ class VectorSettingsAdvancedSettingsFragment :
 
     override var titleRes = R.string.settings_advanced_settings
     override val preferenceXmlRes = R.xml.vector_settings_advanced_settings
+
+    @Inject lateinit var nightlyProxy: NightlyProxy
 
     private var rageshake: RageShake? = null
 
@@ -57,6 +62,11 @@ class VectorSettingsAdvancedSettingsFragment :
     }
 
     override fun bindPref() {
+        setupRageShakeSection()
+        setupNightlySection()
+    }
+
+    private fun setupRageShakeSection() {
         val isRageShakeAvailable = RageShake.isAvailable(requireContext())
 
         if (isRageShakeAvailable) {
@@ -84,6 +94,14 @@ class VectorSettingsAdvancedSettingsFragment :
             }
         } else {
             findPreference<VectorPreferenceCategory>("SETTINGS_RAGE_SHAKE_CATEGORY_KEY")!!.isVisible = false
+        }
+    }
+
+    private fun setupNightlySection() {
+        findPreference<VectorPreferenceCategory>("SETTINGS_NIGHTLY_BUILD_PREFERENCE_KEY")?.isVisible = nightlyProxy.isNightlyBuild()
+        findPreference<VectorPreference>("SETTINGS_NIGHTLY_BUILD_UPDATE_PREFERENCE_KEY")?.setOnPreferenceClickListener {
+            nightlyProxy.updateApplication()
+            true
         }
     }
 }

--- a/vector/src/main/res/xml/vector_settings_advanced_settings.xml
+++ b/vector/src/main/res/xml/vector_settings_advanced_settings.xml
@@ -95,4 +95,16 @@
 
     </im.vector.app.core.preference.VectorPreferenceCategory>
 
+    <im.vector.app.core.preference.VectorPreferenceCategory
+        android:key="SETTINGS_NIGHTLY_BUILD_PREFERENCE_KEY"
+        android:title="@string/settings_nightly_build"
+        app:isPreferenceVisible="true">
+
+        <im.vector.app.core.preference.VectorPreference
+            android:key="SETTINGS_NIGHTLY_BUILD_UPDATE_PREFERENCE_KEY"
+            android:persistent="false"
+            android:title="@string/settings_nightly_build_update" />
+
+    </im.vector.app.core.preference.VectorPreferenceCategory>
+
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

sign in to firebase app inside the app does not work properly, so it is annoying to have a popup, even only once a day.

This PR disables the popup and add a section in the preference (Advanced settings), only visible in nightly builds, to be able to try to upgrade (and sign in) manually from there.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Do not annoy the user with a non-working feature.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->


|Sign in issue|New setting|
|-|-|
|<img width="324" alt="image" src="https://user-images.githubusercontent.com/3940906/205905086-3f9217a2-4674-4f1b-82fd-18810130210e.png">|<img width="321" alt="image" src="https://user-images.githubusercontent.com/3940906/205905145-5c4903b1-6ffe-483b-9c27-e229203b0622.png">|


## Tests

<!-- Explain how you tested your development -->

- NA

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
