### PR TITLE
Be able to let the user trust several Fingerprints during login flow.

### DIFF
--- a/vector/src/main/java/im/vector/app/features/login/HomeServerConnectionConfigFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/login/HomeServerConnectionConfigFactory.kt
@@ -23,7 +23,7 @@ import javax.inject.Inject
 
 class HomeServerConnectionConfigFactory @Inject constructor() {
 
-    fun create(url: String?, fingerprint: Fingerprint? = null): HomeServerConnectionConfig? {
+    fun create(url: String?, fingerprints: List<Fingerprint>? = null): HomeServerConnectionConfig? {
         if (url == null) {
             return null
         }
@@ -31,13 +31,7 @@ class HomeServerConnectionConfigFactory @Inject constructor() {
         return try {
             HomeServerConnectionConfig.Builder()
                     .withHomeServerUri(url)
-                    .run {
-                        if (fingerprint == null) {
-                            this
-                        } else {
-                            withAllowedFingerPrints(listOf(fingerprint))
-                        }
-                    }
+                    .withAllowedFingerPrints(fingerprints)
                     .build()
         } catch (t: Throwable) {
             Timber.e(t)

--- a/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
+++ b/vector/src/test/java/im/vector/app/features/onboarding/OnboardingViewModelTest.kt
@@ -621,7 +621,7 @@ class OnboardingViewModelTest {
 
     @Test
     fun `when editing homeserver errors with certificate error, then emits error`() = runTest {
-        fakeHomeServerConnectionConfigFactory.givenConfigFor(A_HOMESERVER_URL, fingerprint = null, A_HOMESERVER_CONFIG)
+        fakeHomeServerConnectionConfigFactory.givenConfigFor(A_HOMESERVER_URL, fingerprints = null, A_HOMESERVER_CONFIG)
         fakeStartAuthenticationFlowUseCase.givenErrors(A_HOMESERVER_CONFIG, AN_UNRECOGNISED_CERTIFICATE_ERROR)
         val editAction = OnboardingAction.HomeServerChange.EditHomeServer(A_HOMESERVER_URL)
         val test = viewModel.test()
@@ -640,7 +640,7 @@ class OnboardingViewModelTest {
 
     @Test
     fun `when selecting homeserver errors with certificate error, then emits error`() = runTest {
-        fakeHomeServerConnectionConfigFactory.givenConfigFor(A_HOMESERVER_URL, fingerprint = null, A_HOMESERVER_CONFIG)
+        fakeHomeServerConnectionConfigFactory.givenConfigFor(A_HOMESERVER_URL, fingerprints = null, A_HOMESERVER_CONFIG)
         fakeStartAuthenticationFlowUseCase.givenErrors(A_HOMESERVER_CONFIG, AN_UNRECOGNISED_CERTIFICATE_ERROR)
         val selectAction = OnboardingAction.HomeServerChange.SelectHomeServer(A_HOMESERVER_URL)
         val test = viewModel.test()
@@ -842,7 +842,7 @@ class OnboardingViewModelTest {
                 A_HOMESERVER_URL,
                 SELECTED_HOMESERVER_STATE,
                 config = A_HOMESERVER_CONFIG.copy(allowedFingerprints = listOf(A_FINGERPRINT)),
-                fingerprint = A_FINGERPRINT,
+                fingerprints = listOf(A_FINGERPRINT),
         )
 
         viewModel.handle(OnboardingAction.UserAcceptCertificate(A_FINGERPRINT, OnboardingAction.HomeServerChange.SelectHomeServer(A_HOMESERVER_URL)))
@@ -866,7 +866,7 @@ class OnboardingViewModelTest {
                 A_HOMESERVER_URL,
                 SELECTED_HOMESERVER_STATE,
                 config = A_HOMESERVER_CONFIG.copy(allowedFingerprints = listOf(A_FINGERPRINT)),
-                fingerprint = A_FINGERPRINT,
+                fingerprints = listOf(A_FINGERPRINT),
         )
         val test = viewModel.test()
 
@@ -886,7 +886,7 @@ class OnboardingViewModelTest {
 
     @Test
     fun `given DirectLogin retry action, when accepting user certificate, then logs in directly`() = runTest {
-        fakeHomeServerConnectionConfigFactory.givenConfigFor("https://dummy.org", A_FINGERPRINT, A_HOMESERVER_CONFIG)
+        fakeHomeServerConnectionConfigFactory.givenConfigFor("https://dummy.org", listOf(A_FINGERPRINT), A_HOMESERVER_CONFIG)
         fakeDirectLoginUseCase.givenSuccessResult(A_DIRECT_LOGIN, config = A_HOMESERVER_CONFIG, result = fakeSession)
         givenInitialisesSession(fakeSession)
         val test = viewModel.test()
@@ -1175,16 +1175,16 @@ class OnboardingViewModelTest {
             homeserverUrl: String,
             resultingState: SelectedHomeserverState,
             config: HomeServerConnectionConfig = A_HOMESERVER_CONFIG,
-            fingerprint: Fingerprint? = null,
+            fingerprints: List<Fingerprint>? = null,
     ) {
-        fakeHomeServerConnectionConfigFactory.givenConfigFor(homeserverUrl, fingerprint, config)
+        fakeHomeServerConnectionConfigFactory.givenConfigFor(homeserverUrl, fingerprints, config)
         fakeStartAuthenticationFlowUseCase.givenResult(config, StartAuthenticationResult(isHomeserverOutdated = false, resultingState))
         givenRegistrationResultFor(RegisterAction.StartRegistration, RegistrationActionHandler.Result.StartRegistration)
         fakeHomeServerHistoryService.expectUrlToBeAdded(config.homeServerUri.toString())
     }
 
     private fun givenUpdatingHomeserverErrors(homeserverUrl: String, resultingState: SelectedHomeserverState, error: Throwable) {
-        fakeHomeServerConnectionConfigFactory.givenConfigFor(homeserverUrl, fingerprint = null, A_HOMESERVER_CONFIG)
+        fakeHomeServerConnectionConfigFactory.givenConfigFor(homeserverUrl, fingerprints = null, A_HOMESERVER_CONFIG)
         fakeStartAuthenticationFlowUseCase.givenResult(A_HOMESERVER_CONFIG, StartAuthenticationResult(isHomeserverOutdated = false, resultingState))
         givenRegistrationResultFor(RegisterAction.StartRegistration, RegistrationActionHandler.Result.Error(error))
         fakeHomeServerHistoryService.expectUrlToBeAdded(A_HOMESERVER_CONFIG.homeServerUri.toString())
@@ -1209,13 +1209,13 @@ class OnboardingViewModelTest {
 
     private fun givenHomeserverSelectionFailsWithNetworkError() {
         fakeContext.givenHasConnection()
-        fakeHomeServerConnectionConfigFactory.givenConfigFor(A_HOMESERVER_URL, fingerprint = null, A_HOMESERVER_CONFIG)
+        fakeHomeServerConnectionConfigFactory.givenConfigFor(A_HOMESERVER_URL, fingerprints = null, A_HOMESERVER_CONFIG)
         fakeStartAuthenticationFlowUseCase.givenHomeserverUnavailable(A_HOMESERVER_CONFIG)
     }
 
     private fun givenHomeserverSelectionFailsWith(cause: Throwable) {
         fakeContext.givenHasConnection()
-        fakeHomeServerConnectionConfigFactory.givenConfigFor(A_HOMESERVER_URL, fingerprint = null, A_HOMESERVER_CONFIG)
+        fakeHomeServerConnectionConfigFactory.givenConfigFor(A_HOMESERVER_URL, fingerprints = null, A_HOMESERVER_CONFIG)
         fakeStartAuthenticationFlowUseCase.givenErrors(A_HOMESERVER_CONFIG, cause)
     }
 }

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeHomeServerConnectionConfigFactory.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeHomeServerConnectionConfigFactory.kt
@@ -25,7 +25,7 @@ import org.matrix.android.sdk.api.network.ssl.Fingerprint
 class FakeHomeServerConnectionConfigFactory {
     val instance: HomeServerConnectionConfigFactory = mockk()
 
-    fun givenConfigFor(url: String, fingerprint: Fingerprint? = null, config: HomeServerConnectionConfig) {
-        every { instance.create(url, fingerprint) } returns config
+    fun givenConfigFor(url: String, fingerprints: List<Fingerprint>? = null, config: HomeServerConnectionConfig) {
+        every { instance.create(url, fingerprints) } returns config
     }
 }


### PR DESCRIPTION
It was the case before, see `LoginViewModel.handleUserAcceptCertificate(...)`

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
