### PR TITLE
Replace 'organize' with 'organise' for localization experience on Weblate

### DIFF
--- a/changelog.d/8104.misc
+++ b/changelog.d/8104.misc
@@ -1,0 +1,1 @@
+Replace 'organize' with 'organise'

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -792,7 +792,7 @@
     <string name="thread_list_modal_all_threads_subtitle">Shows all threads from current room</string>
     <string name="thread_list_modal_my_threads_title">My Threads</string>
     <string name="thread_list_modal_my_threads_subtitle">Shows all threads you’ve participated in</string>
-    <string name="thread_list_empty_title">Keep discussions organized with threads</string>
+    <string name="thread_list_empty_title">Keep discussions organised with threads</string>
     <string name="thread_list_empty_subtitle">Threads help keep your conversations on-topic and easy to track.</string>
     <string name="thread_list_not_available">Your homeserver does not support listing threads yet.</string>
     <!-- Parameter %s will be replaced by the value of string reply_in_thread -->
@@ -2954,7 +2954,7 @@
     <string name="create_spaces_who_are_you_working_with">Who are you working with?</string>
     <string name="create_spaces_make_sure_access">Make sure the right people have access to %s.</string>
     <string name="create_spaces_just_me">Just me</string>
-    <string name="create_spaces_organise_rooms">A private space to organize your rooms</string>
+    <string name="create_spaces_organise_rooms">A private space to organise your rooms</string>
     <string name="create_spaces_me_and_teammates">Me and teammates</string>
     <string name="create_spaces_private_teammates">A private space for you &amp; your teammates</string>
     <string name="space_type_public">Public</string>


### PR DESCRIPTION
Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other :

## Content

<!-- Describe shortly what has been changed -->

This PR replaces `organize` with `organise` in order to align with matrix-react-sdk and element-ios.

`Keep discussions organised with threads.`
https://translate.element.io/translate/element-android/element-app/en/?checksum=aa45538cfd3f0c0e
https://translate.element.io/translate/element-web/matrix-react-sdk/en/?checksum=9ee667f56799cb6a
https://translate.element.io/translate/riot-ios/riot-ios/en/?checksum=802677fb3d9e9174

`A private space to organise your rooms`
https://translate.element.io/translate/element-android/element-app/en/?checksum=dedc9f54b1ac7004
https://translate.element.io/translate/element-web/matrix-react-sdk/en/?checksum=4135b1ab2ad8cead
https://translate.element.io/translate/riot-ios/riot-ios/en/?checksum=cd5e006916a81319

Create a Weblate account to check those keys, if you do not have one yet.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
