### PR TITLE
Reduce number of crypto database transactions when handling the sync response

### DIFF
--- a/changelog.d/7879.bugfix
+++ b/changelog.d/7879.bugfix
@@ -1,0 +1,1 @@
+Reduce number of crypto database transactions when handling the sync response

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -3501,4 +3501,7 @@
     <string name="message_reply_to_sender_sent_video">sent a video.</string>
     <string name="message_reply_to_sender_sent_sticker">sent a sticker.</string>
     <string name="message_reply_to_sender_created_poll">created a poll.</string>
+
+    <string name="settings_access_token">Access Token</string>
+    <string name="settings_access_token_summary">Your access token gives full access to your account. Do not share it with anyone.</string>
 </resources>

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/crosssigning/CryptoCrossSigningKeys.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/crosssigning/CryptoCrossSigningKeys.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 The Matrix.org Foundation C.I.C.
+ * Copyright 2023 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package org.matrix.android.sdk.internal.crypto.store
+package org.matrix.android.sdk.api.session.crypto.crosssigning
 
-import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigningKeys
-import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
-
-internal data class UserDataToStore(
-        val userDevices: MutableMap<String, Map<String, CryptoDeviceInfo>> = mutableMapOf(),
-        val userCrossSigningKeys: MutableMap<String, CryptoCrossSigningKeys> = mutableMapOf(),
+/**
+ * Container for the three cross signing keys: master, self signing and user signing.
+ */
+data class CryptoCrossSigningKeys(
+        val masterKey: CryptoCrossSigningKey?,
+        val selfSigningKey: CryptoCrossSigningKey?,
+        val userSigningKey: CryptoCrossSigningKey?,
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/crosssigning/UserIdentity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/crosssigning/UserIdentity.kt
@@ -19,7 +19,7 @@ package org.matrix.android.sdk.api.session.crypto.crosssigning
 /**
  * Container for the three cross signing keys: master, self signing and user signing.
  */
-data class CryptoCrossSigningKeys(
+data class UserIdentity(
         val masterKey: CryptoCrossSigningKey?,
         val selfSigningKey: CryptoCrossSigningKey?,
         val userSigningKey: CryptoCrossSigningKey?,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -384,6 +384,7 @@ internal class DefaultCryptoService @Inject constructor(
                 }
             }
         }
+        cryptoStore.onSyncWillProcess()
     }
 
     private fun internalStart() {
@@ -432,6 +433,7 @@ internal class DefaultCryptoService @Inject constructor(
      * @param syncResponse the syncResponse
      */
     fun onSyncCompleted(syncResponse: SyncResponse) {
+        cryptoStore.onSyncCompleted()
         cryptoCoroutineScope.launch(coroutineDispatchers.crypto) {
             runCatching {
                 if (syncResponse.deviceLists != null) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -431,6 +431,7 @@ internal class DefaultCryptoService @Inject constructor(
      * A sync response has been received.
      *
      * @param syncResponse the syncResponse
+     * @param cryptoStoreAggregator data aggregated during the sync response treatment to store
      */
     fun onSyncCompleted(syncResponse: SyncResponse, cryptoStoreAggregator: CryptoStoreAggregator) {
         cryptoStore.storeData(cryptoStoreAggregator)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DefaultCryptoService.kt
@@ -89,6 +89,7 @@ import org.matrix.android.sdk.internal.crypto.model.SessionInfo
 import org.matrix.android.sdk.internal.crypto.model.toRest
 import org.matrix.android.sdk.internal.crypto.repository.WarnOnUnknownDeviceRepository
 import org.matrix.android.sdk.internal.crypto.store.IMXCryptoStore
+import org.matrix.android.sdk.internal.crypto.store.db.CryptoStoreAggregator
 import org.matrix.android.sdk.internal.crypto.tasks.DeleteDeviceTask
 import org.matrix.android.sdk.internal.crypto.tasks.GetDeviceInfoTask
 import org.matrix.android.sdk.internal.crypto.tasks.GetDevicesTask
@@ -192,21 +193,21 @@ internal class DefaultCryptoService @Inject constructor(
     private val isStarting = AtomicBoolean(false)
     private val isStarted = AtomicBoolean(false)
 
-    fun onStateEvent(roomId: String, event: Event) {
+    fun onStateEvent(roomId: String, event: Event, cryptoStoreAggregator: CryptoStoreAggregator?) {
         when (event.type) {
             EventType.STATE_ROOM_ENCRYPTION -> onRoomEncryptionEvent(roomId, event)
             EventType.STATE_ROOM_MEMBER -> onRoomMembershipEvent(roomId, event)
-            EventType.STATE_ROOM_HISTORY_VISIBILITY -> onRoomHistoryVisibilityEvent(roomId, event)
+            EventType.STATE_ROOM_HISTORY_VISIBILITY -> onRoomHistoryVisibilityEvent(roomId, event, cryptoStoreAggregator)
         }
     }
 
-    fun onLiveEvent(roomId: String, event: Event, isInitialSync: Boolean) {
+    fun onLiveEvent(roomId: String, event: Event, isInitialSync: Boolean, cryptoStoreAggregator: CryptoStoreAggregator?) {
         // handle state events
         if (event.isStateEvent()) {
             when (event.type) {
                 EventType.STATE_ROOM_ENCRYPTION -> onRoomEncryptionEvent(roomId, event)
                 EventType.STATE_ROOM_MEMBER -> onRoomMembershipEvent(roomId, event)
-                EventType.STATE_ROOM_HISTORY_VISIBILITY -> onRoomHistoryVisibilityEvent(roomId, event)
+                EventType.STATE_ROOM_HISTORY_VISIBILITY -> onRoomHistoryVisibilityEvent(roomId, event, cryptoStoreAggregator)
             }
         }
 
@@ -384,7 +385,6 @@ internal class DefaultCryptoService @Inject constructor(
                 }
             }
         }
-        cryptoStore.onSyncWillProcess()
     }
 
     private fun internalStart() {
@@ -432,8 +432,8 @@ internal class DefaultCryptoService @Inject constructor(
      *
      * @param syncResponse the syncResponse
      */
-    fun onSyncCompleted(syncResponse: SyncResponse) {
-        cryptoStore.onSyncCompleted()
+    fun onSyncCompleted(syncResponse: SyncResponse, cryptoStoreAggregator: CryptoStoreAggregator) {
+        cryptoStore.storeData(cryptoStoreAggregator)
         cryptoCoroutineScope.launch(coroutineDispatchers.crypto) {
             runCatching {
                 if (syncResponse.deviceLists != null) {
@@ -1000,15 +1000,26 @@ internal class DefaultCryptoService @Inject constructor(
         }
     }
 
-    private fun onRoomHistoryVisibilityEvent(roomId: String, event: Event) {
+    private fun onRoomHistoryVisibilityEvent(roomId: String, event: Event, cryptoStoreAggregator: CryptoStoreAggregator?) {
         if (!event.isStateEvent()) return
         val eventContent = event.content.toModel<RoomHistoryVisibilityContent>()
         val historyVisibility = eventContent?.historyVisibility
         if (historyVisibility == null) {
-            cryptoStore.setShouldShareHistory(roomId, false)
+            if (cryptoStoreAggregator != null) {
+                cryptoStoreAggregator.setShouldShareHistoryData[roomId] = false
+            } else {
+                // Store immediately
+                cryptoStore.setShouldShareHistory(roomId, false)
+            }
         } else {
-            cryptoStore.setShouldEncryptForInvitedMembers(roomId, historyVisibility != RoomHistoryVisibility.JOINED)
-            cryptoStore.setShouldShareHistory(roomId, historyVisibility.shouldShareHistory())
+            if (cryptoStoreAggregator != null) {
+                cryptoStoreAggregator.setShouldEncryptForInvitedMembersData[roomId] = historyVisibility != RoomHistoryVisibility.JOINED
+                cryptoStoreAggregator.setShouldShareHistoryData[roomId] = historyVisibility.shouldShareHistory()
+            } else {
+                // Store immediately
+                cryptoStore.setShouldEncryptForInvitedMembers(roomId, historyVisibility != RoomHistoryVisibility.JOINED)
+                cryptoStore.setShouldShareHistory(roomId, historyVisibility.shouldShareHistory())
+            }
         }
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DeviceListManager.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DeviceListManager.kt
@@ -24,8 +24,8 @@ import org.matrix.android.sdk.api.MatrixPatterns
 import org.matrix.android.sdk.api.auth.data.Credentials
 import org.matrix.android.sdk.api.extensions.measureMetric
 import org.matrix.android.sdk.api.metrics.DownloadDeviceKeysMetricsPlugin
-import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigningKeys
 import org.matrix.android.sdk.api.session.crypto.crosssigning.DeviceTrustLevel
+import org.matrix.android.sdk.api.session.crypto.crosssigning.UserIdentity
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
 import org.matrix.android.sdk.api.session.crypto.model.MXUsersDevicesMap
 import org.matrix.android.sdk.internal.crypto.model.CryptoInfoMapper
@@ -420,7 +420,7 @@ internal class DeviceListManager @Inject constructor(
             val userSigningKey = response.userSigningKeys?.get(userId)?.toCryptoModel()?.also {
                 Timber.v("## CRYPTO | CrossSigning : Got keys for $userId : USK ${it.unpaddedBase64PublicKey}")
             }
-            userDataToStore.userCrossSigningKeys[userId] = CryptoCrossSigningKeys(
+            userDataToStore.userIdentities[userId] = UserIdentity(
                     masterKey = masterKey,
                     selfSigningKey = selfSigningKey,
                     userSigningKey = userSigningKey

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DeviceListManager.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DeviceListManager.kt
@@ -427,7 +427,7 @@ internal class DeviceListManager @Inject constructor(
             )
         }
 
-        cryptoStore.storeUserDataToStore(userDataToStore)
+        cryptoStore.storeData(userDataToStore)
 
         // Update devices trust for these users
         // dispatchDeviceChange(downloadUsers)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DeviceListManager.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/DeviceListManager.kt
@@ -24,6 +24,7 @@ import org.matrix.android.sdk.api.MatrixPatterns
 import org.matrix.android.sdk.api.auth.data.Credentials
 import org.matrix.android.sdk.api.extensions.measureMetric
 import org.matrix.android.sdk.api.metrics.DownloadDeviceKeysMetricsPlugin
+import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigningKeys
 import org.matrix.android.sdk.api.session.crypto.crosssigning.DeviceTrustLevel
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
 import org.matrix.android.sdk.api.session.crypto.model.MXUsersDevicesMap
@@ -419,7 +420,11 @@ internal class DeviceListManager @Inject constructor(
             val userSigningKey = response.userSigningKeys?.get(userId)?.toCryptoModel()?.also {
                 Timber.v("## CRYPTO | CrossSigning : Got keys for $userId : USK ${it.unpaddedBase64PublicKey}")
             }
-            userDataToStore.userCrossSigningKeys[userId] = Triple(masterKey, selfSigningKey, userSigningKey)
+            userDataToStore.userCrossSigningKeys[userId] = CryptoCrossSigningKeys(
+                    masterKey = masterKey,
+                    selfSigningKey = selfSigningKey,
+                    userSigningKey = userSigningKey
+            )
         }
 
         cryptoStore.storeUserDataToStore(userDataToStore)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
@@ -22,7 +22,6 @@ import org.matrix.android.sdk.api.session.crypto.GlobalCryptoConfig
 import org.matrix.android.sdk.api.session.crypto.NewSessionListener
 import org.matrix.android.sdk.api.session.crypto.OutgoingKeyRequest
 import org.matrix.android.sdk.api.session.crypto.OutgoingRoomKeyRequestState
-import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigningKey
 import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigningKeys
 import org.matrix.android.sdk.api.session.crypto.crosssigning.MXCrossSigningInfo
 import org.matrix.android.sdk.api.session.crypto.crosssigning.PrivateKeysInfo

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
@@ -48,7 +48,19 @@ import org.matrix.olm.OlmOutboundGroupSession
  */
 internal interface IMXCryptoStore {
 
+    /**
+     * Notify the store that a sync response treatment is starting.
+     * Impacted methods:
+     * - [setShouldShareHistory]
+     * - [setShouldEncryptForInvitedMembers]
+     * @See [onSyncCompleted] to notify that the treatment is over.
+     */
     fun onSyncWillProcess()
+
+    /**
+     * Notify the store that the sync treatment response is finished.
+     * The store will save all aggregated data.
+     */
     fun onSyncCompleted()
 
     /**
@@ -291,6 +303,9 @@ internal interface IMXCryptoStore {
 
     fun shouldEncryptForInvitedMembers(roomId: String): Boolean
 
+    /**
+     * The data is not stored immediately, this MUST be call during a sync response treatment.
+     */
     fun setShouldEncryptForInvitedMembers(roomId: String, shouldEncryptForInvitedMembers: Boolean)
 
     fun shouldShareHistory(roomId: String): Boolean
@@ -298,6 +313,7 @@ internal interface IMXCryptoStore {
     /**
      * Sets a boolean flag that will determine whether or not room history (existing inbound sessions)
      * will be shared to new user invites.
+     * The data is not stored immediately, this MUST be call during a sync response treatment.
      *
      * @param roomId the room id
      * @param shouldShareHistory The boolean flag
@@ -582,5 +598,8 @@ internal interface IMXCryptoStore {
     fun tidyUpDataBase()
     fun getOutgoingRoomKeyRequests(inStates: Set<OutgoingRoomKeyRequestState>): List<OutgoingKeyRequest>
 
+    /**
+     * Store a bunch of data related to the users. @See [UserDataToStore].
+     */
     fun storeUserDataToStore(userDataToStore: UserDataToStore)
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
@@ -583,4 +583,6 @@ internal interface IMXCryptoStore {
     fun areDeviceKeysUploaded(): Boolean
     fun tidyUpDataBase()
     fun getOutgoingRoomKeyRequests(inStates: Set<OutgoingRoomKeyRequestState>): List<OutgoingKeyRequest>
+
+    fun storeUserDataToStore(userDataToStore: UserDataToStore)
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
@@ -39,6 +39,7 @@ import org.matrix.android.sdk.api.util.Optional
 import org.matrix.android.sdk.internal.crypto.model.MXInboundMegolmSessionWrapper
 import org.matrix.android.sdk.internal.crypto.model.OlmSessionWrapper
 import org.matrix.android.sdk.internal.crypto.model.OutboundGroupSessionWrapper
+import org.matrix.android.sdk.internal.crypto.store.db.CryptoStoreAggregator
 import org.matrix.android.sdk.internal.crypto.store.db.model.KeysBackupDataEntity
 import org.matrix.olm.OlmAccount
 import org.matrix.olm.OlmOutboundGroupSession
@@ -47,21 +48,6 @@ import org.matrix.olm.OlmOutboundGroupSession
  * The crypto data store.
  */
 internal interface IMXCryptoStore {
-
-    /**
-     * Notify the store that a sync response treatment is starting.
-     * Impacted methods:
-     * - [setShouldShareHistory]
-     * - [setShouldEncryptForInvitedMembers]
-     * @See [onSyncCompleted] to notify that the treatment is over.
-     */
-    fun onSyncWillProcess()
-
-    /**
-     * Notify the store that the sync treatment response is finished.
-     * The store will save all aggregated data.
-     */
-    fun onSyncCompleted()
 
     /**
      * @return the device id
@@ -307,7 +293,11 @@ internal interface IMXCryptoStore {
     fun shouldEncryptForInvitedMembers(roomId: String): Boolean
 
     /**
-     * The data is not stored immediately, this MUST be call during a sync response treatment.
+     * Sets a boolean flag that will determine whether or not this device should encrypt Events for
+     * invited members.
+     *
+     * @param roomId the room id
+     * @param shouldEncryptForInvitedMembers The boolean flag
      */
     fun setShouldEncryptForInvitedMembers(roomId: String, shouldEncryptForInvitedMembers: Boolean)
 
@@ -316,7 +306,6 @@ internal interface IMXCryptoStore {
     /**
      * Sets a boolean flag that will determine whether or not room history (existing inbound sessions)
      * will be shared to new user invites.
-     * The data is not stored immediately, this MUST be call during a sync response treatment.
      *
      * @param roomId the room id
      * @param shouldShareHistory The boolean flag
@@ -600,6 +589,11 @@ internal interface IMXCryptoStore {
     fun areDeviceKeysUploaded(): Boolean
     fun tidyUpDataBase()
     fun getOutgoingRoomKeyRequests(inStates: Set<OutgoingRoomKeyRequestState>): List<OutgoingKeyRequest>
+
+    /**
+     * Store a bunch of data collected during a sync response treatment. @See [CryptoStoreAggregator].
+     */
+    fun storeData(cryptoStoreAggregator: CryptoStoreAggregator)
 
     /**
      * Store a bunch of data related to the users. @See [UserDataToStore].

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
@@ -48,6 +48,9 @@ import org.matrix.olm.OlmOutboundGroupSession
  */
 internal interface IMXCryptoStore {
 
+    fun onSyncWillProcess()
+    fun onSyncCompleted()
+
     /**
      * @return the device id
      */

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
@@ -23,6 +23,7 @@ import org.matrix.android.sdk.api.session.crypto.NewSessionListener
 import org.matrix.android.sdk.api.session.crypto.OutgoingKeyRequest
 import org.matrix.android.sdk.api.session.crypto.OutgoingRoomKeyRequestState
 import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigningKey
+import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigningKeys
 import org.matrix.android.sdk.api.session.crypto.crosssigning.MXCrossSigningInfo
 import org.matrix.android.sdk.api.session.crypto.crosssigning.PrivateKeysInfo
 import org.matrix.android.sdk.api.session.crypto.keysbackup.SavedKeyBackupKeyInfo
@@ -235,9 +236,7 @@ internal interface IMXCryptoStore {
 
     fun storeUserCrossSigningKeys(
             userId: String,
-            masterKey: CryptoCrossSigningKey?,
-            selfSigningKey: CryptoCrossSigningKey?,
-            userSigningKey: CryptoCrossSigningKey?
+            cryptoCrossSigningKeys: CryptoCrossSigningKeys
     )
 
     /**

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
@@ -601,5 +601,5 @@ internal interface IMXCryptoStore {
     /**
      * Store a bunch of data related to the users. @See [UserDataToStore].
      */
-    fun storeUserDataToStore(userDataToStore: UserDataToStore)
+    fun storeData(userDataToStore: UserDataToStore)
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/IMXCryptoStore.kt
@@ -22,9 +22,9 @@ import org.matrix.android.sdk.api.session.crypto.GlobalCryptoConfig
 import org.matrix.android.sdk.api.session.crypto.NewSessionListener
 import org.matrix.android.sdk.api.session.crypto.OutgoingKeyRequest
 import org.matrix.android.sdk.api.session.crypto.OutgoingRoomKeyRequestState
-import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigningKeys
 import org.matrix.android.sdk.api.session.crypto.crosssigning.MXCrossSigningInfo
 import org.matrix.android.sdk.api.session.crypto.crosssigning.PrivateKeysInfo
+import org.matrix.android.sdk.api.session.crypto.crosssigning.UserIdentity
 import org.matrix.android.sdk.api.session.crypto.keysbackup.SavedKeyBackupKeyInfo
 import org.matrix.android.sdk.api.session.crypto.model.AuditTrail
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
@@ -245,9 +245,12 @@ internal interface IMXCryptoStore {
      */
     fun storeUserDevices(userId: String, devices: Map<String, CryptoDeviceInfo>?)
 
-    fun storeUserCrossSigningKeys(
+    /**
+     * Store the cross signing keys for the user userId.
+     */
+    fun storeUserIdentity(
             userId: String,
-            cryptoCrossSigningKeys: CryptoCrossSigningKeys
+            userIdentity: UserIdentity
     )
 
     /**

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/UserDataToStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/UserDataToStore.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.crypto.store
+
+import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigningKey
+import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
+
+internal data class UserDataToStore(
+        val userDevices: MutableMap<String, Map<String, CryptoDeviceInfo>> = mutableMapOf(),
+        val userCrossSigningKeys: MutableMap<String, Triple<CryptoCrossSigningKey?, CryptoCrossSigningKey?, CryptoCrossSigningKey?>> = mutableMapOf(),
+)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/UserDataToStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/UserDataToStore.kt
@@ -20,6 +20,12 @@ import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigning
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
 
 internal data class UserDataToStore(
+        /**
+         * Map of userId -> (Map of deviceId -> [CryptoDeviceInfo]).
+         */
         val userDevices: MutableMap<String, Map<String, CryptoDeviceInfo>> = mutableMapOf(),
+        /**
+         * Map of userId -> [CryptoCrossSigningKeys].
+         */
         val userCrossSigningKeys: MutableMap<String, CryptoCrossSigningKeys> = mutableMapOf(),
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/UserDataToStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/UserDataToStore.kt
@@ -16,7 +16,7 @@
 
 package org.matrix.android.sdk.internal.crypto.store
 
-import org.matrix.android.sdk.api.session.crypto.crosssigning.CryptoCrossSigningKeys
+import org.matrix.android.sdk.api.session.crypto.crosssigning.UserIdentity
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
 
 internal data class UserDataToStore(
@@ -25,7 +25,7 @@ internal data class UserDataToStore(
          */
         val userDevices: MutableMap<String, Map<String, CryptoDeviceInfo>> = mutableMapOf(),
         /**
-         * Map of userId -> [CryptoCrossSigningKeys].
+         * Map of userId -> [UserIdentity].
          */
-        val userCrossSigningKeys: MutableMap<String, CryptoCrossSigningKeys> = mutableMapOf(),
+        val userIdentities: MutableMap<String, UserIdentity> = mutableMapOf(),
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/CryptoStoreAggregator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/CryptoStoreAggregator.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.crypto.store.db
+
+data class CryptoStoreAggregator(
+        val setShouldShareHistoryData: MutableMap<String, Boolean> = mutableMapOf()
+)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/CryptoStoreAggregator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/CryptoStoreAggregator.kt
@@ -19,4 +19,9 @@ package org.matrix.android.sdk.internal.crypto.store.db
 data class CryptoStoreAggregator(
         val setShouldShareHistoryData: MutableMap<String, Boolean> = mutableMapOf(),
         val setShouldEncryptForInvitedMembersData: MutableMap<String, Boolean> = mutableMapOf(),
-)
+) {
+    fun isEmpty(): Boolean {
+        return setShouldShareHistoryData.isEmpty() &&
+                setShouldEncryptForInvitedMembersData.isEmpty()
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/CryptoStoreAggregator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/CryptoStoreAggregator.kt
@@ -17,5 +17,6 @@
 package org.matrix.android.sdk.internal.crypto.store.db
 
 data class CryptoStoreAggregator(
-        val setShouldShareHistoryData: MutableMap<String, Boolean> = mutableMapOf()
+        val setShouldShareHistoryData: MutableMap<String, Boolean> = mutableMapOf(),
+        val setShouldEncryptForInvitedMembersData: MutableMap<String, Boolean> = mutableMapOf(),
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/Helper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/Helper.kt
@@ -20,10 +20,12 @@ import android.util.Base64
 import io.realm.Realm
 import io.realm.RealmConfiguration
 import io.realm.RealmObject
+import timber.log.Timber
 import java.io.ByteArrayOutputStream
 import java.io.ObjectOutputStream
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
+import kotlin.system.measureTimeMillis
 
 /**
  * Get realm, invoke the action, close realm, and return the result of the action.
@@ -55,10 +57,12 @@ internal fun <T : RealmObject> doRealmQueryAndCopyList(realmConfiguration: Realm
 /**
  * Get realm instance, invoke the action in a transaction and close realm.
  */
-internal fun doRealmTransaction(realmConfiguration: RealmConfiguration, action: (Realm) -> Unit) {
-    Realm.getInstance(realmConfiguration).use { realm ->
-        realm.executeTransaction { action.invoke(it) }
-    }
+internal fun doRealmTransaction(tag: String, realmConfiguration: RealmConfiguration, action: (Realm) -> Unit) {
+    measureTimeMillis {
+        Realm.getInstance(realmConfiguration).use { realm ->
+            realm.executeTransaction { action.invoke(it) }
+        }
+    }.also { Timber.w("doRealmTransaction for $tag took $it millis") }
 }
 
 internal fun doRealmTransactionAsync(realmConfiguration: RealmConfiguration, action: (Realm) -> Unit) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -1824,7 +1824,11 @@ internal class RealmCryptoStore @Inject constructor(
         val aggregator = cryptoStoreAggregator ?: return Unit.also {
             Timber.e("cryptoStoreAggregator is null...")
         }
+        cryptoStoreAggregator = null
 
+        if (aggregator.isEmpty()) {
+            return
+        }
         doRealmTransaction("onSyncCompleted", realmConfiguration) { realm ->
             // setShouldShareHistory
             aggregator.setShouldShareHistoryData.map {
@@ -1835,6 +1839,5 @@ internal class RealmCryptoStore @Inject constructor(
                 CryptoRoomEntity.getOrCreate(realm, it.key).shouldEncryptForInvitedMembers = it.value
             }
         }
-        cryptoStoreAggregator = null
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -708,9 +708,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun setShouldEncryptForInvitedMembers(roomId: String, shouldEncryptForInvitedMembers: Boolean) {
-        doRealmTransaction(realmConfiguration) {
-            CryptoRoomEntity.getOrCreate(it, roomId).shouldEncryptForInvitedMembers = shouldEncryptForInvitedMembers
-        }
+        cryptoStoreAggregator?.setShouldEncryptForInvitedMembersData?.put(roomId, shouldEncryptForInvitedMembers)
     }
 
     override fun setShouldShareHistory(roomId: String, shouldShareHistory: Boolean) {
@@ -1831,6 +1829,10 @@ internal class RealmCryptoStore @Inject constructor(
             // setShouldShareHistory
             aggregator.setShouldShareHistoryData.map {
                 CryptoRoomEntity.getOrCreate(realm, it.key).shouldShareHistory = it.value
+            }
+            // setShouldEncryptForInvitedMembers
+            aggregator.setShouldEncryptForInvitedMembersData.map {
+                CryptoRoomEntity.getOrCreate(realm, it.key).shouldEncryptForInvitedMembers = it.value
             }
         }
         cryptoStoreAggregator = null

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -1852,7 +1852,7 @@ internal class RealmCryptoStore @Inject constructor(
         }
     }
 
-    override fun storeUserDataToStore(userDataToStore: UserDataToStore) {
+    override fun storeData(userDataToStore: UserDataToStore) {
         doRealmTransaction("storeUserDataToStore", realmConfiguration) { realm ->
             userDataToStore.userDevices.forEach {
                 storeUserDevices(realm, it.key, it.value)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -147,7 +147,7 @@ internal class RealmCryptoStore @Inject constructor(
 
     init {
         // Ensure CryptoMetadataEntity is inserted in DB
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("init", realmConfiguration) { realm ->
             var currentMetadata = realm.where<CryptoMetadataEntity>().findFirst()
 
             var deleteAll = false
@@ -189,7 +189,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun deleteStore() {
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("deleteStore", realmConfiguration) {
             it.deleteAll()
         }
     }
@@ -218,7 +218,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun storeDeviceId(deviceId: String) {
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("storeDeviceId", realmConfiguration) {
             it.where<CryptoMetadataEntity>().findFirst()?.deviceId = deviceId
         }
     }
@@ -230,7 +230,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun saveOlmAccount() {
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("saveOlmAccount", realmConfiguration) {
             it.where<CryptoMetadataEntity>().findFirst()?.putOlmAccount(olmAccount)
         }
     }
@@ -248,7 +248,7 @@ internal class RealmCryptoStore @Inject constructor(
 
     @Synchronized
     override fun getOrCreateOlmAccount(): OlmAccount {
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("getOrCreateOlmAccount", realmConfiguration) {
             val metaData = it.where<CryptoMetadataEntity>().findFirst()
             val existing = metaData!!.getOlmAccount()
             if (existing == null) {
@@ -288,7 +288,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun storeUserDevices(userId: String, devices: Map<String, CryptoDeviceInfo>?) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("storeUserDevices", realmConfiguration) { realm ->
             if (devices == null) {
                 Timber.d("Remove user $userId")
                 // Remove the user
@@ -331,7 +331,7 @@ internal class RealmCryptoStore @Inject constructor(
             selfSigningKey: CryptoCrossSigningKey?,
             userSigningKey: CryptoCrossSigningKey?
     ) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("storeUserCrossSigningKeys", realmConfiguration) { realm ->
             UserEntity.getOrCreate(realm, userId)
                     .let { userEntity ->
                         if (masterKey == null || selfSigningKey == null) {
@@ -480,7 +480,7 @@ internal class RealmCryptoStore @Inject constructor(
 
     override fun storePrivateKeysInfo(msk: String?, usk: String?, ssk: String?) {
         Timber.v("## CRYPTO | *** storePrivateKeysInfo ${msk != null}, ${usk != null}, ${ssk != null}")
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("storePrivateKeysInfo", realmConfiguration) { realm ->
             realm.where<CryptoMetadataEntity>().findFirst()?.apply {
                 xSignMasterPrivateKey = msk
                 xSignUserPrivateKey = usk
@@ -490,7 +490,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun saveBackupRecoveryKey(recoveryKey: String?, version: String?) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("saveBackupRecoveryKey", realmConfiguration) { realm ->
             realm.where<CryptoMetadataEntity>().findFirst()?.apply {
                 keyBackupRecoveryKey = recoveryKey
                 keyBackupRecoveryKeyVersion = version
@@ -516,7 +516,7 @@ internal class RealmCryptoStore @Inject constructor(
 
     override fun storeMSKPrivateKey(msk: String?) {
         Timber.v("## CRYPTO | *** storeMSKPrivateKey ${msk != null} ")
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("storeMSKPrivateKey", realmConfiguration) { realm ->
             realm.where<CryptoMetadataEntity>().findFirst()?.apply {
                 xSignMasterPrivateKey = msk
             }
@@ -525,7 +525,7 @@ internal class RealmCryptoStore @Inject constructor(
 
     override fun storeSSKPrivateKey(ssk: String?) {
         Timber.v("## CRYPTO | *** storeSSKPrivateKey ${ssk != null} ")
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("storeSSKPrivateKey", realmConfiguration) { realm ->
             realm.where<CryptoMetadataEntity>().findFirst()?.apply {
                 xSignSelfSignedPrivateKey = ssk
             }
@@ -534,7 +534,7 @@ internal class RealmCryptoStore @Inject constructor(
 
     override fun storeUSKPrivateKey(usk: String?) {
         Timber.v("## CRYPTO | *** storeUSKPrivateKey ${usk != null} ")
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("storeUSKPrivateKey", realmConfiguration) { realm ->
             realm.where<CryptoMetadataEntity>().findFirst()?.apply {
                 xSignUserPrivateKey = usk
             }
@@ -667,7 +667,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun storeRoomAlgorithm(roomId: String, algorithm: String?) {
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("storeRoomAlgorithm", realmConfiguration) {
             CryptoRoomEntity.getOrCreate(it, roomId).let { entity ->
                 entity.algorithm = algorithm
                 // store anyway the new algorithm, but mark the room
@@ -729,7 +729,7 @@ internal class RealmCryptoStore @Inject constructor(
         if (sessionIdentifier != null) {
             val key = OlmSessionEntity.createPrimaryKey(sessionIdentifier, deviceKey)
 
-            doRealmTransaction(realmConfiguration) {
+            doRealmTransaction("storeSession", realmConfiguration) {
                 val realmOlmSession = OlmSessionEntity().apply {
                     primaryKey = key
                     sessionId = sessionIdentifier
@@ -786,7 +786,7 @@ internal class RealmCryptoStore @Inject constructor(
             return
         }
 
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("storeInboundGroupSessions", realmConfiguration) { realm ->
             sessions.forEach { wrapper ->
 
                 val sessionIdentifier = try {
@@ -910,7 +910,7 @@ internal class RealmCryptoStore @Inject constructor(
     override fun removeInboundGroupSession(sessionId: String, senderKey: String) {
         val key = OlmInboundGroupSessionEntity.createPrimaryKey(sessionId, senderKey)
 
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("removeInboundGroupSession", realmConfiguration) {
             it.where<OlmInboundGroupSessionEntity>()
                     .equalTo(OlmInboundGroupSessionEntityFields.PRIMARY_KEY, key)
                     .findAll()
@@ -929,7 +929,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun setKeyBackupVersion(keyBackupVersion: String?) {
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("setKeyBackupVersion", realmConfiguration) {
             it.where<CryptoMetadataEntity>().findFirst()?.backupVersion = keyBackupVersion
         }
     }
@@ -941,7 +941,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun setKeysBackupData(keysBackupData: KeysBackupDataEntity?) {
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("setKeysBackupData", realmConfiguration) {
             if (keysBackupData == null) {
                 // Clear the table
                 it.where<KeysBackupDataEntity>()
@@ -955,7 +955,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun resetBackupMarkers() {
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("resetBackupMarkers", realmConfiguration) {
             it.where<OlmInboundGroupSessionEntity>()
                     .findAll()
                     .map { inboundGroupSession ->
@@ -969,7 +969,7 @@ internal class RealmCryptoStore @Inject constructor(
             return
         }
 
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("markBackupDoneForInboundGroupSessions", realmConfiguration) { realm ->
             olmInboundGroupSessionWrappers.forEach { olmInboundGroupSessionWrapper ->
                 try {
                     val sessionIdentifier =
@@ -1028,13 +1028,13 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun setGlobalBlacklistUnverifiedDevices(block: Boolean) {
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("setGlobalBlacklistUnverifiedDevices", realmConfiguration) {
             it.where<CryptoMetadataEntity>().findFirst()?.globalBlacklistUnverifiedDevices = block
         }
     }
 
     override fun enableKeyGossiping(enable: Boolean) {
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("enableKeyGossiping", realmConfiguration) {
             it.where<CryptoMetadataEntity>().findFirst()?.globalEnableKeyGossiping = enable
         }
     }
@@ -1058,13 +1058,13 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun enableShareKeyOnInvite(enable: Boolean) {
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("enableShareKeyOnInvite", realmConfiguration) {
             it.where<CryptoMetadataEntity>().findFirst()?.enableKeyForwardingOnInvite = enable
         }
     }
 
     override fun setDeviceKeysUploaded(uploaded: Boolean) {
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("setDeviceKeysUploaded", realmConfiguration) {
             it.where<CryptoMetadataEntity>().findFirst()?.deviceKeysSentToServer = uploaded
         }
     }
@@ -1111,7 +1111,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun blockUnverifiedDevicesInRoom(roomId: String, block: Boolean) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("blockUnverifiedDevicesInRoom", realmConfiguration) { realm ->
             CryptoRoomEntity.getById(realm, roomId)
                     ?.blacklistUnverifiedDevices = block
         }
@@ -1131,7 +1131,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun saveDeviceTrackingStatuses(deviceTrackingStatuses: Map<String, Int>) {
-        doRealmTransaction(realmConfiguration) {
+        doRealmTransaction("saveDeviceTrackingStatuses", realmConfiguration) {
             deviceTrackingStatuses
                     .map { entry ->
                         UserEntity.getOrCreate(it, entry.key)
@@ -1264,7 +1264,7 @@ internal class RealmCryptoStore @Inject constructor(
     ): OutgoingKeyRequest {
         // Insert the request and return the one passed in parameter
         lateinit var request: OutgoingKeyRequest
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("getOrAddOutgoingRoomKeyRequest", realmConfiguration) { realm ->
 
             val existing = realm.where<OutgoingKeyRequestEntity>()
                     .equalTo(OutgoingKeyRequestEntityFields.MEGOLM_SESSION_ID, requestBody.sessionId)
@@ -1302,7 +1302,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun updateOutgoingRoomKeyRequestState(requestId: String, newState: OutgoingRoomKeyRequestState) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("updateOutgoingRoomKeyRequestState", realmConfiguration) { realm ->
             realm.where<OutgoingKeyRequestEntity>()
                     .equalTo(OutgoingKeyRequestEntityFields.REQUEST_ID, requestId)
                     .findFirst()?.apply {
@@ -1316,7 +1316,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun updateOutgoingRoomKeyRequiredIndex(requestId: String, newIndex: Int) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("updateOutgoingRoomKeyRequiredIndex", realmConfiguration) { realm ->
             realm.where<OutgoingKeyRequestEntity>()
                     .equalTo(OutgoingKeyRequestEntityFields.REQUEST_ID, requestId)
                     .findFirst()?.apply {
@@ -1333,7 +1333,7 @@ internal class RealmCryptoStore @Inject constructor(
             fromDevice: String?,
             event: Event
     ) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("updateOutgoingRoomKeyReply", realmConfiguration) { realm ->
             realm.where<OutgoingKeyRequestEntity>()
                     .equalTo(OutgoingKeyRequestEntityFields.ROOM_ID, roomId)
                     .equalTo(OutgoingKeyRequestEntityFields.MEGOLM_SESSION_ID, sessionId)
@@ -1349,7 +1349,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun deleteOutgoingRoomKeyRequest(requestId: String) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("deleteOutgoingRoomKeyRequest", realmConfiguration) { realm ->
             realm.where<OutgoingKeyRequestEntity>()
                     .equalTo(OutgoingKeyRequestEntityFields.REQUEST_ID, requestId)
                     .findFirst()?.deleteOnCascade()
@@ -1357,7 +1357,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun deleteOutgoingRoomKeyRequestInState(state: OutgoingRoomKeyRequestState) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("deleteOutgoingRoomKeyRequestInState", realmConfiguration) { realm ->
             realm.where<OutgoingKeyRequestEntity>()
                     .equalTo(OutgoingKeyRequestEntityFields.REQUEST_STATE_STR, state.name)
                     .findAll()
@@ -1493,7 +1493,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun setMyCrossSigningInfo(info: MXCrossSigningInfo?) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("setMyCrossSigningInfo", realmConfiguration) { realm ->
             realm.where<CryptoMetadataEntity>().findFirst()?.userId?.let { userId ->
                 addOrUpdateCrossSigningInfo(realm, userId, info)
             }
@@ -1501,7 +1501,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun setUserKeysAsTrusted(userId: String, trusted: Boolean) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("setUserKeysAsTrusted", realmConfiguration) { realm ->
             val xInfoEntity = realm.where(CrossSigningInfoEntity::class.java)
                     .equalTo(CrossSigningInfoEntityFields.USER_ID, userId)
                     .findFirst()
@@ -1521,7 +1521,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun setDeviceTrust(userId: String, deviceId: String, crossSignedVerified: Boolean, locallyVerified: Boolean?) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("setDeviceTrust", realmConfiguration) { realm ->
             realm.where(DeviceInfoEntity::class.java)
                     .equalTo(DeviceInfoEntityFields.PRIMARY_KEY, DeviceInfoEntity.createPrimaryKey(userId, deviceId))
                     .findFirst()?.let { deviceInfoEntity ->
@@ -1541,7 +1541,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun clearOtherUserTrust() {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("clearOtherUserTrust", realmConfiguration) { realm ->
             val xInfoEntities = realm.where(CrossSigningInfoEntity::class.java)
                     .findAll()
             xInfoEntities?.forEach { info ->
@@ -1556,7 +1556,7 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun updateUsersTrust(check: (String) -> Boolean) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("updateUsersTrust", realmConfiguration) { realm ->
             val xInfoEntities = realm.where(CrossSigningInfoEntity::class.java)
                     .findAll()
             xInfoEntities?.forEach { xInfoEntity ->
@@ -1664,13 +1664,13 @@ internal class RealmCryptoStore @Inject constructor(
     }
 
     override fun setCrossSigningInfo(userId: String, info: MXCrossSigningInfo?) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("setCrossSigningInfo", realmConfiguration) { realm ->
             addOrUpdateCrossSigningInfo(realm, userId, info)
         }
     }
 
     override fun markMyMasterKeyAsLocallyTrusted(trusted: Boolean) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("markMyMasterKeyAsLocallyTrusted", realmConfiguration) { realm ->
             realm.where<CryptoMetadataEntity>().findFirst()?.userId?.let { myUserId ->
                 CrossSigningInfoEntity.get(realm, myUserId)?.getMasterKey()?.let { xInfoEntity ->
                     val level = xInfoEntity.trustLevelEntity
@@ -1709,7 +1709,7 @@ internal class RealmCryptoStore @Inject constructor(
         val roomId = withHeldContent.roomId ?: return
         val sessionId = withHeldContent.sessionId ?: return
         if (withHeldContent.algorithm != MXCRYPTO_ALGORITHM_MEGOLM) return
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("addWithHeldMegolmSession", realmConfiguration) { realm ->
             WithHeldSessionEntity.getOrCreate(realm, roomId, sessionId)?.let {
                 it.code = withHeldContent.code
                 it.senderKey = withHeldContent.senderKey
@@ -1741,7 +1741,7 @@ internal class RealmCryptoStore @Inject constructor(
             deviceIdentityKey: String,
             chainIndex: Int
     ) {
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("markedSessionAsShared", realmConfiguration) { realm ->
             SharedSessionEntity.create(
                     realm = realm,
                     roomId = roomId,
@@ -1790,7 +1790,7 @@ internal class RealmCryptoStore @Inject constructor(
      */
     override fun tidyUpDataBase() {
         val prevWeekTs = clock.epochMillis() - 7 * 24 * 60 * 60 * 1_000
-        doRealmTransaction(realmConfiguration) { realm ->
+        doRealmTransaction("tidyUpDataBase", realmConfiguration) { realm ->
 
             // Clean the old ones?
             realm.where<OutgoingKeyRequestEntity>()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/StreamEventsManager.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/StreamEventsManager.kt
@@ -42,14 +42,12 @@ internal class StreamEventsManager @Inject constructor() {
         listeners.remove(listener)
     }
 
-    fun dispatchLiveEventReceived(event: Event, roomId: String, initialSync: Boolean) {
+    fun dispatchLiveEventReceived(event: Event, roomId: String) {
         Timber.v("## dispatchLiveEventReceived ${event.eventId}")
         coroutineScope.launch {
-            if (!initialSync) {
-                listeners.forEach {
-                    tryOrNull {
-                        it.onLiveEvent(roomId, event)
-                    }
+            listeners.forEach {
+                tryOrNull {
+                    it.onLiveEvent(roomId, event)
                 }
             }
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateLocalRoomTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/create/CreateLocalRoomTask.kt
@@ -176,7 +176,7 @@ internal class DefaultCreateLocalRoomTask @Inject constructor(
                 }
 
                 // Give info to crypto module
-                cryptoService.onStateEvent(roomId, event)
+                cryptoService.onStateEvent(roomId, event, null)
             }
 
             roomMemberContentsByUser.getOrPut(event.senderId) {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
@@ -29,6 +29,7 @@ import org.matrix.android.sdk.api.session.sync.model.RoomsSyncResponse
 import org.matrix.android.sdk.api.session.sync.model.SyncResponse
 import org.matrix.android.sdk.internal.SessionManager
 import org.matrix.android.sdk.internal.crypto.DefaultCryptoService
+import org.matrix.android.sdk.internal.crypto.store.db.CryptoStoreAggregator
 import org.matrix.android.sdk.internal.di.SessionDatabase
 import org.matrix.android.sdk.internal.di.SessionId
 import org.matrix.android.sdk.internal.session.SessionListeners
@@ -92,7 +93,7 @@ internal class SyncResponseHandler @Inject constructor(
 
             postTreatmentSyncResponse(syncResponse, isInitialSync)
 
-            markCryptoSyncCompleted(syncResponse)
+            markCryptoSyncCompleted(syncResponse, aggregator.cryptoStoreAggregator)
 
             handlePostSync()
 
@@ -218,10 +219,10 @@ internal class SyncResponseHandler @Inject constructor(
         }
     }
 
-    private fun markCryptoSyncCompleted(syncResponse: SyncResponse) {
+    private fun markCryptoSyncCompleted(syncResponse: SyncResponse, cryptoStoreAggregator: CryptoStoreAggregator) {
         relevantPlugins.measureSpan("task", "crypto_sync_handler_onSyncCompleted") {
             measureTimeMillis {
-                cryptoSyncHandler.onSyncCompleted(syncResponse)
+                cryptoSyncHandler.onSyncCompleted(syncResponse, cryptoStoreAggregator)
             }.also {
                 Timber.v("cryptoSyncHandler.onSyncCompleted took $it ms")
             }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponsePostTreatmentAggregator.kt
@@ -16,6 +16,8 @@
 
 package org.matrix.android.sdk.internal.session.sync
 
+import org.matrix.android.sdk.internal.crypto.store.db.CryptoStoreAggregator
+
 internal class SyncResponsePostTreatmentAggregator {
     // List of RoomId
     val ephemeralFilesToDelete = mutableListOf<String>()
@@ -28,4 +30,7 @@ internal class SyncResponsePostTreatmentAggregator {
 
     // Set of users to call `crossSigningService.checkTrustAndAffectedRoomShields` once per sync
     val userIdsForCheckingTrustAndAffectedRoomShields = mutableSetOf<String>()
+
+    // For the crypto store
+    val cryptoStoreAggregator = CryptoStoreAggregator()
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/CryptoSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/CryptoSyncHandler.kt
@@ -29,6 +29,7 @@ import org.matrix.android.sdk.api.session.room.model.message.MessageContent
 import org.matrix.android.sdk.api.session.sync.model.SyncResponse
 import org.matrix.android.sdk.api.session.sync.model.ToDeviceSyncResponse
 import org.matrix.android.sdk.internal.crypto.DefaultCryptoService
+import org.matrix.android.sdk.internal.crypto.store.db.CryptoStoreAggregator
 import org.matrix.android.sdk.internal.crypto.tasks.toDeviceTracingId
 import org.matrix.android.sdk.internal.crypto.verification.DefaultVerificationService
 import org.matrix.android.sdk.internal.session.sync.ProgressReporter
@@ -85,8 +86,8 @@ internal class CryptoSyncHandler @Inject constructor(
         }
     }
 
-    fun onSyncCompleted(syncResponse: SyncResponse) {
-        cryptoService.onSyncCompleted(syncResponse)
+    fun onSyncCompleted(syncResponse: SyncResponse, cryptoStoreAggregator: CryptoStoreAggregator) {
+        cryptoService.onSyncCompleted(syncResponse, cryptoStoreAggregator)
     }
 
     /**

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
@@ -376,8 +376,15 @@ internal class RoomSyncHandler @Inject constructor(
         roomEntity.chunks.clearWith { it.deleteOnCascade(deleteStateEvents = true, canDeleteRoot = true) }
         roomTypingUsersHandler.handle(realm, roomId, null)
         roomChangeMembershipStateDataSource.setMembershipFromSync(roomId, Membership.LEAVE)
-        roomSummaryUpdater.update(realm, roomId, membership, roomSync.summary,
-                roomSync.unreadNotifications, roomSync.unreadThreadNotifications, aggregator = aggregator)
+        roomSummaryUpdater.update(
+                realm,
+                roomId,
+                membership,
+                roomSync.summary,
+                roomSync.unreadNotifications,
+                roomSync.unreadThreadNotifications,
+                aggregator = aggregator,
+        )
         return roomEntity
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
@@ -423,7 +423,9 @@ internal class RoomSyncHandler @Inject constructor(
             val isInitialSync = insertType == EventInsertType.INITIAL_SYNC
 
             eventIds.add(event.eventId)
-            liveEventService.get().dispatchLiveEventReceived(event, roomId, isInitialSync)
+            if (!isInitialSync) {
+                liveEventService.get().dispatchLiveEventReceived(event, roomId)
+            }
 
             if (event.isEncrypted() && !isInitialSync) {
                 try {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/RoomSyncHandler.kt
@@ -258,7 +258,7 @@ internal class RoomSyncHandler @Inject constructor(
                     root = eventEntity
                 }
                 // Give info to crypto module
-                cryptoService.onStateEvent(roomId, event)
+                cryptoService.onStateEvent(roomId, event, aggregator.cryptoStoreAggregator)
                 roomMemberEventHandler.handle(realm, roomId, event, isInitialSync, aggregator)
             }
         }
@@ -495,7 +495,7 @@ internal class RoomSyncHandler @Inject constructor(
                 }
             }
             // Give info to crypto module
-            cryptoService.onLiveEvent(roomEntity.roomId, event, isInitialSync)
+            cryptoService.onLiveEvent(roomEntity.roomId, event, isInitialSync, aggregator.cryptoStoreAggregator)
 
             // Try to remove local echo
             event.unsignedData?.transactionId?.also { txId ->

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsAdvancedSettingsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsAdvancedSettingsFragment.kt
@@ -25,6 +25,7 @@ import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.core.preference.VectorPreference
 import im.vector.app.core.preference.VectorPreferenceCategory
 import im.vector.app.core.preference.VectorSwitchPreference
+import im.vector.app.core.utils.copyToClipboard
 import im.vector.app.features.analytics.plan.MobileScreen
 import im.vector.app.features.home.NightlyProxy
 import im.vector.app.features.rageshake.RageShake
@@ -64,6 +65,14 @@ class VectorSettingsAdvancedSettingsFragment :
     override fun bindPref() {
         setupRageShakeSection()
         setupNightlySection()
+        setupDevToolsSection()
+    }
+
+    private fun setupDevToolsSection() {
+        findPreference<VectorPreference>("SETTINGS_ACCESS_TOKEN")?.setOnPreferenceClickListener {
+            copyToClipboard(requireActivity(), session.sessionParams.credentials.accessToken)
+            true
+        }
     }
 
     private fun setupRageShakeSection() {

--- a/vector/src/main/res/xml/vector_settings_advanced_settings.xml
+++ b/vector/src/main/res/xml/vector_settings_advanced_settings.xml
@@ -93,6 +93,12 @@
             android:title="@string/settings_key_requests"
             app:fragment="im.vector.app.features.settings.devtools.KeyRequestsFragment" />
 
+        <im.vector.app.core.preference.VectorPreference
+            android:key="SETTINGS_ACCESS_TOKEN"
+            android:persistent="false"
+            android:summary="@string/settings_access_token_summary"
+            android:title="@string/settings_access_token" />
+
     </im.vector.app.core.preference.VectorPreferenceCategory>
 
     <im.vector.app.core.preference.VectorPreferenceCategory


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Performance

## Content

<!-- Describe shortly what has been changed -->
Batch crypto database writing to avoid multiple transactions which takes about 100ms each.
See commit per commit for the changes.

On my main Matrix account (~600 rooms) an initial sync (clear cache, so with non-empty crypto DB) was taking 8 minutes, with this change, it's only 1 minutes and 40 seconds. With a fake crypto store, it's only 30 seconds, but I do not want to dig more since this code will be replaced soon.

This PR also add a way to copy the access token to the clipboard.

### Risk

Changing the way data is inserted in the Crypto database may have some side effect. Can you check that @BillCarsonFr ?

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Improve perf of the app and SDK.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Perform initial sync.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
