### PR TITLE
Space setting category doesn't show up

### DIFF
--- a/changelog.d/7989.bugfix
+++ b/changelog.d/7989.bugfix
@@ -1,0 +1,1 @@
+Space setting category doesn't show up

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsPreferencesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsPreferencesFragment.kt
@@ -103,7 +103,7 @@ class VectorSettingsPreferencesFragment :
         }
 
         findPreference<Preference>(VectorPreferences.SETTINGS_PREF_SPACE_CATEGORY)!!.let { pref ->
-            pref.isVisible = !vectorFeatures.isNewAppLayoutFeatureEnabled()
+            pref.isVisible = !vectorPreferences.isNewAppLayoutEnabled()
             pref.isEnabled = !vectorPreferences.isNewAppLayoutEnabled()
         }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Display the "Space" category setting when in old app layout.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #7989 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Enable the new app layout in the labs settings
- Go to Settings -> Preferences
- Check the "Space" category setting is not displayed
- Disable the new app layout in the labs settings
- Go to Settings -> Preferences
- Check the "Space" category setting is displayed
- Check the settings can be edited
- Check the home displays the correct rooms depending on the value of the setting

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
