### PR TITLE
matrix-sdk: Ensure correct room for events loaded by chunks

### DIFF
--- a/changelog.d/8168.bugfix
+++ b/changelog.d/8168.bugfix
@@ -1,0 +1,1 @@
+Fix timeline loading a wrong room on permalink if a matching event id is found in a different room

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ThreadEventsHelper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/helper/ThreadEventsHelper.kt
@@ -297,7 +297,7 @@ internal fun updateThreadNotifications(roomId: String, realm: Realm, currentUser
     val readReceipt = findMyReadReceipt(realm, roomId, currentUserId, threadId = rootThreadEventId) ?: return
 
     val readReceiptChunk = ChunkEntity
-            .findIncludingEvent(realm, readReceipt) ?: return
+            .findIncludingEvent(realm, roomId, readReceipt) ?: return
 
     val readReceiptChunkThreadEvents = readReceiptChunk
             .timelineEvents

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/query/ChunkEntityQueries.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/query/ChunkEntityQueries.kt
@@ -72,15 +72,16 @@ internal fun ChunkEntity.Companion.findEventInThreadChunk(realm: Realm, roomId: 
             .findFirst()
 }
 
-internal fun ChunkEntity.Companion.findAllIncludingEvents(realm: Realm, eventIds: List<String>): RealmResults<ChunkEntity> {
+internal fun ChunkEntity.Companion.findAllIncludingEvents(realm: Realm, roomId: String, eventIds: List<String>): RealmResults<ChunkEntity> {
     return realm.where<ChunkEntity>()
+            .equalTo(ChunkEntityFields.ROOM.ROOM_ID, roomId)
             .`in`(ChunkEntityFields.TIMELINE_EVENTS.EVENT_ID, eventIds.toTypedArray())
             .isNull(ChunkEntityFields.ROOT_THREAD_EVENT_ID)
             .findAll()
 }
 
-internal fun ChunkEntity.Companion.findIncludingEvent(realm: Realm, eventId: String): ChunkEntity? {
-    return findAllIncludingEvents(realm, listOf(eventId)).firstOrNull()
+internal fun ChunkEntity.Companion.findIncludingEvent(realm: Realm, roomId: String, eventId: String): ChunkEntity? {
+    return findAllIncludingEvents(realm, roomId, listOf(eventId)).firstOrNull()
 }
 
 internal fun ChunkEntity.Companion.create(

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/query/ReadQueries.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/query/ReadQueries.kt
@@ -76,11 +76,11 @@ private fun hasReadMissingEvent(realm: Realm,
                                 userId: String,
                                 eventId: String,
                                 threadId: String? = ReadService.THREAD_ID_MAIN): Boolean {
-    return realm.doesEventExistInChunkHistory(eventId) && realm.hasReadReceiptInLatestChunk(latestChunkEntity, roomId, userId, threadId)
+    return realm.doesEventExistInChunkHistory(roomId, eventId) && realm.hasReadReceiptInLatestChunk(latestChunkEntity, roomId, userId, threadId)
 }
 
-private fun Realm.doesEventExistInChunkHistory(eventId: String): Boolean {
-    return ChunkEntity.findIncludingEvent(this, eventId) != null
+private fun Realm.doesEventExistInChunkHistory(roomId: String, eventId: String): Boolean {
+    return ChunkEntity.findIncludingEvent(this, roomId, eventId) != null
 }
 
 private fun Realm.hasReadReceiptInLatestChunk(latestChunkEntity: ChunkEntity, roomId: String, userId: String, threadId: String?): Boolean {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/FetchTokenAndPaginateTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/FetchTokenAndPaginateTask.kt
@@ -59,7 +59,7 @@ internal class DefaultFetchTokenAndPaginateTask @Inject constructor(
                 ?: throw IllegalStateException("No token found")
 
         monarchy.awaitTransaction { realm ->
-            val chunkToUpdate = ChunkEntity.findIncludingEvent(realm, params.lastKnownEventId)
+            val chunkToUpdate = ChunkEntity.findIncludingEvent(realm, params.roomId, params.lastKnownEventId)
             if (params.direction == PaginationDirection.FORWARDS) {
                 chunkToUpdate?.nextToken = fromToken
             } else {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/LoadTimelineStrategy.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/LoadTimelineStrategy.kt
@@ -278,7 +278,7 @@ internal class LoadTimelineStrategy constructor(
                         .findAll()
             }
             is Mode.Permalink -> {
-                ChunkEntity.findAllIncludingEvents(realm, listOf(mode.originEventId))
+                ChunkEntity.findAllIncludingEvents(realm, roomId, listOf(mode.originEventId))
             }
             is Mode.Thread -> {
                 recreateThreadChunkEntity(realm, mode.rootThreadEventId)


### PR DESCRIPTION
Chunks should not load events from other rooms if they happen to be requested for one eventId that already exists in a different room.




<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Always check for correct roomId when loading events from chunks.

## Motivation and context

Motivation from a client that renders rich replies (although the broken scenario can most likely appear in other cases as well, may be less severe):

If somebody links an invalid eventId in a room, which however is valid in a different room, this can mess up our timelines badly. This can be reproduced by replying to an event in a room, then forward the reply to a different room with a client that also forwards the replied-to information (such as FluffyChat - likely a bug though). Then click on the rich reply to open the eventId. Previously, Android could find the event from the other room and thus replace the correct timeline with the wrong one.
Together with the feature to always open the timeline at the last read event, this can persistently replace the timeline of one room with the wrong one.

Compare e.g. https://matrix.to/#/!bfebJVBOZMnORmkVdO:matrix.org/$wUyRiMQEjaWOpJ-XpdBJzuXkh95N7bce2pVT4IMXW50?via=schildi.chat&via=matrix.org&via=envs.net linking to an event that exists here
https://matrix.to/#/!SDwMepdfgrmExhyxYZ:schildi.chat/$MO2G4MZZ1zg0Ymc9gTfekIyw7QFkNn4OvYQKK1PAGlE


## Tests

See motivation.


## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR


## Sign-off

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>