### PR TITLE
Update to latest version of Lint (8.0.0-alpha10)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,3 +39,7 @@ signing.element.keyPassword=Secret
 signing.element.nightly.storePassword=Secret
 signing.element.nightly.keyId=Secret
 signing.element.nightly.keyPassword=Secret
+
+# Customise the Lint version to use a more recent version than the one bundled with AGP
+# https://googlesamples.github.io/android-custom-lint-rules/usage/newer-lint.md.html
+android.experimental.lint.version=8.0.0-alpha10

--- a/vector/src/main/java/im/vector/app/features/home/NotificationPermissionManager.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NotificationPermissionManager.kt
@@ -21,7 +21,6 @@ import android.app.Activity
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.result.ActivityResultLauncher
-import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import im.vector.app.R
@@ -35,17 +34,12 @@ class NotificationPermissionManager @Inject constructor(
         private val vectorPreferences: VectorPreferences,
 ) {
 
-    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.TIRAMISU)
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     fun isPermissionGranted(activity: Activity): Boolean {
-        return if (sdkIntProvider.isAtLeast(Build.VERSION_CODES.TIRAMISU)) {
-            ContextCompat.checkSelfPermission(
-                    activity,
-                    Manifest.permission.POST_NOTIFICATIONS
-            ) == PackageManager.PERMISSION_GRANTED
-        } else {
-            // No notification permission management before API 33.
-            true
-        }
+        return ContextCompat.checkSelfPermission(
+                activity,
+                Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
     }
 
     fun eventuallyRequestPermission(

--- a/vector/src/main/java/im/vector/app/features/settings/troubleshoot/TestSystemSettings.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/troubleshoot/TestSystemSettings.kt
@@ -15,12 +15,14 @@
  */
 package im.vector.app.features.settings.troubleshoot
 
+import android.os.Build
 import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.FragmentActivity
 import im.vector.app.R
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.utils.startNotificationSettingsIntent
 import im.vector.app.features.home.NotificationPermissionManager
+import org.matrix.android.sdk.api.util.BuildVersionSdkIntProvider
 import javax.inject.Inject
 
 /**
@@ -30,6 +32,7 @@ import javax.inject.Inject
 class TestSystemSettings @Inject constructor(
         private val context: FragmentActivity,
         private val stringProvider: StringProvider,
+        private val sdkIntProvider: BuildVersionSdkIntProvider,
         private val notificationPermissionManager: NotificationPermissionManager,
 ) : TroubleshootTest(R.string.settings_troubleshoot_test_system_settings_title) {
 
@@ -39,19 +42,19 @@ class TestSystemSettings @Inject constructor(
             quickFix = null
             status = TestStatus.SUCCESS
         } else {
-            if (notificationPermissionManager.isPermissionGranted(context)) {
-                description = stringProvider.getString(R.string.settings_troubleshoot_test_system_settings_failed)
-                quickFix = object : TroubleshootQuickFix(R.string.open_settings) {
-                    override fun doFix() {
-                        startNotificationSettingsIntent(context, testParameters.activityResultLauncher)
-                    }
-                }
-            } else {
+            if (sdkIntProvider.isAtLeast(Build.VERSION_CODES.TIRAMISU) && notificationPermissionManager.isPermissionGranted(context).not()) {
                 // In this case, we can ask for user permission
                 description = stringProvider.getString(R.string.settings_troubleshoot_test_system_settings_permission_failed)
                 quickFix = object : TroubleshootQuickFix(R.string.grant_permission) {
                     override fun doFix() {
                         notificationPermissionManager.askPermission(testParameters.permissionResultLauncher)
+                    }
+                }
+            } else {
+                description = stringProvider.getString(R.string.settings_troubleshoot_test_system_settings_failed)
+                quickFix = object : TroubleshootQuickFix(R.string.open_settings) {
+                    override fun doFix() {
+                        startNotificationSettingsIntent(context, testParameters.activityResultLauncher)
                     }
                 }
             }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Using gradle flag to set lint version to a more recent one than the one bundled with AGP version.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
With the current version (7.3.1) there are many false positives reported by Lint.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

N/A

## Tests

<!-- Explain how you tested your development -->

- Run `./gradlew vector-app:lintGplayRelease`
- Check there are no errors reported by the analysis

## Tested devices

N/A

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
