### PR TITLE
FIx UI Tests

### DIFF
--- a/vector-app/src/androidTest/java/im/vector/app/EspressoExt.kt
+++ b/vector-app/src/androidTest/java/im/vector/app/EspressoExt.kt
@@ -89,7 +89,7 @@ fun getString(@StringRes id: Int): String {
     return EspressoHelper.getCurrentActivity()!!.resources.getString(id)
 }
 
-fun waitForView(viewMatcher: Matcher<View>, timeout: Long = 10_000, waitForDisplayed: Boolean = true): ViewAction {
+fun waitForView(viewMatcher: Matcher<View>, timeout: Long = 20_000, waitForDisplayed: Boolean = true): ViewAction {
     return object : ViewAction {
         private val clock = DefaultClock()
 

--- a/vector-app/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector-app/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -129,11 +129,12 @@ class UiAllScreensSanityTest {
                 addSpace().also { openMenu(publicSpaceName) }
 
                 leaveSpace()
-                // Some instability with the bottomsheet
-                // not sure what's the source, maybe the expanded state?
-                Thread.sleep(10_000)
             }
         }
+
+        // Some instability with the bottomsheet
+        // not sure what's the source, maybe the expanded state?
+        Thread.sleep(10_000)
 
         elementRobot.space { selectSpace(spaceName) }
 
@@ -177,7 +178,6 @@ class UiAllScreensSanityTest {
      * Testing multiple threads screens
      */
     private fun testThreadScreens() {
-//        elementRobot.toggleLabFeature(LabFeature.THREAD_MESSAGES)
         elementRobot.newRoom {
             createNewRoom {
                 crawl()
@@ -191,6 +191,5 @@ class UiAllScreensSanityTest {
                 }
             }
         }
-//        elementRobot.toggleLabFeature(LabFeature.THREAD_MESSAGES)
     }
 }

--- a/vector-app/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
+++ b/vector-app/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt
@@ -28,7 +28,6 @@ import im.vector.app.espresso.tools.ScreenshotFailureRule
 import im.vector.app.features.MainActivity
 import im.vector.app.getString
 import im.vector.app.ui.robot.ElementRobot
-import im.vector.app.ui.robot.settings.labs.LabFeature
 import im.vector.app.ui.robot.settings.labs.LabFeaturesPreferences
 import im.vector.app.ui.robot.withDeveloperMode
 import org.junit.Rule
@@ -130,6 +129,9 @@ class UiAllScreensSanityTest {
                 addSpace().also { openMenu(publicSpaceName) }
 
                 leaveSpace()
+                // Some instability with the bottomsheet
+                // not sure what's the source, maybe the expanded state?
+                Thread.sleep(10_000)
             }
         }
 
@@ -175,7 +177,7 @@ class UiAllScreensSanityTest {
      * Testing multiple threads screens
      */
     private fun testThreadScreens() {
-        elementRobot.toggleLabFeature(LabFeature.THREAD_MESSAGES)
+//        elementRobot.toggleLabFeature(LabFeature.THREAD_MESSAGES)
         elementRobot.newRoom {
             createNewRoom {
                 crawl()
@@ -189,6 +191,6 @@ class UiAllScreensSanityTest {
                 }
             }
         }
-        elementRobot.toggleLabFeature(LabFeature.THREAD_MESSAGES)
+//        elementRobot.toggleLabFeature(LabFeature.THREAD_MESSAGES)
     }
 }

--- a/vector-app/src/androidTest/java/im/vector/app/ui/robot/space/SpaceCreateRobot.kt
+++ b/vector-app/src/androidTest/java/im/vector/app/ui/robot/space/SpaceCreateRobot.kt
@@ -28,7 +28,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import im.vector.app.R
 import im.vector.app.espresso.tools.waitUntilActivityVisible
-import im.vector.app.espresso.tools.waitUntilDialogVisible
 import im.vector.app.espresso.tools.waitUntilViewVisible
 import im.vector.app.features.home.HomeActivity
 import im.vector.app.features.home.room.detail.RoomDetailActivity
@@ -86,14 +85,17 @@ class SpaceCreateRobot {
         clickOn(R.id.nextButton)
         waitUntilViewVisible(withId(R.id.recyclerView))
         clickOn(R.id.nextButton)
+//        waitUntilActivityVisible<RoomDetailActivity> {
+//            waitUntilDialogVisible(withId(R.id.inviteByMxidButton))
+//        }
+//        // close invite dialog
+//        pressBack()
         waitUntilActivityVisible<RoomDetailActivity> {
-            waitUntilDialogVisible(withId(R.id.inviteByMxidButton))
+            pressBack()
         }
-        // close invite dialog
-        pressBack()
-        waitUntilViewVisible(withId(R.id.timelineRecyclerView))
+//        waitUntilViewVisible(withId(R.id.timelineRecyclerView))
         // close room
-        pressBack()
+//        pressBack()
         waitUntilViewVisible(withId(R.id.roomListContainer))
     }
 }

--- a/vector-app/src/androidTest/java/im/vector/app/ui/robot/space/SpaceMenuRobot.kt
+++ b/vector-app/src/androidTest/java/im/vector/app/ui/robot/space/SpaceMenuRobot.kt
@@ -89,9 +89,8 @@ class SpaceMenuRobot {
         clickOnSheet(R.id.leaveSpace)
         waitUntilActivityVisible<SpaceLeaveAdvancedActivity> {
             waitUntilViewVisible(ViewMatchers.withId(R.id.roomList))
+            clickOn(R.id.spaceLeaveSelectAll)
+            clickOn(R.id.spaceLeaveButton)
         }
-        clickOn(R.id.spaceLeaveSelectAll)
-        clickOn(R.id.spaceLeaveButton)
-        waitUntilViewVisible(ViewMatchers.withId(R.id.groupListView))
     }
 }


### PR DESCRIPTION
UI tests failing for several reasons:

- Threads are enabled by default now, so existing test was toggling off before running the tests
- Was testing some (old) feature on spaces where the bottom sheet to invite was shown on first enter room
- Flackiness with the space bottomsheet chooser (was ok when in drawerà