### PR TITLE
Fix StackOverFlow exception when stop action is called within the tick event

### DIFF
--- a/changelog.d/8127.bugfix
+++ b/changelog.d/8127.bugfix
@@ -1,0 +1,1 @@
+CountUpTimer - Fix StackOverFlow exception when stop action is called within the tick event

--- a/library/core-utils/src/main/java/im/vector/lib/core/utils/timer/CountUpTimer.kt
+++ b/library/core-utils/src/main/java/im/vector/lib/core/utils/timer/CountUpTimer.kt
@@ -35,6 +35,7 @@ class CountUpTimer(
     private val elapsedTime: AtomicLong = AtomicLong(0)
 
     private fun startCounter() {
+        counterJob?.cancel()
         counterJob = coroutineScope.launch {
             while (true) {
                 delay(intervalInMs - elapsedTime() % intervalInMs)
@@ -54,27 +55,52 @@ class CountUpTimer(
         }
     }
 
+    /**
+     * Start a new timer with the initial given time, if any.
+     * If the timer is already started, it will be restarted.
+     */
     fun start(initialTime: Long = 0L) {
         elapsedTime.set(initialTime)
-        resume()
-    }
-
-    fun pause() {
-        tickListener?.onTick(elapsedTime())
-        counterJob?.cancel()
-        counterJob = null
-    }
-
-    fun resume() {
         lastTime.set(clock.epochMillis())
         startCounter()
     }
 
+    /**
+     * Pause the timer at the current time.
+     */
+    fun pause() {
+        pauseAndTick()
+    }
+
+    /**
+     * Resume the timer from the current time.
+     * Does nothing if the timer is already running.
+     */
+    fun resume() {
+        if (counterJob?.isActive != true) {
+            lastTime.set(clock.epochMillis())
+            startCounter()
+        }
+    }
+
+    /**
+     * Stop and reset the timer.
+     */
     fun stop() {
-        tickListener?.onTick(elapsedTime())
-        counterJob?.cancel()
-        counterJob = null
+        pauseAndTick()
         elapsedTime.set(0L)
+    }
+
+    private fun pauseAndTick() {
+        if (counterJob?.isActive == true) {
+            // get the elapsed time before cancelling the timer
+            val elapsedTime = elapsedTime()
+            // cancel the timer before ticking
+            counterJob?.cancel()
+            counterJob = null
+            // tick with the computed elapsed time
+            tickListener?.onTick(elapsedTime)
+        }
     }
 
     fun interface TickListener {

--- a/library/core-utils/src/test/java/im/vector/lib/core/utils/timer/CountUpTimerTest.kt
+++ b/library/core-utils/src/test/java/im/vector/lib/core/utils/timer/CountUpTimerTest.kt
@@ -121,7 +121,7 @@ internal class CountUpTimerTest {
         advanceTimeBy(AN_INTERVAL * 10)
 
         // Then
-        verify(exactly = 2) { timer.stop() } // one call at the first tick, a second time because of the tick on the previous stop action
+        verify(exactly = 2) { timer.stop() } // one call at the first tick, a second time because of the tick of the first stop
         verify(exactly = 2) { tickListener.onTick(any()) } // one after reaching the first interval, a second after the stop action
     }
 
@@ -146,7 +146,7 @@ internal class CountUpTimerTest {
         advanceTimeBy(AN_INTERVAL * 10)
 
         // Then
-        verify(exactly = 2) { timer.pause() } // one call at the first tick, a second time because of the tick on the previous pause action
+        verify(exactly = 2) { timer.pause() } // one call at the first tick, a second time because of the tick of the first pause
         verify(exactly = 2) { tickListener.onTick(any()) } // one after reaching the first interval, a second after the pause action
     }
 }

--- a/library/core-utils/src/test/java/im/vector/lib/core/utils/timer/CountUpTimerTest.kt
+++ b/library/core-utils/src/test/java/im/vector/lib/core/utils/timer/CountUpTimerTest.kt
@@ -19,6 +19,8 @@ package im.vector.lib.core.utils.timer
 import im.vector.lib.core.utils.test.fakes.FakeClock
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
 import io.mockk.verifySequence
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy
@@ -36,6 +38,7 @@ internal class CountUpTimerTest {
 
     @Test
     fun `when pausing and resuming the timer, the timer ticks the right values at the right moments`() = runTest {
+        // Given
         every { fakeClock.epochMillis() } answers { currentTime }
         val tickListener = mockk<CountUpTimer.TickListener>(relaxed = true)
         val timer = CountUpTimer(
@@ -44,6 +47,7 @@ internal class CountUpTimerTest {
                 intervalInMs = AN_INTERVAL,
         ).also { it.tickListener = tickListener }
 
+        // When
         timer.start()
         advanceTimeBy(AN_INTERVAL / 2) // no tick
         timer.pause() // tick
@@ -52,6 +56,7 @@ internal class CountUpTimerTest {
         advanceTimeBy(AN_INTERVAL * 4) // tick * 4
         timer.stop() // tick
 
+        // Then
         verifySequence {
             tickListener.onTick(AN_INTERVAL / 2)
             tickListener.onTick(AN_INTERVAL)
@@ -64,6 +69,7 @@ internal class CountUpTimerTest {
 
     @Test
     fun `given an initial time, the timer ticks the right values at the right moments`() = runTest {
+        // Given
         every { fakeClock.epochMillis() } answers { currentTime }
         val tickListener = mockk<CountUpTimer.TickListener>(relaxed = true)
         val timer = CountUpTimer(
@@ -72,6 +78,7 @@ internal class CountUpTimerTest {
                 intervalInMs = AN_INTERVAL,
         ).also { it.tickListener = tickListener }
 
+        // When
         timer.start(AN_INITIAL_TIME)
         advanceTimeBy(AN_INTERVAL) // tick
         timer.pause() // tick
@@ -80,6 +87,7 @@ internal class CountUpTimerTest {
         advanceTimeBy(AN_INTERVAL * 4) // tick * 4
         timer.stop() // tick
 
+        // Then
         val offset = AN_INITIAL_TIME % AN_INTERVAL
         verifySequence {
             tickListener.onTick(AN_INITIAL_TIME + AN_INTERVAL - offset)
@@ -90,5 +98,55 @@ internal class CountUpTimerTest {
             tickListener.onTick(AN_INITIAL_TIME + AN_INTERVAL * 5 - offset)
             tickListener.onTick(AN_INITIAL_TIME + AN_INTERVAL * 5)
         }
+    }
+
+    @Test
+    fun `when stopping the timer on tick, the stop action is called twice and the timer ticks twice`() = runTest {
+        // Given
+        every { fakeClock.epochMillis() } answers { currentTime }
+        val timer = spyk(
+                CountUpTimer(
+                        coroutineScope = this,
+                        clock = fakeClock,
+                        intervalInMs = AN_INTERVAL,
+                )
+        )
+        val tickListener = mockk<CountUpTimer.TickListener> {
+            every { onTick(any()) } answers { timer.stop() }
+        }
+        timer.tickListener = tickListener
+
+        // When
+        timer.start()
+        advanceTimeBy(AN_INTERVAL * 10)
+
+        // Then
+        verify(exactly = 2) { timer.stop() } // one call at the first tick, a second time because of the tick on the previous stop action
+        verify(exactly = 2) { tickListener.onTick(any()) } // one after reaching the first interval, a second after the stop action
+    }
+
+    @Test
+    fun `when pausing the timer on tick, the pause action is called twice and the timer ticks twice`() = runTest {
+        // Given
+        every { fakeClock.epochMillis() } answers { currentTime }
+        val timer = spyk(
+                CountUpTimer(
+                        coroutineScope = this,
+                        clock = fakeClock,
+                        intervalInMs = AN_INTERVAL,
+                )
+        )
+        val tickListener = mockk<CountUpTimer.TickListener> {
+            every { onTick(any()) } answers { timer.pause() }
+        }
+        timer.tickListener = tickListener
+
+        // When
+        timer.start()
+        advanceTimeBy(AN_INTERVAL * 10)
+
+        // Then
+        verify(exactly = 2) { timer.pause() } // one call at the first tick, a second time because of the tick on the previous pause action
+        verify(exactly = 2) { tickListener.onTick(any()) } // one after reaching the first interval, a second after the pause action
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Verify if the timer is still running before calling the stop or pause action and triggering a new tick event

## Motivation and context

Fix a regression introduced by #8058 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

- Record a voice message
- Listen to the voice message until the end
- The timer should be correctly stopped and reset, the app should not freeze anymore

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the ~develop~ hotfix/1.5.25 branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
