### PR TITLE
threads are enabled by default end forced to enabled for existing users

### DIFF
--- a/changelog.d/5503.misc
+++ b/changelog.d/5503.misc
@@ -1,0 +1,1 @@
+[Threads] - Threads Labs Flag is enabled by default and forced to be enabled for existing users, but sill can be disabled manually

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/MatrixConfiguration.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/MatrixConfiguration.kt
@@ -66,7 +66,7 @@ data class MatrixConfiguration(
         /**
          * Thread messages default enable/disabled value.
          */
-        val threadMessagesEnabledDefault: Boolean = false,
+        val threadMessagesEnabledDefault: Boolean = true,
         /**
          * List of network interceptors, they will be added when building an OkHttp client.
          */

--- a/vector-config/src/main/res/values/config-settings.xml
+++ b/vector-config/src/main/res/values/config-settings.xml
@@ -39,7 +39,7 @@
     <!-- Level 1: Labs -->
     <bool name="settings_labs_deferred_dm_visible">true</bool>
     <bool name="settings_labs_deferred_dm_default">true</bool>
-    <bool name="settings_labs_thread_messages_default">false</bool>
+    <bool name="settings_labs_thread_messages_default">true</bool>
     <bool name="settings_labs_new_app_layout_default">true</bool>
     <bool name="settings_labs_new_session_manager_default">false</bool>
     <bool name="settings_labs_new_session_manager_visible">true</bool>

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -254,6 +254,12 @@ class HomeActivityViewModel @AssistedInject constructor(
 //        }
 
         when {
+            !vectorPreferences.areThreadMessagesEnabled() && !vectorPreferences.wasThreadFlagChangedManually() -> {
+                vectorPreferences.setThreadMessagesEnabled()
+                lightweightSettingsStorage.setThreadMessagesEnabled(vectorPreferences.areThreadMessagesEnabled())
+                // Clear Cache
+                _viewEvents.post(HomeActivityViewEvents.MigrateThreads(checkSession = false))
+            }
             // Notify users
             vectorPreferences.shouldNotifyUserAboutThreads() && vectorPreferences.areThreadMessagesEnabled() -> {
                 Timber.i("----> Notify users about threads")

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -239,6 +239,7 @@ class VectorPreferences @Inject constructor(
 
         // This key will be used to identify clients with the new thread support enabled m.thread
         const val SETTINGS_LABS_ENABLE_THREAD_MESSAGES = "SETTINGS_LABS_ENABLE_THREAD_MESSAGES_FINAL"
+        const val SETTINGS_LABS_THREAD_MESSAGES_CHANGED_BY_USER = "SETTINGS_LABS_THREAD_MESSAGES_CHANGED_BY_USER"
         const val SETTINGS_THREAD_MESSAGES_SYNCED = "SETTINGS_THREAD_MESSAGES_SYNCED"
 
         // This key will be used to enable user for displaying live user info or not.
@@ -1126,6 +1127,24 @@ class VectorPreferences @Inject constructor(
         defaultPrefs
                 .edit()
                 .putBoolean(SETTINGS_LABS_ENABLE_THREAD_MESSAGES, true)
+                .apply()
+    }
+
+    /**
+     * Indicates whether or not user changed threads flag manually. We need this to not force flag to be enabled on app start.
+     * Should be removed when Threads flag will be removed
+     */
+    fun wasThreadFlagChangedManually(): Boolean {
+        return defaultPrefs.getBoolean(SETTINGS_LABS_THREAD_MESSAGES_CHANGED_BY_USER, false)
+    }
+
+    /**
+     * Sets the flag to indicate that user changed threads flag (e.g. disabled them).
+     */
+    fun setThreadFlagChangedManually() {
+        defaultPrefs
+                .edit()
+                .putBoolean(SETTINGS_LABS_THREAD_MESSAGES_CHANGED_BY_USER, true)
                 .apply()
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/labs/VectorSettingsLabsFragment.kt
@@ -141,6 +141,7 @@ class VectorSettingsLabsFragment :
      */
     private fun onThreadsPreferenceClicked() {
         // We should migrate threads only if threads are disabled
+        vectorPreferences.setThreadFlagChangedManually()
         vectorPreferences.setShouldMigrateThreads(!vectorPreferences.areThreadMessagesEnabled())
         lightweightSettingsStorage.setThreadMessagesEnabled(vectorPreferences.areThreadMessagesEnabled())
         displayLoadingView()


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

we want to enable threads by default and force to be enabled for existing users, but still let users disable it via labs flag

## Motivation and context

closes #5503 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
