### PR TITLE
Pause voice broadcast if there is no network

### DIFF
--- a/changelog.d/7890.feature
+++ b/changelog.d/7890.feature
@@ -1,0 +1,1 @@
+[Voice Broadcast] Handle connection errors while recording

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -3125,6 +3125,7 @@
     <string name="error_voice_broadcast_blocked_by_someone_else_message">Someone else is already recording a voice broadcast. Wait for their voice broadcast to end to start a new one.</string>
     <string name="error_voice_broadcast_already_in_progress_message">You are already recording a voice broadcast. Please end your current voice broadcast to start a new one.</string>
     <string name="error_voice_broadcast_unable_to_play">Unable to play this voice broadcast.</string>
+    <string name="error_voice_broadcast_no_connection_recording">Connection error - Recording paused</string>
     <!-- Examples of usage: 6h 15min 30sec left / 15min 30sec left / 30sec left -->
     <string name="voice_broadcast_recording_time_left">%1$s left</string>
     <string name="stop_voice_broadcast_dialog_title">Stop live broadcasting?</string>

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastRecordingItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageVoiceBroadcastRecordingItem.kt
@@ -17,6 +17,8 @@
 package im.vector.app.features.home.room.detail.timeline.item
 
 import android.widget.ImageButton
+import android.widget.TextView
+import androidx.constraintlayout.widget.Group
 import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
@@ -55,11 +57,11 @@ abstract class MessageVoiceBroadcastRecordingItem : AbsMessageVoiceBroadcastItem
     }
 
     override fun renderLiveIndicator(holder: Holder) {
-        when (voiceBroadcastState) {
-            VoiceBroadcastState.STARTED,
-            VoiceBroadcastState.RESUMED -> renderPlayingLiveIndicator(holder)
-            VoiceBroadcastState.PAUSED -> renderPausedLiveIndicator(holder)
-            VoiceBroadcastState.STOPPED, null -> renderNoLiveIndicator(holder)
+        when (recorder?.recordingState) {
+            VoiceBroadcastRecorder.State.Recording -> renderPlayingLiveIndicator(holder)
+            VoiceBroadcastRecorder.State.Error,
+            VoiceBroadcastRecorder.State.Paused -> renderPausedLiveIndicator(holder)
+            VoiceBroadcastRecorder.State.Idle, null -> renderNoLiveIndicator(holder)
         }
     }
 
@@ -85,7 +87,9 @@ abstract class MessageVoiceBroadcastRecordingItem : AbsMessageVoiceBroadcastItem
             VoiceBroadcastRecorder.State.Recording -> renderRecordingState(holder)
             VoiceBroadcastRecorder.State.Paused -> renderPausedState(holder)
             VoiceBroadcastRecorder.State.Idle -> renderStoppedState(holder)
+            VoiceBroadcastRecorder.State.Error -> renderErrorState(holder, true)
         }
+        renderLiveIndicator(holder)
     }
 
     private fun renderVoiceBroadcastState(holder: Holder) {
@@ -101,6 +105,7 @@ abstract class MessageVoiceBroadcastRecordingItem : AbsMessageVoiceBroadcastItem
     private fun renderRecordingState(holder: Holder) = with(holder) {
         stopRecordButton.isEnabled = true
         recordButton.isEnabled = true
+        renderErrorState(holder, false)
 
         val drawableColor = colorProvider.getColorFromAttribute(R.attr.vctr_content_secondary)
         val drawable = drawableProvider.getDrawable(R.drawable.ic_play_pause_pause, drawableColor)
@@ -113,6 +118,7 @@ abstract class MessageVoiceBroadcastRecordingItem : AbsMessageVoiceBroadcastItem
     private fun renderPausedState(holder: Holder) = with(holder) {
         stopRecordButton.isEnabled = true
         recordButton.isEnabled = true
+        renderErrorState(holder, false)
 
         recordButton.setImageResource(R.drawable.ic_recording_dot)
         recordButton.contentDescription = holder.view.resources.getString(R.string.a11y_resume_voice_broadcast_record)
@@ -123,6 +129,12 @@ abstract class MessageVoiceBroadcastRecordingItem : AbsMessageVoiceBroadcastItem
     private fun renderStoppedState(holder: Holder) = with(holder) {
         recordButton.isEnabled = false
         stopRecordButton.isEnabled = false
+        renderErrorState(holder, false)
+    }
+
+    private fun renderErrorState(holder: Holder, isOnError: Boolean) = with(holder) {
+        controlsGroup.isVisible = !isOnError
+        errorView.isVisible = isOnError
     }
 
     override fun unbind(holder: Holder) {
@@ -142,6 +154,8 @@ abstract class MessageVoiceBroadcastRecordingItem : AbsMessageVoiceBroadcastItem
         val remainingTimeMetadata by bind<VoiceBroadcastMetadataView>(R.id.remainingTimeMetadata)
         val recordButton by bind<ImageButton>(R.id.recordButton)
         val stopRecordButton by bind<ImageButton>(R.id.stopRecordButton)
+        val errorView by bind<TextView>(R.id.errorView)
+        val controlsGroup by bind<Group>(R.id.controlsGroup)
     }
 
     companion object {

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/recording/VoiceBroadcastRecorder.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/recording/VoiceBroadcastRecorder.kt
@@ -33,6 +33,8 @@ interface VoiceBroadcastRecorder : VoiceRecorder {
     val currentRemainingTime: Long?
 
     fun startRecordVoiceBroadcast(voiceBroadcast: VoiceBroadcast, chunkLength: Int, maxLength: Int)
+
+    fun pauseOnError()
     fun addListener(listener: Listener)
     fun removeListener(listener: Listener)
 
@@ -46,5 +48,6 @@ interface VoiceBroadcastRecorder : VoiceRecorder {
         Recording,
         Paused,
         Idle,
+        Error,
     }
 }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/recording/VoiceBroadcastRecorderQ.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/recording/VoiceBroadcastRecorderQ.kt
@@ -29,10 +29,14 @@ import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
 import im.vector.app.features.voicebroadcast.usecase.GetVoiceBroadcastStateEventLiveUseCase
 import im.vector.lib.core.utils.timer.CountUpTimer
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.content.ContentAttachmentData
+import org.matrix.android.sdk.api.session.sync.SyncState
+import org.matrix.android.sdk.flow.flow
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
 
@@ -47,6 +51,7 @@ class VoiceBroadcastRecorderQ(
     private val sessionScope get() = session.coroutineScope
 
     private var voiceBroadcastStateObserver: Job? = null
+    private var syncStateObserver: Job? = null
 
     private var maxFileSize = 0L // zero or negative for no limit
     private var currentVoiceBroadcast: VoiceBroadcast? = null
@@ -96,21 +101,36 @@ class VoiceBroadcastRecorderQ(
         observeVoiceBroadcastStateEvent(voiceBroadcast)
     }
 
-    override fun pauseRecord() {
+    override fun startRecord(roomId: String) {
+        super.startRecord(roomId)
+        observeConnectionState()
+    }
+
+    override fun pauseOnError() {
         if (recordingState != VoiceBroadcastRecorder.State.Recording) return
-        tryOrNull { mediaRecorder?.stop() }
-        mediaRecorder?.reset()
+
+        pauseRecorder()
+        stopObservingConnectionState()
+        recordingState = VoiceBroadcastRecorder.State.Error
+    }
+
+    override fun pauseRecord() {
+        if (recordingState !in arrayOf(VoiceBroadcastRecorder.State.Recording, VoiceBroadcastRecorder.State.Error)) return
+
+        pauseRecorder()
+        stopObservingConnectionState()
         recordingState = VoiceBroadcastRecorder.State.Paused
-        recordingTicker.pause()
         notifyOutputFileCreated()
     }
 
     override fun resumeRecord() {
         if (recordingState != VoiceBroadcastRecorder.State.Paused) return
+
         currentSequence++
         currentVoiceBroadcast?.let { startRecord(it.roomId) }
         recordingState = VoiceBroadcastRecorder.State.Recording
         recordingTicker.resume()
+        observeConnectionState()
     }
 
     override fun stopRecord() {
@@ -127,6 +147,8 @@ class VoiceBroadcastRecorderQ(
         // Do not observe anymore voice broadcast changes
         voiceBroadcastStateObserver?.cancel()
         voiceBroadcastStateObserver = null
+
+        stopObservingConnectionState()
 
         // Reset data
         currentSequence = 0
@@ -195,6 +217,27 @@ class VoiceBroadcastRecorderQ(
         } else {
             null
         }
+    }
+
+    private fun pauseRecorder() {
+        if (recordingState != VoiceBroadcastRecorder.State.Recording) return
+
+        tryOrNull { mediaRecorder?.stop() }
+        mediaRecorder?.reset()
+        recordingTicker.pause()
+    }
+
+    private fun observeConnectionState() {
+        syncStateObserver = session.flow().liveSyncState()
+                .distinctUntilChanged()
+                .filter { it is SyncState.NoNetwork }
+                .onEach { pauseOnError() }
+                .launchIn(sessionScope)
+    }
+
+    private fun stopObservingConnectionState() {
+        syncStateObserver?.cancel()
+        syncStateObserver = null
     }
 
     private inner class RecordingTicker(

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/recording/usecase/PauseVoiceBroadcastUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/recording/usecase/PauseVoiceBroadcastUseCase.kt
@@ -16,17 +16,25 @@
 
 package im.vector.app.features.voicebroadcast.recording.usecase
 
+import im.vector.app.features.session.coroutineScope
 import im.vector.app.features.voicebroadcast.VoiceBroadcastConstants
 import im.vector.app.features.voicebroadcast.model.MessageVoiceBroadcastInfoContent
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
 import im.vector.app.features.voicebroadcast.model.asVoiceBroadcastEvent
 import im.vector.app.features.voicebroadcast.recording.VoiceBroadcastRecorder
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.take
+import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.query.QueryStringValue
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.getRoom
 import org.matrix.android.sdk.api.session.room.Room
 import org.matrix.android.sdk.api.session.room.model.relation.RelationDefaultContent
+import org.matrix.android.sdk.api.session.sync.SyncState
+import org.matrix.android.sdk.flow.flow
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -51,25 +59,35 @@ class PauseVoiceBroadcastUseCase @Inject constructor(
         }
     }
 
-    private suspend fun pauseVoiceBroadcast(room: Room, reference: RelationDefaultContent?) {
+    private suspend fun pauseVoiceBroadcast(room: Room, reference: RelationDefaultContent?, remainingRetry: Int = 3) {
         Timber.d("## PauseVoiceBroadcastUseCase: Send new voice broadcast info state event")
 
-        // save the last sequence number and immediately pause the recording
-        val lastSequence = voiceBroadcastRecorder?.currentSequence
-        pauseRecording()
+        try {
+            // save the last sequence number and immediately pause the recording
+            val lastSequence = voiceBroadcastRecorder?.currentSequence
 
-        room.stateService().sendStateEvent(
-                eventType = VoiceBroadcastConstants.STATE_ROOM_VOICE_BROADCAST_INFO,
-                stateKey = session.myUserId,
-                body = MessageVoiceBroadcastInfoContent(
-                        relatesTo = reference,
-                        voiceBroadcastStateStr = VoiceBroadcastState.PAUSED.value,
-                        lastChunkSequence = lastSequence,
-                ).toContent(),
-        )
-    }
+            room.stateService().sendStateEvent(
+                    eventType = VoiceBroadcastConstants.STATE_ROOM_VOICE_BROADCAST_INFO,
+                    stateKey = session.myUserId,
+                    body = MessageVoiceBroadcastInfoContent(
+                            relatesTo = reference,
+                            voiceBroadcastStateStr = VoiceBroadcastState.PAUSED.value,
+                            lastChunkSequence = lastSequence,
+                    ).toContent(),
+            )
 
-    private fun pauseRecording() {
-        voiceBroadcastRecorder?.pauseRecord()
+            voiceBroadcastRecorder?.pauseRecord()
+        } catch (e: Failure) {
+            if (remainingRetry > 0) {
+                voiceBroadcastRecorder?.pauseOnError()
+                // Retry if there is no network issue (sync is running well)
+                session.flow().liveSyncState()
+                        .filter { it is SyncState.Running }
+                        .take(1)
+                        .onEach { pauseVoiceBroadcast(room, reference, remainingRetry - 1) }
+                        .launchIn(session.coroutineScope)
+            }
+            throw e
+        }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/recording/usecase/StartVoiceBroadcastUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/recording/usecase/StartVoiceBroadcastUseCase.kt
@@ -58,6 +58,7 @@ class StartVoiceBroadcastUseCase @Inject constructor(
         private val buildMeta: BuildMeta,
         private val getRoomLiveVoiceBroadcastsUseCase: GetRoomLiveVoiceBroadcastsUseCase,
         private val stopVoiceBroadcastUseCase: StopVoiceBroadcastUseCase,
+        private val pauseVoiceBroadcastUseCase: PauseVoiceBroadcastUseCase,
 ) {
 
     suspend fun execute(roomId: String): Result<Unit> = runCatching {
@@ -101,6 +102,14 @@ class StartVoiceBroadcastUseCase @Inject constructor(
             override fun onRemainingTimeUpdated(remainingTime: Long?) {
                 if (remainingTime != null && remainingTime <= 0) {
                     session.coroutineScope.launch { stopVoiceBroadcastUseCase.execute(room.roomId) }
+                }
+            }
+
+            override fun onStateUpdated(state: VoiceBroadcastRecorder.State) {
+                if (state == VoiceBroadcastRecorder.State.Error) {
+                    session.coroutineScope.launch {
+                        pauseVoiceBroadcastUseCase.execute(room.roomId)
+                    }
                 }
             }
         })

--- a/vector/src/main/res/layout/item_timeline_event_voice_broadcast_listening_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_voice_broadcast_listening_stub.xml
@@ -40,51 +40,59 @@
     <TextView
         android:id="@+id/titleText"
         style="@style/Widget.Vector.TextView.Body.Medium"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="4dp"
         android:contentDescription="@string/avatar"
+        android:ellipsize="end"
+        android:maxLines="1"
+        app:layout_constraintEnd_toStartOf="@id/liveIndicator"
         app:layout_constraintStart_toEndOf="@id/avatarRightBarrier"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="@sample/rooms.json/data/name" />
 
-    <androidx.constraintlayout.helper.widget.Flow
-        android:id="@+id/metadataFlow"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/metadataGroup"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
+        android:layout_marginEnd="4dp"
         android:orientation="vertical"
-        app:constraint_referenced_ids="broadcasterNameMetadata,bufferingMetadata,voiceBroadcastMetadata,listenersCountMetadata"
-        app:flow_horizontalAlign="start"
-        app:flow_verticalGap="4dp"
+        app:layout_constraintEnd_toStartOf="@id/liveIndicator"
         app:layout_constraintStart_toEndOf="@id/avatarRightBarrier"
-        app:layout_constraintTop_toBottomOf="@id/titleText" />
+        app:layout_constraintTop_toBottomOf="@id/titleText">
 
-    <im.vector.app.features.voicebroadcast.views.VoiceBroadcastMetadataView
-        android:id="@+id/broadcasterNameMetadata"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:metadataIcon="@drawable/ic_voice_broadcast_mic"
-        tools:metadataValue="@sample/users.json/data/displayName" />
+        <im.vector.app.features.voicebroadcast.views.VoiceBroadcastMetadataView
+            android:id="@+id/broadcasterNameMetadata"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            app:metadataIcon="@drawable/ic_voice_broadcast_mic"
+            tools:metadataValue="@sample/users.json/data/displayName" />
 
-    <im.vector.app.features.voicebroadcast.views.VoiceBroadcastBufferingView
-        android:id="@+id/bufferingMetadata"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        <im.vector.app.features.voicebroadcast.views.VoiceBroadcastBufferingView
+            android:id="@+id/bufferingMetadata"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp" />
 
-    <im.vector.app.features.voicebroadcast.views.VoiceBroadcastMetadataView
-        android:id="@+id/voiceBroadcastMetadata"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:metadataIcon="@drawable/ic_voice_broadcast"
-        app:metadataValue="@string/attachment_type_voice_broadcast" />
+        <im.vector.app.features.voicebroadcast.views.VoiceBroadcastMetadataView
+            android:id="@+id/voiceBroadcastMetadata"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            app:metadataIcon="@drawable/ic_voice_broadcast"
+            app:metadataValue="@string/attachment_type_voice_broadcast" />
 
-    <im.vector.app.features.voicebroadcast.views.VoiceBroadcastMetadataView
-        android:id="@+id/listenersCountMetadata"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:metadataIcon="@drawable/ic_member_small"
-        app:metadataValue="@string/no_value_placeholder"
-        tools:metadataValue="5 listeners" />
+        <im.vector.app.features.voicebroadcast.views.VoiceBroadcastMetadataView
+            android:id="@+id/listenersCountMetadata"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            app:metadataIcon="@drawable/ic_member_small"
+            app:metadataValue="@string/no_value_placeholder"
+            tools:metadataValue="5 listeners" />
+    </LinearLayout>
 
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/headerBottomBarrier"
@@ -92,7 +100,7 @@
         android:layout_height="wrap_content"
         app:barrierDirection="bottom"
         app:barrierMargin="10dp"
-        app:constraint_referenced_ids="roomAvatarImageView,titleText,metadataFlow" />
+        app:constraint_referenced_ids="roomAvatarImageView,titleText,metadataGroup" />
 
     <androidx.constraintlayout.helper.widget.Flow
         android:id="@+id/controllerButtonsFlow"

--- a/vector/src/main/res/layout/item_timeline_event_voice_broadcast_recording_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_voice_broadcast_recording_stub.xml
@@ -38,39 +38,45 @@
     <TextView
         android:id="@+id/titleText"
         style="@style/Widget.Vector.TextView.Body.Medium"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="4dp"
         android:contentDescription="@string/avatar"
+        android:ellipsize="end"
+        android:maxLines="1"
+        app:layout_constraintEnd_toStartOf="@id/liveIndicator"
         app:layout_constraintStart_toEndOf="@id/avatarRightBarrier"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="@sample/users.json/data/displayName" />
+        tools:text="@sample/rooms.json/data/name" />
 
-    <androidx.constraintlayout.helper.widget.Flow
-        android:id="@+id/metadataFlow"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/metadataGroup"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
+        android:layout_marginEnd="4dp"
         android:orientation="vertical"
-        app:constraint_referenced_ids="listenersCountMetadata,remainingTimeMetadata"
-        app:flow_horizontalAlign="start"
-        app:flow_verticalGap="4dp"
+        app:layout_constraintEnd_toStartOf="@id/liveIndicator"
         app:layout_constraintStart_toEndOf="@id/avatarRightBarrier"
-        app:layout_constraintTop_toBottomOf="@id/titleText" />
+        app:layout_constraintTop_toBottomOf="@id/titleText">
 
-    <im.vector.app.features.voicebroadcast.views.VoiceBroadcastMetadataView
-        android:id="@+id/listenersCountMetadata"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:metadataIcon="@drawable/ic_member_small"
-        app:metadataValue="@string/no_value_placeholder"
-        tools:metadataValue="5 listening" />
+        <im.vector.app.features.voicebroadcast.views.VoiceBroadcastMetadataView
+            android:id="@+id/listenersCountMetadata"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            app:metadataIcon="@drawable/ic_member_small"
+            app:metadataValue="@string/no_value_placeholder"
+            tools:metadataValue="5 listening" />
 
-    <im.vector.app.features.voicebroadcast.views.VoiceBroadcastMetadataView
-        android:id="@+id/remainingTimeMetadata"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:metadataIcon="@drawable/ic_timer"
-        tools:metadataValue="3h 2m 50s left" />
+        <im.vector.app.features.voicebroadcast.views.VoiceBroadcastMetadataView
+            android:id="@+id/remainingTimeMetadata"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            app:metadataIcon="@drawable/ic_timer"
+            tools:metadataValue="3h 2m 50s left" />
+    </LinearLayout>
 
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/headerBottomBarrier"
@@ -78,7 +84,7 @@
         android:layout_height="wrap_content"
         app:barrierDirection="bottom"
         app:barrierMargin="12dp"
-        app:constraint_referenced_ids="roomAvatarImageView,titleText,metadataFlow" />
+        app:constraint_referenced_ids="roomAvatarImageView,titleText,metadataGroup" />
 
     <androidx.constraintlayout.helper.widget.Flow
         android:id="@+id/controllerButtonsFlow"

--- a/vector/src/main/res/layout/item_timeline_event_voice_broadcast_recording_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_voice_broadcast_recording_stub.xml
@@ -107,4 +107,27 @@
         android:contentDescription="@string/a11y_stop_voice_broadcast_record"
         android:src="@drawable/ic_stop" />
 
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/controlsGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:constraint_referenced_ids="controllerButtonsFlow,recordButton,stopRecordButton" />
+
+    <TextView
+        android:id="@+id/errorView"
+        style="@style/Widget.Vector.TextView.Caption"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:drawablePadding="4dp"
+        android:gravity="center"
+        android:text="@string/error_voice_broadcast_no_connection_recording"
+        android:textColor="?colorError"
+        android:visibility="gone"
+        app:drawableStartCompat="@drawable/ic_voice_broadcast_error"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/headerBottomBarrier"
+        tools:visibility="visible" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/vector/src/test/java/im/vector/app/features/voicebroadcast/usecase/StartVoiceBroadcastUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/voicebroadcast/usecase/StartVoiceBroadcastUseCaseTest.kt
@@ -60,7 +60,8 @@ class StartVoiceBroadcastUseCaseTest {
                     context = FakeContext().instance,
                     buildMeta = mockk(),
                     getRoomLiveVoiceBroadcastsUseCase = fakeGetRoomLiveVoiceBroadcastsUseCase,
-                    stopVoiceBroadcastUseCase = mockk()
+                    stopVoiceBroadcastUseCase = mockk(),
+                    pauseVoiceBroadcastUseCase = mockk(),
             )
     )
 


### PR DESCRIPTION
## Type of change

- [x] WIP Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Handle the connection errors during a voice broadcast by pausing the recorder and sending the pause state event when the network is back.

Also fixed some layout issues on voice broadcast tiles

## Motivation and context

Close #7890 

## Screenshots / GIFs

<img width="537" alt="image" src="https://user-images.githubusercontent.com/11990514/214158766-eb88efb9-02c9-4bb9-a020-ffa45bf88834.png">

## Tests

<!-- Explain how you tested your development -->

- Start a VB
- Turn off mobile data & wifi
- Then an error message about the connection status should be displayed in the VB tile with no controls available.
- Turn on the network, then the VB is correctly paused, controls are available and the previous chunk should be sent.
- We can then resume and stop the VB.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
