### PR TITLE
[Poll] Fix votes aggregation process (PSG-1153)

### DIFF
--- a/changelog.d/6121.bugfix
+++ b/changelog.d/6121.bugfix
@@ -1,0 +1,1 @@
+Android app does not show correct poll data

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/aggregation/poll/DefaultPollAggregationProcessor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/aggregation/poll/DefaultPollAggregationProcessor.kt
@@ -84,7 +84,6 @@ internal class DefaultPollAggregationProcessor @Inject constructor(
         val roomId = event.roomId ?: return false
         val senderId = event.senderId ?: return false
         val targetEventId = event.getRelationContent()?.eventId ?: return false
-        val targetPollContent = getPollContent(session, roomId, targetEventId) ?: return false
 
         val annotationsSummaryEntity = getAnnotationsSummaryEntity(realm, roomId, targetEventId)
         val aggregatedPollSummaryEntity = getAggregatedPollSummaryEntity(realm, annotationsSummaryEntity)
@@ -108,7 +107,8 @@ internal class DefaultPollAggregationProcessor @Inject constructor(
         }
 
         val vote = content.getBestResponse()?.answers?.first() ?: return false
-        if (!targetPollContent.getBestPollCreationInfo()?.answers?.map { it.id }?.contains(vote).orFalse()) {
+        val targetPollContent = getPollContent(session, roomId, targetEventId)
+        if (targetPollContent != null && !targetPollContent.getBestPollCreationInfo()?.answers?.map { it.id }?.contains(vote).orFalse()) {
             return false
         }
 

--- a/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/aggregation/poll/DefaultPollAggregationProcessorTest.kt
+++ b/matrix-sdk-android/src/test/java/org/matrix/android/sdk/internal/session/room/aggregation/poll/DefaultPollAggregationProcessorTest.kt
@@ -148,6 +148,19 @@ class DefaultPollAggregationProcessorTest {
     }
 
     @Test
+    fun `given a poll response event and no existing poll start event, when processing, then is processed and returns true`() {
+        // Given
+        mockRoom(roomId = A_ROOM_ID, eventId = AN_EVENT_ID, hasExistingTimelineEvent = false)
+        every { realm.instance.createObject(PollResponseAggregatedSummaryEntity::class.java) } returns PollResponseAggregatedSummaryEntity()
+
+        // When
+        val result = pollAggregationProcessor.handlePollResponseEvent(session, realm.instance, A_POLL_RESPONSE_EVENT)
+
+        // Then
+        result.shouldBeTrue()
+    }
+
+    @Test
     fun `given a poll end event, when processing, then is processed and return true`() = runTest {
         // Given
         every { realm.instance.createObject(PollResponseAggregatedSummaryEntity::class.java) } returns PollResponseAggregatedSummaryEntity()
@@ -234,11 +247,12 @@ class DefaultPollAggregationProcessorTest {
 
     private fun mockRoom(
             roomId: String,
-            eventId: String
+            eventId: String,
+            hasExistingTimelineEvent: Boolean = true,
     ) {
         val room = mockk<Room>()
         every { session.getRoom(roomId) } returns room
-        every { room.getTimelineEvent(eventId) } returns A_TIMELINE_EVENT
+        every { room.getTimelineEvent(eventId) } returns if (hasExistingTimelineEvent) A_TIMELINE_EVENT else null
     }
 
     private fun mockRedactionPowerLevels(userId: String, isAbleToRedact: Boolean): PowerLevelsHelper {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Fixing issue about poll votes aggregation: taking the poll response events into account even if the related poll start event has not been synced yet.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #6121 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Go to a room with polls and many users (e.g. https://matrix.to/#/#archlinux:archlinux.org)
- Go to the poll history list
- After some polls have been loaded, check the number of votes is correct

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
