### PR TITLE
[Session Manager] Other sessions list: cannot select/deselect session by a long press when in select mode (PSG-1111)

### DIFF
--- a/changelog.d/7792.bugfix
+++ b/changelog.d/7792.bugfix
@@ -1,0 +1,1 @@
+[Session Manager] Other sessions list: cannot select/deselect session by a long press when in select mode

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsFragment.kt
@@ -341,6 +341,8 @@ class OtherSessionsFragment :
     override fun onOtherSessionLongClicked(deviceId: String) = withState(viewModel) { state ->
         if (!state.isSelectModeEnabled) {
             enableSelectMode(true, deviceId)
+        } else {
+            viewModel.handle(OtherSessionsAction.ToggleSelectionForDevice(deviceId))
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
In the other sessions list screen, when long pressing a session item, toggle selection of this item even in selection mode.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7792 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Enable the labs setting for new session manager
- Go to Settings -> Security & Privacy -> Show all sessions
- Press the View all button in the other sessions list (need more than 5 other sessions)
- Long press one session to enable the selection mode
- Long press another session
- Check it select this other session
- Long press a selected session
- Check it un-select the pressed session


## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
