### PR TITLE
[Poll history] Fixing small issue about font style (PSG-1178)

### DIFF
--- a/changelog.d/8190.bugfix
+++ b/changelog.d/8190.bugfix
@@ -1,0 +1,1 @@
+[Poll history] Fixing small issue about font style

--- a/vector/src/main/res/layout/fragment_room_polls_list.xml
+++ b/vector/src/main/res/layout/fragment_room_polls_list.xml
@@ -55,6 +55,7 @@
         android:textAppearance="@style/TextAppearance.Vector.Body"
         android:textColor="?vctr_content_secondary"
         android:textSize="15sp"
+        android:lineSpacingMultiplier="1.2"
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/vector/src/main/res/layout/fragment_room_polls_list.xml
+++ b/vector/src/main/res/layout/fragment_room_polls_list.xml
@@ -54,7 +54,7 @@
         android:gravity="center"
         android:textAppearance="@style/TextAppearance.Vector.Body"
         android:textColor="?vctr_content_secondary"
-        android:textSize="17sp"
+        android:textSize="15sp"
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Reducing size and increasing the line spacing of the empty list title in poll history screen.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Feedback from design review.

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|<img src="https://user-images.githubusercontent.com/46314705/222100497-f144c55d-eda1-4571-a23d-78a7ffb83616.png" width=300>|<img src="https://user-images.githubusercontent.com/46314705/222100261-56f3aa60-705d-40dd-a696-ee7ae3cf208d.png" width=300>|

## Tests

<!-- Explain how you tested your development -->

- Go to a poll history of a room with no polls

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 11

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
