### PR TITLE
Fix lint false positive

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/di/SerializeNulls.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/di/SerializeNulls.kt
@@ -16,7 +16,6 @@
 
 package org.matrix.android.sdk.internal.di
 
-import androidx.annotation.Nullable
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonQualifier
 import com.squareup.moshi.Moshi
@@ -28,7 +27,6 @@ import java.lang.reflect.Type
 internal annotation class SerializeNulls {
     companion object {
         val JSON_ADAPTER_FACTORY: JsonAdapter.Factory = object : JsonAdapter.Factory {
-            @Nullable
             override fun create(type: Type, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>? {
                 val nextAnnotations = Types.nextAnnotations(annotations, SerializeNulls::class.java)
                         ?: return null

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/interceptors/FormattedJsonHttpLogger.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/interceptors/FormattedJsonHttpLogger.kt
@@ -16,7 +16,6 @@
 
 package org.matrix.android.sdk.internal.network.interceptors
 
-import androidx.annotation.NonNull
 import okhttp3.logging.HttpLoggingInterceptor
 import org.json.JSONArray
 import org.json.JSONException
@@ -38,7 +37,7 @@ internal class FormattedJsonHttpLogger(
      * @param message
      */
     @Synchronized
-    override fun log(@NonNull message: String) {
+    override fun log(message: String) {
         Timber.v(message)
 
         // Try to log formatted Json only if there is a chance that [message] contains Json.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/parsing/CheckNumberType.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/network/parsing/CheckNumberType.kt
@@ -16,7 +16,6 @@
 
 package org.matrix.android.sdk.internal.network.parsing
 
-import androidx.annotation.Nullable
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
@@ -32,14 +31,12 @@ internal interface CheckNumberType {
 
     companion object {
         val JSON_ADAPTER_FACTORY = object : JsonAdapter.Factory {
-            @Nullable
             override fun create(type: Type, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>? {
                 if (type !== Any::class.java) {
                     return null
                 }
                 val delegate: JsonAdapter<Any> = moshi.nextAdapter(this, Any::class.java, emptySet())
                 return object : JsonAdapter<Any?>() {
-                    @Nullable
                     @Throws(IOException::class)
                     override fun fromJson(reader: JsonReader): Any? {
                         return if (reader.peek() !== JsonReader.Token.NUMBER) {

--- a/tools/lint/lint.xml
+++ b/tools/lint/lint.xml
@@ -77,6 +77,7 @@
     <issue id="UseValueOf" severity="error" />
     <issue id="ObsoleteSdkInt" severity="error" />
     <issue id="Recycle" severity="error" />
+    <issue id="KotlinNullnessAnnotation" severity="error" />
     <issue id="KotlinPropertyAccess" severity="error" />
     <issue id="DefaultLocale" severity="error" />
     <issue id="CheckResult" severity="error" />

--- a/vector/src/main/java/im/vector/app/core/resources/StringArrayProvider.kt
+++ b/vector/src/main/java/im/vector/app/core/resources/StringArrayProvider.kt
@@ -18,7 +18,6 @@ package im.vector.app.core.resources
 
 import android.content.res.Resources
 import androidx.annotation.ArrayRes
-import androidx.annotation.NonNull
 import javax.inject.Inject
 
 class StringArrayProvider @Inject constructor(private val resources: Resources) {
@@ -31,7 +30,6 @@ class StringArrayProvider @Inject constructor(private val resources: Resources) 
      * @return The string array associated with the resource, stripped of styled
      * text information.
      */
-    @NonNull
     fun getStringArray(@ArrayRes resId: Int): Array<String> {
         return resources.getStringArray(resId)
     }

--- a/vector/src/main/java/im/vector/app/core/resources/StringProvider.kt
+++ b/vector/src/main/java/im/vector/app/core/resources/StringProvider.kt
@@ -17,7 +17,6 @@
 package im.vector.app.core.resources
 
 import android.content.res.Resources
-import androidx.annotation.NonNull
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import javax.inject.Inject
@@ -32,7 +31,6 @@ class StringProvider @Inject constructor(private val resources: Resources) {
      * @return The string data associated with the resource, stripped of styled
      * text information.
      */
-    @NonNull
     fun getString(@StringRes resId: Int): String {
         return resources.getString(resId)
     }
@@ -48,12 +46,10 @@ class StringProvider @Inject constructor(private val resources: Resources) {
      * @return The string data associated with the resource, formatted and
      * stripped of styled text information.
      */
-    @NonNull
     fun getString(@StringRes resId: Int, vararg formatArgs: Any?): String {
         return resources.getString(resId, *formatArgs)
     }
 
-    @NonNull
     fun getQuantityString(@PluralsRes resId: Int, quantity: Int, vararg formatArgs: Any?): String {
         return resources.getQuantityString(resId, quantity, *formatArgs)
     }


### PR DESCRIPTION
Sometimes lint reports false positives. I do not want to ignore the corresponding rules, instead I have added a baseline with all the false positive so that they are ignore now.

This is a temporary solution, but I do not know why lint is changing behavior. AGP version hasn't been changed recently (7.3.1).

This is a recurring issue though...