### PR TITLE
Fix oom crashes.

### DIFF
--- a/changelog.d/7962.bugfix
+++ b/changelog.d/7962.bugfix
@@ -1,0 +1,1 @@
+Fix OOM crashes.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/DefaultTimeline.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/DefaultTimeline.kt
@@ -102,7 +102,6 @@ internal class DefaultTimeline(
             realm = backgroundRealm,
             eventDecryptor = eventDecryptor,
             paginationTask = paginationTask,
-            realmConfiguration = realmConfiguration,
             fetchTokenAndPaginateTask = fetchTokenAndPaginateTask,
             fetchThreadTimelineTask = fetchThreadTimelineTask,
             getContextOfEventTask = getEventTask,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/LoadTimelineStrategy.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/LoadTimelineStrategy.kt
@@ -19,7 +19,6 @@ package org.matrix.android.sdk.internal.session.room.timeline
 import io.realm.OrderedCollectionChangeSet
 import io.realm.OrderedRealmCollectionChangeListener
 import io.realm.Realm
-import io.realm.RealmConfiguration
 import io.realm.RealmResults
 import io.realm.kotlin.createObject
 import io.realm.kotlin.executeTransactionAwait
@@ -97,7 +96,6 @@ internal class LoadTimelineStrategy constructor(
             val realm: AtomicReference<Realm>,
             val eventDecryptor: TimelineEventDecryptor,
             val paginationTask: PaginationTask,
-            val realmConfiguration: RealmConfiguration,
             val fetchThreadTimelineTask: FetchThreadTimelineTask,
             val fetchTokenAndPaginateTask: FetchTokenAndPaginateTask,
             val getContextOfEventTask: GetContextOfEventTask,
@@ -351,7 +349,6 @@ internal class LoadTimelineStrategy constructor(
                     fetchThreadTimelineTask = dependencies.fetchThreadTimelineTask,
                     eventDecryptor = dependencies.eventDecryptor,
                     paginationTask = dependencies.paginationTask,
-                    realmConfiguration = dependencies.realmConfiguration,
                     fetchTokenAndPaginateTask = dependencies.fetchTokenAndPaginateTask,
                     timelineEventMapper = dependencies.timelineEventMapper,
                     uiEchoManager = uiEchoManager,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/LoadTimelineStrategy.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/LoadTimelineStrategy.kt
@@ -360,7 +360,6 @@ internal class LoadTimelineStrategy constructor(
                     initialEventId = mode.originEventId(),
                     onBuiltEvents = dependencies.onEventsUpdated,
                     onEventsDeleted = dependencies.onEventsDeleted,
-                    realm = dependencies.realm,
                     localEchoEventFactory = dependencies.localEchoEventFactory,
                     decorator = createTimelineEventDecorator()
             )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/SendingEventsDataSource.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/SendingEventsDataSource.kt
@@ -72,7 +72,8 @@ internal class RealmSendingEventsDataSource(
         if (frozenSendingTimelineEvents?.isValid == true) {
             frozenSendingTimelineEvents?.realm?.close()
         }
-        frozenSendingTimelineEvents = sendingEvents?.freeze()
+        // Do not freeze empty list
+        frozenSendingTimelineEvents = sendingEvents?.takeIf { it.isNotEmpty() }?.freeze()
     }
 
     override fun buildSendingEvents(): List<TimelineEvent> {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/SendingEventsDataSource.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/SendingEventsDataSource.kt
@@ -42,12 +42,12 @@ internal class RealmSendingEventsDataSource(
 
     private var roomEntity: RoomEntity? = null
     private var sendingTimelineEvents: RealmList<TimelineEventEntity>? = null
-    private var frozenSendingTimelineEvents: RealmList<TimelineEventEntity>? = null
+    private var mappedSendingTimelineEvents: List<TimelineEvent> = emptyList()
 
     private val sendingTimelineEventsListener = RealmChangeListener<RealmList<TimelineEventEntity>> { events ->
         if (events.isValid) {
             uiEchoManager.onSentEventsInDatabase(events.map { it.eventId })
-            updateFrozenResults(events)
+            mapSendingEvents(events)
             onEventsUpdated(false)
         }
     }
@@ -57,38 +57,29 @@ internal class RealmSendingEventsDataSource(
         roomEntity = RoomEntity.where(safeRealm, roomId = roomId).findFirst()
         sendingTimelineEvents = roomEntity?.sendingTimelineEvents
         sendingTimelineEvents?.addChangeListener(sendingTimelineEventsListener)
-        updateFrozenResults(sendingTimelineEvents)
+        mapSendingEvents(sendingTimelineEvents)
     }
 
     override fun stop() {
         sendingTimelineEvents?.removeChangeListener(sendingTimelineEventsListener)
-        updateFrozenResults(null)
+        mapSendingEvents(null)
         sendingTimelineEvents = null
         roomEntity = null
     }
 
-    private fun updateFrozenResults(sendingEvents: RealmList<TimelineEventEntity>?) {
-        // Makes sure to close the previous frozen realm
-        if (frozenSendingTimelineEvents?.isValid == true) {
-            frozenSendingTimelineEvents?.realm?.close()
-        }
-        // Do not freeze empty list
-        frozenSendingTimelineEvents = sendingEvents?.takeIf { it.isNotEmpty() }?.freeze()
+    private fun mapSendingEvents(sendingEvents: RealmList<TimelineEventEntity>?) {
+        mappedSendingTimelineEvents = sendingEvents?.map { timelineEventMapper.map(it) }.orEmpty()
     }
 
     override fun buildSendingEvents(): List<TimelineEvent> {
         val builtSendingEvents = mutableListOf<TimelineEvent>()
         uiEchoManager.getInMemorySendingEvents()
                 .addWithUiEcho(builtSendingEvents)
-        if (frozenSendingTimelineEvents?.isValid == true) {
-            frozenSendingTimelineEvents
-                    ?.filter { timelineEvent ->
-                        builtSendingEvents.none { it.eventId == timelineEvent.eventId }
-                    }
-                    ?.map {
-                        timelineEventMapper.map(it)
-                    }?.addWithUiEcho(builtSendingEvents)
-        }
+        mappedSendingTimelineEvents
+                .filter { timelineEvent ->
+                    builtSendingEvents.none { it.eventId == timelineEvent.eventId }
+                }
+                .addWithUiEcho(builtSendingEvents)
 
         return builtSendingEvents
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
@@ -18,7 +18,6 @@ package org.matrix.android.sdk.internal.session.room.timeline
 
 import io.realm.OrderedCollectionChangeSet
 import io.realm.OrderedRealmCollectionChangeListener
-import io.realm.RealmConfiguration
 import io.realm.RealmObjectChangeListener
 import io.realm.RealmQuery
 import io.realm.RealmResults
@@ -61,7 +60,6 @@ internal class TimelineChunk(
         private val fetchThreadTimelineTask: FetchThreadTimelineTask,
         private val eventDecryptor: TimelineEventDecryptor,
         private val paginationTask: PaginationTask,
-        private val realmConfiguration: RealmConfiguration,
         private val fetchTokenAndPaginateTask: FetchTokenAndPaginateTask,
         private val timelineEventMapper: TimelineEventMapper,
         private val uiEchoManager: UIEchoManager?,
@@ -602,7 +600,6 @@ internal class TimelineChunk(
                 timelineId = timelineId,
                 eventDecryptor = eventDecryptor,
                 paginationTask = paginationTask,
-                realmConfiguration = realmConfiguration,
                 fetchThreadTimelineTask = fetchThreadTimelineTask,
                 fetchTokenAndPaginateTask = fetchTokenAndPaginateTask,
                 timelineEventMapper = timelineEventMapper,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/TimelineChunk.kt
@@ -18,7 +18,6 @@ package org.matrix.android.sdk.internal.session.room.timeline
 
 import io.realm.OrderedCollectionChangeSet
 import io.realm.OrderedRealmCollectionChangeListener
-import io.realm.Realm
 import io.realm.RealmConfiguration
 import io.realm.RealmObjectChangeListener
 import io.realm.RealmQuery
@@ -48,7 +47,6 @@ import org.matrix.android.sdk.internal.session.sync.handler.room.ThreadsAwarenes
 import timber.log.Timber
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicReference
 
 /**
  * This is a wrapper around a ChunkEntity in the database.
@@ -72,7 +70,6 @@ internal class TimelineChunk(
         private val initialEventId: String?,
         private val onBuiltEvents: (Boolean) -> Unit,
         private val onEventsDeleted: () -> Unit,
-        private val realm: AtomicReference<Realm>,
         private val decorator: TimelineEventDecorator,
         val localEchoEventFactory: LocalEchoEventFactory,
 ) {
@@ -616,7 +613,6 @@ internal class TimelineChunk(
                 onBuiltEvents = this.onBuiltEvents,
                 onEventsDeleted = this.onEventsDeleted,
                 decorator = this.decorator,
-                realm = realm,
                 localEchoEventFactory = localEchoEventFactory
         )
     }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/decorator/UiEchoDecorator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/decorator/UiEchoDecorator.kt
@@ -19,9 +19,9 @@ package org.matrix.android.sdk.internal.session.room.timeline.decorator
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
 import org.matrix.android.sdk.internal.session.room.timeline.UIEchoManager
 
-internal class UiEchoDecorator(private val uiEchoManager: UIEchoManager?) : TimelineEventDecorator {
+internal class UiEchoDecorator(private val uiEchoManager: UIEchoManager) : TimelineEventDecorator {
 
     override fun decorate(timelineEvent: TimelineEvent): TimelineEvent {
-        return uiEchoManager?.decorateEventWithReactionUiEcho(timelineEvent) ?: timelineEvent
+        return uiEchoManager.decorateEventWithReactionUiEcho(timelineEvent)
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/SyncResponsePostTreatmentAggregatorHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/SyncResponsePostTreatmentAggregatorHandler.kt
@@ -105,7 +105,8 @@ internal class SyncResponsePostTreatmentAggregatorHandler @Inject constructor(
                 .enqueue()
     }
 
-    private fun handleUserIdsForCheckingTrustAndAffectedRoomShields(userIdsWithDeviceUpdate: Iterable<String>) {
+    private fun handleUserIdsForCheckingTrustAndAffectedRoomShields(userIdsWithDeviceUpdate: Collection<String>) {
+        if (userIdsWithDeviceUpdate.isEmpty()) return
         crossSigningService.checkTrustAndAffectedRoomShields(userIdsWithDeviceUpdate.toList())
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -797,7 +797,7 @@ class TimelineFragment :
         }
         // We use a custom layout for this menu item, so we need to set a ClickListener
         menu.findItem(R.id.open_matrix_apps)?.let { menuItem ->
-            menuItem.actionView?.debouncedClicks {
+            menuItem.actionView?.setOnClickListener {
                 handleMenuItemSelected(menuItem)
             }
         }
@@ -808,7 +808,7 @@ class TimelineFragment :
 
         // Custom thread notification menu item
         menu.findItem(R.id.menu_timeline_thread_list)?.let { menuItem ->
-            menuItem.actionView?.debouncedClicks {
+            menuItem.actionView?.setOnClickListener {
                 handleMenuItemSelected(menuItem)
             }
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
This PR fixes 2 abusive memory usage issues:
- First one (4c06bdc14e0c72d77b601e06c5906598e19d642b) is regarding the settings of a click listener on MenuItem, which was creating Job each time the Fragment in invalidated. But previous Job was not cancelled. Replacing by simple `setOnClickListener` fixes the issue.
- Second one (0b5e0fea72e08a9986631869f2c6f2e913d5ac35) is regarding frozen Realm objects. When Realm object are frozen, further Realm transactions consumes more memory. It was useless to freeze empty list, and non empty list are temporary, since this is for sending Events, so it's still OK to freeze them.

Other commits are just cleanup.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Application stability

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open a room.
- Observe application memory usage, or wait for the app to crash.

It can be speed up by setting timeout for sync request to 100ms, to force many Realm transactions.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
