### PR TITLE
Voice Broadcast - only send a notification on the first chunk

### DIFF
--- a/changelog.d/7845.wip
+++ b/changelog.d/7845.wip
@@ -1,0 +1,1 @@
+[Voice Broadcast] Only display a notification on the first voice chunk

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -2295,6 +2295,7 @@
     <string name="sent_verification_conclusion">Verification Conclusion</string>
     <string name="sent_location">Shared their location</string>
     <string name="sent_live_location">Shared their live location</string>
+    <string name="started_a_voice_broadcast">Started a voice broadcast</string>
 
     <string name="verification_request_waiting">Waiting…</string>
     <string name="verification_request_other_cancelled">%s canceled</string>

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/format/DisplayableEventFormatter.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/format/DisplayableEventFormatter.kt
@@ -27,6 +27,7 @@ import im.vector.app.core.resources.StringProvider
 import im.vector.app.features.html.EventHtmlRenderer
 import im.vector.app.features.voicebroadcast.VoiceBroadcastConstants
 import im.vector.app.features.voicebroadcast.isLive
+import im.vector.app.features.voicebroadcast.isVoiceBroadcast
 import im.vector.app.features.voicebroadcast.model.asVoiceBroadcastEvent
 import me.gujun.android.span.image
 import me.gujun.android.span.span
@@ -39,6 +40,7 @@ import org.matrix.android.sdk.api.session.room.model.message.MessageContent
 import org.matrix.android.sdk.api.session.room.model.message.MessagePollContent
 import org.matrix.android.sdk.api.session.room.model.message.MessageTextContent
 import org.matrix.android.sdk.api.session.room.model.message.MessageType
+import org.matrix.android.sdk.api.session.room.model.message.asMessageAudioEvent
 import org.matrix.android.sdk.api.session.room.model.relation.ReactionContent
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
 import org.matrix.android.sdk.api.session.room.timeline.getTextDisplayableContent
@@ -86,10 +88,16 @@ class DisplayableEventFormatter @Inject constructor(
                             simpleFormat(senderName, stringProvider.getString(R.string.sent_an_image), appendAuthor)
                         }
                         MessageType.MSGTYPE_AUDIO -> {
-                            if ((messageContent as? MessageAudioContent)?.voiceMessageIndicator != null) {
-                                simpleFormat(senderName, stringProvider.getString(R.string.sent_a_voice_message), appendAuthor)
-                            } else {
-                                simpleFormat(senderName, stringProvider.getString(R.string.sent_an_audio_file), appendAuthor)
+                            when {
+                                (messageContent as? MessageAudioContent)?.voiceMessageIndicator == null -> {
+                                    simpleFormat(senderName, stringProvider.getString(R.string.sent_an_audio_file), appendAuthor)
+                                }
+                                timelineEvent.root.asMessageAudioEvent().isVoiceBroadcast() -> {
+                                    simpleFormat(senderName, stringProvider.getString(R.string.started_a_voice_broadcast), appendAuthor)
+                                }
+                                else -> {
+                                    simpleFormat(senderName, stringProvider.getString(R.string.sent_a_voice_message), appendAuthor)
+                                }
                             }
                         }
                         MessageType.MSGTYPE_VIDEO -> {

--- a/vector/src/main/java/im/vector/app/features/notifications/FilteredEventDetector.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/FilteredEventDetector.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package im.vector.app.features.notifications
+
+import im.vector.app.ActiveSessionDataSource
+import im.vector.app.features.voicebroadcast.isVoiceBroadcast
+import im.vector.app.features.voicebroadcast.sequence
+import org.matrix.android.sdk.api.session.events.model.isVoiceMessage
+import org.matrix.android.sdk.api.session.getRoom
+import org.matrix.android.sdk.api.session.room.getTimelineEvent
+import org.matrix.android.sdk.api.session.room.model.message.asMessageAudioEvent
+import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
+import javax.inject.Inject
+
+class FilteredEventDetector @Inject constructor(
+        private val activeSessionDataSource: ActiveSessionDataSource
+) {
+
+    /**
+     * Returns true if the given event should be ignored.
+     * Used to skip notifications if a non expected message is received.
+     */
+    fun shouldBeIgnored(notifiableEvent: NotifiableEvent): Boolean {
+        val session = activeSessionDataSource.currentValue?.orNull() ?: return false
+
+        if (notifiableEvent is NotifiableMessageEvent) {
+            val room = session.getRoom(notifiableEvent.roomId) ?: return false
+            val timelineEvent = room.getTimelineEvent(notifiableEvent.eventId) ?: return false
+            return timelineEvent.shouldBeIgnored()
+        }
+        return false
+    }
+
+    /**
+     * Whether the timeline event should be ignored.
+     */
+    private fun TimelineEvent.shouldBeIgnored(): Boolean {
+        if (root.isVoiceMessage()) {
+            val audioEvent = root.asMessageAudioEvent()
+            // if the event is a voice message related to a voice broadcast, only show the event on the first chunk.
+            return audioEvent.isVoiceBroadcast() && audioEvent?.sequence != 1
+        }
+
+        return false
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotificationDrawerManager.kt
@@ -47,6 +47,7 @@ class NotificationDrawerManager @Inject constructor(
         private val notifiableEventProcessor: NotifiableEventProcessor,
         private val notificationRenderer: NotificationRenderer,
         private val notificationEventPersistence: NotificationEventPersistence,
+        private val filteredEventDetector: FilteredEventDetector,
         private val buildMeta: BuildMeta,
 ) {
 
@@ -98,6 +99,11 @@ class NotificationDrawerManager @Inject constructor(
             Timber.d("onNotifiableEventReceived(): $notifiableEvent")
         } else {
             Timber.d("onNotifiableEventReceived(): is push: ${notifiableEvent.canBeReplaced}")
+        }
+
+        if (filteredEventDetector.shouldBeIgnored(notifiableEvent)) {
+            Timber.d("onNotifiableEventReceived(): ignore the event")
+            return
         }
 
         add(notifiableEvent)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] WIP Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

During the handling of the notifications, notify only the first voice chunk of a voice broadcast, and ignore the other events related to the voice broadcast chunks

## Motivation and context

Close #7845 

## Screenshots / GIFs

https://user-images.githubusercontent.com/11990514/212134974-33339bae-49ca-40d7-b801-c58ee13231a2.mp4

## Tests

- Enable all notifications on Android device
- Start a voice broadcast from another device
- Pause or wait 2 min to send a chunk
- Verify that a voice broadcast notification appears on Android device
- Resume & Pause again the VB or wait for a second chunk
- Verify that there is no new notification
- Verify that the other notifications (text or simple voice message) are still working

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
