### PR TITLE
Open general settings performance

### DIFF
--- a/changelog.d/5918.bugfix
+++ b/changelog.d/5918.bugfix
@@ -1,0 +1,1 @@
+If media cache is large, Settings > General takes a long time to open

--- a/vector/src/main/java/im/vector/app/core/utils/FileUtils.kt
+++ b/vector/src/main/java/im/vector/app/core/utils/FileUtils.kt
@@ -17,6 +17,7 @@
 package im.vector.app.core.utils
 
 import android.content.Context
+import androidx.annotation.WorkerThread
 import timber.log.Timber
 import java.io.File
 import java.util.Locale
@@ -125,6 +126,7 @@ fun getFileExtension(fileUri: String): String? {
  * Size
  * ========================================================================================== */
 
+@WorkerThread
 fun getSizeOfFiles(root: File): Long {
     return root.walkTopDown()
             .onEnter {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Compute cache storage in background.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #5918 
Also reported in FOSDEM.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Open the general setting with a big cache. For test add a delay to simulate a long computation and see that the screen is opened and `Loading...` is displayed in the preference summary.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
