### PR TITLE
[Session manager] Security recommendations cards: whole view should be tappable (PSG-1117)

### DIFF
--- a/changelog.d/7795.feature
+++ b/changelog.d/7795.feature
@@ -1,0 +1,1 @@
+[Session manager] Security recommendations cards: whole view should be tappable

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SecurityRecommendationView.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SecurityRecommendationView.kt
@@ -53,6 +53,9 @@ class SecurityRecommendationView @JvmOverloads constructor(
             setImage(it)
         }
 
+        setOnClickListener {
+            callback?.onViewAllClicked()
+        }
         views.recommendationViewAllButton.setOnClickListener {
             callback?.onViewAllClicked()
         }

--- a/vector/src/main/res/layout/view_security_recommendation.xml
+++ b/vector/src/main/res/layout/view_security_recommendation.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/bg_current_session"
+    android:foreground="?attr/selectableItemBackground"
     android:paddingHorizontal="16dp"
     android:paddingTop="16dp"
     android:paddingBottom="8dp">


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
In the session manager main screen, making the whole security recommendation card as tappable (same action as the "View All" button).

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7795 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Enable the labs setting for the new session manager
- Go to Settings -> Security & Privacy -> Show all sessions
- Check you can press either the View All button or the whole card on the security recommendations cards. They should appear when there are either inactive or unverified sessions.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
