### PR TITLE
[Push rules] Call /actions api before /enabled api (PSG-1099)

### DIFF
--- a/changelog.d/8005.sdk
+++ b/changelog.d/8005.sdk
@@ -1,0 +1,1 @@
+[Push rules] Call /actions api before /enabled api

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/pushers/UpdatePushRuleActionsTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/pushers/UpdatePushRuleActionsTask.kt
@@ -34,22 +34,22 @@ internal interface UpdatePushRuleActionsTask : Task<UpdatePushRuleActionsTask.Pa
 
 internal class DefaultUpdatePushRuleActionsTask @Inject constructor(
         private val pushRulesApi: PushRulesApi,
-        private val globalErrorReceiver: GlobalErrorReceiver
+        private val globalErrorReceiver: GlobalErrorReceiver,
 ) : UpdatePushRuleActionsTask {
 
     override suspend fun execute(params: UpdatePushRuleActionsTask.Params) {
+        if (params.actions != null) {
+            val body = mapOf("actions" to params.actions.toJson())
+            executeRequest(globalErrorReceiver) {
+                pushRulesApi.updateRuleActions(params.kind.value, params.ruleId, body)
+            }
+        }
         executeRequest(globalErrorReceiver) {
             pushRulesApi.updateEnableRuleStatus(
                     params.kind.value,
                     params.ruleId,
                     EnabledBody(params.enable)
             )
-        }
-        if (params.actions != null) {
-            val body = mapOf("actions" to params.actions.toJson())
-            executeRequest(globalErrorReceiver) {
-                pushRulesApi.updateRuleActions(params.kind.value, params.ruleId, body)
-            }
         }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
When updating a push rule, calling the /actions endpoint first before calling the /enabled endpoint

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #8005 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

N/A

## Tests

<!-- Explain how you tested your development -->

- Go into Settings -> Notifications -> Default notifications
- Toggle some setting and check the notifications behavior is correct

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
