### PR TITLE
thread message notification should navigate to thread timeline

### DIFF
--- a/changelog.d/7770.bugfix
+++ b/changelog.d/7770.bugfix
@@ -1,0 +1,1 @@
+[Push Notifications] When push notification for threaded message is clicked, thread timeline will be opened instead of room's main timeline

--- a/vector/src/main/java/im/vector/app/features/home/room/threads/ThreadsActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/threads/ThreadsActivity.kt
@@ -26,6 +26,7 @@ import im.vector.app.core.extensions.addFragmentToBackstack
 import im.vector.app.core.extensions.replaceFragment
 import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.databinding.ActivityThreadsBinding
+import im.vector.app.features.MainActivity
 import im.vector.app.features.analytics.extensions.toAnalyticsInteraction
 import im.vector.app.features.analytics.plan.Interaction
 import im.vector.app.features.home.AvatarRenderer
@@ -143,12 +144,19 @@ class ThreadsActivity : VectorBaseActivity<ActivityThreadsBinding>() {
                 context: Context,
                 threadTimelineArgs: ThreadTimelineArgs?,
                 threadListArgs: ThreadListArgs?,
-                eventIdToNavigate: String? = null
+                eventIdToNavigate: String? = null,
+                firstStartMainActivity: Boolean = false
         ): Intent {
-            return Intent(context, ThreadsActivity::class.java).apply {
+            val intent = Intent(context, ThreadsActivity::class.java).apply {
                 putExtra(THREAD_TIMELINE_ARGS, threadTimelineArgs)
                 putExtra(THREAD_EVENT_ID_TO_NAVIGATE, eventIdToNavigate)
                 putExtra(THREAD_LIST_ARGS, threadListArgs)
+            }
+
+            return if (firstStartMainActivity) {
+                MainActivity.getIntentWithNextIntent(context, intent)
+            } else {
+                intent
             }
         }
     }

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
@@ -65,6 +65,7 @@ import im.vector.app.features.home.room.threads.arguments.ThreadTimelineArgs
 import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.settings.troubleshoot.TestNotificationReceiver
 import im.vector.app.features.themes.ThemeUtils
+import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilities
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -585,7 +586,7 @@ class NotificationUtils @Inject constructor(
         val accentColor = ContextCompat.getColor(context, R.color.notification_accent_color)
         // Build the pending intent for when the notification is clicked
         val openIntent = when {
-            threadId != null -> buildOpenThreadIntent(roomInfo, threadId)
+            threadId != null && vectorPreferences.areThreadMessagesEnabled() -> buildOpenThreadIntent(roomInfo, threadId)
             else -> buildOpenRoomIntent(roomInfo.roomId)
         }
 
@@ -847,10 +848,11 @@ class NotificationUtils @Inject constructor(
                 context = context,
                 threadTimelineArgs = threadTimelineArgs,
                 threadListArgs = null,
+                firstStartMainActivity = true,
         )
         threadIntentTap.action = actionIds.tapToView
         // pending intent get reused by system, this will mess up the extra params, so put unique info to avoid that
-        threadIntentTap.data = createIgnoredUri("optenThread?$threadId")
+        threadIntentTap.data = createIgnoredUri("openThread?$threadId")
 
         val roomIntent = RoomDetailActivity.newIntent(
                 context = context,
@@ -858,7 +860,7 @@ class NotificationUtils @Inject constructor(
                         roomId = roomInfo.roomId,
                         switchToParentSpace = true
                 ),
-                firstStartMainActivity = true
+                firstStartMainActivity = false
         )
         // Recreate the back stack
         return TaskStackBuilder.create(context)

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
@@ -60,6 +60,8 @@ import im.vector.app.features.displayname.getBestName
 import im.vector.app.features.home.HomeActivity
 import im.vector.app.features.home.room.detail.RoomDetailActivity
 import im.vector.app.features.home.room.detail.arguments.TimelineArgs
+import im.vector.app.features.home.room.threads.ThreadsActivity
+import im.vector.app.features.home.room.threads.arguments.ThreadTimelineArgs
 import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.settings.troubleshoot.TestNotificationReceiver
 import im.vector.app.features.themes.ThemeUtils
@@ -574,6 +576,7 @@ class NotificationUtils @Inject constructor(
     fun buildMessagesListNotification(
             messageStyle: NotificationCompat.MessagingStyle,
             roomInfo: RoomEventGroupInfo,
+            threadId: String?,
             largeIcon: Bitmap?,
             lastMessageTimestamp: Long,
             senderDisplayNameForReplyCompat: String?,
@@ -581,7 +584,11 @@ class NotificationUtils @Inject constructor(
     ): Notification {
         val accentColor = ContextCompat.getColor(context, R.color.notification_accent_color)
         // Build the pending intent for when the notification is clicked
-        val openRoomIntent = buildOpenRoomIntent(roomInfo.roomId)
+        val openIntent = when {
+            threadId != null -> buildOpenThreadIntent(roomInfo, threadId)
+            else -> buildOpenRoomIntent(roomInfo.roomId)
+        }
+
         val smallIcon = R.drawable.ic_notification
 
         val channelID = if (roomInfo.shouldBing) NOISY_NOTIFICATION_CHANNEL_ID else SILENT_NOTIFICATION_CHANNEL_ID
@@ -666,8 +673,8 @@ class NotificationUtils @Inject constructor(
                         }
                     }
 
-                    if (openRoomIntent != null) {
-                        setContentIntent(openRoomIntent)
+                    if (openIntent != null) {
+                        setContentIntent(openIntent)
                     }
 
                     if (largeIcon != null) {
@@ -820,6 +827,44 @@ class NotificationUtils @Inject constructor(
         return TaskStackBuilder.create(context)
                 .addNextIntentWithParentStack(HomeActivity.newIntent(context, firstStartMainActivity = false))
                 .addNextIntent(roomIntentTap)
+                .getPendingIntent(
+                        clock.epochMillis().toInt(),
+                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntentCompat.FLAG_IMMUTABLE
+                )
+    }
+
+    private fun buildOpenThreadIntent(roomInfo: RoomEventGroupInfo, threadId: String?): PendingIntent? {
+        val threadTimelineArgs = ThreadTimelineArgs(
+                startsThread = false,
+                roomId = roomInfo.roomId,
+                rootThreadEventId = threadId,
+                showKeyboard = false,
+                displayName = roomInfo.roomDisplayName,
+                avatarUrl = null,
+                roomEncryptionTrustLevel = null,
+        )
+        val threadIntentTap = ThreadsActivity.newIntent(
+                context = context,
+                threadTimelineArgs = threadTimelineArgs,
+                threadListArgs = null,
+        )
+        threadIntentTap.action = actionIds.tapToView
+        // pending intent get reused by system, this will mess up the extra params, so put unique info to avoid that
+        threadIntentTap.data = createIgnoredUri("optenThread?$threadId")
+
+        val roomIntent = RoomDetailActivity.newIntent(
+                context = context,
+                timelineArgs = TimelineArgs(
+                        roomId = roomInfo.roomId,
+                        switchToParentSpace = true
+                ),
+                firstStartMainActivity = true
+        )
+        // Recreate the back stack
+        return TaskStackBuilder.create(context)
+                .addNextIntentWithParentStack(HomeActivity.newIntent(context, firstStartMainActivity = false))
+                .addNextIntentWithParentStack(roomIntent)
+                .addNextIntent(threadIntentTap)
                 .getPendingIntent(
                         clock.epochMillis().toInt(),
                         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntentCompat.FLAG_IMMUTABLE

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationUtils.kt
@@ -65,7 +65,6 @@ import im.vector.app.features.home.room.threads.arguments.ThreadTimelineArgs
 import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.settings.troubleshoot.TestNotificationReceiver
 import im.vector.app.features.themes.ThemeUtils
-import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilities
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/vector/src/main/java/im/vector/app/features/notifications/RoomGroupMessageCreator.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/RoomGroupMessageCreator.kt
@@ -33,14 +33,14 @@ class RoomGroupMessageCreator @Inject constructor(
 ) {
 
     fun createRoomMessage(events: List<NotifiableMessageEvent>, roomId: String, userDisplayName: String, userAvatarUrl: String?): RoomNotification.Message {
-        val firstKnownRoomEvent = events[0]
-        val roomName = firstKnownRoomEvent.roomName ?: firstKnownRoomEvent.senderName ?: ""
-        val roomIsGroup = !firstKnownRoomEvent.roomIsDirect
+        val lastKnownRoomEvent = events.last()
+        val roomName = lastKnownRoomEvent.roomName ?: lastKnownRoomEvent.senderName ?: ""
+        val roomIsGroup = !lastKnownRoomEvent.roomIsDirect
         val style = NotificationCompat.MessagingStyle(
                 Person.Builder()
                         .setName(userDisplayName)
                         .setIcon(bitmapLoader.getUserIcon(userAvatarUrl))
-                        .setKey(firstKnownRoomEvent.matrixID)
+                        .setKey(lastKnownRoomEvent.matrixID)
                         .build()
         ).also {
             it.conversationTitle = roomName.takeIf { roomIsGroup }
@@ -75,6 +75,7 @@ class RoomGroupMessageCreator @Inject constructor(
                             it.customSound = events.last().soundName
                             it.isUpdated = events.last().isUpdated
                         },
+                        threadId = lastKnownRoomEvent.threadId,
                         largeIcon = largeBitmap,
                         lastMessageTimestamp,
                         userDisplayName,


### PR DESCRIPTION


<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Currently when user presses on a push notification for a threaded message they are navigated to a room instead of a thread timeline

## Motivation and context

closes #7770 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
