### PR TITLE
Support backup key lost in 4S migration

### DIFF
--- a/changelog.d/8013.bugfix
+++ b/changelog.d/8013.bugfix
@@ -1,0 +1,1 @@
+Support backup key lost in 4S migration

--- a/vector-config/src/main/java/im/vector/app/config/Config.kt
+++ b/vector-config/src/main/java/im/vector/app/config/Config.kt
@@ -97,4 +97,10 @@ object Config {
     val NIGHTLY_ANALYTICS_CONFIG = RELEASE_ANALYTICS_CONFIG.copy(sentryEnvironment = "NIGHTLY")
 
     val SHOW_UNVERIFIED_SESSIONS_ALERT_AFTER_MILLIS = 7.days.inWholeMilliseconds // 1 Week
+
+    /**
+     * When migrating for 4S and if there is an existing backup, we let the option
+     * to enter the existing backup key or we ignore and create a new one
+     */
+    const val IGNORE_EXISTING_BACKUP_ON_MIGRATION_TO_4S = false
 }

--- a/vector-config/src/main/java/im/vector/app/config/Config.kt
+++ b/vector-config/src/main/java/im/vector/app/config/Config.kt
@@ -99,8 +99,9 @@ object Config {
     val SHOW_UNVERIFIED_SESSIONS_ALERT_AFTER_MILLIS = 7.days.inWholeMilliseconds // 1 Week
 
     /**
+     * Define the strategy when migrating existing backup to full 4S.
      * When migrating for 4S and if there is an existing backup, we let the option
-     * to enter the existing backup key or we ignore and create a new one
+     * to enter the existing backup key or we ignore and create a new one.
      */
-    const val IGNORE_EXISTING_BACKUP_ON_MIGRATION_TO_4S = false
+    const val IGNORE_EXISTING_BACKUP_ON_MIGRATION_TO_4S = true
 }

--- a/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapActions.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapActions.kt
@@ -45,6 +45,7 @@ sealed class BootstrapActions : VectorViewModelAction {
     object SaveReqFailed : BootstrapActions()
 
     object HandleForgotBackupPassphrase : BootstrapActions()
+    object MigrationHandleKeyLost : BootstrapActions()
     data class DoMigrateWithPassphrase(val passphrase: String) : BootstrapActions()
     data class DoMigrateWithRecoveryKey(val recoveryKey: String) : BootstrapActions()
 

--- a/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapMigrateBackupFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapMigrateBackupFragment.kt
@@ -88,6 +88,9 @@ class BootstrapMigrateBackupFragment :
         views.bootstrapMigrateContinueButton.debouncedClicks { submit() }
         views.bootstrapMigrateForgotPassphrase.debouncedClicks { sharedViewModel.handle(BootstrapActions.HandleForgotBackupPassphrase) }
         views.bootstrapMigrateUseFile.debouncedClicks { startImportTextFromFileIntent(requireContext(), importFileStartForActivityResult) }
+        views.bootstrapMigrateForgot.debouncedClicks {
+            sharedViewModel.handle(BootstrapActions.MigrationHandleKeyLost)
+        }
     }
 
     private fun submit() = withState(sharedViewModel) { state ->

--- a/vector/src/main/res/layout/fragment_bootstrap_migrate_backup.xml
+++ b/vector/src/main/res/layout/fragment_bootstrap_migrate_backup.xml
@@ -71,4 +71,15 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/bootstrapRecoveryKeyEnterTil" />
 
+    <Button
+        android:id="@+id/bootstrapMigrateForgot"
+        style="@style/Widget.Vector.Button.Text.Destructive"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/layout_vertical_margin"
+        android:text="@string/action_reset"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/bootstrapRecoveryKeyEnterTil" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Adds a button if you forgot your backup pass during 4S migration.
Also added a config option that allows to discard the existing backup and setup 4S with a fresh one (default false).

## Motivation and context


When setting up 4S for the first time on an account with an existing key backup (Migration from old accounts pre 4S), there is no option when the user did forget his backup passphrase/key. 
It's particularly annoying if secure backup is required, because you will be locked out the app (the backup pass is required to setup 4S.

This state of no 4S with existing backup can also happens if a user is deactivated then reactivated, created an issue on synapse to track that https://github.com/matrix-org/synapse/issues/14923


## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->


**New forgot button**
|<img width="263" alt="image" src="https://user-images.githubusercontent.com/9841565/214910518-a1cc6b12-8c0d-4147-8c24-bd987b62711a.png">|<img width="285" alt="image" src="https://user-images.githubusercontent.com/9841565/214910431-041b1870-a02f-4019-9f1f-f86f6cd0006e.png">|


If existing backup ignored user will directly start the setup flow
<img width="327" alt="image" src="https://user-images.githubusercontent.com/9841565/214910796-b177629c-c6d8-4368-a820-d6b107c79f6d.png">


## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
