### PR TITLE
[Poll] Improve rendering of poll end message when poll start event isn't available (PSG-1157)

### DIFF
--- a/changelog.d/8129.bugfix
+++ b/changelog.d/8129.bugfix
@@ -1,0 +1,1 @@
+[Poll] Improve rendering of poll end message when poll start event isn't available

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/MessageEndPollContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/MessageEndPollContent.kt
@@ -33,5 +33,11 @@ data class MessageEndPollContent(
         override val msgType: String = MessageType.MSGTYPE_POLL_END,
         @Json(name = "body") override val body: String = "",
         @Json(name = "m.new_content") override val newContent: Content? = null,
-        @Json(name = "m.relates_to") override val relatesTo: RelationDefaultContent? = null
-) : MessageContent
+        @Json(name = "m.relates_to") override val relatesTo: RelationDefaultContent? = null,
+        @Json(name = "org.matrix.msc1767.text") val unstableText: String? = null,
+        @Json(name = "m.text") val text: String? = null,
+) : MessageContent {
+    fun getBestText() = text ?: unstableText
+}
+
+

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/MessageEndPollContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/message/MessageEndPollContent.kt
@@ -39,5 +39,3 @@ data class MessageEndPollContent(
 ) : MessageContent {
     fun getBestText() = text ?: unstableText
 }
-
-

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoEventFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/send/LocalEchoEventFactory.kt
@@ -242,7 +242,8 @@ internal class LocalEchoEventFactory @Inject constructor(
                 relatesTo = RelationDefaultContent(
                         type = RelationType.REFERENCE,
                         eventId = eventId
-                )
+                ),
+                unstableText = "Ended poll",
         )
         val localId = LocalEcho.createLocalEchoId()
         return Event(

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/PollItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/PollItem.kt
@@ -16,6 +16,7 @@
 
 package im.vector.app.features.home.room.detail.timeline.item
 
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.view.children
@@ -23,6 +24,7 @@ import androidx.core.view.isVisible
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
 import im.vector.app.R
+import im.vector.app.core.extensions.setTextOrHide
 import im.vector.app.features.home.room.detail.RoomDetailAction
 import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
@@ -31,7 +33,7 @@ import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 abstract class PollItem : AbsMessageItem<PollItem.Holder>() {
 
     @EpoxyAttribute
-    var pollQuestion: EpoxyCharSequence? = null
+    var pollTitle: EpoxyCharSequence? = null
 
     @EpoxyAttribute
     var callback: TimelineEventController.Callback? = null
@@ -54,6 +56,9 @@ abstract class PollItem : AbsMessageItem<PollItem.Holder>() {
     @EpoxyAttribute
     var ended: Boolean = false
 
+    @EpoxyAttribute
+    var hasContent: Boolean = true
+
     override fun getViewStubId() = STUB_ID
 
     override fun bind(holder: Holder) {
@@ -61,8 +66,8 @@ abstract class PollItem : AbsMessageItem<PollItem.Holder>() {
 
         renderSendState(holder.view, holder.questionTextView)
 
-        holder.questionTextView.text = pollQuestion?.charSequence
-        holder.votesStatusTextView.text = votesStatus
+        holder.questionTextView.text = pollTitle?.charSequence
+        holder.votesStatusTextView.setTextOrHide(votesStatus)
 
         while (holder.optionsContainer.childCount < optionViewStates.size) {
             holder.optionsContainer.addView(PollOptionView(holder.view.context))
@@ -80,7 +85,8 @@ abstract class PollItem : AbsMessageItem<PollItem.Holder>() {
             }
         }
 
-        holder.endedPollTextView.isVisible = ended
+        holder.endedPollTextView.isVisible = ended && hasContent
+        holder.pollIcon.isVisible = ended && hasContent.not()
     }
 
     private fun onPollItemClick(optionViewState: PollOptionViewState) {
@@ -96,6 +102,7 @@ abstract class PollItem : AbsMessageItem<PollItem.Holder>() {
         val optionsContainer by bind<LinearLayout>(R.id.optionsContainer)
         val votesStatusTextView by bind<TextView>(R.id.optionsVotesStatusTextView)
         val endedPollTextView by bind<TextView>(R.id.endedPollTextView)
+        val pollIcon by bind<ImageView>(R.id.timelinePollIcon)
     }
 
     companion object {

--- a/vector/src/main/res/layout/item_timeline_event_poll.xml
+++ b/vector/src/main/res/layout/item_timeline_event_poll.xml
@@ -21,15 +21,30 @@
     <TextView
         android:id="@+id/questionTextView"
         style="@style/Widget.Vector.TextView.Subtitle"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:textColor="?vctr_content_primary"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@id/timelinePollIcon"
         app:layout_constraintTop_toBottomOf="@id/endedPollTextView"
         tools:text="@sample/poll.json/question" />
+
+    <ImageView
+        android:id="@+id/timelinePollIcon"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginEnd="8dp"
+        android:importantForAccessibility="no"
+        android:src="@drawable/ic_attachment_poll"
+        android:visibility="gone"
+        app:layout_constraintEnd_toStartOf="@id/questionTextView"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/questionTextView"
+        app:tint="?vctr_content_secondary"
+        tools:ignore="ContentDescription" />
 
     <LinearLayout
         android:id="@+id/optionsContainer"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Add a special rendering for the message when receiving a poll End event while the related poll start is not available in the timeline.
Send a fallback text in the poll end event (may be needed by other Matrix clients).

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #8129

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

<img src="https://user-images.githubusercontent.com/46314705/218991480-6c120962-ceae-43b8-b93d-ca17339ef288.png" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/218991491-52f6ae63-6903-437f-b9f6-dba69861cbf3.png" width=300 />

## Tests

<!-- Explain how you tested your development -->

- Create a new room
- Set the setting in the room so that new joiners cannot see the history
- Create a poll
- Invite another user
- Wait for the user to join
- End the previously created poll
- Check the other user sees a simple "Poll ended" message without any other info

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
