### PR TITLE
Show poll question when rendering reply to a poll end event (PSG-1133)

### DIFF
--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/summary/RoomSummaryConstants.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/summary/RoomSummaryConstants.kt
@@ -35,5 +35,6 @@ object RoomSummaryConstants {
             EventType.REACTION
     ) +
             EventType.POLL_START.values +
+            EventType.POLL_END.values +
             EventType.STATE_ROOM_BEACON_INFO.values
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoEventFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoEventFactory.kt
@@ -731,6 +731,7 @@ internal class LocalEchoEventFactory @Inject constructor(
                 localEchoRepository
                         .getRelatedPollEvent(timelineEvent)
                         ?.getLastMessageContent()
+                        ?: timelineEvent.getLastMessageContent()
             }
             else -> timelineEvent.getLastMessageContent()
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoRepository.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoRepository.kt
@@ -25,6 +25,7 @@ import org.matrix.android.sdk.api.session.room.model.message.MessageContent
 import org.matrix.android.sdk.api.session.room.model.message.MessageType
 import org.matrix.android.sdk.api.session.room.send.SendState
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
+import org.matrix.android.sdk.api.session.room.timeline.getRelationContent
 import org.matrix.android.sdk.internal.database.RealmSessionProvider
 import org.matrix.android.sdk.internal.database.asyncTransaction
 import org.matrix.android.sdk.internal.database.mapper.TimelineEventMapper
@@ -227,5 +228,16 @@ internal class LocalEchoRepository @Inject constructor(
         return realmSessionProvider.withRealm { realm ->
             EventEntity.where(realm, eventId = rootThreadEventId).findFirst()?.threadSummaryLatestMessage?.eventId
         } ?: rootThreadEventId
+    }
+
+    fun getRelatedPollEvent(timelineEvent: TimelineEvent): TimelineEvent? {
+        val roomId = timelineEvent.roomId
+        val pollEventId = timelineEvent.getRelationContent()?.eventId ?: return null
+
+        return realmSessionProvider.withRealm { realm ->
+            TimelineEventEntity.where(realm, roomId = roomId, eventId = pollEventId).findFirst()?.let {
+                timelineEventMapper.map(it)
+            }
+        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
@@ -219,6 +219,9 @@ class MessageActionsViewModel @AssistedInject constructor(
                         (timelineEvent.getVectorLastMessageContent() as? MessagePollContent)?.getBestPollCreationInfo()?.question?.getBestQuestion()
                                 ?: stringProvider.getString(R.string.message_reply_to_poll_preview)
                     }
+                    in EventType.POLL_END.values -> {
+                        stringProvider.getString(R.string.message_reply_to_ended_poll_preview)
+                    }
                     else -> null
                 }
             }

--- a/vector/src/test/java/im/vector/app/features/home/room/detail/timeline/render/ProcessBodyOfReplyToEventUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/home/room/detail/timeline/render/ProcessBodyOfReplyToEventUseCaseTest.kt
@@ -31,16 +31,23 @@ import org.junit.Test
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.getPollQuestion
+import org.matrix.android.sdk.api.session.events.model.getRelationContent
 import org.matrix.android.sdk.api.session.events.model.isAudioMessage
 import org.matrix.android.sdk.api.session.events.model.isFileMessage
 import org.matrix.android.sdk.api.session.events.model.isImageMessage
 import org.matrix.android.sdk.api.session.events.model.isLiveLocation
-import org.matrix.android.sdk.api.session.events.model.isPoll
+import org.matrix.android.sdk.api.session.events.model.isPollEnd
+import org.matrix.android.sdk.api.session.events.model.isPollStart
 import org.matrix.android.sdk.api.session.events.model.isSticker
 import org.matrix.android.sdk.api.session.events.model.isVideoMessage
 import org.matrix.android.sdk.api.session.events.model.isVoiceMessage
+import org.matrix.android.sdk.api.session.room.model.message.MessagePollContent
+import org.matrix.android.sdk.api.session.room.model.message.PollCreationInfo
+import org.matrix.android.sdk.api.session.room.model.message.PollQuestion
+import org.matrix.android.sdk.api.session.room.model.relation.RelationDefaultContent
 import org.matrix.android.sdk.api.session.room.model.relation.ReplyToContent
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
+import org.matrix.android.sdk.api.session.room.timeline.getLastMessageContent
 
 private const val A_ROOM_ID = "room-id"
 private const val AN_EVENT_ID = "event-id"
@@ -93,6 +100,7 @@ class ProcessBodyOfReplyToEventUseCaseTest {
     fun setup() {
         givenNewPrefix()
         mockkStatic("org.matrix.android.sdk.api.session.events.model.EventKt")
+        mockkStatic("org.matrix.android.sdk.api.session.room.timeline.TimelineEventKt")
     }
 
     @After
@@ -104,7 +112,7 @@ class ProcessBodyOfReplyToEventUseCaseTest {
     fun `given a replied event of type file message when process the formatted body then content is replaced by correct string`() {
         // Given
         givenTypeOfRepliedEvent(isFileMessage = true)
-        givenNewContentForId(R.string.message_reply_to_sender_sent_file)
+        givenContentForId(R.string.message_reply_to_sender_sent_file, content = A_NEW_CONTENT)
 
         executeAndAssertResult()
     }
@@ -113,7 +121,7 @@ class ProcessBodyOfReplyToEventUseCaseTest {
     fun `given a replied event of type voice message when process the formatted body then content is replaced by correct string`() {
         // Given
         givenTypeOfRepliedEvent(isVoiceMessage = true)
-        givenNewContentForId(R.string.message_reply_to_sender_sent_voice_message)
+        givenContentForId(R.string.message_reply_to_sender_sent_voice_message, content = A_NEW_CONTENT)
 
         executeAndAssertResult()
     }
@@ -122,7 +130,7 @@ class ProcessBodyOfReplyToEventUseCaseTest {
     fun `given a replied event of type audio message when process the formatted body then content is replaced by correct string`() {
         // Given
         givenTypeOfRepliedEvent(isAudioMessage = true)
-        givenNewContentForId(R.string.message_reply_to_sender_sent_audio_file)
+        givenContentForId(R.string.message_reply_to_sender_sent_audio_file, content = A_NEW_CONTENT)
 
         executeAndAssertResult()
     }
@@ -131,7 +139,7 @@ class ProcessBodyOfReplyToEventUseCaseTest {
     fun `given a replied event of type image message when process the formatted body then content is replaced by correct string`() {
         // Given
         givenTypeOfRepliedEvent(isImageMessage = true)
-        givenNewContentForId(R.string.message_reply_to_sender_sent_image)
+        givenContentForId(R.string.message_reply_to_sender_sent_image, content = A_NEW_CONTENT)
 
         executeAndAssertResult()
     }
@@ -140,7 +148,7 @@ class ProcessBodyOfReplyToEventUseCaseTest {
     fun `given a replied event of type video message when process the formatted body then content is replaced by correct string`() {
         // Given
         givenTypeOfRepliedEvent(isVideoMessage = true)
-        givenNewContentForId(R.string.message_reply_to_sender_sent_video)
+        givenContentForId(R.string.message_reply_to_sender_sent_video, content = A_NEW_CONTENT)
 
         executeAndAssertResult()
     }
@@ -149,40 +157,49 @@ class ProcessBodyOfReplyToEventUseCaseTest {
     fun `given a replied event of type sticker message when process the formatted body then content is replaced by correct string`() {
         // Given
         givenTypeOfRepliedEvent(isStickerMessage = true)
-        givenNewContentForId(R.string.message_reply_to_sender_sent_sticker)
+        givenContentForId(R.string.message_reply_to_sender_sent_sticker, content = A_NEW_CONTENT)
 
         executeAndAssertResult()
     }
 
     @Test
-    fun `given a replied event of type poll message with null question when process the formatted body then content is replaced by correct string`() {
+    fun `given a replied event of type poll start message with null question when process the formatted body then content is replaced by correct string`() {
         // Given
-        givenTypeOfRepliedEvent(isPollMessage = true)
-        givenNewContentForId(R.string.message_reply_to_sender_created_poll)
-        every { fakeRepliedEvent.getClearType() } returns EventType.POLL_START.unstable
+        givenTypeOfRepliedEvent(isPollStartMessage = true)
+        givenContentForId(R.string.message_reply_to_sender_created_poll, content = A_NEW_CONTENT)
         every { fakeRepliedEvent.getPollQuestion() } returns null
 
         executeAndAssertResult()
     }
 
     @Test
-    fun `given a replied event of type poll message with existing question when process the formatted body then content is replaced by correct string`() {
+    fun `given a replied event of type poll start message with existing question when process the formatted body then content is replaced by correct string`() {
         // Given
-        givenTypeOfRepliedEvent(isPollMessage = true)
-        givenNewContentForId(R.string.message_reply_to_sender_created_poll)
-        every { fakeRepliedEvent.getClearType() } returns EventType.POLL_START.unstable
+        givenTypeOfRepliedEvent(isPollStartMessage = true)
+        givenContentForId(R.string.message_reply_to_sender_created_poll, content = "")
         every { fakeRepliedEvent.getPollQuestion() } returns A_NEW_CONTENT
 
         executeAndAssertResult()
     }
 
     @Test
-    fun `given a replied event of type poll end message when process the formatted body then content is replaced by correct string`() {
+    fun `given a replied event of type poll end message with null question when process the formatted body then content is replaced by correct string`() {
         // Given
-        givenTypeOfRepliedEvent(isPollMessage = true)
-        givenNewContentForId(R.string.message_reply_to_sender_ended_poll)
-        every { fakeRepliedEvent.getClearType() } returns EventType.POLL_END.unstable
+        givenTypeOfRepliedEvent(isPollEndMessage = true)
+        givenContentForId(R.string.message_reply_to_sender_ended_poll, content = A_NEW_CONTENT)
+        givenPollQuestionReturns(fakeRepliedEvent, null)
         every { fakeRepliedEvent.getPollQuestion() } returns null
+
+        executeAndAssertResult()
+    }
+
+    @Test
+    fun `given a replied event of type poll end message with existing question when process the formatted body then content is replaced by correct string`() {
+        // Given
+        givenTypeOfRepliedEvent(isPollEndMessage = true)
+        givenContentForId(R.string.message_reply_to_sender_ended_poll, content = "")
+        every { fakeRepliedEvent.getClearType() } returns EventType.POLL_END.unstable
+        givenPollQuestionReturns(fakeRepliedEvent, A_NEW_CONTENT)
 
         executeAndAssertResult()
     }
@@ -191,7 +208,7 @@ class ProcessBodyOfReplyToEventUseCaseTest {
     fun `given a replied event of type live location message when process the formatted body then content is replaced by correct string`() {
         // Given
         givenTypeOfRepliedEvent(isLiveLocationMessage = true)
-        givenNewContentForId(R.string.live_location_description)
+        givenContentForId(R.string.live_location_description, content = A_NEW_CONTENT)
 
         executeAndAssertResult()
     }
@@ -242,13 +259,16 @@ class ProcessBodyOfReplyToEventUseCaseTest {
 
     private fun givenARepliedEvent(timelineEvent: TimelineEvent? = mockk()): Event {
         val event = mockk<Event>()
+        val eventId = "event-id"
+        every { event.eventId } returns eventId
+        every { event.roomId } returns A_ROOM_ID
         timelineEvent?.let { every { it.root } returns event }
         fakeActiveSessionHolder
                 .fakeSession
                 .roomService()
                 .getRoom(A_ROOM_ID)
                 .timelineService()
-                .givenTimelineEvent(timelineEvent)
+                .givenTimelineEventReturns(eventId, timelineEvent)
         return event
     }
 
@@ -259,7 +279,8 @@ class ProcessBodyOfReplyToEventUseCaseTest {
             isImageMessage: Boolean = false,
             isVideoMessage: Boolean = false,
             isStickerMessage: Boolean = false,
-            isPollMessage: Boolean = false,
+            isPollEndMessage: Boolean = false,
+            isPollStartMessage: Boolean = false,
             isLiveLocationMessage: Boolean = false,
     ) {
         every { fakeRepliedEvent.isFileMessage() } returns isFileMessage
@@ -268,7 +289,8 @@ class ProcessBodyOfReplyToEventUseCaseTest {
         every { fakeRepliedEvent.isImageMessage() } returns isImageMessage
         every { fakeRepliedEvent.isVideoMessage() } returns isVideoMessage
         every { fakeRepliedEvent.isSticker() } returns isStickerMessage
-        every { fakeRepliedEvent.isPoll() } returns isPollMessage
+        every { fakeRepliedEvent.isPollEnd() } returns isPollEndMessage
+        every { fakeRepliedEvent.isPollStart() } returns isPollStartMessage
         every { fakeRepliedEvent.isLiveLocation() } returns isLiveLocationMessage
     }
 
@@ -276,7 +298,27 @@ class ProcessBodyOfReplyToEventUseCaseTest {
         fakeStringProvider.given(R.string.message_reply_to_prefix, A_NEW_PREFIX)
     }
 
-    private fun givenNewContentForId(@StringRes resId: Int) {
-        fakeStringProvider.given(resId, A_NEW_CONTENT)
+    private fun givenContentForId(@StringRes resId: Int, content: String) {
+        fakeStringProvider.given(resId, content)
+    }
+
+    private fun givenPollQuestionReturns(pollEndEvent: Event, question: String?) {
+        val eventId = "start-event-id"
+        val relationContent = mockk<RelationDefaultContent>()
+        every { relationContent.eventId } returns eventId
+        every { pollEndEvent.getRelationContent() } returns relationContent
+        val timelineEvent = mockk<TimelineEvent>()
+        val messagePollContent = MessagePollContent(
+                pollCreationInfo = PollCreationInfo(
+                        question = PollQuestion(unstableQuestion = question)
+                )
+        )
+        every { timelineEvent.getLastMessageContent() } returns messagePollContent
+        fakeActiveSessionHolder
+                .fakeSession
+                .roomService()
+                .getRoom(A_ROOM_ID)
+                .timelineService()
+                .givenTimelineEventReturns(eventId, timelineEvent)
     }
 }

--- a/vector/src/test/java/im/vector/app/features/poll/create/CreatePollViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/poll/create/CreatePollViewModelTest.kt
@@ -68,7 +68,7 @@ class CreatePollViewModelTest {
                 .roomService()
                 .getRoom(A_FAKE_ROOM_ID)
                 .timelineService()
-                .givenTimelineEvent(A_POLL_START_TIMELINE_EVENT)
+                .givenTimelineEventReturns(A_POLL_START_TIMELINE_EVENT.eventId, A_POLL_START_TIMELINE_EVENT)
     }
 
     @After

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeTimelineService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeTimelineService.kt
@@ -23,7 +23,7 @@ import org.matrix.android.sdk.api.session.room.timeline.TimelineService
 
 class FakeTimelineService : TimelineService by mockk() {
 
-    fun givenTimelineEvent(event: TimelineEvent?) {
-        every { getTimelineEvent(any()) } returns event
+    fun givenTimelineEventReturns(eventId: String, event: TimelineEvent?) {
+        every { getTimelineEvent(eventId) } returns event
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
We recently started to render a message when a poll is ended and users are able to reply ended polls. We need to render poll question for ended poll messages.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Instead of rendering "In reply to ended poll" we will render "In reply to {poll_question}"

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Create a poll
- End a poll
- Reply to the ended poll message
- See the replied message is rendered by including the poll question

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
