### PR TITLE
[Voice Broadcast] Move the live broadcast computation in the room list behind the lab flag

### DIFF
--- a/changelog.d/8042.misc
+++ b/changelog.d/8042.misc
@@ -1,0 +1,1 @@
+[Voice Broadcast] Show Live broadcast in the room list only if the feature flag is enabled in the lab

--- a/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/usecase/GetLiveVoiceBroadcastChunksUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/voicebroadcast/listening/usecase/GetLiveVoiceBroadcastChunksUseCase.kt
@@ -24,17 +24,15 @@ import im.vector.app.features.voicebroadcast.model.VoiceBroadcastEvent
 import im.vector.app.features.voicebroadcast.model.VoiceBroadcastState
 import im.vector.app.features.voicebroadcast.model.asVoiceBroadcastEvent
 import im.vector.app.features.voicebroadcast.sequence
-import im.vector.app.features.voicebroadcast.usecase.GetVoiceBroadcastStateEventLiveUseCase
+import im.vector.app.features.voicebroadcast.usecase.GetVoiceBroadcastStateEventUseCase
 import im.vector.app.features.voicebroadcast.voiceBroadcastId
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.runningReduce
-import kotlinx.coroutines.runBlocking
 import org.matrix.android.sdk.api.session.events.model.RelationType
 import org.matrix.android.sdk.api.session.room.model.message.MessageAudioEvent
 import org.matrix.android.sdk.api.session.room.model.message.asMessageAudioEvent
@@ -48,7 +46,7 @@ import javax.inject.Inject
  */
 class GetLiveVoiceBroadcastChunksUseCase @Inject constructor(
         private val activeSessionHolder: ActiveSessionHolder,
-        private val getVoiceBroadcastEventUseCase: GetVoiceBroadcastStateEventLiveUseCase,
+        private val getVoiceBroadcastEventUseCase: GetVoiceBroadcastStateEventUseCase,
 ) {
 
     fun execute(voiceBroadcast: VoiceBroadcast): Flow<List<MessageAudioEvent>> {
@@ -60,7 +58,7 @@ class GetLiveVoiceBroadcastChunksUseCase @Inject constructor(
         val existingChunks = room.timelineService().getTimelineEventsRelatedTo(RelationType.REFERENCE, voiceBroadcast.voiceBroadcastId)
                 .mapNotNull { timelineEvent -> timelineEvent.root.asMessageAudioEvent().takeIf { it.isVoiceBroadcast() } }
 
-        val voiceBroadcastEvent = runBlocking { getVoiceBroadcastEventUseCase.execute(voiceBroadcast).firstOrNull()?.getOrNull() }
+        val voiceBroadcastEvent = getVoiceBroadcastEventUseCase.execute(voiceBroadcast)
         val voiceBroadcastState = voiceBroadcastEvent?.content?.voiceBroadcastState
 
         return if (voiceBroadcastState == null || voiceBroadcastState == VoiceBroadcastState.STOPPED) {

--- a/vector/src/test/java/im/vector/app/features/home/room/list/usecase/GetLatestPreviewableEventUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/home/room/list/usecase/GetLatestPreviewableEventUseCaseTest.kt
@@ -23,6 +23,7 @@ import im.vector.app.features.voicebroadcast.model.asVoiceBroadcastEvent
 import im.vector.app.features.voicebroadcast.usecase.GetRoomLiveVoiceBroadcastsUseCase
 import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.fakes.FakeRoom
+import im.vector.app.test.fakes.FakeVectorPreferences
 import io.mockk.every
 import io.mockk.mockk
 import org.amshove.kluent.shouldBe
@@ -46,10 +47,12 @@ internal class GetLatestPreviewableEventUseCaseTest {
     private val fakeSessionHolder = FakeActiveSessionHolder()
     private val fakeRoomSummary = mockk<RoomSummary>()
     private val fakeGetRoomLiveVoiceBroadcastsUseCase = mockk<GetRoomLiveVoiceBroadcastsUseCase>()
+    private val fakeVectorPreferences = FakeVectorPreferences()
 
     private val getLatestPreviewableEventUseCase = GetLatestPreviewableEventUseCase(
             fakeSessionHolder.instance,
             fakeGetRoomLiveVoiceBroadcastsUseCase,
+            fakeVectorPreferences.instance,
     )
 
     @Before
@@ -62,6 +65,7 @@ internal class GetLatestPreviewableEventUseCaseTest {
                 every { eventId } returns firstArg()
             }
         }
+        fakeVectorPreferences.givenIsVoiceBroadcastEnabled(true)
     }
 
     @Test

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorPreferences.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorPreferences.kt
@@ -85,4 +85,8 @@ class FakeVectorPreferences {
     fun verifySetIpAddressVisibilityInDeviceManagerScreens(isVisible: Boolean) {
         verify { instance.setIpAddressVisibilityInDeviceManagerScreens(isVisible) }
     }
+
+    fun givenIsVoiceBroadcastEnabled(isEnabled: Boolean) {
+        every { instance.isVoiceBroadcastEnabled() } returns isEnabled
+    }
 }


### PR DESCRIPTION
 ## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other :

## Content

- The computation of the `Live broadcast` label in the room list is moved behind the voice broadcast lab flag. This is a temporary workaround before changing the current implementation.
- Improve existing use case by removing a useless blocking call on a Kotlin Flow. 

## Motivation and context

The computation of the `Live broadcast` label introduced performance issues in the rendering of the room list because it requires a lot of DB queries as this cannot be done at the sdk level by updating the RoomSummaryEntity.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

- Start a voice broadcast in a room
- Verify that the `live broadcast` label is displayed or not in the room list according to the lab flag status

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
