### PR TITLE
Fix the next button disable issue after visiting homeserver screen

### DIFF
--- a/changelog.d/7928.bugfix
+++ b/changelog.d/7928.bugfix
@@ -1,0 +1,1 @@
+Fix the next button disabled issue after going to change homeserver screen

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedLoginFragment.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.autofill.HintConstants
 import androidx.core.view.isVisible
+import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.R
@@ -103,7 +104,7 @@ class FtueAuthCombinedLoginFragment :
 
         combine(views.loginInput.editText().textChanges(), views.loginPasswordInput.editText().textChanges()) { account, password ->
             views.loginSubmit.isEnabled = account.isNotEmpty() && password.isNotEmpty()
-        }.launchIn(viewLifecycleOwner.lifecycleScope)
+        }.flowWithLifecycle(lifecycle).launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     private fun submit() {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content
<!-- Describe shortly what has been changed -->
Fix the next button disabled issue after going to change homeserver screen.
The initial emission of flow is an empty string when coming back after visiting homeserver screen.
Because at that time(```onViewCreated```) the view's state is not restored yet.
Collecting flow after ```onViewStateRestored``` can be the one way to solve this problem.
So ```flowWithLifecycle()``` is added to collect flow after ```onViewStateRestored``` is called.

## Motivation and context
<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix #7928 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|<video src="https://user-images.githubusercontent.com/39683194/217267533-0564ba09-f107-4a2c-8872-dcf361225de4.mp4" />|<video src="https://user-images.githubusercontent.com/39683194/217267763-681c30e0-8060-4c53-986c-dd3565c53025.mp4" />|
 -->



## Tests

<!-- Explain how you tested your development -->
Same steps as mentioned in the issue #7928

## Tested devices

- [x] Physical
- OS version(s): API 33
- [x] Emulator
- OS version(s): API 21

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [=] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
