### PR TITLE
[PTT] Fix element call UI touchable through bottom sheet

### DIFF
--- a/vector/src/main/res/layout/fragment_room_widget.xml
+++ b/vector/src/main/res/layout/fragment_room_widget.xml
@@ -61,6 +61,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="?vctr_system"
+        android:clickable="true"
+        android:focusable="true"
         android:orientation="vertical"
         android:visibility="gone"
         app:behavior_hideable="true"


### PR DESCRIPTION
Target branch is `feature/ons/ptt_bluetooth`

## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fix touch events passing through bluetooth bottom sheet.

## Motivation and context

Prevents accidental touching of the push-to-talk button underneath.

- Fixes https://github.com/matrix-org/element-android-rageshakes/issues/48981
- Fixes https://github.com/matrix-org/element-android-rageshakes/issues/48901


## Screenshots / GIFs
N/A

## Tests

- Start the push-to-talk POC (see https://github.com/vector-im/element-android/pull/6464)
- Open the bluetooth bottom sheet using the toolbar action button
- Tap inside the bottom sheet above where the element call walkie-talkie button is
- Observe the button is not toggled

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 13

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
