### PR TITLE
Voice Broadcast - Rework internal media players coordination

### DIFF
--- a/changelog.d/7979.misc
+++ b/changelog.d/7979.misc
@@ -1,0 +1,1 @@
+[Voice Broadcast] Rework internal media players coordination

--- a/vector/src/main/java/im/vector/app/core/error/ErrorFormatter.kt
+++ b/vector/src/main/java/im/vector/app/core/error/ErrorFormatter.kt
@@ -157,8 +157,7 @@ class DefaultErrorFormatter @Inject constructor(
             RecordingError.BlockedBySomeoneElse -> stringProvider.getString(R.string.error_voice_broadcast_blocked_by_someone_else_message)
             RecordingError.NoPermission -> stringProvider.getString(R.string.error_voice_broadcast_permission_denied_message)
             RecordingError.UserAlreadyBroadcasting -> stringProvider.getString(R.string.error_voice_broadcast_already_in_progress_message)
-            is VoiceBroadcastFailure.ListeningError.UnableToPlay,
-            is VoiceBroadcastFailure.ListeningError.DownloadError -> stringProvider.getString(R.string.error_voice_broadcast_unable_to_play)
+            is VoiceBroadcastFailure.ListeningError -> stringProvider.getString(R.string.error_voice_broadcast_unable_to_play)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastFailure.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/VoiceBroadcastFailure.kt
@@ -31,6 +31,6 @@ sealed class VoiceBroadcastFailure : Throwable() {
          * @property extra an extra code, specific to the error, see [MediaPlayer.OnErrorListener.onError].
          */
         data class UnableToPlay(val what: Int, val extra: Int) : ListeningError()
-        data class DownloadError(override val cause: Throwable?) : ListeningError()
+        data class PrepareMediaPlayerError(override val cause: Throwable? = null) : ListeningError()
     }
 }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -392,7 +392,7 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
     /**
      * Update the live listening state according to:
      * - the voice broadcast state (started/paused/resumed/stopped),
-     * - the playing state (IDLE, PLAYING, PAUSED, BUFFERING),
+     * - the playing state (IDLE, PLAYING, PAUSED, BUFFERING).
      */
     private fun updateLiveListeningMode() {
         val isLiveVoiceBroadcast = mostRecentVoiceBroadcastEvent?.isLive.orFalse()

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/VoiceBroadcastPlayerImpl.kt
@@ -517,7 +517,8 @@ class VoiceBroadcastPlayerImpl @Inject constructor(
                     }
                 }
                 State.Idle -> {
-                    if (playbackTime == null || percentage == null || (playlist.duration - playbackTime) < 50) {
+                    // restart the playback time if player completed with less than 250 ms remaining time
+                    if (playbackTime == null || percentage == null || (playlist.duration - playbackTime) < 250) {
                         playbackTracker.stopPlayback(id)
                     } else {
                         playbackTracker.updatePausedAtPlaybackTime(id, playbackTime, percentage)


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [x] Technical
- [ ] Other :

## Content

- Rework internal media player coordination:
Fix multiple media player created in the same time
Properly cancel and release media player in preparation if needed 
- Remove some legacy code related to the live listening (we don't need to check anymore the playback position)
- Fix playback restart handling

## Motivation and context

Prevent potential media player leaked and improve voice broadcast playback

## Screenshots / GIFs

## Tests

- Play voice broadcasts (live & ended)
- Change the current voice broadcast in the fly, play with the buttons

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
