### PR TITLE
[Voice Broadcast] Stop listening if we reach the last received chunk and there is no last sequence number

### DIFF
--- a/changelog.d/7899.bugfix
+++ b/changelog.d/7899.bugfix
@@ -1,0 +1,1 @@
+[Voice Broadcast] Stop listening if we reach the last received chunk and there is no last sequence number

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -419,7 +419,9 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
             // Next media player is already attached to this player and will start playing automatically
             if (nextMediaPlayer != null) return
 
-            val hasEnded = !isLiveListening && mostRecentVoiceBroadcastEvent?.content?.lastChunkSequence == playlist.currentSequence
+            val currentSequence = playlist.currentSequence ?: 0
+            val lastChunkSequence = mostRecentVoiceBroadcastEvent?.content?.lastChunkSequence ?: 0
+            val hasEnded = !isLiveListening && currentSequence >= lastChunkSequence
             if (hasEnded) {
                 // We'll not receive new chunks anymore so we can stop the live listening
                 stop()


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fix voice broadcast stuck in buffering if there is no last sequence number in the state event (app restart, bad event format).
Also, stop buffering if the current chunk number is higher than the last sequence number (should not happen)

## Motivation and context

Fix issue with buffering

## Screenshots / GIFs

## Tests

- Start recording a VB on device A
- Wait for several chunks to be sent
- Listen to the VB on device B (optional)
- Restart the app on device A -> VB will be automatically stopped
- Verify that the listening is automatically stopped when reaching the last chunk

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
