### PR TITLE
Do not send any request to Posthog if no consent is provided.

### DIFF
--- a/changelog.d/8031.bugfix
+++ b/changelog.d/8031.bugfix
@@ -1,0 +1,1 @@
+Do not send any request to Posthog if no consent is provided.

--- a/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import org.matrix.android.sdk.api.extensions.orFalse
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -59,6 +60,9 @@ class DefaultVectorAnalytics @Inject constructor(
     // Cache for the store values
     private var userConsent: Boolean? = null
     private var analyticsId: String? = null
+
+    // Cache for the properties to send
+    private var pendingUserProperties: UserProperties? = null
 
     override fun init() {
         observeUserConsent()
@@ -112,6 +116,7 @@ class DefaultVectorAnalytics @Inject constructor(
 
     private suspend fun identifyPostHog() {
         val id = analyticsId ?: return
+        if (!userConsent.orFalse()) return
         if (id.isEmpty()) {
             Timber.tag(analyticsTag.value).d("reset")
             posthog?.reset()
@@ -126,7 +131,7 @@ class DefaultVectorAnalytics @Inject constructor(
                 .onEach { consent ->
                     Timber.tag(analyticsTag.value).d("User consent updated to $consent")
                     userConsent = consent
-                    optOutPostHog()
+                    initOrStopPostHog()
                     initOrStopSentry()
                 }
                 .launchIn(globalScope)
@@ -141,8 +146,20 @@ class DefaultVectorAnalytics @Inject constructor(
         }
     }
 
-    private fun optOutPostHog() {
-        userConsent?.let { posthog?.optOut(!it) }
+    private suspend fun initOrStopPostHog() {
+        userConsent?.let { _userConsent ->
+            when (_userConsent) {
+                true -> {
+                    posthog?.optOut(false)
+                    identifyPostHog()
+                    pendingUserProperties?.let { doUpdateUserProperties(it) }
+                    pendingUserProperties = null
+                }
+                false -> {
+                    posthog?.optOut(true)
+                }
+            }
+        }
     }
 
     override fun capture(event: VectorAnalyticsEvent) {
@@ -160,7 +177,17 @@ class DefaultVectorAnalytics @Inject constructor(
     }
 
     override fun updateUserProperties(userProperties: UserProperties) {
-        posthog?.identify(REUSE_EXISTING_ID, userProperties.getProperties()?.toPostHogUserProperties(), IGNORED_OPTIONS)
+        if (userConsent == true) {
+            doUpdateUserProperties(userProperties)
+        } else {
+            pendingUserProperties = userProperties
+        }
+    }
+
+    private fun doUpdateUserProperties(userProperties: UserProperties) {
+        posthog
+                ?.takeIf { userConsent == true }
+                ?.identify(REUSE_EXISTING_ID, userProperties.getProperties()?.toPostHogUserProperties(), IGNORED_OPTIONS)
     }
 
     private fun Map<String, Any?>?.toPostHogProperties(): Properties? {

--- a/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
@@ -156,6 +156,8 @@ class DefaultVectorAnalytics @Inject constructor(
                     pendingUserProperties = null
                 }
                 false -> {
+                    // When opting out, ensure that the queue is flushed first, or it will be flushed later (after user has revoked consent)
+                    posthog?.flush()
                     posthog?.optOut(true)
                 }
             }

--- a/vector/src/test/java/im/vector/app/features/analytics/impl/DefaultVectorAnalyticsTest.kt
+++ b/vector/src/test/java/im/vector/app/features/analytics/impl/DefaultVectorAnalyticsTest.kt
@@ -97,6 +97,7 @@ class DefaultVectorAnalyticsTest {
     @Test
     fun `given lateinit user properties when valid analytics id updates then identify with lateinit properties`() = runTest {
         fakeLateInitUserPropertiesFactory.givenCreatesProperties(A_LATE_INIT_USER_PROPERTIES)
+        fakeAnalyticsStore.givenUserContent(true)
 
         fakeAnalyticsStore.givenAnalyticsId(AN_ANALYTICS_ID)
 
@@ -106,6 +107,7 @@ class DefaultVectorAnalyticsTest {
     @Test
     fun `when signing out then resets posthog and closes Sentry`() = runTest {
         fakeAnalyticsStore.allowSettingAnalyticsIdToCallBackingFlow()
+        fakeAnalyticsStore.givenUserContent(true)
 
         defaultVectorAnalytics.onSignOut()
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

Ensure we never call `posthog.identify` if user did not consent, because it sends request `<server>/decide/?v=2` to the analytic server.

Despite the fact that `posthog.optout(true)` has been called and no analytics is sent when the user has opt-out, calling `posthog.identify` trigger a request to the analytics server. We may consider this as a bug in the library itself, but in the mean time, this PR prevent calling `posthog.identify` is user consent is not set to `true`.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #8020 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Add a breakpoint to `Posthog::identify` and ensure that it's never called when analytics consent is not provided, for instance when the application is started.
- Breakpoints can also be put in `com.posthog.android.ConnectionFactory`.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
