### PR TITLE
[PTT] Start Element Call widget in its own task

### DIFF
--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -284,6 +284,8 @@
         <activity android:name=".features.terms.ReviewTermsActivity" />
         <activity
             android:name=".features.widgets.WidgetActivity"
+            android:launchMode="singleTask"
+            android:taskAffinity=".features.widgets.WidgetActivity.${appTaskAffinitySuffix}"
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
             android:supportsPictureInPicture="true" />
 

--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -284,7 +284,6 @@
         <activity android:name=".features.terms.ReviewTermsActivity" />
         <activity
             android:name=".features.widgets.WidgetActivity"
-            android:launchMode="singleTask"
             android:taskAffinity=".features.widgets.WidgetActivity.${appTaskAffinitySuffix}"
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
             android:supportsPictureInPicture="true" />

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
@@ -63,6 +63,7 @@ class WidgetActivity : VectorBaseActivity<ActivityWidgetBinding>() {
         fun newIntent(context: Context, args: WidgetArgs): Intent {
             return Intent(context, WidgetActivity::class.java).apply {
                 putExtra(Mavericks.KEY_ARG, args)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
         }
 

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetActivity.kt
@@ -63,7 +63,9 @@ class WidgetActivity : VectorBaseActivity<ActivityWidgetBinding>() {
         fun newIntent(context: Context, args: WidgetArgs): Intent {
             return Intent(context, WidgetActivity::class.java).apply {
                 putExtra(Mavericks.KEY_ARG, args)
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                if (args.kind == WidgetKind.ELEMENT_CALL) {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                }
             }
         }
 


### PR DESCRIPTION
Note the target branch is the push-to-talk POC (`feature/ons/ptt_bluetooth`)

## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content
Start Element Call widget in it's own task.

## Motivation and context
- So that the push-to-talk call POC can continue running either in the background or in picture-in-picture mode while sending messages to the room.
- So that pressing back from the home screen does not end the ongoing call or bluetooth connection.

## Screenshots / GIFs

N/A

## Tests

- Start a push-to-talk call (see https://github.com/vector-im/element-android/pull/6464)
- Put the call into PiP or background
- Go to recent apps
- _Note there are two separate tasks: one for the room and one for the call_
- Navigate to the room task
- Press back until you see the home screen
- _Note the call is still running (given the Activity has not been destroyed by the OS)_

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): Android 13, Android 11

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
