### PR TITLE
[Session manager] Other sessions list: filter option is displayed when selection mode is enabled (PSG-1113)

### DIFF
--- a/changelog.d/7784.bugfix
+++ b/changelog.d/7784.bugfix
@@ -1,0 +1,1 @@
+[Session manager] Other sessions list: filter option is displayed when selection mode is enabled

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsFragment.kt
@@ -225,6 +225,7 @@ class OtherSessionsFragment :
 
     override fun invalidate() = withState(viewModel) { state ->
         updateLoading(state.isLoading)
+        updateFilterView(state.isSelectModeEnabled)
         if (state.devices is Success) {
             val devices = state.devices.invoke()
             renderDevices(devices, state.currentFilter, state.isShowingIpAddress)
@@ -238,6 +239,10 @@ class OtherSessionsFragment :
         } else {
             dismissLoadingDialog()
         }
+    }
+
+    private fun updateFilterView(isSelectModeEnabled: Boolean) {
+        views.otherSessionsFilterFrameLayout.isVisible = isSelectModeEnabled.not()
     }
 
     private fun updateToolbar(devices: List<DeviceFullInfo>, isSelectModeEnabled: Boolean) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
In the other session list screen in session manager, hiding the filter option in the top bar when the selection mode is enabled.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7784 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|<img src="https://user-images.githubusercontent.com/46314705/208381768-817baa20-b186-4624-9ed3-07b28838e1ce.png" width=300 />|<img src="https://user-images.githubusercontent.com/46314705/207831407-c60213de-1416-48f1-bab2-db82546feb8a.png" width=300 />|

## Tests

<!-- Explain how you tested your development -->

- Enable the new session manager labs setting
- Go to Settings -> Security & Privacy -> Show all sessions
- Press "View All" button in the other sessions section (need more than 5 other sessions)
- Select one session
- Check the filter icon is not displayed
- Leave the selection mode
- Check the filter icon is displayed

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
