### PR TITLE
[Poll] History list: Load more UI mechanism (PSG-1095)

### DIFF
--- a/changelog.d/7864.wip
+++ b/changelog.d/7864.wip
@@ -1,0 +1,1 @@
+[Poll] Load more UI mechanism

--- a/changelog.d/7864.wip
+++ b/changelog.d/7864.wip
@@ -1,1 +1,1 @@
-[Poll] Load more UI mechanism
+[Poll] History list: Load more UI mechanism

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -3201,6 +3201,7 @@
     <string name="room_polls_active_no_item">There are no active polls in this room</string>
     <string name="room_polls_ended">Past polls</string>
     <string name="room_polls_ended_no_item">There are no past polls in this room</string>
+    <string name="room_polls_load_more">Load more polls</string>
 
     <!-- Location -->
     <string name="location_activity_title_static_sharing">Share location</string>

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -3209,6 +3209,7 @@
         <item quantity="one">"There are no past polls for the past day.\nLoad more polls to view polls for previous days."</item>
         <item quantity="other">"There are no past polls for the past %1$d days.\nLoad more polls to view polls for previous days."</item>
     </plurals>
+    <string name="room_polls_wait_for_display">Displaying polls</string>
     <string name="room_polls_load_more">Load more polls</string>
 
     <!-- Location -->

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -3211,6 +3211,7 @@
     </plurals>
     <string name="room_polls_wait_for_display">Displaying polls</string>
     <string name="room_polls_load_more">Load more polls</string>
+    <string name="room_polls_loading_error">Error fetching polls.</string>
 
     <!-- Location -->
     <string name="location_activity_title_static_sharing">Share location</string>

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -3199,8 +3199,16 @@
     <string name="unable_to_decrypt_some_events_in_poll">Due to decryption errors, some votes may not be counted</string>
     <string name="room_polls_active">Active polls</string>
     <string name="room_polls_active_no_item">There are no active polls in this room</string>
+    <plurals name="room_polls_active_no_item_for_loaded_period">
+        <item quantity="one">"There are no active polls for the past day.\nLoad more polls to view polls for previous days."</item>
+        <item quantity="other">"There are no active polls for the past %1$d days.\nLoad more polls to view polls for previous days."</item>
+    </plurals>
     <string name="room_polls_ended">Past polls</string>
     <string name="room_polls_ended_no_item">There are no past polls in this room</string>
+    <plurals name="room_polls_ended_no_item_for_loaded_period">
+        <item quantity="one">"There are no past polls for the past day.\nLoad more polls to view polls for previous days."</item>
+        <item quantity="other">"There are no past polls for the past %1$d days.\nLoad more polls to view polls for previous days."</item>
+    </plurals>
     <string name="room_polls_load_more">Load more polls</string>
 
     <!-- Location -->

--- a/vector/src/main/java/im/vector/app/core/error/ErrorFormatter.kt
+++ b/vector/src/main/java/im/vector/app/core/error/ErrorFormatter.kt
@@ -20,6 +20,7 @@ import android.content.ActivityNotFoundException
 import im.vector.app.R
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.features.call.dialpad.DialPadLookup
+import im.vector.app.features.roomprofile.polls.RoomPollsLoadingError
 import im.vector.app.features.voice.VoiceFailure
 import im.vector.app.features.voicebroadcast.VoiceBroadcastFailure
 import im.vector.app.features.voicebroadcast.VoiceBroadcastFailure.RecordingError
@@ -138,6 +139,7 @@ class DefaultErrorFormatter @Inject constructor(
                 stringProvider.getString(R.string.login_signin_matrix_id_error_invalid_matrix_id)
             is VoiceFailure -> voiceMessageError(throwable)
             is VoiceBroadcastFailure -> voiceBroadcastMessageError(throwable)
+            is RoomPollsLoadingError -> stringProvider.getString(R.string.room_polls_loading_error)
             is ActivityNotFoundException ->
                 stringProvider.getString(R.string.error_no_external_application_found)
             else -> throwable.localizedMessage

--- a/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/RoomProfileActivity.kt
@@ -76,6 +76,8 @@ class RoomProfileActivity :
         return ActivitySimpleBinding.inflate(layoutInflater)
     }
 
+    override fun getCoordinatorLayout() = views.coordinatorLayout
+
     override fun initUiAndData() {
         sharedActionViewModel = viewModelProvider.get(RoomProfileSharedActionViewModel::class.java)
         roomProfileArgs = intent?.extras?.getParcelableCompat(Mavericks.KEY_ARG) ?: return

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsLoadingError.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsLoadingError.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,4 @@
 
 package im.vector.app.features.roomprofile.polls
 
-import im.vector.app.core.platform.VectorViewEvents
-
-sealed class RoomPollsViewEvent : VectorViewEvents {
-    object LoadingError : RoomPollsViewEvent()
-}
+class RoomPollsLoadingError : Throwable()

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModel.kt
@@ -82,7 +82,6 @@ class RoomPollsViewModel @AssistedInject constructor(
                 .launchIn(viewModelScope)
     }
 
-    // TODO add unit tests
     override fun handle(action: RoomPollsAction) {
         when (action) {
             RoomPollsAction.LoadMorePolls -> handleLoadMore()

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModel.kt
@@ -26,6 +26,7 @@ import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.features.roomprofile.polls.list.domain.GetLoadedPollsStatusUseCase
 import im.vector.app.features.roomprofile.polls.list.domain.GetPollsUseCase
 import im.vector.app.features.roomprofile.polls.list.domain.LoadMorePollsUseCase
+import im.vector.app.features.roomprofile.polls.list.domain.SyncPollsUseCase
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -35,6 +36,7 @@ class RoomPollsViewModel @AssistedInject constructor(
         private val getPollsUseCase: GetPollsUseCase,
         private val getLoadedPollsStatusUseCase: GetLoadedPollsStatusUseCase,
         private val loadMorePollsUseCase: LoadMorePollsUseCase,
+        private val syncPollsUseCase: SyncPollsUseCase,
 ) : VectorViewModel<RoomPollsViewState, RoomPollsAction, RoomPollsViewEvent>(initialState) {
 
     @AssistedFactory
@@ -46,9 +48,8 @@ class RoomPollsViewModel @AssistedInject constructor(
 
     init {
         updateLoadedPollStatus(initialState.roomId)
+        syncPolls(initialState.roomId)
         observePolls()
-        // TODO
-        //  call use case to sync polls until now = initial loading
     }
 
     private fun updateLoadedPollStatus(roomId: String) {
@@ -58,6 +59,14 @@ class RoomPollsViewModel @AssistedInject constructor(
                     canLoadMore = loadedPollsStatus.canLoadMore,
                     nbLoadedDays = loadedPollsStatus.nbLoadedDays
             )
+        }
+    }
+
+    private fun syncPolls(roomId: String) {
+        viewModelScope.launch {
+            setState { copy(isSyncing = true) }
+            syncPollsUseCase.execute(roomId)
+            setState { copy(isSyncing = false) }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModel.kt
@@ -43,6 +43,7 @@ class RoomPollsViewModel @AssistedInject constructor(
     companion object : MavericksViewModelFactory<RoomPollsViewModel, RoomPollsViewState> by hiltMavericksViewModelFactory()
 
     init {
+        // TODO update canLoadMore in viewState
         observePolls()
     }
 
@@ -62,8 +63,8 @@ class RoomPollsViewModel @AssistedInject constructor(
     private fun handleLoadMore() = withState { viewState ->
         viewModelScope.launch {
             setState { copy(isLoadingMore = true) }
-            loadMorePollsUseCase.execute(viewState.roomId)
-            setState { copy(isLoadingMore = false) }
+            val result = loadMorePollsUseCase.execute(viewState.roomId)
+            setState { copy(isLoadingMore = false, canLoadMore = result.canLoadMore) }
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewState.kt
@@ -18,7 +18,7 @@ package im.vector.app.features.roomprofile.polls
 
 import com.airbnb.mvrx.MavericksState
 import im.vector.app.features.roomprofile.RoomProfileArgs
-import im.vector.app.features.roomprofile.polls.list.PollSummary
+import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
 
 // TODO parameter to know whether load more is possible
 // TODO parameter to know whether initial loading is in progress

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewState.kt
@@ -18,10 +18,14 @@ package im.vector.app.features.roomprofile.polls
 
 import com.airbnb.mvrx.MavericksState
 import im.vector.app.features.roomprofile.RoomProfileArgs
+import im.vector.app.features.roomprofile.polls.list.PollSummary
 
+// TODO parameter to know whether load more is possible
+// TODO parameter to know whether initial loading is in progress
 data class RoomPollsViewState(
         val roomId: String,
         val polls: List<PollSummary> = emptyList(),
+        val isLoadingMore: Boolean = false,
 ) : MavericksState {
 
     constructor(roomProfileArgs: RoomProfileArgs) : this(roomId = roomProfileArgs.roomId)

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewState.kt
@@ -30,4 +30,7 @@ data class RoomPollsViewState(
 ) : MavericksState {
 
     constructor(roomProfileArgs: RoomProfileArgs) : this(roomId = roomProfileArgs.roomId)
+
+    fun hasNoPolls() = polls.isEmpty()
+    fun hasNoPollsAndCanLoadMore() = !isSyncing && hasNoPolls() && canLoadMore
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewState.kt
@@ -26,6 +26,7 @@ data class RoomPollsViewState(
         val polls: List<PollSummary> = emptyList(),
         val isLoadingMore: Boolean = false,
         val canLoadMore: Boolean = true,
+        val nbLoadedDays: Int = 0,
 ) : MavericksState {
 
     constructor(roomProfileArgs: RoomProfileArgs) : this(roomId = roomProfileArgs.roomId)

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewState.kt
@@ -20,13 +20,13 @@ import com.airbnb.mvrx.MavericksState
 import im.vector.app.features.roomprofile.RoomProfileArgs
 import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
 
-// TODO parameter to know whether initial loading is in progress
 data class RoomPollsViewState(
         val roomId: String,
         val polls: List<PollSummary> = emptyList(),
         val isLoadingMore: Boolean = false,
         val canLoadMore: Boolean = true,
         val nbLoadedDays: Int = 0,
+        val isSyncing: Boolean = false,
 ) : MavericksState {
 
     constructor(roomProfileArgs: RoomProfileArgs) : this(roomId = roomProfileArgs.roomId)

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/RoomPollsViewState.kt
@@ -20,12 +20,12 @@ import com.airbnb.mvrx.MavericksState
 import im.vector.app.features.roomprofile.RoomProfileArgs
 import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
 
-// TODO parameter to know whether load more is possible
 // TODO parameter to know whether initial loading is in progress
 data class RoomPollsViewState(
         val roomId: String,
         val polls: List<PollSummary> = emptyList(),
         val isLoadingMore: Boolean = false,
+        val canLoadMore: Boolean = true,
 ) : MavericksState {
 
     constructor(roomProfileArgs: RoomProfileArgs) : this(roomId = roomProfileArgs.roomId)

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/active/RoomActivePollsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/active/RoomActivePollsFragment.kt
@@ -24,8 +24,12 @@ import im.vector.app.features.roomprofile.polls.list.ui.RoomPollsListFragment
 @AndroidEntryPoint
 class RoomActivePollsFragment : RoomPollsListFragment() {
 
-    override fun getEmptyListTitle(): String {
-        return getString(R.string.room_polls_active_no_item)
+    override fun getEmptyListTitle(canLoadMore: Boolean, nbLoadedDays: Int): String {
+        return if (canLoadMore) {
+            stringProvider.getQuantityString(R.plurals.room_polls_active_no_item_for_loaded_period, nbLoadedDays, nbLoadedDays)
+        } else {
+            getString(R.string.room_polls_active_no_item)
+        }
     }
 
     override fun getRoomPollsType(): RoomPollsType {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/active/RoomActivePollsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/active/RoomActivePollsFragment.kt
@@ -19,7 +19,7 @@ package im.vector.app.features.roomprofile.polls.active
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
 import im.vector.app.features.roomprofile.polls.RoomPollsType
-import im.vector.app.features.roomprofile.polls.list.RoomPollsListFragment
+import im.vector.app.features.roomprofile.polls.list.ui.RoomPollsListFragment
 
 @AndroidEntryPoint
 class RoomActivePollsFragment : RoomPollsListFragment() {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/ended/RoomEndedPollsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/ended/RoomEndedPollsFragment.kt
@@ -24,8 +24,12 @@ import im.vector.app.features.roomprofile.polls.list.ui.RoomPollsListFragment
 @AndroidEntryPoint
 class RoomEndedPollsFragment : RoomPollsListFragment() {
 
-    override fun getEmptyListTitle(): String {
-        return getString(R.string.room_polls_ended_no_item)
+    override fun getEmptyListTitle(canLoadMore: Boolean, nbLoadedDays: Int): String {
+        return if (canLoadMore) {
+            stringProvider.getQuantityString(R.plurals.room_polls_ended_no_item_for_loaded_period, nbLoadedDays, nbLoadedDays)
+        } else {
+            getString(R.string.room_polls_ended_no_item)
+        }
     }
 
     override fun getRoomPollsType(): RoomPollsType {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/ended/RoomEndedPollsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/ended/RoomEndedPollsFragment.kt
@@ -19,7 +19,7 @@ package im.vector.app.features.roomprofile.polls.ended
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
 import im.vector.app.features.roomprofile.polls.RoomPollsType
-import im.vector.app.features.roomprofile.polls.list.RoomPollsListFragment
+import im.vector.app.features.roomprofile.polls.list.ui.RoomPollsListFragment
 
 @AndroidEntryPoint
 class RoomEndedPollsFragment : RoomPollsListFragment() {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/PollSummary.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/PollSummary.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.roomprofile.polls
+package im.vector.app.features.roomprofile.polls.list
 
 import im.vector.app.features.home.room.detail.timeline.item.PollOptionViewState
 

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/RoomPollLoadMoreItem.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/RoomPollLoadMoreItem.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.roomprofile.polls.list
+
+import android.widget.Button
+import com.airbnb.epoxy.EpoxyAttribute
+import com.airbnb.epoxy.EpoxyModelClass
+import im.vector.app.R
+import im.vector.app.core.epoxy.ClickListener
+import im.vector.app.core.epoxy.VectorEpoxyHolder
+import im.vector.app.core.epoxy.VectorEpoxyModel
+import im.vector.app.core.epoxy.onClick
+
+@EpoxyModelClass
+abstract class RoomPollLoadMoreItem : VectorEpoxyModel<RoomPollLoadMoreItem.Holder>(R.layout.item_poll_load_more) {
+
+    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
+    var clickListener: ClickListener? = null
+
+    override fun bind(holder: Holder) {
+        super.bind(holder)
+        holder.loadMoreButton.onClick(clickListener)
+    }
+
+    class Holder : VectorEpoxyHolder() {
+        val loadMoreButton by bind<Button>(R.id.roomPollsLoadMore)
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/RoomPollLoadMoreItem.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/RoomPollLoadMoreItem.kt
@@ -17,6 +17,8 @@
 package im.vector.app.features.roomprofile.polls.list
 
 import android.widget.Button
+import android.widget.ProgressBar
+import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
@@ -28,15 +30,21 @@ import im.vector.app.core.epoxy.onClick
 @EpoxyModelClass
 abstract class RoomPollLoadMoreItem : VectorEpoxyModel<RoomPollLoadMoreItem.Holder>(R.layout.item_poll_load_more) {
 
+    @EpoxyAttribute
+    var loadingMore: Boolean = false
+
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
     var clickListener: ClickListener? = null
 
     override fun bind(holder: Holder) {
         super.bind(holder)
+        holder.loadMoreButton.isEnabled = loadingMore.not()
         holder.loadMoreButton.onClick(clickListener)
+        holder.loadMoreProgressBar.isVisible = loadingMore
     }
 
     class Holder : VectorEpoxyHolder() {
         val loadMoreButton by bind<Button>(R.id.roomPollsLoadMore)
+        val loadMoreProgressBar by bind<ProgressBar>(R.id.roomPollsLoadMoreProgress)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/RoomPollsController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/RoomPollsController.kt
@@ -31,6 +31,7 @@ class RoomPollsController @Inject constructor(
 
     interface Listener {
         fun onPollClicked(pollId: String)
+        fun onLoadMoreClicked()
     }
 
     var listener: Listener? = null
@@ -46,6 +47,8 @@ class RoomPollsController @Inject constructor(
                 is PollSummary.EndedPoll -> buildEndedPollItem(poll)
             }
         }
+
+        buildLoadMoreItem()
     }
 
     private fun buildActivePollItem(poll: PollSummary.ActivePoll) {
@@ -71,6 +74,14 @@ class RoomPollsController @Inject constructor(
             clickListener {
                 host.listener?.onPollClicked(poll.id)
             }
+        }
+    }
+
+    private fun buildLoadMoreItem() {
+        val host = this
+        roomPollLoadMoreItem {
+            id("roomPollLoadMore")
+            host.listener?.onLoadMoreClicked()
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/RoomPollsController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/RoomPollsController.kt
@@ -21,13 +21,14 @@ import im.vector.app.R
 import im.vector.app.core.date.DateFormatKind
 import im.vector.app.core.date.VectorDateFormatter
 import im.vector.app.core.resources.StringProvider
-import im.vector.app.features.roomprofile.polls.PollSummary
+import im.vector.app.features.roomprofile.polls.RoomPollsViewState
+import java.util.UUID
 import javax.inject.Inject
 
 class RoomPollsController @Inject constructor(
         val dateFormatter: VectorDateFormatter,
         val stringProvider: StringProvider,
-) : TypedEpoxyController<List<PollSummary>>() {
+) : TypedEpoxyController<RoomPollsViewState>() {
 
     interface Listener {
         fun onPollClicked(pollId: String)
@@ -36,19 +37,20 @@ class RoomPollsController @Inject constructor(
 
     var listener: Listener? = null
 
-    override fun buildModels(data: List<PollSummary>?) {
-        if (data.isNullOrEmpty()) {
+    override fun buildModels(viewState: RoomPollsViewState?) {
+        val polls = viewState?.polls
+        if (polls.isNullOrEmpty()) {
             return
         }
 
-        for (poll in data) {
+        for (poll in polls) {
             when (poll) {
                 is PollSummary.ActivePoll -> buildActivePollItem(poll)
                 is PollSummary.EndedPoll -> buildEndedPollItem(poll)
             }
         }
 
-        buildLoadMoreItem()
+        buildLoadMoreItem(viewState.isLoadingMore)
     }
 
     private fun buildActivePollItem(poll: PollSummary.ActivePoll) {
@@ -77,11 +79,14 @@ class RoomPollsController @Inject constructor(
         }
     }
 
-    private fun buildLoadMoreItem() {
+    private fun buildLoadMoreItem(isLoadingMore: Boolean) {
         val host = this
         roomPollLoadMoreItem {
-            id("roomPollLoadMore")
-            host.listener?.onLoadMoreClicked()
+            id(UUID.randomUUID().toString())
+            loadingMore(isLoadingMore)
+            clickListener {
+                host.listener?.onLoadMoreClicked()
+            }
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/RoomPollsListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/RoomPollsListFragment.kt
@@ -27,9 +27,10 @@ import im.vector.app.core.extensions.cleanup
 import im.vector.app.core.extensions.configureWith
 import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.databinding.FragmentRoomPollsListBinding
-import im.vector.app.features.roomprofile.polls.PollSummary
+import im.vector.app.features.roomprofile.polls.RoomPollsAction
 import im.vector.app.features.roomprofile.polls.RoomPollsType
 import im.vector.app.features.roomprofile.polls.RoomPollsViewModel
+import im.vector.app.features.roomprofile.polls.RoomPollsViewState
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -74,15 +75,16 @@ abstract class RoomPollsListFragment :
     }
 
     override fun invalidate() = withState(viewModel) { viewState ->
-        when (getRoomPollsType()) {
-            RoomPollsType.ACTIVE -> renderList(viewState.polls.filterIsInstance(PollSummary.ActivePoll::class.java))
-            RoomPollsType.ENDED -> renderList(viewState.polls.filterIsInstance(PollSummary.EndedPoll::class.java))
+        val filteredPolls = when (getRoomPollsType()) {
+            RoomPollsType.ACTIVE -> viewState.polls.filterIsInstance(PollSummary.ActivePoll::class.java)
+            RoomPollsType.ENDED -> viewState.polls.filterIsInstance(PollSummary.EndedPoll::class.java)
         }
+        renderList(viewState.copy(polls = filteredPolls))
     }
 
-    private fun renderList(polls: List<PollSummary>) {
-        roomPollsController.setData(polls)
-        views.roomPollsEmptyTitle.isVisible = polls.isEmpty()
+    private fun renderList(viewState: RoomPollsViewState) {
+        roomPollsController.setData(viewState)
+        views.roomPollsEmptyTitle.isVisible = viewState.polls.isEmpty()
     }
 
     override fun onPollClicked(pollId: String) {
@@ -91,6 +93,6 @@ abstract class RoomPollsListFragment :
     }
 
     override fun onLoadMoreClicked() {
-        // TODO call viewAction
+        viewModel.handle(RoomPollsAction.LoadMorePolls)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/RoomPollsListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/RoomPollsListFragment.kt
@@ -33,6 +33,8 @@ import im.vector.app.features.roomprofile.polls.RoomPollsViewModel
 import timber.log.Timber
 import javax.inject.Inject
 
+// TODO add and render blocking loader view
+// TODO add and render missing empty view when load more is possible
 abstract class RoomPollsListFragment :
         VectorBaseFragment<FragmentRoomPollsListBinding>(),
         RoomPollsController.Listener {
@@ -86,5 +88,9 @@ abstract class RoomPollsListFragment :
     override fun onPollClicked(pollId: String) {
         // TODO navigate to details
         Timber.d("poll with id $pollId clicked")
+    }
+
+    override fun onLoadMoreClicked() {
+        // TODO call viewAction
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/LoadMorePollsResult.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/LoadMorePollsResult.kt
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.roomprofile.polls.list.domain
+package im.vector.app.features.roomprofile.polls.list.data
 
-import im.vector.app.features.roomprofile.polls.list.data.LoadMorePollsResult
-import im.vector.app.features.roomprofile.polls.list.data.RoomPollRepository
-import javax.inject.Inject
-
-// TODO add unit tests
-class LoadMorePollsUseCase @Inject constructor(
-        private val roomPollRepository: RoomPollRepository,
-) {
-
-    suspend fun execute(roomId: String): LoadMorePollsResult {
-        return roomPollRepository.loadMorePolls(roomId)
-    }
-}
+data class LoadMorePollsResult(
+        val canLoadMore: Boolean,
+)

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/LoadedPollsStatus.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/LoadedPollsStatus.kt
@@ -14,18 +14,9 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.roomprofile.polls.list.domain
+package im.vector.app.features.roomprofile.polls.list.data
 
-import im.vector.app.features.roomprofile.polls.list.data.LoadedPollsStatus
-import im.vector.app.features.roomprofile.polls.list.data.RoomPollRepository
-import javax.inject.Inject
-
-// TODO add unit tests
-class LoadMorePollsUseCase @Inject constructor(
-        private val roomPollRepository: RoomPollRepository,
-) {
-
-    suspend fun execute(roomId: String): LoadedPollsStatus {
-        return roomPollRepository.loadMorePolls(roomId)
-    }
-}
+data class LoadedPollsStatus(
+        val canLoadMore: Boolean,
+        val nbLoadedDays: Int,
+)

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollDataSource.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollDataSource.kt
@@ -163,6 +163,12 @@ class RoomPollDataSource @Inject constructor() {
         Timber.d("roomId=$roomId")
         // TODO
         //  unmock using SDK service + add unit tests
-        delay(3000)
+        if (fakeLoadCounter == 0) {
+            // fake first load
+            loadMorePolls(roomId)
+        } else {
+            // fake sync
+            delay(3000)
+        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollDataSource.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollDataSource.kt
@@ -158,4 +158,11 @@ class RoomPollDataSource @Inject constructor() {
                 ),
         )
     }
+
+    suspend fun syncPolls(roomId: String) {
+        Timber.d("roomId=$roomId")
+        // TODO
+        //  unmock using SDK service + add unit tests
+        delay(3000)
+    }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollDataSource.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollDataSource.kt
@@ -41,6 +41,32 @@ class RoomPollDataSource @Inject constructor() {
         return pollsFlow.asSharedFlow()
     }
 
+    fun getLoadedPollsStatus(roomId: String): LoadedPollsStatus {
+        Timber.d("roomId=$roomId")
+        return LoadedPollsStatus(
+                canLoadMore = canLoadMore(),
+                nbLoadedDays = fakeLoadCounter * 30,
+        )
+    }
+
+    private fun canLoadMore(): Boolean {
+        return fakeLoadCounter < 2
+    }
+
+    suspend fun loadMorePolls(roomId: String): LoadedPollsStatus {
+        // TODO
+        //  unmock using SDK service + add unit tests
+        delay(3000)
+        fakeLoadCounter++
+        when (fakeLoadCounter) {
+            1 -> polls.addAll(getActivePollsPart1() + getEndedPollsPart1())
+            2 -> polls.addAll(getActivePollsPart2() + getEndedPollsPart2())
+            else -> Unit
+        }
+        pollsFlow.emit(polls)
+        return getLoadedPollsStatus(roomId)
+    }
+
     private fun getActivePollsPart1(): List<PollSummary.ActivePoll> {
         return listOf(
                 PollSummary.ActivePoll(
@@ -131,20 +157,5 @@ class RoomPollDataSource @Inject constructor() {
                         ),
                 ),
         )
-    }
-
-    suspend fun loadMorePolls(roomId: String): LoadMorePollsResult {
-        Timber.d("roomId=$roomId")
-        // TODO
-        //  unmock using SDK service + add unit tests
-        delay(3000)
-        fakeLoadCounter++
-        when (fakeLoadCounter) {
-            1 -> polls.addAll(getActivePollsPart1() + getEndedPollsPart1())
-            2 -> polls.addAll(getActivePollsPart2() + getEndedPollsPart2())
-            else -> Unit
-        }
-        pollsFlow.emit(polls)
-        return LoadMorePollsResult(canLoadMore = fakeLoadCounter < 2)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollDataSource.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollDataSource.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.roomprofile.polls.list.data
+
+import im.vector.app.features.home.room.detail.timeline.item.PollOptionViewState
+import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RoomPollDataSource @Inject constructor() {
+
+    // TODO
+    //  unmock using SDK service + add unit tests
+    //  after unmock, expose domain layer model (entity) and do the mapping to PollSummary in the UI layer
+    fun getPolls(roomId: String): Flow<List<PollSummary>> {
+        Timber.d("roomId=$roomId")
+        return flowOf(getActivePolls() + getEndedPolls())
+    }
+
+    private fun getActivePolls(): List<PollSummary.ActivePoll> {
+        return listOf(
+                PollSummary.ActivePoll(
+                        id = "id1",
+                        // 2022/06/28 UTC+1
+                        creationTimestamp = 1656367200000,
+                        title = "Which charity would you like to support?"
+                ),
+                PollSummary.ActivePoll(
+                        id = "id2",
+                        // 2022/06/26 UTC+1
+                        creationTimestamp = 1656194400000,
+                        title = "Which sport should the pupils do this year?"
+                ),
+                PollSummary.ActivePoll(
+                        id = "id3",
+                        // 2022/06/24 UTC+1
+                        creationTimestamp = 1656021600000,
+                        title = "What type of food should we have at the party?"
+                ),
+                PollSummary.ActivePoll(
+                        id = "id4",
+                        // 2022/06/22 UTC+1
+                        creationTimestamp = 1655848800000,
+                        title = "What film should we show at the end of the year party?"
+                ),
+        )
+    }
+
+    private fun getEndedPolls(): List<PollSummary.EndedPoll> {
+        return listOf(
+                PollSummary.EndedPoll(
+                        id = "id1-ended",
+                        // 2022/06/28 UTC+1
+                        creationTimestamp = 1656367200000,
+                        title = "Which charity would you like to support?",
+                        totalVotes = 22,
+                        winnerOptions = listOf(
+                                PollOptionViewState.PollEnded(
+                                        optionId = "id1",
+                                        optionAnswer = "Cancer research",
+                                        voteCount = 13,
+                                        votePercentage = 13 / 22.0,
+                                        isWinner = true,
+                                )
+                        ),
+                ),
+                PollSummary.EndedPoll(
+                        id = "id2-ended",
+                        // 2022/06/26 UTC+1
+                        creationTimestamp = 1656194400000,
+                        title = "Where should we do the offsite?",
+                        totalVotes = 92,
+                        winnerOptions = listOf(
+                                PollOptionViewState.PollEnded(
+                                        optionId = "id1",
+                                        optionAnswer = "Hawaii",
+                                        voteCount = 43,
+                                        votePercentage = 43 / 92.0,
+                                        isWinner = true,
+                                )
+                        ),
+                ),
+                PollSummary.EndedPoll(
+                        id = "id3-ended",
+                        // 2022/06/24 UTC+1
+                        creationTimestamp = 1656021600000,
+                        title = "What type of food should we have at the party?",
+                        totalVotes = 22,
+                        winnerOptions = listOf(
+                                PollOptionViewState.PollEnded(
+                                        optionId = "id1",
+                                        optionAnswer = "Brazilian",
+                                        voteCount = 13,
+                                        votePercentage = 13 / 22.0,
+                                        isWinner = true,
+                                )
+                        ),
+                ),
+        )
+    }
+
+    suspend fun loadMorePolls(roomId: String): LoadMorePollsResult {
+        Timber.d("roomId=$roomId")
+        // TODO
+        //  mock getting more polls + update the given flow
+        //  unmock using SDK service + add unit tests
+        delay(5000)
+        return LoadMorePollsResult(canLoadMore = false)
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollRepository.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollRepository.kt
@@ -20,7 +20,6 @@ import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-// TODO add unit tests
 class RoomPollRepository @Inject constructor(
         private val roomPollDataSource: RoomPollDataSource,
 ) {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollRepository.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollRepository.kt
@@ -14,21 +14,23 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.roomprofile.polls.list.domain
+package im.vector.app.features.roomprofile.polls.list.data
 
-import im.vector.app.features.roomprofile.polls.list.data.RoomPollRepository
 import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 // TODO add unit tests
-class GetPollsUseCase @Inject constructor(
-        private val roomPollRepository: RoomPollRepository,
+class RoomPollRepository @Inject constructor(
+        private val roomPollDataSource: RoomPollDataSource,
 ) {
 
-    fun execute(roomId: String): Flow<List<PollSummary>> {
-        return roomPollRepository.getPolls(roomId)
-                .map { it.sortedByDescending { poll -> poll.creationTimestamp } }
+    // TODO after unmock, expose domain layer model (entity) and do the mapping to PollSummary in the UI layer
+    fun getPolls(roomId: String): Flow<List<PollSummary>> {
+        return roomPollDataSource.getPolls(roomId)
+    }
+
+    suspend fun loadMorePolls(roomId: String): LoadMorePollsResult {
+        return roomPollDataSource.loadMorePolls(roomId)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollRepository.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollRepository.kt
@@ -30,7 +30,11 @@ class RoomPollRepository @Inject constructor(
         return roomPollDataSource.getPolls(roomId)
     }
 
-    suspend fun loadMorePolls(roomId: String): LoadMorePollsResult {
+    fun getLoadedPollsStatus(roomId: String): LoadedPollsStatus {
+        return roomPollDataSource.getLoadedPollsStatus(roomId)
+    }
+
+    suspend fun loadMorePolls(roomId: String): LoadedPollsStatus {
         return roomPollDataSource.loadMorePolls(roomId)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollRepository.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollRepository.kt
@@ -37,4 +37,8 @@ class RoomPollRepository @Inject constructor(
     suspend fun loadMorePolls(roomId: String): LoadedPollsStatus {
         return roomPollDataSource.loadMorePolls(roomId)
     }
+
+    suspend fun syncPolls(roomId: String) {
+        return roomPollDataSource.syncPolls(roomId)
+    }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/GetLoadedPollsStatusUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/GetLoadedPollsStatusUseCase.kt
@@ -14,8 +14,18 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.roomprofile.polls.list.data
+package im.vector.app.features.roomprofile.polls.list.domain
 
-data class LoadMorePollsResult(
-        val canLoadMore: Boolean,
-)
+import im.vector.app.features.roomprofile.polls.list.data.LoadedPollsStatus
+import im.vector.app.features.roomprofile.polls.list.data.RoomPollRepository
+import javax.inject.Inject
+
+// TODO add unit tests
+class GetLoadedPollsStatusUseCase @Inject constructor(
+        private val roomPollRepository: RoomPollRepository,
+) {
+
+    fun execute(roomId: String): LoadedPollsStatus {
+        return roomPollRepository.getLoadedPollsStatus(roomId)
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/GetPollsUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/GetPollsUseCase.kt
@@ -17,7 +17,7 @@
 package im.vector.app.features.roomprofile.polls.list.domain
 
 import im.vector.app.features.home.room.detail.timeline.item.PollOptionViewState
-import im.vector.app.features.roomprofile.polls.list.PollSummary
+import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/GetPollsUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/GetPollsUseCase.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-// TODO add unit tests
 class GetPollsUseCase @Inject constructor(
         private val roomPollRepository: RoomPollRepository,
 ) {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/GetPollsUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/GetPollsUseCase.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,23 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.roomprofile.polls
+package im.vector.app.features.roomprofile.polls.list.domain
 
 import im.vector.app.features.home.room.detail.timeline.item.PollOptionViewState
+import im.vector.app.features.roomprofile.polls.list.PollSummary
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import timber.log.Timber
 import javax.inject.Inject
 
+// TODO add unit tests
 class GetPollsUseCase @Inject constructor() {
 
-    fun execute(): Flow<List<PollSummary>> {
-        // TODO unmock and add unit tests
+    // TODO create a repo + datasources (local + remote) with mocked data by passing a room Id
+    fun execute(roomId: String): Flow<List<PollSummary>> {
+        // TODO call repository to get flow on polls
+        Timber.d("roomId=$roomId")
         return flowOf(getActivePolls() + getEndedPolls())
                 .map { it.sortedByDescending { poll -> poll.creationTimestamp } }
     }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/LoadMorePollsUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/LoadMorePollsUseCase.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.roomprofile.polls
+package im.vector.app.features.roomprofile.polls.list.domain
 
-import im.vector.app.core.platform.VectorViewModelAction
+import kotlinx.coroutines.delay
+import timber.log.Timber
+import javax.inject.Inject
 
-sealed interface RoomPollsAction : VectorViewModelAction {
-    object LoadMorePolls : RoomPollsAction
+// TODO add unit tests
+class LoadMorePollsUseCase @Inject constructor() {
+
+    suspend fun execute(roomId: String) {
+        // TODO call repository to load more polls to be published in a flow
+        Timber.d("roomId=$roomId")
+        delay(5000)
+    }
 }

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/LoadMorePollsUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/LoadMorePollsUseCase.kt
@@ -20,7 +20,6 @@ import im.vector.app.features.roomprofile.polls.list.data.LoadedPollsStatus
 import im.vector.app.features.roomprofile.polls.list.data.RoomPollRepository
 import javax.inject.Inject
 
-// TODO add unit tests
 class LoadMorePollsUseCase @Inject constructor(
         private val roomPollRepository: RoomPollRepository,
 ) {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/SyncPollsUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/domain/SyncPollsUseCase.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.roomprofile.polls.list.domain
+
+import im.vector.app.features.roomprofile.polls.list.data.RoomPollRepository
+import javax.inject.Inject
+
+/**
+ * Sync the polls of a given room from last manual loading (see LoadMorePollsUseCase) until now.
+ */
+class SyncPollsUseCase @Inject constructor(
+        private val roomPollRepository: RoomPollRepository,
+) {
+
+    suspend fun execute(roomId: String) {
+        roomPollRepository.syncPolls(roomId)
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/PollSummary.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/PollSummary.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.roomprofile.polls.list
+package im.vector.app.features.roomprofile.polls.list.ui
 
 import im.vector.app.features.home.room.detail.timeline.item.PollOptionViewState
 

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollItem.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.roomprofile.polls.list
+package im.vector.app.features.roomprofile.polls.list.ui
 
 import android.widget.LinearLayout
 import android.widget.TextView

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollLoadMoreItem.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollLoadMoreItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.roomprofile.polls.list
+package im.vector.app.features.roomprofile.polls.list.ui
 
 import android.widget.Button
 import android.widget.ProgressBar

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsController.kt
@@ -50,7 +50,9 @@ class RoomPollsController @Inject constructor(
             }
         }
 
-        buildLoadMoreItem(viewState.isLoadingMore)
+        if (viewState.canLoadMore) {
+            buildLoadMoreItem(viewState.isLoadingMore)
+        }
     }
 
     private fun buildActivePollItem(poll: PollSummary.ActivePoll) {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsController.kt
@@ -39,7 +39,7 @@ class RoomPollsController @Inject constructor(
 
     override fun buildModels(viewState: RoomPollsViewState?) {
         val polls = viewState?.polls
-        if (polls.isNullOrEmpty()) {
+        if (polls.isNullOrEmpty() || viewState.isSyncing) {
             return
         }
 

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.roomprofile.polls.list
+package im.vector.app.features.roomprofile.polls.list.ui
 
 import com.airbnb.epoxy.TypedEpoxyController
 import im.vector.app.R

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsListFragment.kt
@@ -30,7 +30,9 @@ import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.databinding.FragmentRoomPollsListBinding
 import im.vector.app.features.roomprofile.polls.RoomPollsAction
+import im.vector.app.features.roomprofile.polls.RoomPollsLoadingError
 import im.vector.app.features.roomprofile.polls.RoomPollsType
+import im.vector.app.features.roomprofile.polls.RoomPollsViewEvent
 import im.vector.app.features.roomprofile.polls.RoomPollsViewModel
 import im.vector.app.features.roomprofile.polls.RoomPollsViewState
 import timber.log.Timber
@@ -55,8 +57,17 @@ abstract class RoomPollsListFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        observeViewEvents()
         setupList()
         setupLoadMoreButton()
+    }
+
+    private fun observeViewEvents() {
+        viewModel.observeViewEvents { viewEvent ->
+            when (viewEvent) {
+                RoomPollsViewEvent.LoadingError -> showErrorInSnackbar(RoomPollsLoadingError())
+            }
+        }
     }
 
     abstract fun getEmptyListTitle(canLoadMore: Boolean, nbLoadedDays: Int): String

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsListFragment.kt
@@ -119,11 +119,10 @@ abstract class RoomPollsListFragment :
                 canLoadMore = viewState.canLoadMore,
                 nbLoadedDays = viewState.nbLoadedDays,
         )
-        views.roomPollsEmptyTitle.isVisible = viewState.polls.isEmpty() && !viewState.isSyncing
-        views.roomPollsLoadMoreWhenEmpty.isVisible = viewState.polls.isEmpty() && viewState.canLoadMore && !viewState.isSyncing
-        views.roomPollsLoadMoreWhenEmptyProgress.isVisible = viewState.polls.isEmpty() && viewState.canLoadMore &&
-                viewState.isLoadingMore && !viewState.isSyncing
-        views.roomPollsLoadMoreWhenEmptyProgress.isEnabled = !viewState.isLoadingMore
+        views.roomPollsEmptyTitle.isVisible = !viewState.isSyncing && viewState.hasNoPolls()
+        views.roomPollsLoadMoreWhenEmpty.isVisible = viewState.hasNoPollsAndCanLoadMore()
+        views.roomPollsLoadMoreWhenEmpty.isEnabled = !viewState.isLoadingMore
+        views.roomPollsLoadMoreWhenEmptyProgress.isVisible = viewState.hasNoPollsAndCanLoadMore() && viewState.isLoadingMore
     }
 
     override fun onPollClicked(pollId: String) {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsListFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.roomprofile.polls.list
+package im.vector.app.features.roomprofile.polls.list.ui
 
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/polls/list/ui/RoomPollsListFragment.kt
@@ -38,7 +38,6 @@ import im.vector.app.features.roomprofile.polls.RoomPollsViewState
 import timber.log.Timber
 import javax.inject.Inject
 
-// TODO handle errors during load more or sync
 abstract class RoomPollsListFragment :
         VectorBaseFragment<FragmentRoomPollsListBinding>(),
         RoomPollsController.Listener {

--- a/vector/src/main/res/layout/fragment_room_polls_list.xml
+++ b/vector/src/main/res/layout/fragment_room_polls_list.xml
@@ -26,11 +26,39 @@
         android:gravity="center"
         android:textAppearance="@style/TextAppearance.Vector.Body"
         android:textColor="?vctr_content_secondary"
+        android:textSize="17sp"
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/roomPollsEmptyGuideline"
-        tools:text="@string/room_polls_active_no_item" />
+        tools:text="@string/room_polls_active_no_item"
+        tools:visibility="visible" />
+
+    <Button
+        android:id="@+id/roomPollsLoadMoreWhenEmpty"
+        style="@style/Widget.Vector.Button.Text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/layout_horizontal_margin"
+        android:layout_marginTop="8dp"
+        android:text="@string/room_polls_load_more"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/roomPollsEmptyTitle"
+        tools:visibility="visible" />
+
+    <ProgressBar
+        android:id="@+id/roomPollsLoadMoreWhenEmptyProgress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_marginStart="9dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/roomPollsLoadMoreWhenEmpty"
+        app:layout_constraintStart_toEndOf="@id/roomPollsLoadMoreWhenEmpty"
+        app:layout_constraintTop_toTopOf="@id/roomPollsLoadMoreWhenEmpty"
+        tools:visibility="visible" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/roomPollsEmptyGuideline"

--- a/vector/src/main/res/layout/fragment_room_polls_list.xml
+++ b/vector/src/main/res/layout/fragment_room_polls_list.xml
@@ -17,6 +17,34 @@
         tools:itemCount="5"
         tools:listitem="@layout/item_poll" />
 
+    <ProgressBar
+        android:id="@+id/roomPollsSyncingProgress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:indeterminateTint="?vctr_content_secondary"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/roomPollsSyncingTitle"
+        app:layout_constraintEnd_toStartOf="@id/roomPollsSyncingTitle"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/roomPollsSyncingTitle" />
+
+    <TextView
+        android:id="@+id/roomPollsSyncingTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="9dp"
+        android:layout_marginEnd="@dimen/layout_horizontal_margin"
+        android:gravity="center"
+        android:text="@string/room_polls_wait_for_display"
+        android:textAppearance="@style/TextAppearance.Vector.Body"
+        android:textColor="?vctr_content_secondary"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/roomPollsSyncingProgress"
+        app:layout_constraintTop_toTopOf="@id/roomPollsTitleGuideline" />
+
     <TextView
         android:id="@+id/roomPollsEmptyTitle"
         android:layout_width="0dp"
@@ -30,9 +58,8 @@
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@id/roomPollsEmptyGuideline"
-        tools:text="@string/room_polls_active_no_item"
-        tools:visibility="visible" />
+        app:layout_constraintTop_toTopOf="@id/roomPollsTitleGuideline"
+        tools:text="@string/room_polls_active_no_item" />
 
     <Button
         android:id="@+id/roomPollsLoadMoreWhenEmpty"
@@ -45,8 +72,7 @@
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/roomPollsEmptyTitle"
-        tools:visibility="visible" />
+        app:layout_constraintTop_toBottomOf="@id/roomPollsEmptyTitle" />
 
     <ProgressBar
         android:id="@+id/roomPollsLoadMoreWhenEmptyProgress"
@@ -57,11 +83,10 @@
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@id/roomPollsLoadMoreWhenEmpty"
         app:layout_constraintStart_toEndOf="@id/roomPollsLoadMoreWhenEmpty"
-        app:layout_constraintTop_toTopOf="@id/roomPollsLoadMoreWhenEmpty"
-        tools:visibility="visible" />
+        app:layout_constraintTop_toTopOf="@id/roomPollsLoadMoreWhenEmpty" />
 
     <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/roomPollsEmptyGuideline"
+        android:id="@+id/roomPollsTitleGuideline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"

--- a/vector/src/main/res/layout/item_poll_load_more.xml
+++ b/vector/src/main/res/layout/item_poll_load_more.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <Button
+        android:id="@+id/roomPollsLoadMore"
+        style="@style/Widget.Vector.Button.Text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="38dp"
+        android:layout_marginBottom="46dp"
+        android:padding="0dp"
+        android:text="@string/room_polls_load_more"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ProgressBar
+        android:id="@+id/roomPollsLoadMoreProgress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_marginStart="9dp"
+        app:layout_constraintBottom_toBottomOf="@id/roomPollsLoadMore"
+        app:layout_constraintStart_toEndOf="@id/roomPollsLoadMore"
+        app:layout_constraintTop_toTopOf="@id/roomPollsLoadMore" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/main/res/layout/item_poll_load_more.xml
+++ b/vector/src/main/res/layout/item_poll_load_more.xml
@@ -13,6 +13,7 @@
         android:layout_marginBottom="46dp"
         android:padding="0dp"
         android:text="@string/room_polls_load_more"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/vector/src/test/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModelTest.kt
@@ -17,7 +17,7 @@
 package im.vector.app.features.roomprofile.polls
 
 import com.airbnb.mvrx.test.MavericksTestRule
-import im.vector.app.features.roomprofile.polls.list.PollSummary
+import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
 import im.vector.app.features.roomprofile.polls.list.domain.GetPollsUseCase
 import im.vector.app.test.test
 import im.vector.app.test.testDispatcher

--- a/vector/src/test/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModelTest.kt
@@ -17,6 +17,8 @@
 package im.vector.app.features.roomprofile.polls
 
 import com.airbnb.mvrx.test.MavericksTestRule
+import im.vector.app.features.roomprofile.polls.list.PollSummary
+import im.vector.app.features.roomprofile.polls.list.domain.GetPollsUseCase
 import im.vector.app.test.test
 import im.vector.app.test.testDispatcher
 import io.mockk.every

--- a/vector/src/test/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModelTest.kt
@@ -17,8 +17,11 @@
 package im.vector.app.features.roomprofile.polls
 
 import com.airbnb.mvrx.test.MavericksTestRule
+import im.vector.app.features.roomprofile.polls.list.domain.GetLoadedPollsStatusUseCase
 import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
 import im.vector.app.features.roomprofile.polls.list.domain.GetPollsUseCase
+import im.vector.app.features.roomprofile.polls.list.domain.LoadMorePollsUseCase
+import im.vector.app.features.roomprofile.polls.list.domain.SyncPollsUseCase
 import im.vector.app.test.test
 import im.vector.app.test.testDispatcher
 import io.mockk.every
@@ -36,12 +39,18 @@ class RoomPollsViewModelTest {
     val mavericksTestRule = MavericksTestRule(testDispatcher = testDispatcher)
 
     private val fakeGetPollsUseCase = mockk<GetPollsUseCase>()
+    private val fakeGetLoadedPollsStatusUseCase = mockk<GetLoadedPollsStatusUseCase>()
+    private val fakeLoadMorePollsUseCase = mockk<LoadMorePollsUseCase>()
+    private val fakeSyncPollsUseCase = mockk<SyncPollsUseCase>()
     private val initialState = RoomPollsViewState(ROOM_ID)
 
     private fun createViewModel(): RoomPollsViewModel {
         return RoomPollsViewModel(
                 initialState = initialState,
                 getPollsUseCase = fakeGetPollsUseCase,
+                getLoadedPollsStatusUseCase = fakeGetLoadedPollsStatusUseCase,
+                loadMorePollsUseCase = fakeLoadMorePollsUseCase,
+                syncPollsUseCase = fakeSyncPollsUseCase,
         )
     }
 
@@ -49,7 +58,7 @@ class RoomPollsViewModelTest {
     fun `given viewModel when created then polls list is observed and viewState is updated`() {
         // Given
         val polls = listOf(givenAPollSummary())
-        every { fakeGetPollsUseCase.execute() } returns flowOf(polls)
+        every { fakeGetPollsUseCase.execute(ROOM_ID) } returns flowOf(polls)
         val expectedViewState = initialState.copy(polls = polls)
 
         // When
@@ -61,7 +70,7 @@ class RoomPollsViewModelTest {
                 .assertLatestState(expectedViewState)
                 .finish()
         verify {
-            fakeGetPollsUseCase.execute()
+            fakeGetPollsUseCase.execute(ROOM_ID)
         }
     }
 

--- a/vector/src/test/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/roomprofile/polls/RoomPollsViewModelTest.kt
@@ -17,13 +17,17 @@
 package im.vector.app.features.roomprofile.polls
 
 import com.airbnb.mvrx.test.MavericksTestRule
+import im.vector.app.features.roomprofile.polls.list.data.LoadedPollsStatus
 import im.vector.app.features.roomprofile.polls.list.domain.GetLoadedPollsStatusUseCase
-import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
 import im.vector.app.features.roomprofile.polls.list.domain.GetPollsUseCase
 import im.vector.app.features.roomprofile.polls.list.domain.LoadMorePollsUseCase
 import im.vector.app.features.roomprofile.polls.list.domain.SyncPollsUseCase
+import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
 import im.vector.app.test.test
 import im.vector.app.test.testDispatcher
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -31,7 +35,7 @@ import kotlinx.coroutines.flow.flowOf
 import org.junit.Rule
 import org.junit.Test
 
-private const val ROOM_ID = "room-id"
+private const val A_ROOM_ID = "room-id"
 
 class RoomPollsViewModelTest {
 
@@ -42,7 +46,7 @@ class RoomPollsViewModelTest {
     private val fakeGetLoadedPollsStatusUseCase = mockk<GetLoadedPollsStatusUseCase>()
     private val fakeLoadMorePollsUseCase = mockk<LoadMorePollsUseCase>()
     private val fakeSyncPollsUseCase = mockk<SyncPollsUseCase>()
-    private val initialState = RoomPollsViewState(ROOM_ID)
+    private val initialState = RoomPollsViewState(A_ROOM_ID)
 
     private fun createViewModel(): RoomPollsViewModel {
         return RoomPollsViewModel(
@@ -55,11 +59,17 @@ class RoomPollsViewModelTest {
     }
 
     @Test
-    fun `given viewModel when created then polls list is observed and viewState is updated`() {
+    fun `given viewModel when created then polls list is observed, sync is launched and viewState is updated`() {
         // Given
+        val loadedPollsStatus = givenGetLoadedPollsStatusSuccess()
+        givenSyncPollsWithSuccess()
         val polls = listOf(givenAPollSummary())
-        every { fakeGetPollsUseCase.execute(ROOM_ID) } returns flowOf(polls)
-        val expectedViewState = initialState.copy(polls = polls)
+        every { fakeGetPollsUseCase.execute(A_ROOM_ID) } returns flowOf(polls)
+        val expectedViewState = initialState.copy(
+                polls = polls,
+                canLoadMore = loadedPollsStatus.canLoadMore,
+                nbLoadedDays = loadedPollsStatus.nbLoadedDays,
+        )
 
         // When
         val viewModel = createViewModel()
@@ -70,11 +80,88 @@ class RoomPollsViewModelTest {
                 .assertLatestState(expectedViewState)
                 .finish()
         verify {
-            fakeGetPollsUseCase.execute(ROOM_ID)
+            fakeGetPollsUseCase.execute(A_ROOM_ID)
         }
+        coVerify { fakeSyncPollsUseCase.execute(A_ROOM_ID) }
+    }
+
+    @Test
+    fun `given viewModel and error during sync process when created then error is raised in view event`() {
+        // Given
+        givenGetLoadedPollsStatusSuccess()
+        givenSyncPollsWithError(Exception())
+        val polls = listOf(givenAPollSummary())
+        every { fakeGetPollsUseCase.execute(A_ROOM_ID) } returns flowOf(polls)
+
+        // When
+        val viewModel = createViewModel()
+        val viewModelTest = viewModel.test()
+
+        // Then
+        viewModelTest
+                .assertEvents(RoomPollsViewEvent.LoadingError)
+                .finish()
+        coVerify { fakeSyncPollsUseCase.execute(A_ROOM_ID) }
+    }
+
+    @Test
+    fun `given viewModel when handle load more action then viewState is updated`() {
+        // Given
+        val loadedPollsStatus = givenGetLoadedPollsStatusSuccess()
+        givenSyncPollsWithSuccess()
+        val polls = listOf(givenAPollSummary())
+        every { fakeGetPollsUseCase.execute(A_ROOM_ID) } returns flowOf(polls)
+        val newLoadedPollsStatus = givenLoadMoreWithSuccess()
+        val viewModel = createViewModel()
+        val stateAfterInit = initialState.copy(
+                polls = polls,
+                canLoadMore = loadedPollsStatus.canLoadMore,
+                nbLoadedDays = loadedPollsStatus.nbLoadedDays,
+        )
+
+        // When
+        val viewModelTest = viewModel.test()
+        viewModel.handle(RoomPollsAction.LoadMorePolls)
+
+        // Then
+        viewModelTest
+                .assertStatesChanges(
+                        stateAfterInit,
+                        { copy(isLoadingMore = true) },
+                        { copy(canLoadMore = newLoadedPollsStatus.canLoadMore, nbLoadedDays = newLoadedPollsStatus.nbLoadedDays) },
+                        { copy(isLoadingMore = false) },
+                )
+                .finish()
+        coVerify { fakeLoadMorePollsUseCase.execute(A_ROOM_ID) }
     }
 
     private fun givenAPollSummary(): PollSummary {
         return mockk()
     }
+
+    private fun givenSyncPollsWithSuccess() {
+        coJustRun { fakeSyncPollsUseCase.execute(A_ROOM_ID) }
+    }
+
+    private fun givenSyncPollsWithError(error: Exception) {
+        coEvery { fakeSyncPollsUseCase.execute(A_ROOM_ID) } throws error
+    }
+
+    private fun givenLoadMoreWithSuccess(): LoadedPollsStatus {
+        val loadedPollsStatus = givenALoadedPollsStatus(canLoadMore = false, nbLoadedDays = 20)
+        coEvery { fakeLoadMorePollsUseCase.execute(A_ROOM_ID) } returns loadedPollsStatus
+        return loadedPollsStatus
+    }
+
+    private fun givenGetLoadedPollsStatusSuccess(): LoadedPollsStatus {
+        val loadedPollsStatus = givenALoadedPollsStatus()
+        every { fakeGetLoadedPollsStatusUseCase.execute(A_ROOM_ID) } returns loadedPollsStatus
+        return loadedPollsStatus
+    }
+
+    private fun givenALoadedPollsStatus(canLoadMore: Boolean = true, nbLoadedDays: Int = 10) =
+            LoadedPollsStatus(
+                    canLoadMore = canLoadMore,
+                    nbLoadedDays = nbLoadedDays,
+            )
 }

--- a/vector/src/test/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollRepositoryTest.kt
+++ b/vector/src/test/java/im/vector/app/features/roomprofile/polls/list/data/RoomPollRepositoryTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.roomprofile.polls.list.data
+
+import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+private const val A_ROOM_ID = "room-id"
+
+class RoomPollRepositoryTest {
+
+    private val fakeRoomPollDataSource = mockk<RoomPollDataSource>()
+
+    private val roomPollRepository = RoomPollRepository(
+            roomPollDataSource = fakeRoomPollDataSource,
+    )
+
+    @Test
+    fun `given data source when getting polls then correct method of data source is called`() = runTest {
+        // Given
+        val expectedPolls = listOf<PollSummary>()
+        every { fakeRoomPollDataSource.getPolls(A_ROOM_ID) } returns flowOf(expectedPolls)
+
+        // When
+        val result = roomPollRepository.getPolls(A_ROOM_ID).firstOrNull()
+
+        // Then
+        result shouldBeEqualTo expectedPolls
+        verify { fakeRoomPollDataSource.getPolls(A_ROOM_ID) }
+    }
+
+    @Test
+    fun `given data source when getting loaded polls status then correct method of data source is called`() {
+        // Given
+        val expectedStatus = LoadedPollsStatus(
+                canLoadMore = true,
+                nbLoadedDays = 10,
+        )
+        every { fakeRoomPollDataSource.getLoadedPollsStatus(A_ROOM_ID) } returns expectedStatus
+
+        // When
+        val result = roomPollRepository.getLoadedPollsStatus(A_ROOM_ID)
+
+        // Then
+        result shouldBeEqualTo expectedStatus
+        verify { fakeRoomPollDataSource.getLoadedPollsStatus(A_ROOM_ID) }
+    }
+
+    @Test
+    fun `given data source when loading more polls then correct method of data source is called`() = runTest {
+        // Given
+        coJustRun { fakeRoomPollDataSource.loadMorePolls(A_ROOM_ID) }
+
+        // When
+        roomPollRepository.loadMorePolls(A_ROOM_ID)
+
+        // Then
+        coVerify { fakeRoomPollDataSource.loadMorePolls(A_ROOM_ID) }
+    }
+
+    @Test
+    fun `given data source when syncing polls then correct method of data source is called`() = runTest {
+        // Given
+        coJustRun { fakeRoomPollDataSource.syncPolls(A_ROOM_ID) }
+
+        // When
+        roomPollRepository.syncPolls(A_ROOM_ID)
+
+        // Then
+        coVerify { fakeRoomPollDataSource.syncPolls(A_ROOM_ID) }
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/roomprofile/polls/list/domain/GetLoadedPollsStatusUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/roomprofile/polls/list/domain/GetLoadedPollsStatusUseCaseTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.roomprofile.polls.list.domain
+
+import im.vector.app.features.roomprofile.polls.list.data.LoadedPollsStatus
+import im.vector.app.features.roomprofile.polls.list.data.RoomPollRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class GetLoadedPollsStatusUseCaseTest {
+
+    private val fakeRoomPollRepository = mockk<RoomPollRepository>()
+
+    private val getLoadedPollsStatusUseCase = GetLoadedPollsStatusUseCase(
+            roomPollRepository = fakeRoomPollRepository,
+    )
+
+    @Test
+    fun `given repo when execute then correct method of repo is called`() {
+        // Given
+        val aRoomId = "roomId"
+        val expectedStatus = LoadedPollsStatus(
+                canLoadMore = true,
+                nbLoadedDays = 10,
+        )
+        every { fakeRoomPollRepository.getLoadedPollsStatus(aRoomId) } returns expectedStatus
+
+        // When
+        val status = getLoadedPollsStatusUseCase.execute(aRoomId)
+
+        // Then
+        status shouldBeEqualTo expectedStatus
+        verify { fakeRoomPollRepository.getLoadedPollsStatus(aRoomId) }
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/roomprofile/polls/list/domain/GetPollsUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/roomprofile/polls/list/domain/GetPollsUseCaseTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.roomprofile.polls.list.domain
+
+import im.vector.app.features.roomprofile.polls.list.data.RoomPollRepository
+import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
+import im.vector.app.test.fixtures.RoomPollFixture
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class GetPollsUseCaseTest {
+    private val fakeRoomPollRepository = mockk<RoomPollRepository>()
+
+    private val getPollsUseCase = GetPollsUseCase(
+            roomPollRepository = fakeRoomPollRepository,
+    )
+
+    @Test
+    fun `given repo when execute then correct method of repo is called and polls are sorted most recent first`() = runTest {
+        // Given
+        val aRoomId = "roomId"
+        val poll1 = RoomPollFixture.anActivePollSummary(timestamp = 1)
+        val poll2 = RoomPollFixture.anActivePollSummary(timestamp = 2)
+        val poll3 = RoomPollFixture.anActivePollSummary(timestamp = 3)
+        val polls = listOf<PollSummary>(
+                poll1,
+                poll2,
+                poll3,
+        )
+        every { fakeRoomPollRepository.getPolls(aRoomId) } returns flowOf(polls)
+        val expectedPolls = listOf<PollSummary>(
+                poll3,
+                poll2,
+                poll1,
+        )
+        // When
+        val result = getPollsUseCase.execute(aRoomId).first()
+
+        // Then
+        result shouldBeEqualTo expectedPolls
+        verify { fakeRoomPollRepository.getPolls(aRoomId) }
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/roomprofile/polls/list/domain/LoadMorePollsUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/roomprofile/polls/list/domain/LoadMorePollsUseCaseTest.kt
@@ -16,15 +16,31 @@
 
 package im.vector.app.features.roomprofile.polls.list.domain
 
-import im.vector.app.features.roomprofile.polls.list.data.LoadedPollsStatus
 import im.vector.app.features.roomprofile.polls.list.data.RoomPollRepository
-import javax.inject.Inject
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
 
-class GetLoadedPollsStatusUseCase @Inject constructor(
-        private val roomPollRepository: RoomPollRepository,
-) {
+class LoadMorePollsUseCaseTest {
 
-    fun execute(roomId: String): LoadedPollsStatus {
-        return roomPollRepository.getLoadedPollsStatus(roomId)
+    private val fakeRoomPollRepository = mockk<RoomPollRepository>()
+
+    private val loadMorePollsUseCase = LoadMorePollsUseCase(
+            roomPollRepository = fakeRoomPollRepository,
+    )
+
+    @Test
+    fun `given repo when execute then correct method of repo is called`() = runTest {
+        // Given
+        val aRoomId = "roomId"
+        coJustRun { fakeRoomPollRepository.loadMorePolls(aRoomId) }
+
+        // When
+        loadMorePollsUseCase.execute(aRoomId)
+
+        // Then
+        coVerify { fakeRoomPollRepository.loadMorePolls(aRoomId) }
     }
 }

--- a/vector/src/test/java/im/vector/app/features/roomprofile/polls/list/domain/SyncPollsUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/roomprofile/polls/list/domain/SyncPollsUseCaseTest.kt
@@ -16,15 +16,31 @@
 
 package im.vector.app.features.roomprofile.polls.list.domain
 
-import im.vector.app.features.roomprofile.polls.list.data.LoadedPollsStatus
 import im.vector.app.features.roomprofile.polls.list.data.RoomPollRepository
-import javax.inject.Inject
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
 
-class GetLoadedPollsStatusUseCase @Inject constructor(
-        private val roomPollRepository: RoomPollRepository,
-) {
+class SyncPollsUseCaseTest {
 
-    fun execute(roomId: String): LoadedPollsStatus {
-        return roomPollRepository.getLoadedPollsStatus(roomId)
+    private val fakeRoomPollRepository = mockk<RoomPollRepository>()
+
+    private val syncPollsUseCase = SyncPollsUseCase(
+            roomPollRepository = fakeRoomPollRepository,
+    )
+
+    @Test
+    fun `given repo when execute then correct method of repo is called`() = runTest {
+        // Given
+        val aRoomId = "roomId"
+        coJustRun { fakeRoomPollRepository.syncPolls(aRoomId) }
+
+        // When
+        syncPollsUseCase.execute(aRoomId)
+
+        // Then
+        coVerify { fakeRoomPollRepository.syncPolls(aRoomId) }
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fixtures/RoomPollFixture.kt
+++ b/vector/src/test/java/im/vector/app/test/fixtures/RoomPollFixture.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.test.fixtures
+
+import im.vector.app.features.home.room.detail.timeline.item.PollOptionViewState
+import im.vector.app.features.roomprofile.polls.list.ui.PollSummary
+
+object RoomPollFixture {
+
+    fun anActivePollSummary(
+            id: String = "",
+            timestamp: Long,
+            title: String = "",
+    ) = PollSummary.ActivePoll(
+            id = id,
+            creationTimestamp = timestamp,
+            title = title,
+    )
+
+    fun anEndedPollSummary(
+            id: String = "",
+            timestamp: Long,
+            title: String = "",
+            totalVotes: Int,
+            winnerOptions: List<PollOptionViewState.PollEnded>
+    ) = PollSummary.EndedPoll(
+            id = id,
+            creationTimestamp = timestamp,
+            title = title,
+            totalVotes = totalVotes,
+            winnerOptions = winnerOptions,
+    )
+}


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Implementing UX for loading the polls in the history list. Improving architecture to separate components into dedicated layers. This is only mocked data for now. Real fetching mechanism will be implemented later.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Part of #7864 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<img src="https://user-images.githubusercontent.com/46314705/212339551-7322647f-7796-4a0b-b983-ef6a35e0b211.gif" width=300 />

## Tests

<!-- Explain how you tested your development -->

- Open any room profile screen
- Tap the "Poll history" entry
- Check the UX behavior by pressing the "Load more" button

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
