### PR TITLE
Use same localization sources as Element iOS and matrix-react-sdk - favourites

### DIFF
--- a/changelog.d/8119.misc
+++ b/changelog.d/8119.misc
@@ -1,0 +1,1 @@
+Replace 'favorites' with 'favourites'

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -437,7 +437,7 @@
 
     <!-- Bottom navigation buttons -->
     <string name="bottom_action_notification">Notifications</string>
-    <string name="bottom_action_favourites">Favorites</string>
+    <string name="bottom_action_favourites">Favourites</string>
     <string name="bottom_action_people">People</string>
     <string name="bottom_action_rooms">Rooms</string>
 
@@ -1674,7 +1674,7 @@
 
     <string name="room_list_filter_all">All</string>
     <string name="room_list_filter_unreads">Unreads</string>
-    <string name="room_list_filter_favourites">Favorites</string>
+    <string name="room_list_filter_favourites">Favourites</string>
     <string name="room_list_filter_people">People</string>
 
     <string name="title_activity_emoji_reaction_picker">Reactions</string>
@@ -1942,8 +1942,8 @@
     <string name="room_list_quick_actions_notifications_mentions">"Mentions only"</string>
     <string name="room_list_quick_actions_notifications_mute">"Mute"</string>
     <string name="room_list_quick_actions_settings">"Settings"</string>
-    <string name="room_list_quick_actions_favorite_add">"Add to favorites"</string>
-    <string name="room_list_quick_actions_favorite_remove">"Remove from favorites"</string>
+    <string name="room_list_quick_actions_favorite_add">"Add to favourites"</string>
+    <string name="room_list_quick_actions_favorite_remove">"Remove from favourites"</string>
     <string name="room_list_quick_actions_low_priority_add">"Add to low priority"</string>
     <string name="room_list_quick_actions_low_priority_remove">"Remove from low priority"</string>
     <string name="room_list_quick_actions_leave">"Leave the room"</string>


### PR DESCRIPTION
Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other :

## Content

This PR changes localization keys to use the same ones as Element iOS and matrix-react-sdk.

- https://translate.element.io/translate/riot-ios/riot-ios/en/?checksum=76baf495ead4916e
- https://translate.element.io/translate/element-web/matrix-react-sdk/en/?checksum=803b487ea2424851

Create a Weblate account to verify, if you do not have one yet.

## Motivation and context

For the consistency and the sake of volunteer translators on Weblate.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
