### PR TITLE
[Session manager] Missing info when a session does not support encryption (PSG-1074)

### DIFF
--- a/changelog.d/7853.bugfix
+++ b/changelog.d/7853.bugfix
@@ -1,0 +1,1 @@
+[Session manager] Missing info when a session does not support encryption

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
@@ -142,7 +142,7 @@ class DevicesViewModel @AssistedInject constructor(
                     .map { deviceInfo ->
                         val cryptoDeviceInfo = cryptoList.firstOrNull { it.deviceId == deviceInfo.deviceId }
                         val trustLevelForShield = getEncryptionTrustLevelForDeviceUseCase.execute(currentSessionCrossSigningInfo, cryptoDeviceInfo)
-                        val isInactive = checkIfSessionIsInactiveUseCase.execute(deviceInfo.lastSeenTs ?: 0)
+                        val isInactive = checkIfSessionIsInactiveUseCase.execute(deviceInfo.lastSeenTs)
                         DeviceFullInfo(deviceInfo, cryptoDeviceInfo, trustLevelForShield, isInactive)
                     }
         }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewState.kt
@@ -23,9 +23,13 @@ import im.vector.app.features.settings.devices.v2.verification.CurrentSessionCro
 
 data class DevicesViewState(
         val currentSessionCrossSigningInfo: CurrentSessionCrossSigningInfo = CurrentSessionCrossSigningInfo(),
-        val devices: Async<List<DeviceFullInfo>> = Uninitialized,
-        val unverifiedSessionsCount: Int = 0,
-        val inactiveSessionsCount: Int = 0,
+        val devices: Async<DeviceFullInfoList> = Uninitialized,
         val isLoading: Boolean = false,
         val isShowingIpAddress: Boolean = false,
 ) : MavericksState
+
+data class DeviceFullInfoList(
+        val allSessions: List<DeviceFullInfo>,
+        val unverifiedSessionsCount: Int,
+        val inactiveSessionsCount: Int,
+)

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/GetDeviceFullInfoListUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/GetDeviceFullInfoListUseCase.kt
@@ -75,7 +75,7 @@ class GetDeviceFullInfoListUseCase @Inject constructor(
                 .map { deviceInfo ->
                     val cryptoDeviceInfo = cryptoList.firstOrNull { it.deviceId == deviceInfo.deviceId }
                     val roomEncryptionTrustLevel = getEncryptionTrustLevelForDeviceUseCase.execute(currentSessionCrossSigningInfo, cryptoDeviceInfo)
-                    val isInactive = checkIfSessionIsInactiveUseCase.execute(deviceInfo.lastSeenTs ?: 0)
+                    val isInactive = checkIfSessionIsInactiveUseCase.execute(deviceInfo.lastSeenTs)
                     val isCurrentDevice = currentSessionCrossSigningInfo.deviceId == cryptoDeviceInfo?.deviceId
                     val deviceExtendedInfo = parseDeviceUserAgentUseCase.execute(deviceInfo.getBestLastSeenUserAgent())
                     val matrixClientInfo = deviceInfo.deviceId

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/filter/FilterDevicesUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/filter/FilterDevicesUseCase.kt
@@ -37,7 +37,9 @@ class FilterDevicesUseCase @Inject constructor() {
                         // when current session is not verified, other session status cannot be trusted
                         DeviceManagerFilterType.VERIFIED -> isCurrentSessionVerified && it.cryptoDeviceInfo?.trustLevel?.isCrossSigningVerified().orFalse()
                         // when current session is not verified, other session status cannot be trusted
-                        DeviceManagerFilterType.UNVERIFIED -> isCurrentSessionVerified && !it.cryptoDeviceInfo?.trustLevel?.isCrossSigningVerified().orFalse()
+                        DeviceManagerFilterType.UNVERIFIED ->
+                            (isCurrentSessionVerified && !it.cryptoDeviceInfo?.trustLevel?.isCrossSigningVerified().orFalse()) ||
+                                    it.cryptoDeviceInfo == null
                         DeviceManagerFilterType.INACTIVE -> it.isInactive
                     }
                 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/CheckIfSessionIsInactiveUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/CheckIfSessionIsInactiveUseCase.kt
@@ -24,11 +24,13 @@ class CheckIfSessionIsInactiveUseCase @Inject constructor(
         private val clock: Clock,
 ) {
 
-    fun execute(lastSeenTs: Long): Boolean {
-        // In case of the server doesn't send the last seen date.
-        if (lastSeenTs == 0L) return true
-
-        val diffMilliseconds = clock.epochMillis() - lastSeenTs
-        return diffMilliseconds >= TimeUnit.DAYS.toMillis(SESSION_IS_MARKED_AS_INACTIVE_AFTER_DAYS.toLong())
+    fun execute(lastSeenTsMillis: Long?): Boolean {
+        return if (lastSeenTsMillis == null || lastSeenTsMillis <= 0) {
+            // in these situations we cannot say anything about the inactivity of the session
+            false
+        } else {
+            val diffMilliseconds = clock.epochMillis() - lastSeenTsMillis
+            diffMilliseconds >= TimeUnit.DAYS.toMillis(SESSION_IS_MARKED_AS_INACTIVE_AFTER_DAYS.toLong())
+        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/OtherSessionsController.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/OtherSessionsController.kt
@@ -63,12 +63,13 @@ class OtherSessionsController @Inject constructor(
                 }
                 val drawableColor = host.colorProvider.getColorFromAttribute(R.attr.vctr_content_secondary)
                 val descriptionDrawable = if (device.isInactive) host.drawableProvider.getDrawable(R.drawable.ic_inactive_sessions, drawableColor) else null
+                val sessionName = device.deviceInfo.displayName ?: device.deviceInfo.deviceId
 
                 otherSessionItem {
                     id(device.deviceInfo.deviceId)
                     deviceType(device.deviceExtendedInfo.deviceType)
                     roomEncryptionTrustLevel(device.roomEncryptionTrustLevel)
-                    sessionName(device.deviceInfo.displayName)
+                    sessionName(sessionName)
                     sessionDescription(description)
                     sessionDescriptionDrawable(descriptionDrawable)
                     sessionDescriptionColor(descriptionColor)

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoView.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/list/SessionInfoView.kt
@@ -62,9 +62,10 @@ class SessionInfoView @JvmOverloads constructor(
             stringProvider: StringProvider,
     ) {
         renderDeviceInfo(
-                sessionInfoViewState.deviceFullInfo.deviceInfo.displayName.orEmpty(),
-                sessionInfoViewState.deviceFullInfo.deviceExtendedInfo.deviceType,
-                stringProvider,
+                sessionName = sessionInfoViewState.deviceFullInfo.deviceInfo.displayName
+                        ?: sessionInfoViewState.deviceFullInfo.deviceInfo.deviceId.orEmpty(),
+                deviceType = sessionInfoViewState.deviceFullInfo.deviceExtendedInfo.deviceType,
+                stringProvider = stringProvider,
         )
         renderVerificationStatus(
                 sessionInfoViewState.deviceFullInfo.roomEncryptionTrustLevel,

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/GetDeviceFullInfoUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/GetDeviceFullInfoUseCase.kt
@@ -49,10 +49,10 @@ class GetDeviceFullInfoUseCase @Inject constructor(
             ) { currentSessionCrossSigningInfo, deviceInfo, cryptoDeviceInfo ->
                 val info = deviceInfo.getOrNull()
                 val cryptoInfo = cryptoDeviceInfo.getOrNull()
-                val fullInfo = if (info != null && cryptoInfo != null) {
+                val fullInfo = if (info != null) {
                     val roomEncryptionTrustLevel = getEncryptionTrustLevelForDeviceUseCase.execute(currentSessionCrossSigningInfo, cryptoInfo)
                     val isInactive = checkIfSessionIsInactiveUseCase.execute(info.lastSeenTs)
-                    val isCurrentDevice = currentSessionCrossSigningInfo.deviceId == cryptoInfo.deviceId
+                    val isCurrentDevice = currentSessionCrossSigningInfo.deviceId == info.deviceId
                     val deviceUserAgent = parseDeviceUserAgentUseCase.execute(info.getBestLastSeenUserAgent())
                     val matrixClientInfo = info.deviceId
                             ?.takeIf { it.isNotEmpty() }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/GetDeviceFullInfoUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/GetDeviceFullInfoUseCase.kt
@@ -51,7 +51,7 @@ class GetDeviceFullInfoUseCase @Inject constructor(
                 val cryptoInfo = cryptoDeviceInfo.getOrNull()
                 val fullInfo = if (info != null && cryptoInfo != null) {
                     val roomEncryptionTrustLevel = getEncryptionTrustLevelForDeviceUseCase.execute(currentSessionCrossSigningInfo, cryptoInfo)
-                    val isInactive = checkIfSessionIsInactiveUseCase.execute(info.lastSeenTs ?: 0)
+                    val isInactive = checkIfSessionIsInactiveUseCase.execute(info.lastSeenTs)
                     val isCurrentDevice = currentSessionCrossSigningInfo.deviceId == cryptoInfo.deviceId
                     val deviceUserAgent = parseDeviceUserAgentUseCase.execute(info.getBestLastSeenUserAgent())
                     val matrixClientInfo = info.deviceId

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/filter/FilterDevicesUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/filter/FilterDevicesUseCaseTest.kt
@@ -22,6 +22,7 @@ import im.vector.app.features.settings.devices.v2.details.extended.DeviceExtende
 import im.vector.app.features.settings.devices.v2.list.DeviceType
 import im.vector.app.features.settings.devices.v2.verification.CurrentSessionCrossSigningInfo
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldContainAll
 import org.junit.Test
 import org.matrix.android.sdk.api.session.crypto.crosssigning.DeviceTrustLevel
@@ -82,11 +83,22 @@ private val inactiveUnverifiedDevice = DeviceFullInfo(
         matrixClientInfo = MatrixClientInfoContent(),
 )
 
+private val deviceWithoutEncryptionSupport = DeviceFullInfo(
+        deviceInfo = DeviceInfo(deviceId = "DEVICE_WITHOUT_ENCRYPTION_SUPPORT"),
+        cryptoDeviceInfo = null,
+        roomEncryptionTrustLevel = null,
+        isInactive = false,
+        isCurrentDevice = false,
+        deviceExtendedInfo = DeviceExtendedInfo(DeviceType.UNKNOWN),
+        matrixClientInfo = MatrixClientInfoContent(),
+)
+
 private val devices = listOf(
         activeVerifiedDevice,
         inactiveVerifiedDevice,
         activeUnverifiedDevice,
         inactiveUnverifiedDevice,
+        deviceWithoutEncryptionSupport,
 )
 
 class FilterDevicesUseCaseTest {
@@ -123,8 +135,8 @@ class FilterDevicesUseCaseTest {
         val currentSessionCrossSigningInfo = givenCurrentSessionVerified(true)
         val filteredDeviceList = filterDevicesUseCase.execute(currentSessionCrossSigningInfo, devices, DeviceManagerFilterType.UNVERIFIED, emptyList())
 
-        filteredDeviceList.size shouldBeEqualTo 2
-        filteredDeviceList shouldContainAll listOf(activeUnverifiedDevice, inactiveUnverifiedDevice)
+        filteredDeviceList.size shouldBeEqualTo 3
+        filteredDeviceList shouldContainAll listOf(activeUnverifiedDevice, inactiveUnverifiedDevice, deviceWithoutEncryptionSupport)
     }
 
     @Test
@@ -132,7 +144,8 @@ class FilterDevicesUseCaseTest {
         val currentSessionCrossSigningInfo = givenCurrentSessionVerified(false)
         val filteredDeviceList = filterDevicesUseCase.execute(currentSessionCrossSigningInfo, devices, DeviceManagerFilterType.UNVERIFIED, emptyList())
 
-        filteredDeviceList.size shouldBeEqualTo 0
+        filteredDeviceList.size shouldBeEqualTo 1
+        filteredDeviceList shouldContain deviceWithoutEncryptionSupport
     }
 
     @Test

--- a/vector/src/test/java/im/vector/app/features/settings/devices/v2/list/CheckIfSessionIsInactiveUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/devices/v2/list/CheckIfSessionIsInactiveUseCaseTest.kt
@@ -17,43 +17,69 @@
 package im.vector.app.features.settings.devices.v2.list
 
 import im.vector.app.test.fakes.FakeClock
-import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
 import org.junit.Test
 import java.util.concurrent.TimeUnit
 
-private const val A_TIMESTAMP = 1654689143L
+private const val A_TIMESTAMP_MILLIS = 1654689143000L
 
 class CheckIfSessionIsInactiveUseCaseTest {
 
-    private val clock = FakeClock().apply { givenEpoch(A_TIMESTAMP) }
+    private val clock = FakeClock().apply { givenEpoch(A_TIMESTAMP_MILLIS) }
     private val checkIfSessionIsInactiveUseCase = CheckIfSessionIsInactiveUseCase(clock)
 
     @Test
     fun `given an old last seen date then session is inactive`() {
-        val lastSeenDate = A_TIMESTAMP - TimeUnit.DAYS.toMillis(SESSION_IS_MARKED_AS_INACTIVE_AFTER_DAYS.toLong()) - 1
+        val lastSeenDate = A_TIMESTAMP_MILLIS - TimeUnit.DAYS.toMillis(SESSION_IS_MARKED_AS_INACTIVE_AFTER_DAYS.toLong()) - 1
 
-        checkIfSessionIsInactiveUseCase.execute(lastSeenDate) shouldBeEqualTo true
+        val result = checkIfSessionIsInactiveUseCase.execute(lastSeenDate)
+
+        result.shouldBeTrue()
     }
 
     @Test
     fun `given a last seen date equal to the threshold then session is inactive`() {
-        val lastSeenDate = A_TIMESTAMP - TimeUnit.DAYS.toMillis(SESSION_IS_MARKED_AS_INACTIVE_AFTER_DAYS.toLong())
+        val lastSeenDate = A_TIMESTAMP_MILLIS - TimeUnit.DAYS.toMillis(SESSION_IS_MARKED_AS_INACTIVE_AFTER_DAYS.toLong())
 
-        checkIfSessionIsInactiveUseCase.execute(lastSeenDate) shouldBeEqualTo true
+        val result = checkIfSessionIsInactiveUseCase.execute(lastSeenDate)
+
+        result.shouldBeTrue()
     }
 
     @Test
     fun `given a recent last seen date then session is active`() {
-        val lastSeenDate = A_TIMESTAMP - TimeUnit.DAYS.toMillis(SESSION_IS_MARKED_AS_INACTIVE_AFTER_DAYS.toLong()) + 1
+        val lastSeenDate = A_TIMESTAMP_MILLIS - TimeUnit.DAYS.toMillis(SESSION_IS_MARKED_AS_INACTIVE_AFTER_DAYS.toLong()) + 1
 
-        checkIfSessionIsInactiveUseCase.execute(lastSeenDate) shouldBeEqualTo false
+        val result = checkIfSessionIsInactiveUseCase.execute(lastSeenDate)
+
+        result.shouldBeFalse()
     }
 
     @Test
-    fun `given a last seen date as zero then session is inactive`() {
-        // In case of the server doesn't send the last seen date.
+    fun `given a last seen date as zero then session is not inactive`() {
         val lastSeenDate = 0L
 
-        checkIfSessionIsInactiveUseCase.execute(lastSeenDate) shouldBeEqualTo true
+        val result = checkIfSessionIsInactiveUseCase.execute(lastSeenDate)
+
+        result.shouldBeFalse()
+    }
+
+    @Test
+    fun `given a last seen date as null then session is not inactive`() {
+        val lastSeenDate = null
+
+        val result = checkIfSessionIsInactiveUseCase.execute(lastSeenDate)
+
+        result.shouldBeFalse()
+    }
+
+    @Test
+    fun `given a last seen date as negative then session is not inactive`() {
+        val lastSeenDate = -3L
+
+        val result = checkIfSessionIsInactiveUseCase.execute(lastSeenDate)
+
+        result.shouldBeFalse()
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Fixing small issues in session manager mainly about session which does not support encryption (it might happen for very old sessions).

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7853 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|<img src="https://user-images.githubusercontent.com/46314705/209790375-596f3f38-8911-4793-9edf-28b14843d882.png" width=300 />|<img src="https://user-images.githubusercontent.com/46314705/209789585-2aac9ade-6ac3-4049-b6d4-bfeafcfba3c0.png" width=300 />|
|<img src="https://user-images.githubusercontent.com/46314705/209790368-e765fc81-8ec9-430a-b1fa-96b8b715bec4.png" width=300 />|<img src="https://user-images.githubusercontent.com/46314705/209789580-3207b889-7a7d-46f1-a5fe-be4a56acf71f.png" width=300 />|
|<img src="https://user-images.githubusercontent.com/46314705/209790372-23f111bd-01d8-40a9-bbf4-715ffbf9cb93.png" width=300 />|<img src="https://user-images.githubusercontent.com/46314705/209789583-92c53e1e-fa1f-4af0-9b48-173afd2e125f.png" width=300 />|

## Tests

<!-- Explain how you tested your development -->

- Create a session that does not support encryption using the following command line:

`curl -d '{ "type": "m.login.password", "identifier": { "type": "m.id.user", "user": "..." }, "password": "..." }' -H "Content-Type: application/json" -X POST https://matrix-client.matrix.org/_matrix/client/v3/login`

- Enable the new session manager in labs settings
- Go to Settings -> Security & Privacy -> Show all sessions
- Go to the other sessions list to find the new created session from command line
- Press the item of this session
- Check the info are correct and the session is considered as not supporting encryption
- Check the session appears in the unverified sessions list
- Check the session does not appear in the inactive sessions list
- Check the name of the session is the session ID (since there is no display name set for this session)

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
