### PR TITLE
[Rich text editor] Update list item bullet appearance

### DIFF
--- a/changelog.d/7930.feature
+++ b/changelog.d/7930.feature
@@ -1,0 +1,1 @@
+"[Rich text editor] Update list item bullet appearance"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -101,7 +101,7 @@ ext.libs = [
         ],
         element     : [
                 'opusencoder'             : "io.element.android:opusencoder:1.1.0",
-                'wysiwyg'                 : "io.element.android:wysiwyg:0.14.0"
+                'wysiwyg'                 : "io.element.android:wysiwyg:0.15.0"
         ],
         squareup    : [
                 'moshi'                  : "com.squareup.moshi:moshi:$moshi",

--- a/library/ui-styles/src/main/res/values/styles_edit_text.xml
+++ b/library/ui-styles/src/main/res/values/styles_edit_text.xml
@@ -22,6 +22,7 @@
         <item name="android:clipToPadding">false</item>
         <item name="android:textSize">15sp</item>
         <item name="android:textColor">?vctr_message_text_color</item>
+        <item name="lineHeight">20sp</item>
     </style>
 
 </resources>

--- a/vector/src/main/res/layout/composer_rich_text_layout.xml
+++ b/vector/src/main/res/layout/composer_rich_text_layout.xml
@@ -124,6 +124,8 @@
             app:layout_constraintEnd_toStartOf="@id/composerFullScreenButton"
             app:layout_constraintStart_toStartOf="@id/composerEditTextOuterBorder"
             app:layout_constraintTop_toBottomOf="@id/composerModeBarrier"
+            app:bulletRadius="4sp"
+            app:bulletGap="8sp"
             tools:text="@tools:sample/lorem/random" />
 
         <com.google.android.material.textfield.TextInputEditText


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Update the list item bullet appearance in the rich text editor.

## Motivation and context

[`PSU-1063`](https://element-io.atlassian.net/browse/PSU-1063)

## Screenshots / GIFs

|Before|After|
|-|-|
|![bullet-before](https://user-images.githubusercontent.com/4940864/211568116-56334b79-0956-4fd2-8569-6a5489266c19.png)|![bullet-after](https://user-images.githubusercontent.com/4940864/211564847-7da25adc-54e3-489a-a3d1-5f020ae06413.png)|


## Tests

- Enable the rich text editor in labs
- Start typing a message
- Tap the bullet list button
- _Note the appearance of the bullets_

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 13

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
