### PR TITLE
[Session manager] Other sessions: Filter bottom sheet cut in landscape mode (PSG-1107)

### DIFF
--- a/changelog.d/7786.bugfix
+++ b/changelog.d/7786.bugfix
@@ -1,0 +1,1 @@
+[Session manager] Other sessions: Filter bottom sheet cut in landscape mode

--- a/vector/src/main/res/layout/bottom_sheet_device_manager_filter.xml
+++ b/vector/src/main/res/layout/bottom_sheet_device_manager_filter.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -22,14 +23,16 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:paddingEnd="5dp"
+        android:scrollbarStyle="outsideOverlay"
+        tools:ignore="RtlSymmetry">
 
         <RadioGroup
             android:id="@+id/filterOptionsRadioGroup"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:layoutDirection="rtl"
+            android:paddingTop="24dp"
             android:showDividers="none">
 
             <RadioButton
@@ -37,25 +40,34 @@
                 style="@style/TextAppearance.Vector.Subtitle.Medium.DevicesManagement"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:background="?android:selectableItemBackground"
+                android:button="@null"
                 android:checked="true"
+                android:drawableEnd="?android:attr/listChoiceIndicatorSingle"
                 android:minHeight="0dp"
-                android:text="@string/device_manager_filter_option_all_sessions" />
+                android:text="@string/device_manager_filter_option_all_sessions"
+                android:textAlignment="textStart" />
 
             <RadioButton
                 android:id="@+id/filterOptionVerifiedRadioButton"
                 style="@style/TextAppearance.Vector.Subtitle.Medium.DevicesManagement"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_gravity="start"
                 android:layout_marginTop="24dp"
+                android:background="?android:selectableItemBackground"
+                android:button="@null"
+                android:drawableEnd="?android:attr/listChoiceIndicatorSingle"
                 android:minHeight="0dp"
-                android:text="@string/device_manager_filter_option_verified" />
+                android:text="@string/device_manager_filter_option_verified"
+                android:textAlignment="textStart" />
 
             <TextView
                 android:id="@+id/filterOptionVerifiedTextView"
                 style="@style/TextAppearance.Vector.Body.DevicesManagement"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="end"
                 android:text="@string/device_manager_filter_option_verified_description" />
 
             <RadioButton
@@ -63,16 +75,20 @@
                 style="@style/TextAppearance.Vector.Subtitle.Medium.DevicesManagement"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_gravity="start"
                 android:layout_marginTop="16dp"
+                android:background="?android:selectableItemBackground"
+                android:button="@null"
+                android:drawableEnd="?android:attr/listChoiceIndicatorSingle"
                 android:minHeight="0dp"
-                android:text="@string/device_manager_filter_option_unverified" />
+                android:text="@string/device_manager_filter_option_unverified"
+                android:textAlignment="textStart" />
 
             <TextView
                 android:id="@+id/filterOptionUnverifiedTextView"
                 style="@style/TextAppearance.Vector.Body.DevicesManagement"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="end"
                 android:text="@string/device_manager_filter_option_unverified_description" />
 
             <RadioButton
@@ -80,16 +96,20 @@
                 style="@style/TextAppearance.Vector.Subtitle.Medium.DevicesManagement"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_gravity="start"
                 android:layout_marginTop="16dp"
+                android:background="?android:selectableItemBackground"
+                android:button="@null"
+                android:drawableEnd="?android:attr/listChoiceIndicatorSingle"
                 android:minHeight="0dp"
-                android:text="@string/device_manager_filter_option_inactive" />
+                android:text="@string/device_manager_filter_option_inactive"
+                android:textAlignment="textStart" />
 
             <TextView
                 android:id="@+id/filterOptionInactiveTextView"
                 style="@style/TextAppearance.Vector.Body.DevicesManagement"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="end" />
+                android:layout_height="wrap_content" />
 
         </RadioGroup>
 

--- a/vector/src/main/res/layout/bottom_sheet_device_manager_filter.xml
+++ b/vector/src/main/res/layout/bottom_sheet_device_manager_filter.xml
@@ -20,73 +20,79 @@
         android:layout_marginTop="12dp"
         android:text="@string/device_manager_filter_bottom_sheet_title" />
 
-    <RadioGroup
-        android:id="@+id/filterOptionsRadioGroup"
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
-        android:layoutDirection="rtl"
-        android:showDividers="none">
+        android:layout_height="match_parent">
 
-        <RadioButton
-            android:id="@+id/filterOptionAllSessionsRadioButton"
-            style="@style/TextAppearance.Vector.Subtitle.Medium.DevicesManagement"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:checked="true"
-            android:minHeight="0dp"
-            android:text="@string/device_manager_filter_option_all_sessions" />
-
-        <RadioButton
-            android:id="@+id/filterOptionVerifiedRadioButton"
-            style="@style/TextAppearance.Vector.Subtitle.Medium.DevicesManagement"
+        <RadioGroup
+            android:id="@+id/filterOptionsRadioGroup"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:minHeight="0dp"
-            android:text="@string/device_manager_filter_option_verified" />
+            android:layoutDirection="rtl"
+            android:showDividers="none">
 
-        <TextView
-            android:id="@+id/filterOptionVerifiedTextView"
-            style="@style/TextAppearance.Vector.Body.DevicesManagement"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:text="@string/device_manager_filter_option_verified_description" />
+            <RadioButton
+                android:id="@+id/filterOptionAllSessionsRadioButton"
+                style="@style/TextAppearance.Vector.Subtitle.Medium.DevicesManagement"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:minHeight="0dp"
+                android:text="@string/device_manager_filter_option_all_sessions" />
 
-        <RadioButton
-            android:id="@+id/filterOptionUnverifiedRadioButton"
-            style="@style/TextAppearance.Vector.Subtitle.Medium.DevicesManagement"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:minHeight="0dp"
-            android:text="@string/device_manager_filter_option_unverified" />
+            <RadioButton
+                android:id="@+id/filterOptionVerifiedRadioButton"
+                style="@style/TextAppearance.Vector.Subtitle.Medium.DevicesManagement"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:minHeight="0dp"
+                android:text="@string/device_manager_filter_option_verified" />
 
-        <TextView
-            android:id="@+id/filterOptionUnverifiedTextView"
-            style="@style/TextAppearance.Vector.Body.DevicesManagement"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:text="@string/device_manager_filter_option_unverified_description" />
+            <TextView
+                android:id="@+id/filterOptionVerifiedTextView"
+                style="@style/TextAppearance.Vector.Body.DevicesManagement"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:text="@string/device_manager_filter_option_verified_description" />
 
-        <RadioButton
-            android:id="@+id/filterOptionInactiveRadioButton"
-            style="@style/TextAppearance.Vector.Subtitle.Medium.DevicesManagement"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:minHeight="0dp"
-            android:text="@string/device_manager_filter_option_inactive" />
+            <RadioButton
+                android:id="@+id/filterOptionUnverifiedRadioButton"
+                style="@style/TextAppearance.Vector.Subtitle.Medium.DevicesManagement"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:minHeight="0dp"
+                android:text="@string/device_manager_filter_option_unverified" />
 
-        <TextView
-            android:id="@+id/filterOptionInactiveTextView"
-            style="@style/TextAppearance.Vector.Body.DevicesManagement"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end" />
+            <TextView
+                android:id="@+id/filterOptionUnverifiedTextView"
+                style="@style/TextAppearance.Vector.Body.DevicesManagement"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:text="@string/device_manager_filter_option_unverified_description" />
 
-    </RadioGroup>
+            <RadioButton
+                android:id="@+id/filterOptionInactiveRadioButton"
+                style="@style/TextAppearance.Vector.Subtitle.Medium.DevicesManagement"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:minHeight="0dp"
+                android:text="@string/device_manager_filter_option_inactive" />
+
+            <TextView
+                android:id="@+id/filterOptionInactiveTextView"
+                style="@style/TextAppearance.Vector.Body.DevicesManagement"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end" />
+
+        </RadioGroup>
+
+    </ScrollView>
 
 </LinearLayout>

--- a/vector/src/main/res/layout/bottom_sheet_device_manager_filter.xml
+++ b/vector/src/main/res/layout/bottom_sheet_device_manager_filter.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:paddingHorizontal="24dp"
-    android:paddingBottom="32dp">
+    android:orientation="vertical">
 
     <View
         android:layout_width="36dp"
@@ -19,14 +16,16 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="12dp"
+        android:paddingHorizontal="24dp"
         android:text="@string/device_manager_filter_bottom_sheet_title" />
 
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:paddingEnd="5dp"
-        android:scrollbarStyle="outsideOverlay"
-        tools:ignore="RtlSymmetry">
+        android:clipToPadding="false"
+        android:paddingHorizontal="24dp"
+        android:paddingBottom="32dp"
+        android:scrollbarStyle="outsideOverlay">
 
         <RadioGroup
             android:id="@+id/filterOptionsRadioGroup"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
In the other sessions list screen, making content of bottom sheet to set the filtering option as scrollable.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7786 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

Use a small device (e.g 3.7'')

- Enable the new session manager labs setting
- Go to Settings -> Security & Privacy -> Show all sessions
- Press the View all button in the other sessions section (need more than 5 other sessions)
- Put the phone in landscape mode
- Press the filter option in the top app bar
- Check you can scroll the content to see and select the different options

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
