### PR TITLE
[Session manager] Other sessions list: header should not be sticky (PSG-1115)

### DIFF
--- a/changelog.d/7797.feature
+++ b/changelog.d/7797.feature
@@ -1,1 +1,1 @@
-[Session manager] Other sessions list: Security recommendation header should not be sticky
+[Session manager] Other sessions list: header should not be sticky

--- a/changelog.d/7797.feature
+++ b/changelog.d/7797.feature
@@ -1,0 +1,1 @@
+[Session manager] Other sessions list: Security recommendation header should not be sticky

--- a/vector/src/main/res/layout/fragment_other_sessions.xml
+++ b/vector/src/main/res/layout/fragment_other_sessions.xml
@@ -1,120 +1,132 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:id="@+id/otherSessionsNotFoundLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="72dp"
+            android:layout_marginTop="32dp"
+            android:layout_marginEnd="16dp"
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/otherSessionsNotFoundTextView"
+                style="@style/TextAppearance.Vector.Body"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="@string/device_manager_other_sessions_no_verified_sessions_found" />
+
+            <Button
+                android:id="@+id/otherSessionsClearFilterButton"
+                style="@style/Widget.Vector.Button.Text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:gravity="start"
+                android:padding="0dp"
+                android:text="@string/device_manager_other_sessions_clear_filter" />
+
+        </LinearLayout>
+
+        <im.vector.app.features.settings.devices.v2.list.OtherSessionsView
+            android:id="@+id/deviceListOtherSessions"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="wrap_content">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/otherSessionsToolbar"
+        <com.google.android.material.appbar.CollapsingToolbarLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:navigationIcon="@drawable/ic_back_24dp"
-            app:title="@string/device_manager_sessions_other_title">
+            android:layout_height="match_parent"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed"
+            app:titleEnabled="false"
+            app:toolbarId="@id/otherSessionsToolbar">
 
-            <FrameLayout
-                android:id="@+id/otherSessionsFilterFrameLayout"
-                android:layout_width="wrap_content"
+            <im.vector.app.features.settings.devices.v2.list.SessionsListHeaderView
+                android:id="@+id/deviceListHeaderOtherSessions"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="end"
-                android:layout_marginEnd="8dp"
-                android:padding="8dp">
+                android:layout_marginTop="?attr/actionBarSize"
+                android:layout_marginBottom="32dp"
+                app:layout_collapseMode="parallax"
+                app:sessionsListHeaderDescription="@string/device_manager_sessions_other_description"
+                app:sessionsListHeaderHasLearnMoreLink="false"
+                app:sessionsListHeaderTitle="" />
 
-                <ImageView
+            <im.vector.app.features.settings.devices.v2.othersessions.OtherSessionsSecurityRecommendationView
+                android:id="@+id/otherSessionsSecurityRecommendationView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="?attr/actionBarSize"
+                android:layout_marginBottom="32dp"
+                android:paddingTop="20dp"
+                android:visibility="gone"
+                app:layout_collapseMode="parallax"
+                app:otherSessionsRecommendationDescription="@string/device_manager_other_sessions_recommendation_description_unverified"
+                app:otherSessionsRecommendationImageBackgroundTint="@color/shield_color_warning_background"
+                app:otherSessionsRecommendationImageResource="@drawable/ic_shield_warning_no_border"
+                app:otherSessionsRecommendationTitle="@string/device_manager_other_sessions_recommendation_title_unverified"
+                tools:visibility="visible" />
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/otherSessionsToolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:layout_collapseMode="pin"
+                app:navigationIcon="@drawable/ic_back_24dp"
+                app:title="@string/device_manager_sessions_other_title">
+
+                <FrameLayout
+                    android:id="@+id/otherSessionsFilterFrameLayout"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:contentDescription="@string/a11y_device_manager_filter"
-                    android:src="@drawable/ic_filter" />
+                    android:layout_gravity="end"
+                    android:layout_marginEnd="8dp"
+                    android:padding="8dp">
 
-                <ImageView
-                    android:id="@+id/otherSessionsFilterBadgeImageView"
-                    android:layout_width="12dp"
-                    android:layout_height="12dp"
-                    android:layout_marginStart="12dp"
-                    android:importantForAccessibility="no"
-                    android:src="@drawable/circle_with_transparent_border" />
+                    <ImageView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:contentDescription="@string/a11y_device_manager_filter"
+                        android:src="@drawable/ic_filter" />
 
-            </FrameLayout>
+                    <ImageView
+                        android:id="@+id/otherSessionsFilterBadgeImageView"
+                        android:layout_width="12dp"
+                        android:layout_height="12dp"
+                        android:layout_marginStart="12dp"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/circle_with_transparent_border" />
 
-        </com.google.android.material.appbar.MaterialToolbar>
+                </FrameLayout>
+
+            </com.google.android.material.appbar.MaterialToolbar>
+
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
 
     </com.google.android.material.appbar.AppBarLayout>
 
-
-    <im.vector.app.features.settings.devices.v2.list.SessionsListHeaderView
-        android:id="@+id/deviceListHeaderOtherSessions"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/appBarLayout"
-        app:sessionsListHeaderDescription="@string/device_manager_sessions_other_description"
-        app:sessionsListHeaderHasLearnMoreLink="false"
-        app:sessionsListHeaderTitle="" />
-
-    <im.vector.app.features.settings.devices.v2.othersessions.OtherSessionsSecurityRecommendationView
-        android:id="@+id/otherSessionsSecurityRecommendationView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="20dp"
-        android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/deviceListHeaderOtherSessions"
-        app:otherSessionsRecommendationDescription="@string/device_manager_other_sessions_recommendation_description_unverified"
-        app:otherSessionsRecommendationImageBackgroundTint="@color/shield_color_warning_background"
-        app:otherSessionsRecommendationImageResource="@drawable/ic_shield_warning_no_border"
-        app:otherSessionsRecommendationTitle="@string/device_manager_other_sessions_recommendation_title_unverified"
-        tools:visibility="visible" />
-
-    <LinearLayout
-        android:id="@+id/otherSessionsNotFoundLayout"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="72dp"
-        android:layout_marginTop="32dp"
-        android:layout_marginEnd="16dp"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/otherSessionsSecurityRecommendationView">
-
-        <TextView
-            android:id="@+id/otherSessionsNotFoundTextView"
-            style="@style/TextAppearance.Vector.Body"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            tools:text="@string/device_manager_other_sessions_no_verified_sessions_found" />
-
-        <Button
-            android:id="@+id/otherSessionsClearFilterButton"
-            style="@style/Widget.Vector.Button.Text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            android:gravity="start"
-            android:padding="0dp"
-            android:text="@string/device_manager_other_sessions_clear_filter" />
-
-    </LinearLayout>
-
-    <im.vector.app.features.settings.devices.v2.list.OtherSessionsView
-        android:id="@+id/deviceListOtherSessions"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="32dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/otherSessionsSecurityRecommendationView" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
In the other sessions list screen, making the header as collapsable so that it gives more place to the list.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7797 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

<img src="https://user-images.githubusercontent.com/46314705/208061958-14e72e70-9935-4d6d-a2ac-e74731ecdfdd.gif" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/208061977-bf215957-0624-49c5-ac8f-d705957c2eff.gif" width=300 />

## Tests

<!-- Explain how you tested your development -->

- Enable the labs setting for the new session manager
- Go to Settings -> Security & Privacy -> Show all sessions
- Press the View All button in the Other sessions section (need more than 5 other sessions)
- Check the scrolling behavior of the list and the header with the different filter options

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
