### PR TITLE
[Location sharing] Show own location in map views

### DIFF
--- a/changelog.d/8110.feature
+++ b/changelog.d/8110.feature
@@ -1,0 +1,1 @@
+[Location sharing] Show own location in map views

--- a/library/core-utils/src/main/java/im/vector/lib/core/utils/timer/CountUpTimer.kt
+++ b/library/core-utils/src/main/java/im/vector/lib/core/utils/timer/CountUpTimer.kt
@@ -33,6 +33,7 @@ class CountUpTimer(
 
     private val lastTime: AtomicLong = AtomicLong(clock.epochMillis())
     private val elapsedTime: AtomicLong = AtomicLong(0)
+
     // To ensure that the regular tick value is an exact multiple of `intervalInMs`
     private val specialRound = SpecialRound(intervalInMs)
 

--- a/vector/src/main/java/im/vector/app/features/location/LocationDialog.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationDialog.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.location
+
+import androidx.fragment.app.Fragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import im.vector.app.R
+
+fun Fragment.showUserLocationNotAvailableErrorDialog(onConfirmListener: () -> Unit) {
+    MaterialAlertDialogBuilder(requireActivity())
+            .setTitle(R.string.location_not_available_dialog_title)
+            .setMessage(R.string.location_not_available_dialog_content)
+            .setPositiveButton(R.string.ok) { _, _ ->
+                onConfirmListener()
+            }
+            .setCancelable(false)
+            .show()
+}

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingFragment.kt
@@ -176,14 +176,7 @@ class LocationSharingFragment :
     }
 
     private fun handleLocationNotAvailableError() {
-        MaterialAlertDialogBuilder(requireActivity())
-                .setTitle(R.string.location_not_available_dialog_title)
-                .setMessage(R.string.location_not_available_dialog_content)
-                .setPositiveButton(R.string.ok) { _, _ ->
-                    locationSharingNavigator.quit()
-                }
-                .setCancelable(false)
-                .show()
+        showUserLocationNotAvailableErrorDialog { locationSharingNavigator.quit() }
     }
 
     private fun handleLiveLocationSharingNotEnoughPermission() {

--- a/vector/src/main/java/im/vector/app/features/location/LocationSharingViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationSharingViewState.kt
@@ -47,7 +47,7 @@ data class LocationSharingViewState(
 
 fun LocationSharingViewState.toMapState() = MapState(
         zoomOnlyOnce = true,
-        userLocationData = lastKnownUserLocation,
+        pinLocationData = lastKnownUserLocation,
         pinId = DEFAULT_PIN_ID,
         pinDrawable = null,
         // show the map pin only when target location and user location are not equal

--- a/vector/src/main/java/im/vector/app/features/location/LocationTracker.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationTracker.kt
@@ -92,7 +92,7 @@ class LocationTracker @Inject constructor(
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
     fun start() {
-        if(!isStarting && !isStarted) {
+        if (!isStarting && !isStarted) {
             isStarting = true
             Timber.d("start()")
 

--- a/vector/src/main/java/im/vector/app/features/location/LocationTracker.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationTracker.kt
@@ -66,6 +66,8 @@ class LocationTracker @Inject constructor(
     @VisibleForTesting
     var hasLocationFromGPSProvider = false
 
+    private var isStarted = false
+    private var isStarting = false
     private var firstLocationHandled = false
     private val _locations = MutableSharedFlow<Location>(replay = 1)
 
@@ -90,44 +92,48 @@ class LocationTracker @Inject constructor(
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
     fun start() {
-        // TODO start only if not already started
-        Timber.d("start()")
+        if(!isStarting && !isStarted) {
+            isStarting = true
+            Timber.d("start()")
 
-        if (locationManager == null) {
-            Timber.v("LocationManager is not available")
-            onNoLocationProviderAvailable()
-            return
-        }
+            if (locationManager == null) {
+                Timber.v("LocationManager is not available")
+                onNoLocationProviderAvailable()
+                return
+            }
 
-        val providers = locationManager.allProviders
+            val providers = locationManager.allProviders
 
-        if (providers.isEmpty()) {
-            Timber.v("There is no location provider available")
-            onNoLocationProviderAvailable()
-        } else {
-            // Take GPS first
-            providers.sortedByDescending(::getProviderPriority)
-                    .mapNotNull { provider ->
-                        Timber.d("track location using $provider")
+            if (providers.isEmpty()) {
+                Timber.v("There is no location provider available")
+                onNoLocationProviderAvailable()
+            } else {
+                // Take GPS first
+                providers.sortedByDescending(::getProviderPriority)
+                        .mapNotNull { provider ->
+                            Timber.d("track location using $provider")
 
-                        locationManager.requestLocationUpdates(
-                                provider,
-                                minDurationToUpdateLocationMillis,
-                                MIN_DISTANCE_TO_UPDATE_LOCATION_METERS,
-                                this
-                        )
+                            locationManager.requestLocationUpdates(
+                                    provider,
+                                    minDurationToUpdateLocationMillis,
+                                    MIN_DISTANCE_TO_UPDATE_LOCATION_METERS,
+                                    this
+                            )
 
-                        locationManager.getLastKnownLocation(provider)
-                    }
-                    .maxByOrNull { location -> location.time }
-                    ?.let { latestKnownLocation ->
-                        if (buildMeta.lowPrivacyLoggingEnabled) {
-                            Timber.d("lastKnownLocation: $latestKnownLocation")
-                        } else {
-                            Timber.d("lastKnownLocation: ${latestKnownLocation.provider}")
+                            locationManager.getLastKnownLocation(provider)
                         }
-                        notifyLocation(latestKnownLocation)
-                    }
+                        .maxByOrNull { location -> location.time }
+                        ?.let { latestKnownLocation ->
+                            if (buildMeta.lowPrivacyLoggingEnabled) {
+                                Timber.d("lastKnownLocation: $latestKnownLocation")
+                            } else {
+                                Timber.d("lastKnownLocation: ${latestKnownLocation.provider}")
+                            }
+                            notifyLocation(latestKnownLocation)
+                        }
+            }
+            isStarted = true
+            isStarting = false
         }
     }
 
@@ -149,6 +155,8 @@ class LocationTracker @Inject constructor(
         callbacks.clear()
         hasLocationFromGPSProvider = false
         hasLocationFromFusedProvider = false
+        isStarting = false
+        isStarted = false
     }
 
     /**

--- a/vector/src/main/java/im/vector/app/features/location/LocationTracker.kt
+++ b/vector/src/main/java/im/vector/app/features/location/LocationTracker.kt
@@ -90,6 +90,7 @@ class LocationTracker @Inject constructor(
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
     fun start() {
+        // TODO start only if not already started
         Timber.d("start()")
 
         if (locationManager == null) {

--- a/vector/src/main/java/im/vector/app/features/location/MapState.kt
+++ b/vector/src/main/java/im/vector/app/features/location/MapState.kt
@@ -21,9 +21,10 @@ import androidx.annotation.Px
 
 data class MapState(
         val zoomOnlyOnce: Boolean,
-        val userLocationData: LocationData? = null,
+        val pinLocationData: LocationData? = null,
         val pinId: String,
         val pinDrawable: Drawable? = null,
         val showPin: Boolean = true,
-        @Px val logoMarginBottom: Int = 0
+        val userLocationData: LocationData? = null,
+        @Px val logoMarginBottom: Int = 0,
 )

--- a/vector/src/main/java/im/vector/app/features/location/MapTilerMapView.kt
+++ b/vector/src/main/java/im/vector/app/features/location/MapTilerMapView.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.location
 
 import android.content.Context
 import android.content.res.TypedArray
+import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.Gravity
 import android.widget.ImageView
@@ -170,12 +171,7 @@ class MapTilerMapView @JvmOverloads constructor(
         }
 
         val pinDrawable = state.pinDrawable ?: userLocationDrawable
-        pinDrawable?.let { drawable ->
-            if (!safeMapRefs.style.isFullyLoaded ||
-                    safeMapRefs.style.getImage(state.pinId) == null) {
-                safeMapRefs.style.addImage(state.pinId, drawable.toBitmap())
-            }
-        }
+        addImageToMapStyle(pinDrawable, state.pinId, safeMapRefs)
 
         safeMapRefs.symbolManager.deleteAll()
         state.pinLocationData?.let { locationData ->
@@ -185,28 +181,33 @@ class MapTilerMapView @JvmOverloads constructor(
             }
 
             if (pinDrawable != null && state.showPin) {
-                safeMapRefs.symbolManager.create(
-                        SymbolOptions()
-                                .withLatLng(LatLng(locationData.latitude, locationData.longitude))
-                                .withIconImage(state.pinId)
-                                .withIconAnchor(Property.ICON_ANCHOR_BOTTOM)
-                )
+                createSymbol(locationData, state.pinId, safeMapRefs)
             }
         }
 
         state.userLocationData?.let { locationData ->
-            if (!safeMapRefs.style.isFullyLoaded || safeMapRefs.style.getImage(USER_PIN_ID) == null) {
-                userLocationDrawable?.let { drawable ->
-                    safeMapRefs.style.addImage(USER_PIN_ID, drawable.toBitmap())
-                }
+            addImageToMapStyle(userLocationDrawable, USER_PIN_ID, safeMapRefs)
+            if (userLocationDrawable != null) {
+                createSymbol(locationData, USER_PIN_ID, safeMapRefs)
             }
-            safeMapRefs.symbolManager.create(
-                    SymbolOptions()
-                            .withLatLng(LatLng(locationData.latitude, locationData.longitude))
-                            .withIconImage(USER_PIN_ID)
-                            .withIconAnchor(Property.ICON_ANCHOR_BOTTOM)
-            )
         }
+    }
+
+    private fun addImageToMapStyle(image: Drawable?, imageId: String, mapRefs: MapRefs) {
+        image?.let { drawable ->
+            if (!mapRefs.style.isFullyLoaded || mapRefs.style.getImage(imageId) == null) {
+                mapRefs.style.addImage(imageId, drawable.toBitmap())
+            }
+        }
+    }
+
+    private fun createSymbol(locationData: LocationData, imageId: String, mapRefs: MapRefs) {
+        mapRefs.symbolManager.create(
+                SymbolOptions()
+                        .withLatLng(LatLng(locationData.latitude, locationData.longitude))
+                        .withIconImage(imageId)
+                        .withIconAnchor(Property.ICON_ANCHOR_BOTTOM)
+        )
     }
 
     fun zoomToLocation(locationData: LocationData) {

--- a/vector/src/main/java/im/vector/app/features/location/MapTilerMapView.kt
+++ b/vector/src/main/java/im/vector/app/features/location/MapTilerMapView.kt
@@ -103,9 +103,11 @@ class MapTilerMapView @JvmOverloads constructor(
 
     private fun initMapStyle(map: MapboxMap, url: String) {
         map.setStyle(url) { style ->
+            val symbolManager = SymbolManager(this, map, style)
+            symbolManager.iconAllowOverlap = true
             mapRefs = MapRefs(
                     map,
-                    SymbolManager(this, map, style),
+                    symbolManager,
                     style
             )
             pendingState?.let { render(it) }

--- a/vector/src/main/java/im/vector/app/features/location/MapTilerMapView.kt
+++ b/vector/src/main/java/im/vector/app/features/location/MapTilerMapView.kt
@@ -38,6 +38,8 @@ import im.vector.app.R
 import im.vector.app.core.utils.DimensionConverter
 import timber.log.Timber
 
+private const val USER_PIN_ID = "user-pin-id"
+
 class MapTilerMapView @JvmOverloads constructor(
         context: Context,
         attrs: AttributeSet? = null,
@@ -173,13 +175,13 @@ class MapTilerMapView @JvmOverloads constructor(
             }
         }
 
-        state.userLocationData?.let { locationData ->
+        safeMapRefs.symbolManager.deleteAll()
+        state.pinLocationData?.let { locationData ->
             if (!initZoomDone || !state.zoomOnlyOnce) {
                 zoomToLocation(locationData)
                 initZoomDone = true
             }
 
-            safeMapRefs.symbolManager.deleteAll()
             if (pinDrawable != null && state.showPin) {
                 safeMapRefs.symbolManager.create(
                         SymbolOptions()
@@ -188,6 +190,20 @@ class MapTilerMapView @JvmOverloads constructor(
                                 .withIconAnchor(Property.ICON_ANCHOR_BOTTOM)
                 )
             }
+        }
+
+        state.userLocationData?.let { locationData ->
+            if (!safeMapRefs.style.isFullyLoaded || safeMapRefs.style.getImage(USER_PIN_ID) == null) {
+                userLocationDrawable?.let { drawable ->
+                    safeMapRefs.style.addImage(USER_PIN_ID, drawable.toBitmap())
+                }
+            }
+            safeMapRefs.symbolManager.create(
+                    SymbolOptions()
+                            .withLatLng(LatLng(locationData.latitude, locationData.longitude))
+                            .withIconImage(USER_PIN_ID)
+                            .withIconAnchor(Property.ICON_ANCHOR_BOTTOM)
+            )
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapAction.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapAction.kt
@@ -23,4 +23,5 @@ sealed class LiveLocationMapAction : VectorViewModelAction {
     data class RemoveMapSymbol(val key: String) : LiveLocationMapAction()
     object StopSharing : LiveLocationMapAction()
     object ShowMapLoadingError : LiveLocationMapAction()
+    object ZoomToUserLocation : LiveLocationMapAction()
 }

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewEvents.kt
@@ -17,7 +17,10 @@
 package im.vector.app.features.location.live.map
 
 import im.vector.app.core.platform.VectorViewEvents
+import im.vector.app.features.location.LocationData
 
 sealed interface LiveLocationMapViewEvents : VectorViewEvents {
-    data class Error(val error: Throwable) : LiveLocationMapViewEvents
+    data class LiveLocationError(val error: Throwable) : LiveLocationMapViewEvents
+    data class ZoomToUserLocation(val userLocation: LocationData) : LiveLocationMapViewEvents
+    object UserLocationNotAvailableError : LiveLocationMapViewEvents
 }

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewFragment.kt
@@ -194,7 +194,7 @@ class LiveLocationMapViewFragment :
             updateMap(viewState.userLocations)
         }
         updateUserListBottomSheet(viewState.userLocations)
-        updateLocateButton(showLocateButton = false)
+        updateLocateButton(showLocateButton = viewState.showLocateButton)
     }
 
     private fun updateUserListBottomSheet(userLocations: List<UserLiveLocationViewState>) {

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewFragment.kt
@@ -48,17 +48,25 @@ import im.vector.app.core.extensions.addChildFragment
 import im.vector.app.core.extensions.cleanup
 import im.vector.app.core.extensions.configureWith
 import im.vector.app.core.platform.VectorBaseFragment
+import im.vector.app.core.resources.DrawableProvider
 import im.vector.app.core.utils.DimensionConverter
+import im.vector.app.core.utils.PERMISSIONS_FOR_FOREGROUND_LOCATION_SHARING
+import im.vector.app.core.utils.checkPermissions
+import im.vector.app.core.utils.onPermissionDeniedDialog
 import im.vector.app.core.utils.openLocation
+import im.vector.app.core.utils.registerForPermissionsResult
 import im.vector.app.databinding.FragmentLiveLocationMapViewBinding
 import im.vector.app.features.location.LocationData
 import im.vector.app.features.location.UrlMapProvider
+import im.vector.app.features.location.showUserLocationNotAvailableErrorDialog
 import im.vector.app.features.location.zoomToBounds
 import im.vector.app.features.location.zoomToLocation
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.lang.ref.WeakReference
 import javax.inject.Inject
+
+private const val USER_LOCATION_PIN_ID = "user-location-pin-id"
 
 /**
  * Screen showing a map with all the current users sharing their live location in a room.
@@ -70,6 +78,7 @@ class LiveLocationMapViewFragment :
     @Inject lateinit var urlMapProvider: UrlMapProvider
     @Inject lateinit var bottomSheetController: LiveLocationBottomSheetController
     @Inject lateinit var dimensionConverter: DimensionConverter
+    @Inject lateinit var drawableProvider: DrawableProvider
 
     private val viewModel: LiveLocationMapViewModel by fragmentViewModel()
 
@@ -77,7 +86,7 @@ class LiveLocationMapViewFragment :
     private var mapView: MapView? = null
     private var symbolManager: SymbolManager? = null
     private var mapStyle: Style? = null
-    private val pendingLiveLocations = mutableListOf<UserLiveLocationViewState>()
+    private val userLocationDrawable by lazy { drawableProvider.getDrawable(R.drawable.ic_location_user) }
     private var isMapFirstUpdate = true
     private var onSymbolClickListener: OnSymbolClickListener? = null
     private var mapLoadingErrorListener: MapView.OnDidFailLoadingMapListener? = null
@@ -90,6 +99,7 @@ class LiveLocationMapViewFragment :
         super.onViewCreated(view, savedInstanceState)
         observeViewEvents()
         setupMap()
+        initLocateButton()
 
         views.liveLocationBottomSheetRecyclerView.configureWith(bottomSheetController, hasFixedSize = false, disableItemAnimation = true)
 
@@ -107,8 +117,20 @@ class LiveLocationMapViewFragment :
     private fun observeViewEvents() {
         viewModel.observeViewEvents { viewEvent ->
             when (viewEvent) {
-                is LiveLocationMapViewEvents.Error -> displayErrorDialog(viewEvent.error)
+                is LiveLocationMapViewEvents.LiveLocationError -> displayErrorDialog(viewEvent.error)
+                is LiveLocationMapViewEvents.ZoomToUserLocation -> handleZoomToUserLocationEvent(viewEvent)
+                LiveLocationMapViewEvents.UserLocationNotAvailableError -> handleUserLocationNotAvailableError()
             }
+        }
+    }
+
+    private fun handleZoomToUserLocationEvent(event: LiveLocationMapViewEvents.ZoomToUserLocation) {
+        mapboxMap?.get().zoomToLocation(event.userLocation)
+    }
+
+    private fun handleUserLocationNotAvailableError() {
+        showUserLocationNotAvailableErrorDialog {
+            // do nothing
         }
     }
 
@@ -141,11 +163,30 @@ class LiveLocationMapViewFragment :
                             true
                         }.also { addClickListener(it) }
                     }
-                    pendingLiveLocations
-                            .takeUnless { it.isEmpty() }
-                            ?.let { updateMap(it) }
+                    // force refresh of the map using the last viewState
+                    invalidate()
                 }
             }
+        }
+    }
+
+    private fun initLocateButton() {
+        views.liveLocationMapLocateButton.setOnClickListener {
+            if (checkPermissions(PERMISSIONS_FOR_FOREGROUND_LOCATION_SHARING, requireActivity(), foregroundLocationResultLauncher)) {
+                zoomToUserLocation()
+            }
+        }
+    }
+
+    private fun zoomToUserLocation() {
+        viewModel.handle(LiveLocationMapAction.ZoomToUserLocation)
+    }
+
+    private val foregroundLocationResultLauncher = registerForPermissionsResult { allGranted, deniedPermanently ->
+        if (allGranted) {
+            zoomToUserLocation()
+        } else if (deniedPermanently) {
+            activity?.onPermissionDeniedDialog(R.string.denied_permission_generic)
         }
     }
 
@@ -191,10 +232,15 @@ class LiveLocationMapViewFragment :
             views.mapPreviewLoadingError.isVisible = true
         } else {
             views.mapPreviewLoadingError.isGone = true
-            updateMap(viewState.userLocations)
+            updateMap(userLiveLocations = viewState.userLocations, userLocation = viewState.lastKnownUserLocation)
+        }
+        if (viewState.isLoadingUserLocation) {
+            showLoadingDialog()
+        } else {
+            dismissLoadingDialog()
         }
         updateUserListBottomSheet(viewState.userLocations)
-        updateLocateButton(showLocateButton = viewState.showLocateButton)
+        updateLocateButton(showLocateButton = viewState.showLocateUserButton)
     }
 
     private fun updateUserListBottomSheet(userLocations: List<UserLiveLocationViewState>) {
@@ -253,7 +299,10 @@ class LiveLocationMapViewFragment :
         }
     }
 
-    private fun updateMap(userLiveLocations: List<UserLiveLocationViewState>) {
+    private fun updateMap(
+            userLiveLocations: List<UserLiveLocationViewState>,
+            userLocation: LocationData?,
+    ) {
         symbolManager?.let { sManager ->
             val latLngBoundsBuilder = LatLngBounds.Builder()
             userLiveLocations.forEach { userLocation ->
@@ -266,28 +315,60 @@ class LiveLocationMapViewFragment :
 
             removeOutdatedSymbols(userLiveLocations, sManager)
             updateMapZoomWhenNeeded(userLiveLocations, latLngBoundsBuilder)
-        } ?: postponeUpdateOfMap(userLiveLocations)
-    }
-
-    private fun createOrUpdateSymbol(userLocation: UserLiveLocationViewState, symbolManager: SymbolManager) = withState(viewModel) { state ->
-        val symbolId = state.mapSymbolIds[userLocation.matrixItem.id]
-
-        if (symbolId == null || symbolManager.annotations.get(symbolId) == null) {
-            createSymbol(userLocation, symbolManager)
-        } else {
-            updateSymbol(symbolId, userLocation, symbolManager)
+            if (userLocation == null) {
+                removeUserSymbol(sManager)
+            } else {
+                createOrUpdateUserSymbol(userLocation, sManager)
+            }
         }
     }
 
-    private fun createSymbol(userLocation: UserLiveLocationViewState, symbolManager: SymbolManager) {
-        addUserPinToMapStyle(userLocation.matrixItem.id, userLocation.pinDrawable)
-        val symbolOptions = buildSymbolOptions(userLocation)
-        val symbol = symbolManager.create(symbolOptions)
-        viewModel.handle(LiveLocationMapAction.AddMapSymbol(userLocation.matrixItem.id, symbol.id))
+    private fun createOrUpdateSymbol(userLocation: UserLiveLocationViewState, symbolManager: SymbolManager) {
+        val pinId = userLocation.matrixItem.id
+        val pinDrawable = userLocation.pinDrawable
+        createOrUpdateSymbol(pinId, pinDrawable, userLocation.locationData, symbolManager)
     }
 
-    private fun updateSymbol(symbolId: Long, userLocation: UserLiveLocationViewState, symbolManager: SymbolManager) {
-        val newLocation = LatLng(userLocation.locationData.latitude, userLocation.locationData.longitude)
+    private fun createOrUpdateUserSymbol(locationData: LocationData, symbolManager: SymbolManager) {
+        userLocationDrawable?.let { pinDrawable -> createOrUpdateSymbol(USER_LOCATION_PIN_ID, pinDrawable, locationData, symbolManager) }
+    }
+
+    private fun removeUserSymbol(symbolManager: SymbolManager) = withState(viewModel) { state ->
+        val pinId = USER_LOCATION_PIN_ID
+        state.mapSymbolIds[pinId]?.let { symbolId ->
+            removeSymbol(pinId, symbolId, symbolManager)
+        }
+    }
+
+    private fun createOrUpdateSymbol(
+            pinId: String,
+            pinDrawable: Drawable,
+            locationData: LocationData,
+            symbolManager: SymbolManager
+    ) = withState(viewModel) { state ->
+        val symbolId = state.mapSymbolIds[pinId]
+
+        if (symbolId == null || symbolManager.annotations.get(symbolId) == null) {
+            createSymbol(pinId, pinDrawable, locationData, symbolManager)
+        } else {
+            updateSymbol(symbolId, locationData, symbolManager)
+        }
+    }
+
+    private fun createSymbol(
+            pinId: String,
+            pinDrawable: Drawable,
+            locationData: LocationData,
+            symbolManager: SymbolManager
+    ) {
+        addPinToMapStyle(pinId, pinDrawable)
+        val symbolOptions = buildSymbolOptions(locationData, pinId)
+        val symbol = symbolManager.create(symbolOptions)
+        viewModel.handle(LiveLocationMapAction.AddMapSymbol(pinId, symbol.id))
+    }
+
+    private fun updateSymbol(symbolId: Long, locationData: LocationData, symbolManager: SymbolManager) {
+        val newLocation = LatLng(locationData.latitude, locationData.longitude)
         val symbol = symbolManager.annotations.get(symbolId)
         symbol?.let {
             it.latLng = newLocation
@@ -296,17 +377,11 @@ class LiveLocationMapViewFragment :
     }
 
     private fun removeOutdatedSymbols(userLiveLocations: List<UserLiveLocationViewState>, symbolManager: SymbolManager) = withState(viewModel) { state ->
-        val userIdsToRemove = state.mapSymbolIds.keys.subtract(userLiveLocations.map { it.matrixItem.id }.toSet())
-        userIdsToRemove.forEach { userId ->
-            removeUserPinFromMapStyle(userId)
-            viewModel.handle(LiveLocationMapAction.RemoveMapSymbol(userId))
-
-            state.mapSymbolIds[userId]?.let { symbolId ->
-                Timber.d("trying to delete symbol with id: $symbolId")
-                symbolManager.annotations.get(symbolId)?.let {
-                    symbolManager.delete(it)
-                }
-            }
+        val pinIdsToKeep = userLiveLocations.map { it.matrixItem.id } + USER_LOCATION_PIN_ID
+        val pinIdsToRemove = state.mapSymbolIds.keys.subtract(pinIdsToKeep.toSet())
+        pinIdsToRemove.forEach { pinId ->
+            val symbolId = state.mapSymbolIds[pinId]
+            removeSymbol(pinId, symbolId, symbolManager)
         }
     }
 
@@ -321,27 +396,35 @@ class LiveLocationMapViewFragment :
         }
     }
 
-    private fun postponeUpdateOfMap(userLiveLocations: List<UserLiveLocationViewState>) {
-        pendingLiveLocations.clear()
-        pendingLiveLocations.addAll(userLiveLocations)
-    }
-
-    private fun addUserPinToMapStyle(userId: String, userPinDrawable: Drawable) {
+    private fun addPinToMapStyle(pinId: String, pinDrawable: Drawable) {
         mapStyle?.let { style ->
-            if (style.getImage(userId) == null) {
-                style.addImage(userId, userPinDrawable.toBitmap())
+            if (style.getImage(pinId) == null) {
+                style.addImage(pinId, pinDrawable.toBitmap())
             }
         }
     }
 
-    private fun removeUserPinFromMapStyle(userId: String) {
-        mapStyle?.removeImage(userId)
+    private fun removeSymbol(pinId: String, symbolId: Long?, symbolManager: SymbolManager) {
+        removeUserPinFromMapStyle(pinId)
+
+        symbolId?.let { id ->
+            Timber.d("trying to delete symbol with id: $id")
+            symbolManager.annotations.get(id)?.let {
+                symbolManager.delete(it)
+            }
+        }
+
+        viewModel.handle(LiveLocationMapAction.RemoveMapSymbol(pinId))
     }
 
-    private fun buildSymbolOptions(userLiveLocation: UserLiveLocationViewState) =
+    private fun removeUserPinFromMapStyle(pinId: String) {
+        mapStyle?.removeImage(pinId)
+    }
+
+    private fun buildSymbolOptions(locationData: LocationData, pinId: String) =
             SymbolOptions()
-                    .withLatLng(LatLng(userLiveLocation.locationData.latitude, userLiveLocation.locationData.longitude))
-                    .withIconImage(userLiveLocation.matrixItem.id)
+                    .withLatLng(LatLng(locationData.latitude, locationData.longitude))
+                    .withIconImage(pinId)
                     .withIconAnchor(Property.ICON_ANCHOR_BOTTOM)
 
     private fun handleBottomSheetUserSelected(userId: String) = withState(viewModel) { state ->

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewFragment.kt
@@ -24,6 +24,8 @@ import android.view.ViewGroup
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import androidx.core.view.marginBottom
+import androidx.core.view.marginTop
 import androidx.lifecycle.lifecycleScope
 import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.withState
@@ -192,6 +194,7 @@ class LiveLocationMapViewFragment :
             updateMap(viewState.userLocations)
         }
         updateUserListBottomSheet(viewState.userLocations)
+        updateLocateButton(showLocateButton = false)
     }
 
     private fun updateUserListBottomSheet(userLocations: List<UserLiveLocationViewState>) {
@@ -233,6 +236,20 @@ class LiveLocationMapViewFragment :
                         bottomOffset + dimensionConverter.dpToPx(COPYRIGHT_MARGIN_DP)
                 )
             }
+        }
+    }
+
+    private fun updateLocateButton(showLocateButton: Boolean) {
+        views.liveLocationMapLocateButton.isVisible = showLocateButton
+        adjustCompassButton()
+    }
+
+    private fun adjustCompassButton() {
+        val locateButton = views.liveLocationMapLocateButton
+        locateButton.post {
+            val marginTop = locateButton.height + locateButton.marginTop + locateButton.marginBottom
+            val marginRight = locateButton.context.resources.getDimensionPixelOffset(R.dimen.location_sharing_compass_button_margin_horizontal)
+            mapboxMap?.get()?.uiSettings?.setCompassMargins(0, marginTop, marginRight, 0)
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewModel.kt
@@ -27,7 +27,6 @@ import im.vector.app.features.location.LocationData
 import im.vector.app.features.location.LocationTracker
 import im.vector.app.features.location.live.StopLiveLocationShareUseCase
 import im.vector.app.features.location.live.tracking.LocationSharingServiceConnection
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -132,7 +131,7 @@ class LiveLocationMapViewModel @AssistedInject constructor(
             setState {
                 copy(isLoadingUserLocation = true)
             }
-            viewModelScope.launch(Dispatchers.Main) {
+            viewModelScope.launch(session.coroutineDispatchers.main) {
                 locationTracker.start()
                 locationTracker.requestLastKnownLocation()
             }

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewModel.kt
@@ -28,10 +28,12 @@ import im.vector.app.features.location.live.tracking.LocationSharingServiceConne
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.room.location.UpdateLiveLocationShareResult
 
 class LiveLocationMapViewModel @AssistedInject constructor(
         @Assisted private val initialState: LiveLocationMapViewState,
+        private val session: Session,
         getListOfUserLiveLocationUseCase: GetListOfUserLiveLocationUseCase,
         private val locationSharingServiceConnection: LocationSharingServiceConnection,
         private val stopLiveLocationShareUseCase: StopLiveLocationShareUseCase,
@@ -46,7 +48,7 @@ class LiveLocationMapViewModel @AssistedInject constructor(
 
     init {
         getListOfUserLiveLocationUseCase.execute(initialState.roomId)
-                .onEach { setState { copy(userLocations = it) } }
+                .onEach { setState { copy(userLocations = it, showLocateButton = it.none { it.matrixItem.id == session.myUserId }) } }
                 .launchIn(viewModelScope)
         locationSharingServiceConnection.bind(this)
     }

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewModel.kt
@@ -23,8 +23,11 @@ import dagger.assisted.AssistedInject
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.VectorViewModel
+import im.vector.app.features.location.LocationData
+import im.vector.app.features.location.LocationTracker
 import im.vector.app.features.location.live.StopLiveLocationShareUseCase
 import im.vector.app.features.location.live.tracking.LocationSharingServiceConnection
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -37,7 +40,11 @@ class LiveLocationMapViewModel @AssistedInject constructor(
         getListOfUserLiveLocationUseCase: GetListOfUserLiveLocationUseCase,
         private val locationSharingServiceConnection: LocationSharingServiceConnection,
         private val stopLiveLocationShareUseCase: StopLiveLocationShareUseCase,
-) : VectorViewModel<LiveLocationMapViewState, LiveLocationMapAction, LiveLocationMapViewEvents>(initialState), LocationSharingServiceConnection.Callback {
+        private val locationTracker: LocationTracker,
+) :
+        VectorViewModel<LiveLocationMapViewState, LiveLocationMapAction, LiveLocationMapViewEvents>(initialState),
+        LocationSharingServiceConnection.Callback,
+        LocationTracker.Callback {
 
     @AssistedFactory
     interface Factory : MavericksAssistedViewModelFactory<LiveLocationMapViewModel, LiveLocationMapViewState> {
@@ -48,12 +55,37 @@ class LiveLocationMapViewModel @AssistedInject constructor(
 
     init {
         getListOfUserLiveLocationUseCase.execute(initialState.roomId)
-                .onEach { setState { copy(userLocations = it, showLocateButton = it.none { it.matrixItem.id == session.myUserId }) } }
+                .onEach { setState { copy(userLocations = it, showLocateUserButton = it.none { it.matrixItem.id == session.myUserId }) } }
                 .launchIn(viewModelScope)
         locationSharingServiceConnection.bind(this)
+        initLocationTracking()
+    }
+
+    private fun initLocationTracking() {
+        locationTracker.addCallback(this)
+        locationTracker.locations
+                .onEach(::onLocationUpdate)
+                .launchIn(viewModelScope)
+    }
+
+    private fun onLocationUpdate(locationData: LocationData) = withState { state ->
+        val zoomToUserLocation = state.isLoadingUserLocation
+        val showLocateButton = state.showLocateUserButton
+
+        setState {
+            copy(
+                    lastKnownUserLocation = if (showLocateButton) locationData else null,
+                    isLoadingUserLocation = false,
+            )
+        }
+
+        if (zoomToUserLocation) {
+            _viewEvents.post(LiveLocationMapViewEvents.ZoomToUserLocation(locationData))
+        }
     }
 
     override fun onCleared() {
+        locationTracker.removeCallback(this)
         locationSharingServiceConnection.unbind(this)
         super.onCleared()
     }
@@ -64,6 +96,7 @@ class LiveLocationMapViewModel @AssistedInject constructor(
             is LiveLocationMapAction.RemoveMapSymbol -> handleRemoveMapSymbol(action)
             LiveLocationMapAction.StopSharing -> handleStopSharing()
             LiveLocationMapAction.ShowMapLoadingError -> handleShowMapLoadingError()
+            LiveLocationMapAction.ZoomToUserLocation -> handleZoomToUserLocation()
         }
     }
 
@@ -85,13 +118,26 @@ class LiveLocationMapViewModel @AssistedInject constructor(
         viewModelScope.launch {
             val result = stopLiveLocationShareUseCase.execute(initialState.roomId)
             if (result is UpdateLiveLocationShareResult.Failure) {
-                _viewEvents.post(LiveLocationMapViewEvents.Error(result.error))
+                _viewEvents.post(LiveLocationMapViewEvents.LiveLocationError(result.error))
             }
         }
     }
 
     private fun handleShowMapLoadingError() {
         setState { copy(loadingMapHasFailed = true) }
+    }
+
+    // TODO add unit tests
+    private fun handleZoomToUserLocation() = withState { state ->
+        if (!state.isLoadingUserLocation) {
+            setState {
+                copy(isLoadingUserLocation = true)
+            }
+            viewModelScope.launch(Dispatchers.Main) {
+                locationTracker.start()
+                locationTracker.requestLastKnownLocation()
+            }
+        }
     }
 
     override fun onLocationServiceRunning(roomIds: Set<String>) {
@@ -103,6 +149,10 @@ class LiveLocationMapViewModel @AssistedInject constructor(
     }
 
     override fun onLocationServiceError(error: Throwable) {
-        _viewEvents.post(LiveLocationMapViewEvents.Error(error))
+        _viewEvents.post(LiveLocationMapViewEvents.LiveLocationError(error))
+    }
+
+    override fun onNoLocationProviderAvailable() {
+        _viewEvents.post(LiveLocationMapViewEvents.UserLocationNotAvailableError)
     }
 }

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewModel.kt
@@ -127,7 +127,6 @@ class LiveLocationMapViewModel @AssistedInject constructor(
         setState { copy(loadingMapHasFailed = true) }
     }
 
-    // TODO add unit tests
     private fun handleZoomToUserLocation() = withState { state ->
         if (!state.isLoadingUserLocation) {
             setState {

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewState.kt
@@ -29,7 +29,9 @@ data class LiveLocationMapViewState(
          */
         val mapSymbolIds: Map<String, Long> = emptyMap(),
         val loadingMapHasFailed: Boolean = false,
-        val showLocateButton: Boolean = false,
+        val showLocateUserButton: Boolean = false,
+        val isLoadingUserLocation: Boolean = false,
+        val lastKnownUserLocation: LocationData? = null,
 ) : MavericksState {
     constructor(liveLocationMapViewArgs: LiveLocationMapViewArgs) : this(
             roomId = liveLocationMapViewArgs.roomId

--- a/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/location/live/map/LiveLocationMapViewState.kt
@@ -29,6 +29,7 @@ data class LiveLocationMapViewState(
          */
         val mapSymbolIds: Map<String, Long> = emptyMap(),
         val loadingMapHasFailed: Boolean = false,
+        val showLocateButton: Boolean = false,
 ) : MavericksState {
     constructor(liveLocationMapViewArgs: LiveLocationMapViewArgs) : this(
             roomId = liveLocationMapViewArgs.roomId

--- a/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewEvents.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2021 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,10 @@
 
 package im.vector.app.features.location.preview
 
-import im.vector.app.core.platform.VectorViewModelAction
+import im.vector.app.core.platform.VectorViewEvents
+import im.vector.app.features.location.LocationData
 
-sealed class LocationPreviewAction : VectorViewModelAction {
-    object ShowMapLoadingError : LocationPreviewAction()
-    object ZoomToUserLocation : LocationPreviewAction()
+sealed class LocationPreviewViewEvents : VectorViewEvents {
+    data class ZoomToUserLocation(val userLocation: LocationData) : LocationPreviewViewEvents()
+    object UserLocationNotAvailableError : LocationPreviewViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewModel.kt
@@ -26,13 +26,14 @@ import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.features.home.room.detail.timeline.helper.LocationPinProvider
 import im.vector.app.features.location.LocationData
 import im.vector.app.features.location.LocationTracker
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.session.Session
 
 class LocationPreviewViewModel @AssistedInject constructor(
         @Assisted private val initialState: LocationPreviewViewState,
+        private val session: Session,
         private val locationPinProvider: LocationPinProvider,
         private val locationTracker: LocationTracker,
 ) : VectorViewModel<LocationPreviewViewState, LocationPreviewAction, LocationPreviewViewEvents>(initialState), LocationTracker.Callback {
@@ -83,7 +84,7 @@ class LocationPreviewViewModel @AssistedInject constructor(
             setState {
                 copy(isLoadingUserLocation = true)
             }
-            viewModelScope.launch(Dispatchers.Main) {
+            viewModelScope.launch(session.coroutineDispatchers.main) {
                 locationTracker.start()
                 locationTracker.requestLastKnownLocation()
             }

--- a/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewModel.kt
@@ -23,6 +23,7 @@ import dagger.assisted.AssistedInject
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.VectorViewModel
+import im.vector.app.features.home.room.detail.timeline.helper.LocationPinProvider
 import im.vector.app.features.location.LocationData
 import im.vector.app.features.location.LocationTracker
 import kotlinx.coroutines.Dispatchers
@@ -32,6 +33,7 @@ import kotlinx.coroutines.launch
 
 class LocationPreviewViewModel @AssistedInject constructor(
         @Assisted private val initialState: LocationPreviewViewState,
+        private val locationPinProvider: LocationPinProvider,
         private val locationTracker: LocationTracker,
 ) : VectorViewModel<LocationPreviewViewState, LocationPreviewAction, LocationPreviewViewEvents>(initialState), LocationTracker.Callback {
 
@@ -43,7 +45,16 @@ class LocationPreviewViewModel @AssistedInject constructor(
     companion object : MavericksViewModelFactory<LocationPreviewViewModel, LocationPreviewViewState> by hiltMavericksViewModelFactory()
 
     init {
+        initialState.pinUserId?.let { userId ->
+            initPin(userId)
+        }
         initLocationTracking()
+    }
+
+    private fun initPin(userId: String) {
+        locationPinProvider.create(userId) { pinDrawable ->
+            setState { copy(pinDrawable = pinDrawable) }
+        }
     }
 
     private fun initLocationTracking() {

--- a/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewModel.kt
@@ -94,18 +94,18 @@ class LocationPreviewViewModel @AssistedInject constructor(
         _viewEvents.post(LocationPreviewViewEvents.UserLocationNotAvailableError)
     }
 
-    private fun onLocationUpdate(locationData: LocationData) {
-        withState { state ->
-            if (state.isLoadingUserLocation) {
-                _viewEvents.post(LocationPreviewViewEvents.ZoomToUserLocation(locationData))
-            }
-        }
+    private fun onLocationUpdate(locationData: LocationData) = withState { state ->
+        val zoomToUserLocation = state.isLoadingUserLocation
 
         setState {
             copy(
                     lastKnownUserLocation = locationData,
                     isLoadingUserLocation = false,
             )
+        }
+
+        if (zoomToUserLocation) {
+            _viewEvents.post(LocationPreviewViewEvents.ZoomToUserLocation(locationData))
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewModel.kt
@@ -45,13 +45,11 @@ class LocationPreviewViewModel @AssistedInject constructor(
     companion object : MavericksViewModelFactory<LocationPreviewViewModel, LocationPreviewViewState> by hiltMavericksViewModelFactory()
 
     init {
-        initialState.pinUserId?.let { userId ->
-            initPin(userId)
-        }
+        initPin(initialState.pinUserId)
         initLocationTracking()
     }
 
-    private fun initPin(userId: String) {
+    private fun initPin(userId: String?) {
         locationPinProvider.create(userId) { pinDrawable ->
             setState { copy(pinDrawable = pinDrawable) }
         }

--- a/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewState.kt
@@ -16,11 +16,22 @@
 
 package im.vector.app.features.location.preview
 
+import android.graphics.drawable.Drawable
 import com.airbnb.mvrx.MavericksState
 import im.vector.app.features.location.LocationData
+import im.vector.app.features.location.LocationSharingArgs
 
 data class LocationPreviewViewState(
+        val pinLocationData: LocationData? = null,
+        val pinUserId: String? = null,
+        val pinDrawable: Drawable? = null,
         val loadingMapHasFailed: Boolean = false,
         val isLoadingUserLocation: Boolean = false,
         val lastKnownUserLocation: LocationData? = null,
-) : MavericksState
+) : MavericksState {
+
+    constructor(args: LocationSharingArgs): this(
+            pinLocationData = args.initialLocationData,
+            pinUserId = args.locationOwnerId,
+    )
+}

--- a/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewState.kt
@@ -17,7 +17,10 @@
 package im.vector.app.features.location.preview
 
 import com.airbnb.mvrx.MavericksState
+import im.vector.app.features.location.LocationData
 
 data class LocationPreviewViewState(
-        val loadingMapHasFailed: Boolean = false
+        val loadingMapHasFailed: Boolean = false,
+        val isLoadingUserLocation: Boolean = false,
+        val lastKnownUserLocation: LocationData? = null,
 ) : MavericksState

--- a/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/location/preview/LocationPreviewViewState.kt
@@ -30,7 +30,7 @@ data class LocationPreviewViewState(
         val lastKnownUserLocation: LocationData? = null,
 ) : MavericksState {
 
-    constructor(args: LocationSharingArgs): this(
+    constructor(args: LocationSharingArgs) : this(
             pinLocationData = args.initialLocationData,
             pinUserId = args.locationOwnerId,
     )

--- a/vector/src/main/res/drawable/ic_location_user.xml
+++ b/vector/src/main/res/drawable/ic_location_user.xml
@@ -1,14 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="oval">
-            <size
-                android:width="13dp"
-                android:height="13dp" />
-            <solid android:color="?colorPrimary" />
-            <stroke
-                android:width="2dp"
-                android:color="@color/palette_white" />
-        </shape>
-    </item>
-</layer-list>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="28dp"
+    android:viewportWidth="20"
+    android:viewportHeight="28">
+  <path
+      android:pathData="M10,0.667C4.84,0.667 0.667,4.953 0.667,10.254C0.667,15.965 6.56,23.841 8.987,26.84C9.52,27.497 10.493,27.497 11.027,26.84C13.44,23.841 19.333,15.965 19.333,10.254C19.333,4.953 15.16,0.667 10,0.667ZM10,13.678C8.16,13.678 6.667,12.144 6.667,10.254C6.667,8.364 8.16,6.83 10,6.83C11.84,6.83 13.333,8.364 13.333,10.254C13.333,12.144 11.84,13.678 10,13.678Z"
+      android:fillColor="#0DBD8B"/>
+</vector>

--- a/vector/src/main/res/layout/fragment_live_location_map_view.xml
+++ b/vector/src/main/res/layout/fragment_live_location_map_view.xml
@@ -17,6 +17,20 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <ImageView
+        android:id="@+id/liveLocationMapLocateButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|end"
+        android:layout_marginHorizontal="@dimen/location_sharing_locate_button_margin_horizontal"
+        android:layout_marginVertical="@dimen/location_sharing_locate_button_margin_vertical"
+        android:clickable="true"
+        android:contentDescription="@string/a11y_location_share_locate_button"
+        android:focusable="true"
+        android:src="@drawable/btn_locate"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
     <im.vector.app.features.location.MapLoadingErrorView
         android:id="@+id/mapPreviewLoadingError"
         android:layout_width="match_parent"

--- a/vector/src/main/res/layout/fragment_location_preview.xml
+++ b/vector/src/main/res/layout/fragment_location_preview.xml
@@ -13,7 +13,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:mapbox_renderTextureMode="true"
-        app:showLocateButton="false" />
+        app:showLocateButton="true" />
 
     <im.vector.app.features.location.MapLoadingErrorView
         android:id="@+id/mapPreviewLoadingError"

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeLocationTracker.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeLocationTracker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,19 @@
 
 package im.vector.app.test.fakes
 
-import im.vector.app.features.location.live.tracking.LocationSharingServiceConnection
-import io.mockk.justRun
+import im.vector.app.features.location.LocationTracker
 import io.mockk.mockk
 import io.mockk.verify
 
-class FakeLocationSharingServiceConnection {
+class FakeLocationTracker {
 
-    val instance = mockk<LocationSharingServiceConnection>()
+    val instance: LocationTracker = mockk(relaxed = true)
 
-    fun givenBind() {
-        justRun { instance.bind(any()) }
+    fun verifyAddCallback(callback: LocationTracker.Callback) {
+        verify { instance.addCallback(callback) }
     }
 
-    fun verifyBind(callback: LocationSharingServiceConnection.Callback) {
-        verify { instance.bind(callback) }
-    }
-
-    fun givenUnbind() {
-        justRun { instance.unbind(any()) }
-    }
-
-    fun verifyUnbind(callback: LocationSharingServiceConnection.Callback) {
-        verify { instance.unbind(callback) }
+    fun verifyRemoveCallback(callback: LocationTracker.Callback) {
+        verify { instance.removeCallback(callback) }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Adding locate button in the expanded map views when looking at static or live location sharing.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #8110 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

Static location share
<img src="https://user-images.githubusercontent.com/46314705/219707218-c9d8016c-13b4-4b70-bc28-d08912ade1c0.png" width=300 />

Live location share
<img src="https://user-images.githubusercontent.com/46314705/219708501-756979bb-a59d-4ba1-8873-27c753c8ba55.png" width=300 />

## Tests

<!-- Explain how you tested your development -->

- Open a static location share message
- Check a locate button is displayed on the map
- Press the locate button
- Check the map is centered on the current user location
- Open a running live location share message
- Check a locate button is displayed on the map (only when current user is not live sharing their location)
- Press the locate button
- Check the map is centered on the current user location

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
