### PR TITLE
[Poll] Synchronize polls and message push rules after creation (PSG-1137)

### DIFF
--- a/changelog.d/8130.feature
+++ b/changelog.d/8130.feature
@@ -1,0 +1,1 @@
+[Poll] Synchronize polls and message push rules

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/pushrules/RuleIds.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/pushrules/RuleIds.kt
@@ -61,22 +61,36 @@ object RuleIds {
     const val RULE_ID_FALLBACK = ".m.rule.fallback"
 
     const val RULE_ID_REACTION = ".m.rule.reaction"
+}
 
-    fun getSyncedRules(ruleId: String): List<String> {
-        return when (ruleId) {
-            RULE_ID_ONE_TO_ONE_ROOM -> listOf(
-                    RULE_ID_POLL_START_ONE_TO_ONE,
-                    RULE_ID_POLL_START_ONE_TO_ONE_UNSTABLE,
-                    RULE_ID_POLL_END_ONE_TO_ONE,
-                    RULE_ID_POLL_END_ONE_TO_ONE_UNSTABLE,
-            )
-            RULE_ID_ALL_OTHER_MESSAGES_ROOMS -> listOf(
-                    RULE_ID_POLL_START,
-                    RULE_ID_POLL_START_UNSTABLE,
-                    RULE_ID_POLL_END,
-                    RULE_ID_POLL_END_UNSTABLE,
-            )
-            else -> emptyList()
-        }
+fun RuleIds.getSyncedRules(ruleId: String): List<String> {
+    return when (ruleId) {
+        RULE_ID_ONE_TO_ONE_ROOM -> listOf(
+                RULE_ID_POLL_START_ONE_TO_ONE,
+                RULE_ID_POLL_START_ONE_TO_ONE_UNSTABLE,
+                RULE_ID_POLL_END_ONE_TO_ONE,
+                RULE_ID_POLL_END_ONE_TO_ONE_UNSTABLE,
+        )
+        RULE_ID_ALL_OTHER_MESSAGES_ROOMS -> listOf(
+                RULE_ID_POLL_START,
+                RULE_ID_POLL_START_UNSTABLE,
+                RULE_ID_POLL_END,
+                RULE_ID_POLL_END_UNSTABLE,
+        )
+        else -> emptyList()
+    }
+}
+
+fun RuleIds.getParentRule(ruleId: String): String? {
+    return when (ruleId) {
+        RULE_ID_POLL_START_ONE_TO_ONE,
+        RULE_ID_POLL_START_ONE_TO_ONE_UNSTABLE,
+        RULE_ID_POLL_END_ONE_TO_ONE,
+        RULE_ID_POLL_END_ONE_TO_ONE_UNSTABLE -> RULE_ID_ONE_TO_ONE_ROOM
+        RULE_ID_POLL_START,
+        RULE_ID_POLL_START_UNSTABLE,
+        RULE_ID_POLL_END,
+        RULE_ID_POLL_END_UNSTABLE -> RULE_ID_ALL_OTHER_MESSAGES_ROOMS
+        else -> null
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/pushrules/RuleIds.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/pushrules/RuleIds.kt
@@ -62,35 +62,3 @@ object RuleIds {
 
     const val RULE_ID_REACTION = ".m.rule.reaction"
 }
-
-fun RuleIds.getSyncedRules(ruleId: String): List<String> {
-    return when (ruleId) {
-        RULE_ID_ONE_TO_ONE_ROOM -> listOf(
-                RULE_ID_POLL_START_ONE_TO_ONE,
-                RULE_ID_POLL_START_ONE_TO_ONE_UNSTABLE,
-                RULE_ID_POLL_END_ONE_TO_ONE,
-                RULE_ID_POLL_END_ONE_TO_ONE_UNSTABLE,
-        )
-        RULE_ID_ALL_OTHER_MESSAGES_ROOMS -> listOf(
-                RULE_ID_POLL_START,
-                RULE_ID_POLL_START_UNSTABLE,
-                RULE_ID_POLL_END,
-                RULE_ID_POLL_END_UNSTABLE,
-        )
-        else -> emptyList()
-    }
-}
-
-fun RuleIds.getParentRule(ruleId: String): String? {
-    return when (ruleId) {
-        RULE_ID_POLL_START_ONE_TO_ONE,
-        RULE_ID_POLL_START_ONE_TO_ONE_UNSTABLE,
-        RULE_ID_POLL_END_ONE_TO_ONE,
-        RULE_ID_POLL_END_ONE_TO_ONE_UNSTABLE -> RULE_ID_ONE_TO_ONE_ROOM
-        RULE_ID_POLL_START,
-        RULE_ID_POLL_START_UNSTABLE,
-        RULE_ID_POLL_END,
-        RULE_ID_POLL_END_UNSTABLE -> RULE_ID_ALL_OTHER_MESSAGES_ROOMS
-        else -> null
-    }
-}

--- a/vector/src/main/java/im/vector/app/core/notification/PushRulesUpdater.kt
+++ b/vector/src/main/java/im/vector/app/core/notification/PushRulesUpdater.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.core.notification
+
+import im.vector.app.features.session.coroutineScope
+import im.vector.app.features.settings.notifications.usecase.UpdatePushRulesIfNeededUseCase
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.session.Session
+import org.matrix.android.sdk.api.session.accountdata.UserAccountDataTypes
+import org.matrix.android.sdk.flow.flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Listen changes in Account Data to update the push rules if needed.
+ */
+@Singleton
+class PushRulesUpdater @Inject constructor(
+        private val updatePushRulesIfNeededUseCase: UpdatePushRulesIfNeededUseCase,
+) {
+
+    private var job: Job? = null
+
+    fun onSessionStarted(session: Session) {
+        updatePushRulesOnChange(session)
+    }
+
+    private fun updatePushRulesOnChange(session: Session) {
+        job?.cancel()
+        job = session.coroutineScope.launch {
+            session.flow()
+                    .liveUserAccountData(UserAccountDataTypes.TYPE_PUSH_RULES)
+                    .onEach { updatePushRulesIfNeededUseCase.execute(session) }
+                    .collect()
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/core/session/ConfigureAndStartSessionUseCase.kt
+++ b/vector/src/main/java/im/vector/app/core/session/ConfigureAndStartSessionUseCase.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import im.vector.app.core.extensions.startSyncing
 import im.vector.app.core.notification.NotificationsSettingUpdater
+import im.vector.app.core.notification.PushRulesUpdater
 import im.vector.app.core.session.clientinfo.UpdateMatrixClientInfoUseCase
 import im.vector.app.features.call.webrtc.WebRtcCallManager
 import im.vector.app.features.session.coroutineScope
@@ -37,6 +38,7 @@ class ConfigureAndStartSessionUseCase @Inject constructor(
         private val vectorPreferences: VectorPreferences,
         private val notificationsSettingUpdater: NotificationsSettingUpdater,
         private val updateNotificationSettingsAccountDataUseCase: UpdateNotificationSettingsAccountDataUseCase,
+        private val pushRulesUpdater: PushRulesUpdater,
 ) {
 
     fun execute(session: Session, startSyncing: Boolean = true) {
@@ -50,6 +52,7 @@ class ConfigureAndStartSessionUseCase @Inject constructor(
         updateMatrixClientInfoIfNeeded(session)
         createNotificationSettingsAccountDataIfNeeded(session)
         notificationsSettingUpdater.onSessionStarted(session)
+        pushRulesUpdater.onSessionStarted(session)
     }
 
     private fun updateMatrixClientInfoIfNeeded(session: Session) {

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/RuleIdsExt.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/RuleIdsExt.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.notifications
+
+import org.matrix.android.sdk.api.session.pushrules.RuleIds
+
+fun RuleIds.getSyncedRules(ruleId: String): List<String> {
+    return when (ruleId) {
+        RULE_ID_ONE_TO_ONE_ROOM -> listOf(
+                RULE_ID_POLL_START_ONE_TO_ONE,
+                RULE_ID_POLL_START_ONE_TO_ONE_UNSTABLE,
+                RULE_ID_POLL_END_ONE_TO_ONE,
+                RULE_ID_POLL_END_ONE_TO_ONE_UNSTABLE,
+        )
+        RULE_ID_ALL_OTHER_MESSAGES_ROOMS -> listOf(
+                RULE_ID_POLL_START,
+                RULE_ID_POLL_START_UNSTABLE,
+                RULE_ID_POLL_END,
+                RULE_ID_POLL_END_UNSTABLE,
+        )
+        else -> emptyList()
+    }
+}
+
+fun RuleIds.getParentRule(ruleId: String): String? {
+    return when (ruleId) {
+        RULE_ID_POLL_START_ONE_TO_ONE,
+        RULE_ID_POLL_START_ONE_TO_ONE_UNSTABLE,
+        RULE_ID_POLL_END_ONE_TO_ONE,
+        RULE_ID_POLL_END_ONE_TO_ONE_UNSTABLE -> RULE_ID_ONE_TO_ONE_ROOM
+        RULE_ID_POLL_START,
+        RULE_ID_POLL_START_UNSTABLE,
+        RULE_ID_POLL_END,
+        RULE_ID_POLL_END_UNSTABLE -> RULE_ID_ALL_OTHER_MESSAGES_ROOMS
+        else -> null
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/VectorSettingsPushRuleNotificationViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/VectorSettingsPushRuleNotificationViewModel.kt
@@ -32,7 +32,6 @@ import org.matrix.android.sdk.api.failure.MatrixError
 import org.matrix.android.sdk.api.session.pushrules.Action
 import org.matrix.android.sdk.api.session.pushrules.RuleIds
 import org.matrix.android.sdk.api.session.pushrules.RuleKind
-import org.matrix.android.sdk.api.session.pushrules.getSyncedRules
 import org.matrix.android.sdk.api.session.pushrules.rest.PushRuleAndKind
 
 private typealias ViewModel = VectorSettingsPushRuleNotificationViewModel

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/VectorSettingsPushRuleNotificationViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/VectorSettingsPushRuleNotificationViewModel.kt
@@ -32,6 +32,7 @@ import org.matrix.android.sdk.api.failure.MatrixError
 import org.matrix.android.sdk.api.session.pushrules.Action
 import org.matrix.android.sdk.api.session.pushrules.RuleIds
 import org.matrix.android.sdk.api.session.pushrules.RuleKind
+import org.matrix.android.sdk.api.session.pushrules.getSyncedRules
 import org.matrix.android.sdk.api.session.pushrules.rest.PushRuleAndKind
 
 private typealias ViewModel = VectorSettingsPushRuleNotificationViewModel

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/usecase/UpdatePushRulesIfNeededUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/usecase/UpdatePushRulesIfNeededUseCase.kt
@@ -16,10 +16,10 @@
 
 package im.vector.app.features.settings.notifications.usecase
 
+import im.vector.app.features.settings.notifications.getParentRule
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.pushrules.RuleIds
 import org.matrix.android.sdk.api.session.pushrules.getActions
-import org.matrix.android.sdk.api.session.pushrules.getParentRule
 import org.matrix.android.sdk.api.session.pushrules.rest.PushRule
 import org.matrix.android.sdk.api.session.pushrules.rest.PushRuleAndKind
 import javax.inject.Inject

--- a/vector/src/main/java/im/vector/app/features/settings/notifications/usecase/UpdatePushRulesIfNeededUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/notifications/usecase/UpdatePushRulesIfNeededUseCase.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.notifications.usecase
+
+import org.matrix.android.sdk.api.session.Session
+import org.matrix.android.sdk.api.session.pushrules.RuleIds
+import org.matrix.android.sdk.api.session.pushrules.getActions
+import org.matrix.android.sdk.api.session.pushrules.getParentRule
+import org.matrix.android.sdk.api.session.pushrules.rest.PushRule
+import org.matrix.android.sdk.api.session.pushrules.rest.PushRuleAndKind
+import javax.inject.Inject
+
+class UpdatePushRulesIfNeededUseCase @Inject constructor() {
+
+    suspend fun execute(session: Session) {
+        val ruleSet = session.pushRuleService().getPushRules()
+        val pushRules = ruleSet.getAllRules()
+        val rulesToUpdate = pushRules.mapNotNull { rule ->
+            val parent = RuleIds.getParentRule(rule.ruleId)?.let { ruleId -> ruleSet.findDefaultRule(ruleId) }
+            if (parent != null && (rule.enabled != parent.pushRule.enabled || rule.actions != parent.pushRule.actions)) {
+                PushRuleWithParent(rule, parent)
+            } else {
+                null
+            }
+        }
+
+        rulesToUpdate.forEach {
+            session.pushRuleService().updatePushRuleActions(
+                    kind = it.parent.kind,
+                    ruleId = it.rule.ruleId,
+                    enable = it.parent.pushRule.enabled,
+                    actions = it.parent.pushRule.getActions(),
+            )
+        }
+    }
+
+    private data class PushRuleWithParent(
+            val rule: PushRule,
+            val parent: PushRuleAndKind,
+    )
+}

--- a/vector/src/test/java/im/vector/app/core/session/ConfigureAndStartSessionUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/core/session/ConfigureAndStartSessionUseCaseTest.kt
@@ -22,6 +22,7 @@ import im.vector.app.features.session.coroutineScope
 import im.vector.app.features.settings.devices.v2.notification.UpdateNotificationSettingsAccountDataUseCase
 import im.vector.app.test.fakes.FakeContext
 import im.vector.app.test.fakes.FakeNotificationsSettingUpdater
+import im.vector.app.test.fakes.FakePushRulesUpdater
 import im.vector.app.test.fakes.FakeSession
 import im.vector.app.test.fakes.FakeVectorPreferences
 import im.vector.app.test.fakes.FakeWebRtcCallManager
@@ -47,6 +48,7 @@ class ConfigureAndStartSessionUseCaseTest {
     private val fakeUpdateMatrixClientInfoUseCase = mockk<UpdateMatrixClientInfoUseCase>()
     private val fakeVectorPreferences = FakeVectorPreferences()
     private val fakeNotificationsSettingUpdater = FakeNotificationsSettingUpdater()
+    private val fakePushRulesUpdater = FakePushRulesUpdater()
     private val fakeUpdateNotificationSettingsAccountDataUseCase = mockk<UpdateNotificationSettingsAccountDataUseCase>()
 
     private val configureAndStartSessionUseCase = ConfigureAndStartSessionUseCase(
@@ -56,7 +58,7 @@ class ConfigureAndStartSessionUseCaseTest {
             vectorPreferences = fakeVectorPreferences.instance,
             notificationsSettingUpdater = fakeNotificationsSettingUpdater.instance,
             updateNotificationSettingsAccountDataUseCase = fakeUpdateNotificationSettingsAccountDataUseCase,
-            pushRulesUpdater = mockk(),
+            pushRulesUpdater = fakePushRulesUpdater.instance,
     )
 
     @Before
@@ -79,7 +81,8 @@ class ConfigureAndStartSessionUseCaseTest {
         coJustRun { fakeUpdateMatrixClientInfoUseCase.execute(any()) }
         coJustRun { fakeUpdateNotificationSettingsAccountDataUseCase.execute(any()) }
         fakeVectorPreferences.givenIsClientInfoRecordingEnabled(isEnabled = true)
-        fakeNotificationsSettingUpdater.givenOnSessionsStarted(aSession)
+        fakeNotificationsSettingUpdater.givenOnSessionStarted(aSession)
+        fakePushRulesUpdater.givenOnSessionStarted(aSession)
 
         // When
         configureAndStartSessionUseCase.execute(aSession, startSyncing = true)
@@ -103,7 +106,8 @@ class ConfigureAndStartSessionUseCaseTest {
         fakeWebRtcCallManager.givenCheckForProtocolsSupportIfNeededSucceeds()
         coJustRun { fakeUpdateNotificationSettingsAccountDataUseCase.execute(any()) }
         fakeVectorPreferences.givenIsClientInfoRecordingEnabled(isEnabled = false)
-        fakeNotificationsSettingUpdater.givenOnSessionsStarted(aSession)
+        fakeNotificationsSettingUpdater.givenOnSessionStarted(aSession)
+        fakePushRulesUpdater.givenOnSessionStarted(aSession)
 
         // When
         configureAndStartSessionUseCase.execute(aSession, startSyncing = true)
@@ -130,7 +134,8 @@ class ConfigureAndStartSessionUseCaseTest {
         coJustRun { fakeUpdateMatrixClientInfoUseCase.execute(any()) }
         coJustRun { fakeUpdateNotificationSettingsAccountDataUseCase.execute(any()) }
         fakeVectorPreferences.givenIsClientInfoRecordingEnabled(isEnabled = true)
-        fakeNotificationsSettingUpdater.givenOnSessionsStarted(aSession)
+        fakeNotificationsSettingUpdater.givenOnSessionStarted(aSession)
+        fakePushRulesUpdater.givenOnSessionStarted(aSession)
 
         // When
         configureAndStartSessionUseCase.execute(aSession, startSyncing = false)

--- a/vector/src/test/java/im/vector/app/core/session/ConfigureAndStartSessionUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/core/session/ConfigureAndStartSessionUseCaseTest.kt
@@ -56,6 +56,7 @@ class ConfigureAndStartSessionUseCaseTest {
             vectorPreferences = fakeVectorPreferences.instance,
             notificationsSettingUpdater = fakeNotificationsSettingUpdater.instance,
             updateNotificationSettingsAccountDataUseCase = fakeUpdateNotificationSettingsAccountDataUseCase,
+            pushRulesUpdater = mockk(),
     )
 
     @Before

--- a/vector/src/test/java/im/vector/app/features/settings/notifications/usecase/DisableNotificationsForCurrentSessionUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/notifications/usecase/DisableNotificationsForCurrentSessionUseCaseTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.notifications
+package im.vector.app.features.settings.notifications.usecase
 
 import im.vector.app.core.pushers.UnregisterUnifiedPushUseCase
-import im.vector.app.features.settings.notifications.usecase.DisableNotificationsForCurrentSessionUseCase
-import im.vector.app.features.settings.notifications.usecase.ToggleNotificationsForCurrentSessionUseCase
 import im.vector.app.test.fakes.FakePushersManager
 import io.mockk.coJustRun
 import io.mockk.coVerify

--- a/vector/src/test/java/im/vector/app/features/settings/notifications/usecase/EnableNotificationsForCurrentSessionUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/notifications/usecase/EnableNotificationsForCurrentSessionUseCaseTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.notifications
+package im.vector.app.features.settings.notifications.usecase
 
 import im.vector.app.core.pushers.EnsureFcmTokenIsRetrievedUseCase
 import im.vector.app.core.pushers.RegisterUnifiedPushUseCase
-import im.vector.app.features.settings.notifications.usecase.EnableNotificationsForCurrentSessionUseCase
-import im.vector.app.features.settings.notifications.usecase.ToggleNotificationsForCurrentSessionUseCase
 import im.vector.app.test.fakes.FakePushersManager
 import io.mockk.coJustRun
 import io.mockk.coVerify

--- a/vector/src/test/java/im/vector/app/features/settings/notifications/usecase/ToggleNotificationsForCurrentSessionUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/notifications/usecase/ToggleNotificationsForCurrentSessionUseCaseTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.settings.notifications
+package im.vector.app.features.settings.notifications.usecase
 
 import im.vector.app.features.settings.devices.v2.notification.CheckIfCanToggleNotificationsViaPusherUseCase
 import im.vector.app.features.settings.devices.v2.notification.DeleteNotificationSettingsAccountDataUseCase
 import im.vector.app.features.settings.devices.v2.notification.SetNotificationSettingsAccountDataUseCase
-import im.vector.app.features.settings.notifications.usecase.ToggleNotificationsForCurrentSessionUseCase
 import im.vector.app.test.fakes.FakeActiveSessionHolder
 import im.vector.app.test.fakes.FakeUnifiedPushHelper
 import im.vector.app.test.fixtures.PusherFixture

--- a/vector/src/test/java/im/vector/app/features/settings/notifications/usecase/UpdatePushRulesIfNeededUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/settings/notifications/usecase/UpdatePushRulesIfNeededUseCaseTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.settings.notifications.usecase
+
+import im.vector.app.test.fakes.FakeSession
+import io.mockk.coVerifySequence
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.matrix.android.sdk.api.session.pushrules.Action
+import org.matrix.android.sdk.api.session.pushrules.RuleIds
+import org.matrix.android.sdk.api.session.pushrules.getActions
+import org.matrix.android.sdk.api.session.pushrules.rest.PushRule
+import org.matrix.android.sdk.api.session.pushrules.rest.PushRuleAndKind
+
+internal class UpdatePushRulesIfNeededUseCaseTest {
+
+    private val fakeSession = FakeSession()
+    private val updatePushRulesIfNeededUseCase = UpdatePushRulesIfNeededUseCase()
+
+    @Before
+    fun setup() {
+        mockkStatic("org.matrix.android.sdk.api.session.pushrules.ActionKt")
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun test() = runTest {
+        // Given
+        val firstActions = listOf(Action.Notify)
+        val secondActions = listOf(Action.DoNotNotify)
+        val rules = listOf(
+                // first set of related rules
+                givenARuleId(RuleIds.RULE_ID_ONE_TO_ONE_ROOM, true, firstActions),
+                givenARuleId(RuleIds.RULE_ID_POLL_START_ONE_TO_ONE, true, listOf(Action.DoNotNotify)), // diff
+                givenARuleId(RuleIds.RULE_ID_POLL_START_ONE_TO_ONE_UNSTABLE, true, emptyList()), // diff
+                givenARuleId(RuleIds.RULE_ID_POLL_END_ONE_TO_ONE, false, listOf(Action.Notify)), // diff
+                givenARuleId(RuleIds.RULE_ID_POLL_END_ONE_TO_ONE_UNSTABLE, true, listOf(Action.Notify)),
+                // second set of related rules
+                givenARuleId(RuleIds.RULE_ID_ALL_OTHER_MESSAGES_ROOMS, false, secondActions),
+                givenARuleId(RuleIds.RULE_ID_POLL_START, true, listOf(Action.Notify)), // diff
+                givenARuleId(RuleIds.RULE_ID_POLL_START_UNSTABLE, false, listOf(Action.DoNotNotify)),
+                givenARuleId(RuleIds.RULE_ID_POLL_END, false, listOf(Action.Notify)), // diff
+                givenARuleId(RuleIds.RULE_ID_POLL_END_UNSTABLE, true, listOf()), // diff
+                // Another rule
+                givenARuleId(RuleIds.RULE_ID_CONTAIN_USER_NAME, true, listOf(Action.Notify)),
+        )
+        every { fakeSession.fakePushRuleService.getPushRules().getAllRules() } returns rules
+
+        // When
+        updatePushRulesIfNeededUseCase.execute(fakeSession)
+
+        // Then
+        coVerifySequence {
+            fakeSession.fakePushRuleService.getPushRules()
+            // first set
+            fakeSession.fakePushRuleService.updatePushRuleActions(any(), RuleIds.RULE_ID_POLL_START_ONE_TO_ONE, true, firstActions)
+            fakeSession.fakePushRuleService.updatePushRuleActions(any(), RuleIds.RULE_ID_POLL_START_ONE_TO_ONE_UNSTABLE, true, firstActions)
+            fakeSession.fakePushRuleService.updatePushRuleActions(any(), RuleIds.RULE_ID_POLL_END_ONE_TO_ONE, true, firstActions)
+            // second set
+            fakeSession.fakePushRuleService.updatePushRuleActions(any(), RuleIds.RULE_ID_POLL_START, false, secondActions)
+            fakeSession.fakePushRuleService.updatePushRuleActions(any(), RuleIds.RULE_ID_POLL_END, false, secondActions)
+            fakeSession.fakePushRuleService.updatePushRuleActions(any(), RuleIds.RULE_ID_POLL_END_UNSTABLE, false, secondActions)
+        }
+    }
+
+    private fun givenARuleId(ruleId: String, enabled: Boolean, actions: List<Action>): PushRule {
+        val pushRule = mockk<PushRule> {
+            every { this@mockk.ruleId } returns ruleId
+            every { this@mockk.enabled } returns enabled
+            every { this@mockk.actions } returns actions
+            every { getActions() } returns actions
+        }
+        val ruleAndKind = mockk<PushRuleAndKind> {
+            every { this@mockk.pushRule } returns pushRule
+            every { kind } returns mockk()
+        }
+
+        every { fakeSession.fakePushRuleService.getPushRules().findDefaultRule(ruleId) } returns ruleAndKind
+
+        return pushRule
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakePushRulesUpdater.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakePushRulesUpdater.kt
@@ -16,14 +16,14 @@
 
 package im.vector.app.test.fakes
 
-import im.vector.app.core.notification.NotificationsSettingUpdater
+import im.vector.app.core.notification.PushRulesUpdater
 import io.mockk.justRun
 import io.mockk.mockk
 import org.matrix.android.sdk.api.session.Session
 
-class FakeNotificationsSettingUpdater {
+class FakePushRulesUpdater {
 
-    val instance = mockk<NotificationsSettingUpdater>()
+    val instance = mockk<PushRulesUpdater>()
 
     fun givenOnSessionStarted(session: Session) {
         justRun { instance.onSessionStarted(session) }


### PR DESCRIPTION
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Add an observer on the push rule updates in the account data and realign the push rules with their parent if needed.

## Motivation and context

#8114 introduces the new push rules in the notification settings. The new rules should be aligned with their parent rules as described in the following table:

<img width="1030" alt="image" src="https://user-images.githubusercontent.com/11990514/218795863-d3132ee3-b3da-464e-8e3f-dfed08554678.png">

The purpose of this PR is to verify and fix if necessary the consistency of the new rules with their parent when changes are detected in the account data.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

- Manually change and break the poll rules in the account data using the devtools on the web interface
- Verify that the Android client automatically realign the rules with the parent one (by refreshing the account data after an incremental sync)

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
