### PR TITLE
[Session manager] Sessions without encryption support should not prompt to verify (PSG-1004)

### DIFF
--- a/changelog.d/7733.bugfix
+++ b/changelog.d/7733.bugfix
@@ -1,0 +1,1 @@
+[Session manager] Sessions without encryption support should not prompt to verify

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -3305,6 +3305,7 @@
     <string name="device_manager_verification_status_detail_current_session_unverified">Verify your current session for enhanced secure messaging.</string>
     <string name="device_manager_verification_status_detail_other_session_unverified">Verify or sign out from this session for best security and reliability.</string>
     <string name="device_manager_verification_status_detail_other_session_unknown">Verify your current session to reveal this session\'s verification status.</string>
+    <string name="device_manager_verification_status_detail_session_encryption_not_supported">This session doesn\'t support encryption and thus can\'t be verified.</string>
     <string name="device_manager_verify_session">Verify Session</string>
     <string name="device_manager_view_details">View Details</string>
     <string name="device_manager_other_sessions_view_all">View All (%1$d)</string>
@@ -3397,6 +3398,7 @@
     <!-- TODO TO BE REMOVED -->
     <string name="device_manager_learn_more_sessions_verified" tools:ignore="UnusedResources">Verified sessions have logged in with your credentials and then been verified, either using your secure passphrase or by cross-verifying.\n\nThis means they hold encryption keys for your previous messages, and confirm to other users you are communicating with that these sessions are really you.</string>
     <string name="device_manager_learn_more_sessions_verified_description">Verified sessions are anywhere you are using this account after entering your passphrase or confirming your identity with another verified session.\n\nThis means that you have all the keys needed to unlock your encrypted messages and confirm to other users that you trust this session.</string>
+    <string name="device_manager_learn_more_sessions_encryption_not_supported">This session doesn\'t support encryption, so it can\'t be verified.\n\nYou won\'t be able to participate in rooms where encryption is enabled when using this session.\n\nFor best security and privacy, it is recommended to use Matrix clients that support encryption.</string>
     <string name="device_manager_learn_more_session_rename_title">Renaming sessions</string>
     <string name="device_manager_learn_more_session_rename">Other users in direct messages and rooms that you join are able to view a full list of your sessions.\n\nThis provides them with confidence that they are really speaking to you, but it also means they can see the session name you enter here.</string>
     <string name="labs_enable_session_manager_title">Enable new session manager</string>

--- a/vector/src/main/java/im/vector/app/core/ui/views/ShieldImageView.kt
+++ b/vector/src/main/java/im/vector/app/core/ui/views/ShieldImageView.kt
@@ -40,20 +40,26 @@ class ShieldImageView @JvmOverloads constructor(
 
     /**
      * Renders device shield with the support of unknown shields instead of black shields which is used for rooms.
-     * @param roomEncryptionTrustLevel trust level that is usally calculated with [im.vector.app.features.settings.devices.TrustUtils.shieldForTrust]
+     * @param roomEncryptionTrustLevel trust level that is usually calculated with [im.vector.app.features.settings.devices.TrustUtils.shieldForTrust]
      * @param borderLess if true then the shield icon with border around is used
      */
     fun renderDeviceShield(roomEncryptionTrustLevel: RoomEncryptionTrustLevel?, borderLess: Boolean = false) {
-        isVisible = roomEncryptionTrustLevel != null
-
-        if (roomEncryptionTrustLevel == RoomEncryptionTrustLevel.Default) {
-            contentDescription = context.getString(R.string.a11y_trust_level_default)
-            setImageResource(
-                    if (borderLess) R.drawable.ic_shield_unknown_no_border
-                    else R.drawable.ic_shield_unknown
-            )
-        } else {
-            render(roomEncryptionTrustLevel, borderLess)
+        when (roomEncryptionTrustLevel) {
+            null -> {
+                contentDescription = context.getString(R.string.a11y_trust_level_warning)
+                setImageResource(
+                        if (borderLess) R.drawable.ic_shield_warning_no_border
+                        else R.drawable.ic_shield_warning
+                )
+            }
+            RoomEncryptionTrustLevel.Default -> {
+                contentDescription = context.getString(R.string.a11y_trust_level_default)
+                setImageResource(
+                        if (borderLess) R.drawable.ic_shield_unknown_no_border
+                        else R.drawable.ic_shield_unknown
+                )
+            }
+            else -> render(roomEncryptionTrustLevel, borderLess)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/UnknownDeviceDetectorSharedViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/UnknownDeviceDetectorSharedViewModel.kt
@@ -104,7 +104,7 @@ class UnknownDeviceDetectorSharedViewModel @AssistedInject constructor(
 //                    Timber.v("## Detector trigger canCrossSign ${pInfo.get().selfSigned != null}")
             infoList
                     .filter { info ->
-                        // filter verified session, by checking the crypto device info
+                        // filter out verified sessions or those which do not support encryption (i.e. without crypto info)
                         cryptoList.firstOrNull { info.deviceId == it.deviceId }?.isVerified?.not().orFalse()
                     }
                     // filter out ignored devices

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
@@ -88,7 +88,7 @@ data class DevicesViewState(
 data class DeviceFullInfo(
         val deviceInfo: DeviceInfo,
         val cryptoDeviceInfo: CryptoDeviceInfo?,
-        val trustLevelForShield: RoomEncryptionTrustLevel,
+        val trustLevelForShield: RoomEncryptionTrustLevel?,
         val isInactive: Boolean,
 )
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/DeviceFullInfo.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/DeviceFullInfo.kt
@@ -25,7 +25,7 @@ import org.matrix.android.sdk.api.session.crypto.model.RoomEncryptionTrustLevel
 data class DeviceFullInfo(
         val deviceInfo: DeviceInfo,
         val cryptoDeviceInfo: CryptoDeviceInfo?,
-        val roomEncryptionTrustLevel: RoomEncryptionTrustLevel,
+        val roomEncryptionTrustLevel: RoomEncryptionTrustLevel?,
         val isInactive: Boolean,
         val isCurrentDevice: Boolean,
         val deviceExtendedInfo: DeviceExtendedInfo,

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoView.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoView.kt
@@ -85,13 +85,14 @@ class SessionInfoView @JvmOverloads constructor(
     }
 
     private fun renderVerificationStatus(
-            encryptionTrustLevel: RoomEncryptionTrustLevel,
+            encryptionTrustLevel: RoomEncryptionTrustLevel?,
             isCurrentSession: Boolean,
             hasLearnMoreLink: Boolean,
             isVerifyButtonVisible: Boolean,
     ) {
         views.sessionInfoVerificationStatusImageView.renderDeviceShield(encryptionTrustLevel)
         when {
+            encryptionTrustLevel == null -> renderCrossSigningEncryptionNotSupported()
             encryptionTrustLevel == RoomEncryptionTrustLevel.Trusted -> renderCrossSigningVerified(isCurrentSession)
             encryptionTrustLevel == RoomEncryptionTrustLevel.Default && !isCurrentSession -> renderCrossSigningUnknown()
             else -> renderCrossSigningUnverified(isCurrentSession, isVerifyButtonVisible)
@@ -146,6 +147,14 @@ class SessionInfoView @JvmOverloads constructor(
     private fun renderCrossSigningUnknown() {
         views.sessionInfoVerificationStatusTextView.text = context.getString(R.string.device_manager_verification_status_unknown)
         views.sessionInfoVerificationStatusDetailTextView.text = context.getString(R.string.device_manager_verification_status_detail_other_session_unknown)
+        views.sessionInfoVerifySessionButton.isVisible = false
+    }
+
+    private fun renderCrossSigningEncryptionNotSupported() {
+        views.sessionInfoVerificationStatusTextView.text = context.getString(R.string.device_manager_verification_status_unverified)
+        views.sessionInfoVerificationStatusTextView.setTextColor(ThemeUtils.getColor(context, R.attr.colorError))
+        views.sessionInfoVerificationStatusDetailTextView.text =
+                context.getString(R.string.device_manager_verification_status_detail_session_encryption_not_supported)
         views.sessionInfoVerifySessionButton.isVisible = false
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
@@ -229,7 +229,7 @@ class SessionOverviewFragment :
             )
             views.sessionOverviewInfo.render(infoViewState, dateFormatter, drawableProvider, colorProvider, stringProvider)
             views.sessionOverviewInfo.onLearnMoreClickListener = {
-                showLearnMoreInfoVerificationStatus(deviceInfo.roomEncryptionTrustLevel == RoomEncryptionTrustLevel.Trusted)
+                showLearnMoreInfoVerificationStatus(deviceInfo.roomEncryptionTrustLevel)
             }
         } else {
             views.sessionOverviewInfo.isVisible = false
@@ -293,21 +293,28 @@ class SessionOverviewFragment :
         }
     }
 
-    private fun showLearnMoreInfoVerificationStatus(isVerified: Boolean) {
-        val titleResId = if (isVerified) {
-            R.string.device_manager_verification_status_verified
-        } else {
-            R.string.device_manager_verification_status_unverified
+    private fun showLearnMoreInfoVerificationStatus(roomEncryptionTrustLevel: RoomEncryptionTrustLevel?) {
+        val args = when(roomEncryptionTrustLevel) {
+            null -> {
+                // encryption not supported
+                SessionLearnMoreBottomSheet.Args(
+                        title = getString(R.string.device_manager_verification_status_unverified),
+                        description = getString(R.string.device_manager_learn_more_sessions_encryption_not_supported),
+                )
+            }
+            RoomEncryptionTrustLevel.Trusted -> {
+                SessionLearnMoreBottomSheet.Args(
+                        title = getString(R.string.device_manager_verification_status_verified),
+                        description = getString(R.string.device_manager_learn_more_sessions_verified_description),
+                )
+            }
+            else -> {
+                SessionLearnMoreBottomSheet.Args(
+                        title = getString(R.string.device_manager_verification_status_unverified),
+                        description = getString(R.string.device_manager_learn_more_sessions_unverified),
+                )
+            }
         }
-        val descriptionResId = if (isVerified) {
-            R.string.device_manager_learn_more_sessions_verified_description
-        } else {
-            R.string.device_manager_learn_more_sessions_unverified
-        }
-        val args = SessionLearnMoreBottomSheet.Args(
-                title = getString(titleResId),
-                description = getString(descriptionResId),
-        )
         SessionLearnMoreBottomSheet.show(childFragmentManager, args)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
@@ -294,7 +294,7 @@ class SessionOverviewFragment :
     }
 
     private fun showLearnMoreInfoVerificationStatus(roomEncryptionTrustLevel: RoomEncryptionTrustLevel?) {
-        val args = when(roomEncryptionTrustLevel) {
+        val args = when (roomEncryptionTrustLevel) {
             null -> {
                 // encryption not supported
                 SessionLearnMoreBottomSheet.Args(

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForDeviceUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForDeviceUseCase.kt
@@ -26,7 +26,7 @@ class GetEncryptionTrustLevelForDeviceUseCase @Inject constructor(
 ) {
 
     fun execute(currentSessionCrossSigningInfo: CurrentSessionCrossSigningInfo, cryptoDeviceInfo: CryptoDeviceInfo?): RoomEncryptionTrustLevel? {
-        if(cryptoDeviceInfo == null) {
+        if (cryptoDeviceInfo == null) {
             return null
         }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForDeviceUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForDeviceUseCase.kt
@@ -25,11 +25,15 @@ class GetEncryptionTrustLevelForDeviceUseCase @Inject constructor(
         private val getEncryptionTrustLevelForOtherDeviceUseCase: GetEncryptionTrustLevelForOtherDeviceUseCase,
 ) {
 
-    fun execute(currentSessionCrossSigningInfo: CurrentSessionCrossSigningInfo, cryptoDeviceInfo: CryptoDeviceInfo?): RoomEncryptionTrustLevel {
+    fun execute(currentSessionCrossSigningInfo: CurrentSessionCrossSigningInfo, cryptoDeviceInfo: CryptoDeviceInfo?): RoomEncryptionTrustLevel? {
+        if(cryptoDeviceInfo == null) {
+            return null
+        }
+
         val legacyMode = !currentSessionCrossSigningInfo.isCrossSigningInitialized
         val trustMSK = currentSessionCrossSigningInfo.isCrossSigningVerified
-        val isCurrentDevice = !cryptoDeviceInfo?.deviceId.isNullOrEmpty() && cryptoDeviceInfo?.deviceId == currentSessionCrossSigningInfo.deviceId
-        val deviceTrustLevel = cryptoDeviceInfo?.trustLevel
+        val isCurrentDevice = !cryptoDeviceInfo.deviceId.isNullOrEmpty() && cryptoDeviceInfo.deviceId == currentSessionCrossSigningInfo.deviceId
+        val deviceTrustLevel = cryptoDeviceInfo.trustLevel
 
         return when {
             isCurrentDevice -> getEncryptionTrustLevelForCurrentDeviceUseCase.execute(trustMSK, legacyMode)

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForDeviceUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/verification/GetEncryptionTrustLevelForDeviceUseCaseTest.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.settings.devices.v2.verification
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.matrix.android.sdk.api.session.crypto.crosssigning.DeviceTrustLevel
@@ -87,6 +88,20 @@ class GetEncryptionTrustLevelForDeviceUseCaseTest {
                     deviceTrustLevel = cryptoDeviceInfo.trustLevel
             )
         }
+    }
+
+    @Test
+    fun `given no crypto device info when computing trust level then result is null`() {
+        val currentSessionCrossSigningInfo = givenCurrentSessionCrossSigningInfo(
+                deviceId = A_DEVICE_ID,
+                isCrossSigningInitialized = true,
+                isCrossSigningVerified = false
+        )
+        val cryptoDeviceInfo = null
+
+        val result = getEncryptionTrustLevelForDeviceUseCase.execute(currentSessionCrossSigningInfo, cryptoDeviceInfo)
+
+        result shouldBe null
     }
 
     private fun givenCurrentSessionCrossSigningInfo(


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Render a specific UI in session manager screens (main screen and session overview screen) when a session does not support encryption.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7733 
See also https://github.com/vector-im/element-web/issues/23722

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

<img src="https://user-images.githubusercontent.com/46314705/206215943-7a4af82f-282a-4eb8-ba9a-a83022f7fd0f.png" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/206215967-17fc50d5-94d2-4e11-a432-f6464d7b74d2.png" width=300 />
<img src="https://user-images.githubusercontent.com/46314705/206215989-05ef3cbf-58ce-480a-ae58-854aa412f6dc.png" width=300 />

## Tests

<!-- Explain how you tested your development -->

For my tests, I mocked locally the data (setting the `CryptoDeviceInfo` to `null`)
- Enable new Session manager labs flag
- Go to "Settings -> Security & Privacy -> Show all sessions"
- Check the UI for the current session is correct
- Press a session entry in the other sessions list which does support encryption
- Check the UI for the session overview screen is correct
- Press "Learn more"
- Check the displayed text is correct

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
