### PR TITLE
[Timeline]: Editing a reply from iOS breaks the "in reply to" rendering (PSG-1168)

### DIFF
--- a/changelog.d/8150.bugfix
+++ b/changelog.d/8150.bugfix
@@ -1,0 +1,1 @@
+[Timeline]: Editing a reply from iOS breaks the "in reply to" rendering

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/timeline/TimelineEvent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/timeline/TimelineEvent.kt
@@ -28,6 +28,7 @@ import org.matrix.android.sdk.api.session.events.model.isLiveLocation
 import org.matrix.android.sdk.api.session.events.model.isPoll
 import org.matrix.android.sdk.api.session.events.model.isReply
 import org.matrix.android.sdk.api.session.events.model.isSticker
+import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.room.model.EventAnnotationsSummary
 import org.matrix.android.sdk.api.session.room.model.ReadReceipt
@@ -36,6 +37,7 @@ import org.matrix.android.sdk.api.session.room.model.message.MessageBeaconLocati
 import org.matrix.android.sdk.api.session.room.model.message.MessageContent
 import org.matrix.android.sdk.api.session.room.model.message.MessageContentWithFormattedBody
 import org.matrix.android.sdk.api.session.room.model.message.MessageEndPollContent
+import org.matrix.android.sdk.api.session.room.model.message.MessageFormat
 import org.matrix.android.sdk.api.session.room.model.message.MessagePollContent
 import org.matrix.android.sdk.api.session.room.model.message.MessageStickerContent
 import org.matrix.android.sdk.api.session.room.model.message.MessageTextContent
@@ -157,7 +159,39 @@ fun TimelineEvent.getLastMessageContent(): MessageContent? {
 }
 
 fun TimelineEvent.getLastEditNewContent(): Content? {
-    return annotations?.editSummary?.latestEdit?.getClearContent()?.toModel<MessageContent>()?.newContent
+    val lastContent = annotations?.editSummary?.latestEdit?.getClearContent()?.toModel<MessageContent>()?.newContent
+    return if (isReply()) {
+        val previousFormattedBody = root.getClearContent().toModel<MessageTextContent>()?.formattedBody
+        if (previousFormattedBody?.isNotEmpty() == true) {
+            val lastMessageContent = lastContent.toModel<MessageTextContent>()
+            lastMessageContent?.let { ensureCorrectFormattedBodyInTextReply(it, previousFormattedBody) }?.toContent() ?: lastContent
+        } else {
+            lastContent
+        }
+    } else {
+        lastContent
+    }
+}
+
+private const val MX_REPLY_END_TAG = "</mx-reply>"
+
+/**
+ * Not every client sends a formatted body in the last edited event since this is not required in the
+ * [Matrix specification](https://spec.matrix.org/v1.4/client-server-api/#applying-mnew_content).
+ * We must ensure there is one so that it is still considered as a reply when rendering the message.
+ */
+private fun ensureCorrectFormattedBodyInTextReply(messageTextContent: MessageTextContent, previousFormattedBody: String): MessageTextContent {
+    return when {
+        messageTextContent.formattedBody.isNullOrEmpty() && previousFormattedBody.contains(MX_REPLY_END_TAG) -> {
+            // take previous formatted body with the new body content
+            val newFormattedBody = previousFormattedBody.replaceAfterLast(MX_REPLY_END_TAG, messageTextContent.body)
+            messageTextContent.copy(
+                    formattedBody = newFormattedBody,
+                    format = MessageFormat.FORMAT_MATRIX_HTML,
+            )
+        }
+        else -> messageTextContent
+    }
 }
 
 private fun TimelineEvent.getLastPollEditNewContent(): Content? {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
When getting the last edited content for a reply, we ensure there is a formatted body so that it is still considered as a reply in the timeline.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
According to [Matrix specification](https://spec.matrix.org/v1.4/client-server-api/#applying-mnew_content) the formatted body is not mandatory so we should cover missing formatted body cases.
Closes #8150 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- From iOS client, send a reply to a message
- From iOS client, edit the reply
- Check in Android client, the message is well rendered in the timeline

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
