### PR TITLE
Remove hardcoded color on save button

### DIFF
--- a/changelog.d/8208.bugfix
+++ b/changelog.d/8208.bugfix
@@ -1,0 +1,1 @@
+Replace hardcoded colors by theming colors on save button.

--- a/vector/src/main/res/drawable/ic_composer_rich_text_save.xml
+++ b/vector/src/main/res/drawable/ic_composer_rich_text_save.xml
@@ -5,12 +5,12 @@
     android:viewportHeight="36">
   <path
       android:pathData="M18,18m-18,0a18,18 0,1 1,36 0a18,18 0,1 1,-36 0"
-      android:fillColor="#0DBD8B"/>
+      android:fillColor="?colorPrimary"/>
   <path
       android:pathData="M9.818,18.787L14.705,23.818L26.182,12"
       android:strokeLineJoin="round"
       android:strokeWidth="2.5"
       android:fillColor="#00000000"
-      android:strokeColor="#ffffff"
+      android:strokeColor="?colorOnPrimary"
       android:strokeLineCap="round"/>
 </vector>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Save button background color is hardcoded. Now we use the theming colors instead.

Similar to : 
- https://github.com/vector-im/element-android/pull/8142

## Motivation and context

## Screenshots / GIFs

## Tests

<!-- Explain how you tested your development -->

- Edit a message

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

Signed-off-by: Julien DAUPHANT <julien.dauphant@beta.gouv.fr>
