### PR TITLE
Tapping slightly left or right of the 30s buttons highlights the whole cell instead of registering as button presses

### DIFF
--- a/changelog.d/7929.misc
+++ b/changelog.d/7929.misc
@@ -1,0 +1,1 @@
+Tapping slightly left or right of the 30s buttons highlights the whole cell instead of registering as button presses

--- a/vector/src/main/res/layout/item_timeline_event_voice_broadcast_listening_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_voice_broadcast_listening_stub.xml
@@ -105,8 +105,8 @@
 
     <ImageButton
         android:id="@+id/fastBackwardButton"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
+        android:layout_width="@dimen/voice_broadcast_player_button_size"
+        android:layout_height="@dimen/voice_broadcast_player_button_size"
         android:background="@drawable/bg_rounded_button"
         android:contentDescription="@string/a11y_voice_broadcast_fast_backward"
         android:src="@drawable/ic_player_backward_30"
@@ -126,8 +126,8 @@
 
     <ImageButton
         android:id="@+id/fastForwardButton"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
+        android:layout_width="@dimen/voice_broadcast_player_button_size"
+        android:layout_height="@dimen/voice_broadcast_player_button_size"
         android:background="@drawable/bg_rounded_button"
         android:contentDescription="@string/a11y_voice_broadcast_fast_forward"
         android:src="@drawable/ic_player_forward_30"


### PR DESCRIPTION
#7929 