### PR TITLE
View event replay

### DIFF
--- a/vector/src/main/java/im/vector/app/core/utils/SharedEvent.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/SharedEvent.kt
@@ -16,16 +16,17 @@
 
 package im.vector.app.core.utils
 
+import im.vector.app.core.platform.VectorViewEvents
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.transform
 import java.util.concurrent.CopyOnWriteArraySet
 
-interface SharedEvents<out T> {
+interface SharedEvents<out T : VectorViewEvents> {
     fun stream(consumerId: String): Flow<T>
 }
 
-class EventQueue<T>(capacity: Int) : SharedEvents<T> {
+class EventQueue<T : VectorViewEvents>(capacity: Int) : SharedEvents<T> {
 
     private val innerQueue = MutableSharedFlow<OneTimeEvent<T>>(replay = capacity)
 
@@ -42,7 +43,7 @@ class EventQueue<T>(capacity: Int) : SharedEvents<T> {
  *
  * Keeps track of who has already handled its content.
  */
-private class OneTimeEvent<out T>(private val content: T) {
+private class OneTimeEvent<out T : VectorViewEvents>(private val content: T) {
 
     private val handlers = CopyOnWriteArraySet<String>()
 
@@ -53,6 +54,6 @@ private class OneTimeEvent<out T>(private val content: T) {
     fun getIfNotHandled(asker: String): T? = if (handlers.add(asker)) content else null
 }
 
-private fun <T> Flow<OneTimeEvent<T>>.filterNotHandledBy(consumerId: String): Flow<T> = transform { event ->
+private fun <T : VectorViewEvents> Flow<OneTimeEvent<T>>.filterNotHandledBy(consumerId: String): Flow<T> = transform { event ->
     event.getIfNotHandled(consumerId)?.let { emit(it) }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
https://github.com/vector-im/element-android/pull/7724 introduced a regression, especially on the login screen.
In case of error, a ViewEvent can be triggered. But next Fragment to be displayed will also handle this Event, which is not expected.

The change in this PR ensure that Event older than 150ms cannot be handled.

Navigation Event triggered when the app is in background can be ignored due to this change, but this is an edge case, and we do not want to do a bigger rework of this part on the code base right now, and fixing the issue is more important.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Mainly avoid displaying several time the same issue during the sign up / sign in flow.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
