### PR TITLE
Add aggregated unread indicator for spaces in the new layout

### DIFF
--- a/changelog.d/8157.feature
+++ b/changelog.d/8157.feature
@@ -1,0 +1,1 @@
+Add aggregated unread indicator for spaces in the new layout

--- a/vector/src/main/java/im/vector/app/core/di/MavericksViewModelModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/MavericksViewModelModule.kt
@@ -40,6 +40,7 @@ import im.vector.app.features.discovery.DiscoverySettingsViewModel
 import im.vector.app.features.discovery.change.SetIdentityServerViewModel
 import im.vector.app.features.home.HomeActivityViewModel
 import im.vector.app.features.home.HomeDetailViewModel
+import im.vector.app.features.home.NewHomeDetailViewModel
 import im.vector.app.features.home.UnknownDeviceDetectorSharedViewModel
 import im.vector.app.features.home.UnreadMessagesSharedViewModel
 import im.vector.app.features.home.UserColorAccountDataViewModel
@@ -717,4 +718,9 @@ interface MavericksViewModelModule {
     @IntoMap
     @MavericksViewModelKey(RoomPollDetailViewModel::class)
     fun roomPollDetailViewModelFactory(factory: RoomPollDetailViewModel.Factory): MavericksAssistedViewModelFactory<*, *>
+
+    @Binds
+    @IntoMap
+    @MavericksViewModelKey(NewHomeDetailViewModel::class)
+    fun newHomeDetailViewModelFactory(factory: NewHomeDetailViewModel.Factory): MavericksAssistedViewModelFactory<*, *>
 }

--- a/vector/src/main/java/im/vector/app/features/home/GetSpacesNotificationBadgeStateUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/home/GetSpacesNotificationBadgeStateUseCase.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home
+
+import im.vector.app.features.home.room.list.UnreadCounterBadgeView
+import im.vector.app.features.spaces.GetSpacesUseCase
+import im.vector.app.features.spaces.notification.GetNotificationCountForSpacesUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import org.matrix.android.sdk.api.query.QueryStringValue
+import org.matrix.android.sdk.api.query.SpaceFilter
+import org.matrix.android.sdk.api.session.room.model.Membership
+import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import org.matrix.android.sdk.api.session.room.spaceSummaryQueryParams
+import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
+import javax.inject.Inject
+
+class GetSpacesNotificationBadgeStateUseCase @Inject constructor(
+        private val getNotificationCountForSpacesUseCase: GetNotificationCountForSpacesUseCase,
+        private val getSpacesUseCase: GetSpacesUseCase,
+) {
+
+    fun execute(): Flow<UnreadCounterBadgeView.State> {
+        val params = spaceSummaryQueryParams {
+            memberships = listOf(Membership.INVITE)
+            displayName = QueryStringValue.IsNotEmpty
+        }
+        return combine(
+                getNotificationCountForSpacesUseCase.execute(SpaceFilter.NoFilter),
+                getSpacesUseCase.execute(params),
+        ) { spacesNotificationCount, spaceInvites ->
+            computeSpacesNotificationCounterBadgeState(spacesNotificationCount, spaceInvites)
+        }
+    }
+
+    private fun computeSpacesNotificationCounterBadgeState(
+            spacesNotificationCount: RoomAggregateNotificationCount,
+            spaceInvites: List<RoomSummary>,
+    ): UnreadCounterBadgeView.State {
+        val hasPendingSpaceInvites = spaceInvites.isNotEmpty()
+        return if (hasPendingSpaceInvites && spacesNotificationCount.notificationCount == 0) {
+            UnreadCounterBadgeView.State.Text(
+                    text = "!",
+                    highlighted = true,
+            )
+        } else {
+            UnreadCounterBadgeView.State.Count(
+                    count = spacesNotificationCount.notificationCount,
+                    highlighted = spacesNotificationCount.isHighlight || hasPendingSpaceInvites,
+            )
+        }
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
@@ -398,7 +398,7 @@ class NewHomeDetailFragment :
         } else {
             UnreadCounterBadgeView.State.Count(
                     count = spacesNotificationCount.notificationCount,
-                    highlighted = spacesNotificationCount.isHighlight,
+                    highlighted = spacesNotificationCount.isHighlight || hasPendingSpaceInvites,
             )
         }
         views.spacesUnreadCounterBadge.render(badgeState)

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
@@ -185,7 +185,7 @@ class NewHomeDetailFragment :
                 }
 
         newHomeDetailViewModel.onEach { viewState ->
-            refreshUnreadCounterBadge(viewState.spacesNotificationCount)
+            refreshUnreadCounterBadge(viewState.spacesNotificationCount, viewState.hasPendingSpaceInvites)
         }
     }
 
@@ -386,11 +386,21 @@ class NewHomeDetailFragment :
         }
     }
 
-    private fun refreshUnreadCounterBadge(roomAggregateNotificationCount: RoomAggregateNotificationCount) {
-        val badgeState = UnreadCounterBadgeView.State.Count(
-                count = roomAggregateNotificationCount.notificationCount,
-                highlighted = roomAggregateNotificationCount.isHighlight,
-        )
+    private fun refreshUnreadCounterBadge(
+            spacesNotificationCount: RoomAggregateNotificationCount,
+            hasPendingSpaceInvites: Boolean,
+    ) {
+        val badgeState = if (hasPendingSpaceInvites && spacesNotificationCount.notificationCount == 0) {
+            UnreadCounterBadgeView.State.Text(
+                    text = "!",
+                    highlighted = true,
+            )
+        } else {
+            UnreadCounterBadgeView.State.Count(
+                    count = spacesNotificationCount.notificationCount,
+                    highlighted = spacesNotificationCount.isHighlight,
+            )
+        }
         views.spacesUnreadCounterBadge.render(badgeState)
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
@@ -64,7 +64,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.matrix.android.sdk.api.session.crypto.model.DeviceInfo
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
-import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -185,7 +184,7 @@ class NewHomeDetailFragment :
                 }
 
         newHomeDetailViewModel.onEach { viewState ->
-            refreshUnreadCounterBadge(viewState.spacesNotificationCount, viewState.hasPendingSpaceInvites)
+            refreshUnreadCounterBadge(viewState.spacesNotificationCounterBadgeState)
         }
     }
 
@@ -386,21 +385,7 @@ class NewHomeDetailFragment :
         }
     }
 
-    private fun refreshUnreadCounterBadge(
-            spacesNotificationCount: RoomAggregateNotificationCount,
-            hasPendingSpaceInvites: Boolean,
-    ) {
-        val badgeState = if (hasPendingSpaceInvites && spacesNotificationCount.notificationCount == 0) {
-            UnreadCounterBadgeView.State.Text(
-                    text = "!",
-                    highlighted = true,
-            )
-        } else {
-            UnreadCounterBadgeView.State.Count(
-                    count = spacesNotificationCount.notificationCount,
-                    highlighted = spacesNotificationCount.isHighlight || hasPendingSpaceInvites,
-            )
-        }
+    private fun refreshUnreadCounterBadge(badgeState: UnreadCounterBadgeView.State) {
         views.spacesUnreadCounterBadge.render(badgeState)
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
@@ -47,6 +47,7 @@ import im.vector.app.features.call.SharedKnownCallsViewModel
 import im.vector.app.features.call.VectorCallActivity
 import im.vector.app.features.call.dialpad.PstnDialActivity
 import im.vector.app.features.call.webrtc.WebRtcCallManager
+import im.vector.app.features.home.room.list.UnreadCounterBadgeView
 import im.vector.app.features.home.room.list.actions.RoomListSharedAction
 import im.vector.app.features.home.room.list.actions.RoomListSharedActionViewModel
 import im.vector.app.features.home.room.list.home.HomeRoomListFragment
@@ -63,6 +64,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.matrix.android.sdk.api.session.crypto.model.DeviceInfo
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -82,6 +84,7 @@ class NewHomeDetailFragment :
     @Inject lateinit var buildMeta: BuildMeta
 
     private val viewModel: HomeDetailViewModel by fragmentViewModel()
+    private val newHomeDetailViewModel: NewHomeDetailViewModel by fragmentViewModel()
     private val unknownDeviceDetectorSharedViewModel: UnknownDeviceDetectorSharedViewModel by activityViewModel()
     private val serverBackupStatusViewModel: ServerBackupStatusViewModel by activityViewModel()
 
@@ -180,6 +183,10 @@ class NewHomeDetailFragment :
                     currentCallsViewPresenter.updateCall(callManager.getCurrentCall(), callManager.getCalls())
                     invalidateOptionsMenu()
                 }
+
+        newHomeDetailViewModel.onEach { viewState ->
+            refreshUnreadCounterBadge(viewState.spacesNotificationCount)
+        }
     }
 
     private fun setupObservers() {
@@ -377,6 +384,14 @@ class NewHomeDetailFragment :
         state.myMatrixItem?.let { user ->
             avatarRenderer.render(user, views.avatar)
         }
+    }
+
+    private fun refreshUnreadCounterBadge(roomAggregateNotificationCount: RoomAggregateNotificationCount) {
+        val badgeState = UnreadCounterBadgeView.State.Count(
+                count = roomAggregateNotificationCount.notificationCount,
+                highlighted = roomAggregateNotificationCount.isHighlight,
+        )
+        views.spacesUnreadCounterBadge.render(badgeState)
     }
 
     override fun onTapToReturnToCall() {

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailViewModel.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home
+
+import com.airbnb.mvrx.MavericksViewModelFactory
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import im.vector.app.core.di.MavericksAssistedViewModelFactory
+import im.vector.app.core.di.hiltMavericksViewModelFactory
+import im.vector.app.core.platform.EmptyAction
+import im.vector.app.core.platform.EmptyViewEvents
+import im.vector.app.core.platform.VectorViewModel
+import im.vector.app.features.roomprofile.polls.RoomPollsViewModel
+import im.vector.app.features.roomprofile.polls.RoomPollsViewState
+import im.vector.app.features.spaces.notification.GetNotificationCountForSpacesUseCase
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.matrix.android.sdk.api.query.SpaceFilter
+
+class NewHomeDetailViewModel @AssistedInject constructor(
+        @Assisted initialState: NewHomeDetailViewState,
+        private val getNotificationCountForSpacesUseCase: GetNotificationCountForSpacesUseCase,
+) : VectorViewModel<NewHomeDetailViewState, EmptyAction, EmptyViewEvents>(initialState) {
+
+    @AssistedFactory
+    interface Factory : MavericksAssistedViewModelFactory<NewHomeDetailViewModel, NewHomeDetailViewState> {
+        override fun create(initialState: NewHomeDetailViewState): NewHomeDetailViewModel
+    }
+
+    companion object : MavericksViewModelFactory<NewHomeDetailViewModel, NewHomeDetailViewState> by hiltMavericksViewModelFactory()
+
+    init {
+        observeSpacesNotificationCount()
+    }
+
+    private fun observeSpacesNotificationCount() {
+        getNotificationCountForSpacesUseCase.execute(SpaceFilter.NoFilter)
+                .onEach { setState { copy(spacesNotificationCount = it) } }
+                .launchIn(viewModelScope)
+    }
+
+    override fun handle(action: EmptyAction) {
+        // do nothing
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailViewModel.kt
@@ -25,19 +25,12 @@ import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.EmptyAction
 import im.vector.app.core.platform.EmptyViewEvents
 import im.vector.app.core.platform.VectorViewModel
-import im.vector.app.features.spaces.GetSpacesUseCase
-import im.vector.app.features.spaces.notification.GetNotificationCountForSpacesUseCase
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import org.matrix.android.sdk.api.query.QueryStringValue
-import org.matrix.android.sdk.api.query.SpaceFilter
-import org.matrix.android.sdk.api.session.room.model.Membership
-import org.matrix.android.sdk.api.session.room.spaceSummaryQueryParams
 
 class NewHomeDetailViewModel @AssistedInject constructor(
         @Assisted initialState: NewHomeDetailViewState,
-        private val getNotificationCountForSpacesUseCase: GetNotificationCountForSpacesUseCase,
-        private val getSpacesUseCase: GetSpacesUseCase,
+        private val getSpacesNotificationBadgeStateUseCase: GetSpacesNotificationBadgeStateUseCase,
 ) : VectorViewModel<NewHomeDetailViewState, EmptyAction, EmptyViewEvents>(initialState) {
 
     @AssistedFactory
@@ -48,23 +41,12 @@ class NewHomeDetailViewModel @AssistedInject constructor(
     companion object : MavericksViewModelFactory<NewHomeDetailViewModel, NewHomeDetailViewState> by hiltMavericksViewModelFactory()
 
     init {
-        observeSpacesNotificationCount()
-        observeSpacesInvite()
+        observeSpacesNotificationBadgeState()
     }
 
-    private fun observeSpacesNotificationCount() {
-        getNotificationCountForSpacesUseCase.execute(SpaceFilter.NoFilter)
-                .onEach { setState { copy(spacesNotificationCount = it) } }
-                .launchIn(viewModelScope)
-    }
-
-    private fun observeSpacesInvite() {
-        val params = spaceSummaryQueryParams {
-            memberships = listOf(Membership.INVITE)
-            displayName = QueryStringValue.IsNotEmpty
-        }
-        getSpacesUseCase.execute(params)
-                .onEach { setState { copy(hasPendingSpaceInvites = it.isNotEmpty()) } }
+    private fun observeSpacesNotificationBadgeState() {
+        getSpacesNotificationBadgeStateUseCase.execute()
+                .onEach { badgeState -> setState { copy(spacesNotificationCounterBadgeState = badgeState) } }
                 .launchIn(viewModelScope)
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailViewModel.kt
@@ -34,7 +34,6 @@ import org.matrix.android.sdk.api.query.SpaceFilter
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.spaceSummaryQueryParams
 
-// TODO add unit tests
 class NewHomeDetailViewModel @AssistedInject constructor(
         @Assisted initialState: NewHomeDetailViewState,
         private val getNotificationCountForSpacesUseCase: GetNotificationCountForSpacesUseCase,

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailViewState.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home
+
+import com.airbnb.mvrx.MavericksState
+import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
+
+data class NewHomeDetailViewState(
+        val spacesNotificationCount: RoomAggregateNotificationCount = RoomAggregateNotificationCount(notificationCount = 0, highlightCount = 0),
+) : MavericksState

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailViewState.kt
@@ -21,4 +21,5 @@ import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotification
 
 data class NewHomeDetailViewState(
         val spacesNotificationCount: RoomAggregateNotificationCount = RoomAggregateNotificationCount(notificationCount = 0, highlightCount = 0),
+        val hasPendingSpaceInvites: Boolean = false,
 ) : MavericksState

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailViewState.kt
@@ -17,9 +17,8 @@
 package im.vector.app.features.home
 
 import com.airbnb.mvrx.MavericksState
-import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
+import im.vector.app.features.home.room.list.UnreadCounterBadgeView
 
 data class NewHomeDetailViewState(
-        val spacesNotificationCount: RoomAggregateNotificationCount = RoomAggregateNotificationCount(notificationCount = 0, highlightCount = 0),
-        val hasPendingSpaceInvites: Boolean = false,
+        val spacesNotificationCounterBadgeState: UnreadCounterBadgeView.State = UnreadCounterBadgeView.State.Count(count = 0, highlighted = false),
 ) : MavericksState

--- a/vector/src/main/java/im/vector/app/features/spaces/GetSpacesUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/GetSpacesUseCase.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.spaces
+
+import im.vector.app.core.di.ActiveSessionHolder
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import org.matrix.android.sdk.api.session.space.SpaceSummaryQueryParams
+import org.matrix.android.sdk.flow.flow
+import javax.inject.Inject
+
+// TODO add unit tests
+class GetSpacesUseCase @Inject constructor(
+        private val activeSessionHolder: ActiveSessionHolder,
+) {
+
+    fun execute(params: SpaceSummaryQueryParams): Flow<List<RoomSummary>> {
+        val session = activeSessionHolder.getSafeActiveSession()
+
+        return session?.flow()?.liveSpaceSummaries(params) ?: emptyFlow()
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/spaces/SpaceListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/SpaceListViewModel.kt
@@ -29,7 +29,6 @@ import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.features.analytics.AnalyticsTracker
 import im.vector.app.features.analytics.plan.Interaction
-import im.vector.app.features.invite.AutoAcceptInvites
 import im.vector.app.features.session.coroutineScope
 import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.spaces.notification.GetNotificationCountForSpacesUseCase
@@ -53,16 +52,15 @@ import org.matrix.android.sdk.api.session.space.SpaceOrderUtils
 import org.matrix.android.sdk.api.session.space.model.SpaceOrderContent
 import org.matrix.android.sdk.api.session.space.model.TopLevelSpaceComparator
 import org.matrix.android.sdk.api.util.toMatrixItem
-import org.matrix.android.sdk.flow.flow
 
 class SpaceListViewModel @AssistedInject constructor(
         @Assisted initialState: SpaceListViewState,
         private val spaceStateHandler: SpaceStateHandler,
         private val session: Session,
         private val vectorPreferences: VectorPreferences,
-        private val autoAcceptInvites: AutoAcceptInvites,
         private val analyticsTracker: AnalyticsTracker,
-        private val getNotificationCountForSpacesUseCase: GetNotificationCountForSpacesUseCase,
+        getNotificationCountForSpacesUseCase: GetNotificationCountForSpacesUseCase,
+        private val getSpacesUseCase: GetSpacesUseCase,
 ) : VectorViewModel<SpaceListViewState, SpaceListAction, SpaceListViewEvents>(initialState) {
 
     @AssistedFactory
@@ -238,7 +236,7 @@ class SpaceListViewModel @AssistedInject constructor(
         }
 
         combine(
-                session.flow().liveSpaceSummaries(params),
+                getSpacesUseCase.execute(params),
                 session.accountDataService()
                         .getLiveRoomAccountDataEvents(setOf(RoomAccountDataTypes.EVENT_TYPE_SPACE_ORDER))
                         .asFlow()

--- a/vector/src/main/java/im/vector/app/features/spaces/notification/GetNotificationCountForSpacesUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/notification/GetNotificationCountForSpacesUseCase.kt
@@ -19,7 +19,6 @@ package im.vector.app.features.spaces.notification
 import androidx.lifecycle.asFlow
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.features.invite.AutoAcceptInvites
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOn

--- a/vector/src/main/java/im/vector/app/features/spaces/notification/GetNotificationCountForSpacesUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/notification/GetNotificationCountForSpacesUseCase.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.spaces.notification
+
+import androidx.lifecycle.asFlow
+import im.vector.app.core.di.ActiveSessionHolder
+import im.vector.app.features.invite.AutoAcceptInvites
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.sample
+import org.matrix.android.sdk.api.query.SpaceFilter
+import org.matrix.android.sdk.api.session.room.RoomSortOrder
+import org.matrix.android.sdk.api.session.room.model.Membership
+import org.matrix.android.sdk.api.session.room.roomSummaryQueryParams
+import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
+import javax.inject.Inject
+
+// TODO add unit tests
+class GetNotificationCountForSpacesUseCase @Inject constructor(
+        private val activeSessionHolder: ActiveSessionHolder,
+        private val autoAcceptInvites: AutoAcceptInvites,
+) {
+
+    fun execute(spaceFilter: SpaceFilter): Flow<RoomAggregateNotificationCount> {
+        val session = activeSessionHolder.getSafeActiveSession()
+
+        val spaceQueryParams = roomSummaryQueryParams {
+            this.memberships = listOf(Membership.JOIN)
+            this.spaceFilter = spaceFilter
+        }
+        return session
+                ?.roomService()
+                ?.getPagedRoomSummariesLive(queryParams = spaceQueryParams, sortOrder = RoomSortOrder.NONE)
+                ?.asFlow()
+                ?.sample(300)
+                ?.mapLatest {
+                    val inviteCount = if (autoAcceptInvites.hideInvites) {
+                        0
+                    } else {
+                        session.roomService().getRoomSummaries(
+                                roomSummaryQueryParams { this.memberships = listOf(Membership.INVITE) }
+                        ).size
+                    }
+                    val totalCount = session.roomService().getNotificationCountForRooms(spaceQueryParams)
+                    RoomAggregateNotificationCount(
+                            notificationCount = totalCount.notificationCount + inviteCount,
+                            highlightCount = totalCount.highlightCount + inviteCount,
+                    )
+                }
+                ?.flowOn(Dispatchers.Default)
+                ?: emptyFlow()
+    }
+}

--- a/vector/src/main/java/im/vector/app/features/spaces/notification/GetNotificationCountForSpacesUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/spaces/notification/GetNotificationCountForSpacesUseCase.kt
@@ -32,7 +32,6 @@ import org.matrix.android.sdk.api.session.room.roomSummaryQueryParams
 import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
 import javax.inject.Inject
 
-// TODO add unit tests
 class GetNotificationCountForSpacesUseCase @Inject constructor(
         private val activeSessionHolder: ActiveSessionHolder,
         private val autoAcceptInvites: AutoAcceptInvites,
@@ -64,7 +63,7 @@ class GetNotificationCountForSpacesUseCase @Inject constructor(
                             highlightCount = totalCount.highlightCount + inviteCount,
                     )
                 }
-                ?.flowOn(Dispatchers.Default)
+                ?.flowOn(session.coroutineDispatchers.main)
                 ?: emptyFlow()
     }
 }

--- a/vector/src/main/res/layout/fragment_new_home_detail.xml
+++ b/vector/src/main/res/layout/fragment_new_home_detail.xml
@@ -120,6 +120,28 @@
         tools:targetApi="lollipop_mr1"
         tools:visibility="visible" />
 
+    <im.vector.app.features.home.room.list.UnreadCounterBadgeView
+        android:id="@+id/spacesUnreadCounterBadge"
+        style="@style/Widget.Vector.TextView.Micro"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp"
+        android:elevation="15dp"
+        android:gravity="center"
+        android:minWidth="16dp"
+        android:minHeight="16dp"
+        android:paddingStart="4dp"
+        android:paddingEnd="4dp"
+        android:textColor="?colorOnError"
+        app:layout_constraintCircle="@id/newLayoutOpenSpacesButton"
+        app:layout_constraintCircleAngle="45"
+        app:layout_constraintCircleRadius="24dp"
+        tools:background="@drawable/bg_unread_highlight"
+        tools:ignore="MissingConstraints"
+        tools:text="147"
+        tools:visibility="visible" />
+
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/newLayoutCreateChatButton"
         style="@style/Widget.Vector.FloatingActionButton"

--- a/vector/src/test/java/im/vector/app/features/home/GetSpacesNotificationBadgeStateUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/home/GetSpacesNotificationBadgeStateUseCaseTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home
+
+import im.vector.app.features.home.room.list.UnreadCounterBadgeView
+import im.vector.app.features.spaces.GetSpacesUseCase
+import im.vector.app.features.spaces.notification.GetNotificationCountForSpacesUseCase
+import im.vector.app.test.test
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.matrix.android.sdk.api.query.QueryStringValue
+import org.matrix.android.sdk.api.query.SpaceFilter
+import org.matrix.android.sdk.api.session.room.model.Membership
+import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
+
+internal class GetSpacesNotificationBadgeStateUseCaseTest {
+
+    private val fakeGetNotificationCountForSpacesUseCase = mockk<GetNotificationCountForSpacesUseCase>()
+    private val fakeGetSpacesUseCase = mockk<GetSpacesUseCase>()
+
+    private val getSpacesNotificationBadgeStateUseCase = GetSpacesNotificationBadgeStateUseCase(
+            getNotificationCountForSpacesUseCase = fakeGetNotificationCountForSpacesUseCase,
+            getSpacesUseCase = fakeGetSpacesUseCase,
+    )
+
+    @Test
+    fun `given flow of spaces invite and notification count then flow of state is correct`() = runTest {
+        // Given
+        val noSpacesInvite = emptyList<RoomSummary>()
+        val existingSpaceInvite = listOf<RoomSummary>(mockk())
+        val noNotification = RoomAggregateNotificationCount(
+                notificationCount = 0,
+                highlightCount = 0,
+        )
+        val existingNotificationNotHighlighted = RoomAggregateNotificationCount(
+                notificationCount = 1,
+                highlightCount = 0,
+        )
+        val existingNotificationHighlighted = RoomAggregateNotificationCount(
+                notificationCount = 1,
+                highlightCount = 1,
+        )
+        every { fakeGetSpacesUseCase.execute(any()) } returns
+                flowOf(noSpacesInvite, existingSpaceInvite, existingSpaceInvite, noSpacesInvite, noSpacesInvite)
+        every { fakeGetNotificationCountForSpacesUseCase.execute(any()) } returns
+                flowOf(noNotification, noNotification, existingNotificationNotHighlighted, existingNotificationNotHighlighted, existingNotificationHighlighted)
+
+        // When
+        val testObserver = getSpacesNotificationBadgeStateUseCase.execute().test(this)
+        advanceUntilIdle()
+
+        // Then
+        val expectedState1 = UnreadCounterBadgeView.State.Count(count = 0, highlighted = false)
+        val expectedState2 = UnreadCounterBadgeView.State.Text(text = "!", highlighted = true)
+        val expectedState3 = UnreadCounterBadgeView.State.Count(count = 1, highlighted = true)
+        val expectedState4 = UnreadCounterBadgeView.State.Count(count = 1, highlighted = false)
+        val expectedState5 = UnreadCounterBadgeView.State.Count(count = 1, highlighted = true)
+        testObserver
+                .assertValues(expectedState1, expectedState2, expectedState3, expectedState4, expectedState5)
+                .finish()
+        verify {
+            fakeGetSpacesUseCase.execute(match {
+                it.memberships == listOf(Membership.INVITE) && it.displayName == QueryStringValue.IsNotEmpty
+            })
+        }
+        verify { fakeGetNotificationCountForSpacesUseCase.execute(SpaceFilter.NoFilter) }
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/home/NewHomeDetailViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/home/NewHomeDetailViewModelTest.kt
@@ -18,7 +18,6 @@ package im.vector.app.features.home
 
 import com.airbnb.mvrx.test.MavericksTestRule
 import im.vector.app.features.home.room.list.UnreadCounterBadgeView
-import im.vector.app.features.spaces.GetSpacesUseCase
 import im.vector.app.test.test
 import io.mockk.every
 import io.mockk.mockk

--- a/vector/src/test/java/im/vector/app/features/home/NewHomeDetailViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/home/NewHomeDetailViewModelTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home
+
+import com.airbnb.mvrx.test.MavericksTestRule
+import im.vector.app.features.spaces.GetSpacesUseCase
+import im.vector.app.features.spaces.notification.GetNotificationCountForSpacesUseCase
+import im.vector.app.test.test
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Rule
+import org.junit.Test
+import org.matrix.android.sdk.api.query.SpaceFilter
+import org.matrix.android.sdk.api.session.room.model.Membership
+import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
+
+internal class NewHomeDetailViewModelTest {
+
+    @get:Rule
+    val mavericksTestRule = MavericksTestRule(testDispatcher = UnconfinedTestDispatcher())
+
+    private val initialState = NewHomeDetailViewState()
+    private val fakeGetNotificationCountForSpacesUseCase = mockk<GetNotificationCountForSpacesUseCase>()
+    private val fakeGetSpacesUseCase = mockk<GetSpacesUseCase>()
+
+    private fun createViewModel(): NewHomeDetailViewModel {
+        return NewHomeDetailViewModel(
+                initialState = initialState,
+                getNotificationCountForSpacesUseCase = fakeGetNotificationCountForSpacesUseCase,
+                getSpacesUseCase = fakeGetSpacesUseCase,
+        )
+    }
+
+    @Test
+    fun `given the viewModel is created then viewState is updated with space notifications count and pending space invites`() {
+        // Given
+        val spacesNotificationCount = RoomAggregateNotificationCount(
+                notificationCount = 1,
+                highlightCount = 1,
+        )
+        every { fakeGetNotificationCountForSpacesUseCase.execute(any()) } returns flowOf(spacesNotificationCount)
+        val spaceInvites = listOf<RoomSummary>(mockk())
+        every { fakeGetSpacesUseCase.execute(any()) } returns flowOf(spaceInvites)
+        val expectedViewState = initialState.copy(
+                spacesNotificationCount = spacesNotificationCount,
+                hasPendingSpaceInvites = true,
+        )
+
+        // When
+        val viewModel = createViewModel()
+        val viewModelTest = viewModel.test()
+
+        // Then
+        viewModelTest
+                .assertLatestState(expectedViewState)
+                .finish()
+        verify {
+            fakeGetNotificationCountForSpacesUseCase.execute(SpaceFilter.NoFilter)
+            fakeGetSpacesUseCase.execute(match { it.memberships == listOf(Membership.INVITE) })
+        }
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/spaces/GetSpacesUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/spaces/GetSpacesUseCaseTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.spaces
+
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import im.vector.app.test.fakes.FakeFlowLiveDataConversions
+import im.vector.app.test.fakes.givenAsFlow
+import im.vector.app.test.test
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import org.matrix.android.sdk.api.session.space.SpaceSummaryQueryParams
+
+internal class GetSpacesUseCaseTest {
+
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+    private val fakeFlowLiveDataConversions = FakeFlowLiveDataConversions()
+
+    private val getSpacesUseCase = GetSpacesUseCase(
+            activeSessionHolder = fakeActiveSessionHolder.instance,
+    )
+
+    @Before
+    fun setUp() {
+        fakeFlowLiveDataConversions.setup()
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `given params when execute then the list of summaries is returned`() = runTest {
+        // Given
+        val queryParams = givenSpaceQueryParams()
+        val firstSummaries = listOf<RoomSummary>(mockk())
+        val nextSummaries = listOf<RoomSummary>(mockk())
+        fakeActiveSessionHolder.fakeSession
+                .fakeSpaceService
+                .givenGetSpaceSummariesReturns(firstSummaries)
+        fakeActiveSessionHolder.fakeSession
+                .fakeSpaceService
+                .givenGetSpaceSummariesLiveReturns(nextSummaries)
+                .givenAsFlow()
+
+        // When
+        val testObserver = getSpacesUseCase.execute(queryParams).test(this)
+        advanceUntilIdle()
+
+        // Then
+        testObserver
+                .assertValues(firstSummaries, nextSummaries)
+                .finish()
+        verify {
+            fakeActiveSessionHolder.fakeSession.fakeSpaceService.getSpaceSummaries(queryParams)
+            fakeActiveSessionHolder.fakeSession.fakeSpaceService.getSpaceSummariesLive(queryParams)
+        }
+    }
+
+    @Test
+    fun `given no active session when execute then empty flow is returned`() = runTest {
+        // Given
+        fakeActiveSessionHolder.givenGetSafeActiveSessionReturns(null)
+        val queryParams = givenSpaceQueryParams()
+
+        // When
+        val testObserver = getSpacesUseCase.execute(queryParams).test(this)
+        advanceUntilIdle()
+
+        // Then
+        testObserver
+                .assertNoValues()
+                .finish()
+        verify(inverse = true) {
+            fakeActiveSessionHolder.fakeSession.fakeSpaceService.getSpaceSummaries(queryParams)
+            fakeActiveSessionHolder.fakeSession.fakeSpaceService.getSpaceSummariesLive(queryParams)
+        }
+    }
+
+    private fun givenSpaceQueryParams(): SpaceSummaryQueryParams {
+        return mockk()
+    }
+}

--- a/vector/src/test/java/im/vector/app/features/spaces/notification/GetNotificationCountForSpacesUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/spaces/notification/GetNotificationCountForSpacesUseCaseTest.kt
@@ -62,7 +62,7 @@ internal class GetNotificationCountForSpacesUseCaseTest {
     }
 
     @Test
-    fun `given space filter and hide invites when execute then correct notification count is returned`() = runTest {
+    fun `given space filter and auto accept invites when execute then correct notification count is returned`() = runTest {
         // given
         val spaceFilter = SpaceFilter.NoFilter
         val pagedList = mockk<PagedList<RoomSummary>>()
@@ -78,7 +78,7 @@ internal class GetNotificationCountForSpacesUseCaseTest {
         fakeActiveSessionHolder.fakeSession
                 .fakeRoomService
                 .givenGetNotificationCountForRoomsReturns(expectedNotificationCount)
-        fakeAutoAcceptInvites._hideInvites = true
+        fakeAutoAcceptInvites._isEnabled = true
 
         // When
         val testObserver = getNotificationCountForSpacesUseCase.execute(spaceFilter).test(this)
@@ -121,7 +121,7 @@ internal class GetNotificationCountForSpacesUseCaseTest {
         fakeActiveSessionHolder.fakeSession
                 .fakeRoomService
                 .givenGetRoomSummaries(invitedRooms)
-        fakeAutoAcceptInvites._hideInvites = false
+        fakeAutoAcceptInvites._isEnabled = false
         val expectedNotificationCount = RoomAggregateNotificationCount(
                 notificationCount = notificationCount.notificationCount + invitedRooms.size,
                 highlightCount = notificationCount.highlightCount + invitedRooms.size,

--- a/vector/src/test/java/im/vector/app/features/spaces/notification/GetNotificationCountForSpacesUseCaseTest.kt
+++ b/vector/src/test/java/im/vector/app/features/spaces/notification/GetNotificationCountForSpacesUseCaseTest.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.spaces.notification
+
+import androidx.paging.PagedList
+import im.vector.app.test.fakes.FakeActiveSessionHolder
+import im.vector.app.test.fakes.FakeAutoAcceptInvites
+import im.vector.app.test.fakes.FakeFlowLiveDataConversions
+import im.vector.app.test.fakes.givenAsFlow
+import im.vector.app.test.test
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.flow.sample
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.matrix.android.sdk.api.query.SpaceFilter
+import org.matrix.android.sdk.api.session.room.RoomSortOrder
+import org.matrix.android.sdk.api.session.room.model.Membership
+import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
+
+internal class GetNotificationCountForSpacesUseCaseTest {
+
+    private val fakeActiveSessionHolder = FakeActiveSessionHolder()
+    private val fakeAutoAcceptInvites = FakeAutoAcceptInvites()
+    private val fakeFlowLiveDataConversions = FakeFlowLiveDataConversions()
+
+    private val getNotificationCountForSpacesUseCase = GetNotificationCountForSpacesUseCase(
+            activeSessionHolder = fakeActiveSessionHolder.instance,
+            autoAcceptInvites = fakeAutoAcceptInvites,
+    )
+
+    @Before
+    fun setUp() {
+        fakeFlowLiveDataConversions.setup()
+        mockkStatic("kotlinx.coroutines.flow.FlowKt")
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `given space filter and hide invites when execute then correct notification count is returned`() = runTest {
+        // given
+        val spaceFilter = SpaceFilter.NoFilter
+        val pagedList = mockk<PagedList<RoomSummary>>()
+        val pagedListFlow = fakeActiveSessionHolder.fakeSession
+                .fakeRoomService
+                .givenGetPagedRoomSummariesLiveReturns(pagedList)
+                .givenAsFlow()
+        every { pagedListFlow.sample(any<Long>()) } returns pagedListFlow
+        val expectedNotificationCount = RoomAggregateNotificationCount(
+                notificationCount = 1,
+                highlightCount = 0,
+        )
+        fakeActiveSessionHolder.fakeSession
+                .fakeRoomService
+                .givenGetNotificationCountForRoomsReturns(expectedNotificationCount)
+        fakeAutoAcceptInvites._hideInvites = true
+
+        // When
+        val testObserver = getNotificationCountForSpacesUseCase.execute(spaceFilter).test(this)
+        advanceUntilIdle()
+
+        // Then
+        testObserver
+                .assertValues(expectedNotificationCount)
+                .finish()
+        verify {
+            fakeActiveSessionHolder.fakeSession.fakeRoomService.getNotificationCountForRooms(
+                    queryParams = match { it.memberships == listOf(Membership.JOIN) && it.spaceFilter == spaceFilter }
+            )
+            fakeActiveSessionHolder.fakeSession.fakeRoomService.getPagedRoomSummariesLive(
+                    queryParams = match { it.memberships == listOf(Membership.JOIN) && it.spaceFilter == spaceFilter },
+                    pagedListConfig = any(),
+                    sortOrder = RoomSortOrder.NONE,
+            )
+        }
+    }
+
+    @Test
+    fun `given space filter and show invites when execute then correct notification count is returned`() = runTest {
+        // given
+        val spaceFilter = SpaceFilter.NoFilter
+        val pagedList = mockk<PagedList<RoomSummary>>()
+        val pagedListFlow = fakeActiveSessionHolder.fakeSession
+                .fakeRoomService
+                .givenGetPagedRoomSummariesLiveReturns(pagedList)
+                .givenAsFlow()
+        every { pagedListFlow.sample(any<Long>()) } returns pagedListFlow
+        val notificationCount = RoomAggregateNotificationCount(
+                notificationCount = 1,
+                highlightCount = 0,
+        )
+        fakeActiveSessionHolder.fakeSession
+                .fakeRoomService
+                .givenGetNotificationCountForRoomsReturns(notificationCount)
+        val invitedRooms = listOf<RoomSummary>(mockk())
+        fakeActiveSessionHolder.fakeSession
+                .fakeRoomService
+                .givenGetRoomSummaries(invitedRooms)
+        fakeAutoAcceptInvites._hideInvites = false
+        val expectedNotificationCount = RoomAggregateNotificationCount(
+                notificationCount = notificationCount.notificationCount + invitedRooms.size,
+                highlightCount = notificationCount.highlightCount + invitedRooms.size,
+        )
+
+        // When
+        val testObserver = getNotificationCountForSpacesUseCase.execute(spaceFilter).test(this)
+        advanceUntilIdle()
+
+        // Then
+        testObserver
+                .assertValues(expectedNotificationCount)
+                .finish()
+        verify {
+            fakeActiveSessionHolder.fakeSession.fakeRoomService.getRoomSummaries(
+                    queryParams = match { it.memberships == listOf(Membership.INVITE) }
+            )
+            fakeActiveSessionHolder.fakeSession.fakeRoomService.getNotificationCountForRooms(
+                    queryParams = match { it.memberships == listOf(Membership.JOIN) && it.spaceFilter == spaceFilter }
+            )
+            fakeActiveSessionHolder.fakeSession.fakeRoomService.getPagedRoomSummariesLive(
+                    queryParams = match { it.memberships == listOf(Membership.JOIN) && it.spaceFilter == spaceFilter },
+                    pagedListConfig = any(),
+                    sortOrder = RoomSortOrder.NONE,
+            )
+        }
+    }
+
+    @Test
+    fun `given no active session when execute then empty flow is returned`() = runTest {
+        // given
+        val spaceFilter = SpaceFilter.NoFilter
+        fakeActiveSessionHolder.givenGetSafeActiveSessionReturns(null)
+
+        // When
+        val testObserver = getNotificationCountForSpacesUseCase.execute(spaceFilter).test(this)
+
+        // Then
+        testObserver
+                .assertNoValues()
+                .finish()
+        verify(inverse = true) {
+            fakeActiveSessionHolder.fakeSession.fakeRoomService.getPagedRoomSummariesLive(
+                    queryParams = any(),
+                    pagedListConfig = any(),
+                    sortOrder = any(),
+            )
+        }
+    }
+}

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeAutoAcceptInvites.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeAutoAcceptInvites.kt
@@ -21,7 +21,11 @@ import im.vector.app.features.invite.AutoAcceptInvites
 class FakeAutoAcceptInvites : AutoAcceptInvites {
 
     var _isEnabled: Boolean = false
+    var _hideInvites: Boolean = false
 
     override val isEnabled: Boolean
         get() = _isEnabled
+
+    override val hideInvites: Boolean
+        get() = _hideInvites
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeAutoAcceptInvites.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeAutoAcceptInvites.kt
@@ -21,11 +21,7 @@ import im.vector.app.features.invite.AutoAcceptInvites
 class FakeAutoAcceptInvites : AutoAcceptInvites {
 
     var _isEnabled: Boolean = false
-    var _hideInvites: Boolean = false
 
     override val isEnabled: Boolean
         get() = _isEnabled
-
-    override val hideInvites: Boolean
-        get() = _hideInvites
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeFlowLiveDataConversions.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeFlowLiveDataConversions.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.asFlow
 import io.mockk.every
 import io.mockk.mockkStatic
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
 class FakeFlowLiveDataConversions {
@@ -28,6 +29,8 @@ class FakeFlowLiveDataConversions {
     }
 }
 
-fun <T> LiveData<T>.givenAsFlow() {
-    every { asFlow() } returns flowOf(value!!)
+fun <T> LiveData<T>.givenAsFlow(): Flow<T> {
+    return flowOf(value!!).also {
+        every { asFlow() } returns it
+    }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeRoomService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeRoomService.kt
@@ -16,10 +16,14 @@
 
 package im.vector.app.test.fakes
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.paging.PagedList
 import io.mockk.every
 import io.mockk.mockk
 import org.matrix.android.sdk.api.session.room.RoomService
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
+import org.matrix.android.sdk.api.session.room.summary.RoomAggregateNotificationCount
 
 class FakeRoomService(
         private val fakeRoom: FakeRoom = FakeRoom()
@@ -33,5 +37,19 @@ class FakeRoomService(
 
     fun set(roomSummary: RoomSummary?) {
         every { getRoomSummary(any()) } returns roomSummary
+    }
+
+    fun givenGetPagedRoomSummariesLiveReturns(pagedList: PagedList<RoomSummary>): LiveData<PagedList<RoomSummary>> {
+        return MutableLiveData(pagedList).also {
+            every { getPagedRoomSummariesLive(queryParams = any(), pagedListConfig = any(), sortOrder = any()) } returns it
+        }
+    }
+
+    fun givenGetNotificationCountForRoomsReturns(roomAggregateNotificationCount: RoomAggregateNotificationCount) {
+        every { getNotificationCountForRooms(queryParams = any()) } returns roomAggregateNotificationCount
+    }
+
+    fun givenGetRoomSummaries(roomSummaries: List<RoomSummary>) {
+        every { getRoomSummaries(any()) } returns roomSummaries
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeSession.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeSession.kt
@@ -46,6 +46,7 @@ class FakeSession(
         val fakeUserService: FakeUserService = FakeUserService(),
         private val fakeEventService: FakeEventService = FakeEventService(),
         val fakeSessionAccountDataService: FakeSessionAccountDataService = FakeSessionAccountDataService(),
+        val fakeSpaceService: FakeSpaceService = FakeSpaceService(),
 ) : Session by mockk(relaxed = true) {
 
     init {
@@ -66,6 +67,7 @@ class FakeSession(
     override fun pushersService() = fakePushersService
     override fun accountDataService() = fakeSessionAccountDataService
     override fun userService() = fakeUserService
+    override fun spaceService() = fakeSpaceService
 
     fun givenVectorStore(vectorSessionStore: VectorSessionStore) {
         coEvery {

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeSpaceService.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeSpaceService.kt
@@ -14,23 +14,24 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.spaces
+package im.vector.app.test.fakes
 
-import im.vector.app.core.di.ActiveSessionHolder
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import io.mockk.every
+import io.mockk.mockk
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
-import org.matrix.android.sdk.api.session.space.SpaceSummaryQueryParams
-import org.matrix.android.sdk.flow.flow
-import javax.inject.Inject
+import org.matrix.android.sdk.api.session.space.SpaceService
 
-class GetSpacesUseCase @Inject constructor(
-        private val activeSessionHolder: ActiveSessionHolder,
-) {
+class FakeSpaceService : SpaceService by mockk() {
 
-    fun execute(params: SpaceSummaryQueryParams): Flow<List<RoomSummary>> {
-        val session = activeSessionHolder.getSafeActiveSession()
+    fun givenGetSpaceSummariesLiveReturns(roomSummaries: List<RoomSummary>): LiveData<List<RoomSummary>> {
+        return MutableLiveData(roomSummaries).also {
+            every { getSpaceSummariesLive(any()) } returns it
+        }
+    }
 
-        return session?.flow()?.liveSpaceSummaries(params) ?: emptyFlow()
+    fun givenGetSpaceSummariesReturns(roomSummaries: List<RoomSummary>) {
+        every { getSpaceSummaries(any()) } returns roomSummaries
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
In the new app layout, adding a notification badge on top of the floating action button which opens the spaces list bottom sheet.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #8157 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<img src="https://user-images.githubusercontent.com/46314705/220651831-1f8957ea-4532-4c4f-a3d2-d1086c18115d.png" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/220651839-ab587c2d-382f-46fc-ba6a-7d1de4b0412f.png" width=300 />
<img src="https://user-images.githubusercontent.com/46314705/220652177-1eef9724-3722-4996-9041-78f43209faba.png" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/220652207-8608c5dc-7ae3-4fdd-b949-f5fb4432e051.png" width=300 />
<img src="https://user-images.githubusercontent.com/46314705/220652537-a2397cb4-b0d0-4b0d-b356-4a3ce05c0700.png" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/220652545-fd030443-2307-4dba-9278-a3742864510c.png" width=300 />
<img src="https://user-images.githubusercontent.com/46314705/220652787-eb2d5150-4fe2-4553-8396-6c2b72e53924.png" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/220652796-babaec45-67bd-4cce-ac84-4434f21a6f08.png" width=300 />
<img src="https://user-images.githubusercontent.com/46314705/220653688-09b0ef84-84b7-4e3d-9949-60956432d0ef.png" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/220653699-0324953f-ea2e-4136-bb8a-79f6accb936a.png" width=300 />
<img src="https://user-images.githubusercontent.com/46314705/220653829-26cfe7e2-a9ab-4e65-9ac6-4539719c859b.png" width=300 /> <img src="https://user-images.githubusercontent.com/46314705/220653834-d89c4ae3-22d2-4608-bf4c-0f8ab5c76bc2.png" width=300 />


## Tests

<!-- Explain how you tested your development -->

- Open the app with new layout
- Send message in some rooms and check the badge counter is correctly displayed
- Send invite to a space
- Check the badge counter is red while the space invite is pending

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
