### PR TITLE
Replace 'Use Bots' with 'Use bots' for localization experience on Weblate

### DIFF
--- a/changelog.d/8115.misc
+++ b/changelog.d/8115.misc
@@ -1,0 +1,1 @@
+Replace 'Bots' with 'bots' inside terms_description_for_integration_manager

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -1823,7 +1823,7 @@
     <!-- Terms -->
     <string name="terms_of_service">Terms of Service</string>
     <string name="terms_description_for_identity_server">Be discoverable by others</string>
-    <string name="terms_description_for_integration_manager">Use Bots, bridges, widgets and sticker packs</string>
+    <string name="terms_description_for_integration_manager">Use bots, bridges, widgets and sticker packs</string>
 
     <string name="identity_server">Identity server</string>
     <string name="disconnect_identity_server">Disconnect identity server</string>


### PR DESCRIPTION
Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other :

## Content

<!-- Describe shortly what has been changed -->

This PR replace `Bots` with `bots` to help translators choose an existing translation, if any. Please note that localized keys are case sensitive on Weblate:

- https://translate.element.io/translate/element-web/matrix-react-sdk/en/?checksum=da6abfa2f95bf3c
- https://translate.element.io/translate/element-android/element-app/en/?checksum=87ef32a0d2e7c642

Create a Weblate account to see the difference, if you do not have one yet.

## Motivation and context

1. Let translators reuse an existing translation, if any
2. Make translation consistent among projects

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
