### PR TITLE
Make verification bottom sheet cancellable on tap outside (PSG-1139)

### DIFF
--- a/changelog.d/4025.bugfix
+++ b/changelog.d/4025.bugfix
@@ -1,0 +1,1 @@
+Fix can't get out of a verification dialog

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationBottomSheet.kt
@@ -17,6 +17,7 @@ package im.vector.app.features.crypto.verification
 
 import android.app.Activity
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.KeyEvent
@@ -85,7 +86,7 @@ class VerificationBottomSheet : VectorBaseBottomSheetDialogFragment<BottomSheetV
     }
 
     init {
-        isCancelable = false
+        isCancelable = true
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -395,6 +396,11 @@ class VerificationBottomSheet : VectorBaseBottomSheetDialogFragment<BottomSheetV
         }
 
         const val WAITING_SELF_VERIF_TAG: String = "WAITING_SELF_VERIF_TAG"
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        super.onCancel(dialog)
+        viewModel.confirmCancel()
     }
 }
 

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/VerificationBottomSheet.kt
@@ -85,10 +85,6 @@ class VerificationBottomSheet : VectorBaseBottomSheetDialogFragment<BottomSheetV
         return BottomSheetVerificationBinding.inflate(inflater, container, false)
     }
 
-    init {
-        isCancelable = true
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -210,6 +206,8 @@ class VerificationBottomSheet : VectorBaseBottomSheetDialogFragment<BottomSheetV
             )
             return@withState
         }
+
+        isCancelable = state.isVerificationRequired.not()
 
         // Did the request result in a SAS transaction?
         if (state.sasTransactionState != null) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Verification bottom sheet was not cancellable when tapping outside of it. The only way was to click skip and answer are you sure bottom sheet. And users report that verification process can be stuck and there is no way to dismiss the bottom sheet.

<!-- Describe shortly what has been changed -->

## Motivation and context
Fixes #4025.

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Login from another device
- Relaunch Android application
- See the "New login" alert, tap on it
- See the verification bottom sheet is shown
- Tap outside of the bottom sheet and see it is dismissed and process is cancelled

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
