### PR TITLE
Verification request is not showing when verify session popup is displayed (PSG-1017)

### DIFF
--- a/changelog.d/7743.bugfix
+++ b/changelog.d/7743.bugfix
@@ -1,0 +1,1 @@
+Verification request is not showing when verify session popup is displayed

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/IncomingVerificationRequestHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/IncomingVerificationRequestHandler.kt
@@ -72,10 +72,11 @@ class IncomingVerificationRequestHandler @Inject constructor(
                 val user = session.getUserOrDefault(tx.otherUserId).toMatrixItem()
                 val name = user.getBestName()
                 val alert = VerificationVectorAlert(
-                        uid,
-                        context.getString(R.string.sas_incoming_request_notif_title),
-                        context.getString(R.string.sas_incoming_request_notif_content, name),
-                        R.drawable.ic_shield_black,
+                        uid = uid,
+                        title = context.getString(R.string.sas_incoming_request_notif_title),
+                        description = context.getString(R.string.sas_incoming_request_notif_content, name),
+                        iconId = R.drawable.ic_shield_black,
+                        priority = PopupAlertManager.INCOMING_VERIFICATION_REQUEST_PRIORITY,
                         shouldBeDisplayedIn = { activity ->
                             if (activity is VectorBaseActivity<*>) {
                                 // TODO a bit too ugly :/
@@ -85,7 +86,7 @@ class IncomingVerificationRequestHandler @Inject constructor(
                                     }
                                 } ?: true
                             } else true
-                        }
+                        },
                 )
                         .apply {
                             viewBinder = VerificationVectorAlert.ViewBinder(user, avatarRenderer.get())
@@ -130,8 +131,8 @@ class IncomingVerificationRequestHandler @Inject constructor(
             // if not this request will be underneath and not visible by the user...
             // it will re-appear later
             if (pr.otherUserId == session?.myUserId) {
-                // XXX this is a bit hard coded :/
-                popupAlertManager.cancelAlert("review_login")
+                popupAlertManager.cancelAlert(PopupAlertManager.REVIEW_LOGIN_UID)
+                popupAlertManager.cancelAlert(PopupAlertManager.VERIFY_SESSION_UID)
             }
             val user = session.getUserOrDefault(pr.otherUserId).toMatrixItem()
             val name = user.getBestName()
@@ -142,17 +143,18 @@ class IncomingVerificationRequestHandler @Inject constructor(
             }
 
             val alert = VerificationVectorAlert(
-                    uniqueIdForVerificationRequest(pr),
-                    context.getString(R.string.sas_incoming_request_notif_title),
-                    description,
-                    R.drawable.ic_shield_black,
+                    uid = uniqueIdForVerificationRequest(pr),
+                    title = context.getString(R.string.sas_incoming_request_notif_title),
+                    description = description,
+                    iconId = R.drawable.ic_shield_black,
+                    priority = PopupAlertManager.INCOMING_VERIFICATION_REQUEST_PRIORITY,
                     shouldBeDisplayedIn = { activity ->
                         if (activity is RoomDetailActivity) {
                             activity.intent?.extras?.getParcelableCompat<TimelineArgs>(RoomDetailActivity.EXTRA_ROOM_DETAIL_ARGS)?.let {
                                 it.roomId != pr.roomId
                             } ?: true
                         } else true
-                    }
+                    },
             )
                     .apply {
                         viewBinder = VerificationVectorAlert.ViewBinder(user, avatarRenderer.get())

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/IncomingVerificationRequestHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/IncomingVerificationRequestHandler.kt
@@ -128,12 +128,9 @@ class IncomingVerificationRequestHandler @Inject constructor(
         // For incoming request we should prompt (if not in activity where this request apply)
         if (pr.isIncoming) {
             // if it's a self verification for my devices, we can discard the review login alert
-            // if not this request will be underneath and not visible by the user...
+            // if not, this request will be underneath and not visible by the user...
             // it will re-appear later
-            if (pr.otherUserId == session?.myUserId) {
-                popupAlertManager.cancelAlert(PopupAlertManager.REVIEW_LOGIN_UID)
-                popupAlertManager.cancelAlert(PopupAlertManager.VERIFY_SESSION_UID)
-            }
+            cancelAnyVerifySessionAlerts(pr)
             val user = session.getUserOrDefault(pr.otherUserId).toMatrixItem()
             val name = user.getBestName()
             val description = if (name == pr.otherUserId) {
@@ -159,6 +156,7 @@ class IncomingVerificationRequestHandler @Inject constructor(
                     .apply {
                         viewBinder = VerificationVectorAlert.ViewBinder(user, avatarRenderer.get())
                         contentAction = Runnable {
+                            cancelAnyVerifySessionAlerts(pr)
                             (weakCurrentActivity?.get() as? VectorBaseActivity<*>)?.let {
                                 val roomId = pr.roomId
                                 if (roomId.isNullOrBlank()) {
@@ -185,6 +183,13 @@ class IncomingVerificationRequestHandler @Inject constructor(
                         expirationTimestamp = clock.epochMillis() + (5 * 60 * 1000L)
                     }
             popupAlertManager.postVectorAlert(alert)
+        }
+    }
+
+    private fun cancelAnyVerifySessionAlerts(pr: PendingVerificationRequest) {
+        if (pr.otherUserId == session?.myUserId) {
+            popupAlertManager.cancelAlert(PopupAlertManager.REVIEW_LOGIN_UID)
+            popupAlertManager.cancelAlert(PopupAlertManager.VERIFY_SESSION_UID)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -437,9 +437,10 @@ class HomeActivity :
     private fun handleAskPasswordToInitCrossSigning(events: HomeActivityViewEvents.AskPasswordToInitCrossSigning) {
         // We need to ask
         promptSecurityEvent(
-                events.userItem,
-                R.string.upgrade_security,
-                R.string.security_prompt_text
+                uid = PopupAlertManager.UPGRADE_SECURITY_UID,
+                userItem = events.userItem,
+                titleRes = R.string.upgrade_security,
+                descRes = R.string.security_prompt_text,
         ) {
             it.navigator.upgradeSessionSecurity(it, true)
         }
@@ -448,9 +449,10 @@ class HomeActivity :
     private fun handleCrossSigningInvalidated(event: HomeActivityViewEvents.OnCrossSignedInvalidated) {
         // We need to ask
         promptSecurityEvent(
-                event.userItem,
-                R.string.crosssigning_verify_this_session,
-                R.string.confirm_your_identity
+                uid = PopupAlertManager.VERIFY_SESSION_UID,
+                userItem = event.userItem,
+                titleRes = R.string.crosssigning_verify_this_session,
+                descRes = R.string.confirm_your_identity,
         ) {
             it.navigator.waitSessionVerification(it)
         }
@@ -459,9 +461,10 @@ class HomeActivity :
     private fun handleOnNewSession(event: HomeActivityViewEvents.CurrentSessionNotVerified) {
         // We need to ask
         promptSecurityEvent(
-                event.userItem,
-                R.string.crosssigning_verify_this_session,
-                R.string.confirm_your_identity
+                uid = PopupAlertManager.VERIFY_SESSION_UID,
+                userItem = event.userItem,
+                titleRes = R.string.crosssigning_verify_this_session,
+                descRes = R.string.confirm_your_identity,
         ) {
             if (event.waitForIncomingRequest) {
                 it.navigator.waitSessionVerification(it)
@@ -474,9 +477,10 @@ class HomeActivity :
     private fun handleCantVerify(event: HomeActivityViewEvents.CurrentSessionCannotBeVerified) {
         // We need to ask
         promptSecurityEvent(
-                event.userItem,
-                R.string.crosssigning_cannot_verify_this_session,
-                R.string.crosssigning_cannot_verify_this_session_desc
+                uid = PopupAlertManager.UPGRADE_SECURITY_UID,
+                userItem = event.userItem,
+                titleRes = R.string.crosssigning_cannot_verify_this_session,
+                descRes = R.string.crosssigning_cannot_verify_this_session_desc,
         ) {
             it.navigator.open4SSetup(it, SetupMode.PASSPHRASE_AND_NEEDED_SECRETS_RESET)
         }
@@ -485,7 +489,7 @@ class HomeActivity :
     private fun handlePromptToEnablePush() {
         popupAlertManager.postVectorAlert(
                 DefaultVectorAlert(
-                        uid = "enablePush",
+                        uid = PopupAlertManager.ENABLE_PUSH_UID,
                         title = getString(R.string.alert_push_are_disabled_title),
                         description = getString(R.string.alert_push_are_disabled_description),
                         iconId = R.drawable.ic_room_actions_notifications_mutes,
@@ -518,10 +522,16 @@ class HomeActivity :
         )
     }
 
-    private fun promptSecurityEvent(userItem: MatrixItem.UserItem, titleRes: Int, descRes: Int, action: ((VectorBaseActivity<*>) -> Unit)) {
+    private fun promptSecurityEvent(
+            uid: String,
+            userItem: MatrixItem.UserItem,
+            titleRes: Int,
+            descRes: Int,
+            action: ((VectorBaseActivity<*>) -> Unit),
+    ) {
         popupAlertManager.postVectorAlert(
                 VerificationVectorAlert(
-                        uid = "upgradeSecurity",
+                        uid = uid,
                         title = getString(titleRes),
                         description = getString(descRes),
                         iconId = R.drawable.ic_shield_warning

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
@@ -156,7 +156,7 @@ class HomeDetailFragment :
         unknownDeviceDetectorSharedViewModel.onEach { state ->
             state.unknownSessions.invoke()?.let { unknownDevices ->
                 if (unknownDevices.firstOrNull()?.currentSessionTrust == true) {
-                    val uid = "review_login"
+                    val uid = PopupAlertManager.REVIEW_LOGIN_UID
                     alertManager.cancelAlert(uid)
                     val olderUnverified = unknownDevices.filter { !it.isNew }
                     val newest = unknownDevices.firstOrNull { it.isNew }?.deviceInfo

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
@@ -160,7 +160,7 @@ class NewHomeDetailFragment :
         unknownDeviceDetectorSharedViewModel.onEach { state ->
             state.unknownSessions.invoke()?.let { unknownDevices ->
                 if (unknownDevices.firstOrNull()?.currentSessionTrust == true) {
-                    val uid = "review_login"
+                    val uid = PopupAlertManager.REVIEW_LOGIN_UID
                     alertManager.cancelAlert(uid)
                     val olderUnverified = unknownDevices.filter { !it.isNew }
                     val newest = unknownDevices.firstOrNull { it.isNew }?.deviceInfo

--- a/vector/src/main/java/im/vector/app/features/popup/PopupAlertManager.kt
+++ b/vector/src/main/java/im/vector/app/features/popup/PopupAlertManager.kt
@@ -50,6 +50,12 @@ class PopupAlertManager @Inject constructor(
 
     companion object {
         const val INCOMING_CALL_PRIORITY = Int.MAX_VALUE
+        const val INCOMING_VERIFICATION_REQUEST_PRIORITY = 1
+        const val DEFAULT_PRIORITY = 0
+        const val REVIEW_LOGIN_UID = "review_login"
+        const val UPGRADE_SECURITY_UID = "upgrade_security"
+        const val VERIFY_SESSION_UID = "verify_session"
+        const val ENABLE_PUSH_UID = "enable_push"
     }
 
     private var weakCurrentActivity: WeakReference<Activity>? = null
@@ -145,7 +151,7 @@ class PopupAlertManager @Inject constructor(
 
     private fun displayNextIfPossible() {
         val currentActivity = weakCurrentActivity?.get()
-        if (Alerter.isShowing || currentActivity == null || currentActivity.isDestroyed) {
+        if (currentActivity == null || currentActivity.isDestroyed) {
             // will retry later
             return
         }

--- a/vector/src/main/java/im/vector/app/features/popup/VectorAlert.kt
+++ b/vector/src/main/java/im/vector/app/features/popup/VectorAlert.kt
@@ -98,7 +98,7 @@ open class DefaultVectorAlert(
 
     override val dismissOnClick: Boolean = true
 
-    override val priority: Int = 0
+    override val priority: Int = PopupAlertManager.DEFAULT_PRIORITY
 
     override val isLight: Boolean = false
 

--- a/vector/src/main/java/im/vector/app/features/popup/VerificationVectorAlert.kt
+++ b/vector/src/main/java/im/vector/app/features/popup/VerificationVectorAlert.kt
@@ -30,6 +30,7 @@ class VerificationVectorAlert(
         title: String,
         override val description: String,
         @DrawableRes override val iconId: Int?,
+        override val priority: Int = PopupAlertManager.DEFAULT_PRIORITY,
         /**
          * Alert are displayed by default, but let this lambda return false to prevent displaying.
          */


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Fix an issue about the display priority of popup alerts when there is an incoming verification request. Priority of the incoming verification requests alert has been raised and any existing alerts about verification of sessions are canceled when a new request arrives.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7743 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open a verified session on device A (can be any client: web, Android, iOS)
- Login to a new session in the Android app (device B)
- When landing in the home screen, see there is a popup displayed to ask to verify the session
- From device A, request a verification on the new session on device B
- Check the popup for the incoming request is displayed on device B
- Tap the popup
- Check the verification flow is started
- Check there is no popup to ask to verify the session on device B

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
