### PR TITLE
[Rich text editor] Fix code appearance

### DIFF
--- a/changelog.d/8171.bugfix
+++ b/changelog.d/8171.bugfix
@@ -1,0 +1,1 @@
+[Rich text editor] Fix code appearance

--- a/vector/src/main/res/drawable/bg_code_block.xml
+++ b/vector/src/main/res/drawable/bg_code_block.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2018 The Android Open Source Project
+  ~ Modifications Copyright 2022 New Vector Ltd
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?vctr_system"/>
+    <stroke android:width="@dimen/code_block_border_width" android:color="?vctr_content_quinary"/>
+    <corners android:radius="@dimen/code_block_border_radius"/>
+</shape>

--- a/vector/src/main/res/drawable/bg_inline_code_multi_line_left.xml
+++ b/vector/src/main/res/drawable/bg_inline_code_multi_line_left.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2018 The Android Open Source Project
+  ~ Modifications Copyright 2022 New Vector Ltd
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?vctr_system"/>
+    <stroke android:width="@dimen/inline_code_border_width" android:color="?vctr_content_quinary"/>
+    <corners android:topLeftRadius="@dimen/inline_code_border_radius"
+        android:bottomLeftRadius="@dimen/inline_code_border_radius"/>
+</shape>

--- a/vector/src/main/res/drawable/bg_inline_code_multi_line_mid.xml
+++ b/vector/src/main/res/drawable/bg_inline_code_multi_line_mid.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2018 The Android Open Source Project
+  ~ Modifications Copyright 2022 New Vector Ltd
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?vctr_system"/>
+    <stroke android:width="@dimen/inline_code_border_width" android:color="?vctr_content_quinary"/>
+</shape>

--- a/vector/src/main/res/drawable/bg_inline_code_multi_line_right.xml
+++ b/vector/src/main/res/drawable/bg_inline_code_multi_line_right.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2018 The Android Open Source Project
+  ~ Modifications Copyright 2022 New Vector Ltd
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?vctr_system"/>
+    <stroke android:width="@dimen/inline_code_border_width" android:color="?vctr_content_quinary"/>
+    <corners android:topRightRadius="@dimen/inline_code_border_radius"
+        android:bottomRightRadius="@dimen/inline_code_border_radius"/>
+</shape>

--- a/vector/src/main/res/drawable/bg_inline_code_single_line.xml
+++ b/vector/src/main/res/drawable/bg_inline_code_single_line.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2018 The Android Open Source Project
+  ~ Modifications Copyright 2022 New Vector Ltd
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?vctr_system"/>
+    <stroke android:width="@dimen/inline_code_border_width" android:color="?vctr_content_quinary"/>
+    <corners android:radius="@dimen/inline_code_border_radius"/>
+</shape>

--- a/vector/src/main/res/layout/composer_rich_text_layout.xml
+++ b/vector/src/main/res/layout/composer_rich_text_layout.xml
@@ -126,6 +126,11 @@
             app:layout_constraintTop_toBottomOf="@id/composerModeBarrier"
             app:bulletRadius="4sp"
             app:bulletGap="8sp"
+            app:codeBlockBackgroundDrawable="@drawable/bg_code_block"
+            app:inlineCodeSingleLineBg="@drawable/bg_inline_code_single_line"
+            app:inlineCodeMultiLineBgLeft="@drawable/bg_inline_code_multi_line_left"
+            app:inlineCodeMultiLineBgMid="@drawable/bg_inline_code_multi_line_mid"
+            app:inlineCodeMultiLineBgRight="@drawable/bg_inline_code_multi_line_right"
             tools:text="@tools:sample/lorem/random" />
 
         <com.google.android.material.textfield.TextInputEditText

--- a/vector/src/main/res/layout/item_timeline_event_text_message_rich_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_text_message_rich_stub.xml
@@ -8,4 +8,10 @@
     android:layout_height="wrap_content"
     android:textAlignment="viewStart"
     android:textColor="?vctr_content_primary"
+    app:codeBlockBackgroundDrawable="@drawable/bg_code_block"
+    app:inlineCodeSingleLineBg="@drawable/bg_inline_code_single_line"
+    app:inlineCodeMultiLineBgLeft="@drawable/bg_inline_code_multi_line_left"
+    app:inlineCodeMultiLineBgMid="@drawable/bg_inline_code_multi_line_mid"
+    app:inlineCodeMultiLineBgRight="@drawable/bg_inline_code_multi_line_right"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:text="@sample/messages.json/data/message" />


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fix issue where inline code does not display with the correct background color if the system theme is different to the theme selected in the in-app settings.

## Motivation and context

Fixes vector-im/verticals-internal#23

## Screenshots / GIFs

| Light in-app, dark system | Dark in-app, light system | Black in-app, light system|
|-|-|-|
|![light](https://user-images.githubusercontent.com/4940864/221224502-68313f7a-4363-4777-999d-77b658648925.png)|![dark](https://user-images.githubusercontent.com/4940864/221224491-3ea9d8dd-67fe-463e-b147-cb638d46a3ef.png)|![black](https://user-images.githubusercontent.com/4940864/221224506-73680542-90af-4472-8347-9320497bed3e.png)|

## Tests

- Go to the in-app settings and enable the light theme
- Go to the system settings and enable dark mode
- (or vice-versa)
- Enable the rich text editor
- Compose code in the rich text editor
- _Note the background of the code_
- Send the code to the room
- _Note the background of the code in the timeline_

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 13

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
