### PR TITLE
Support for MSC3906 v2

### DIFF
--- a/changelog.d/8212.feature
+++ b/changelog.d/8212.feature
@@ -1,0 +1,1 @@
+Updates to protocol used for Sign in with QR code

--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/api/rendezvous/RendezvousTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/api/rendezvous/RendezvousTest.kt
@@ -25,27 +25,53 @@ import org.junit.Test
 import org.matrix.android.sdk.InstrumentedTest
 import org.matrix.android.sdk.api.rendezvous.channels.ECDHRendezvousChannel
 import org.matrix.android.sdk.api.rendezvous.model.RendezvousError
+import org.matrix.android.sdk.api.rendezvous.model.RendezvousFlow
 import org.matrix.android.sdk.common.CommonTestHelper
 
 class RendezvousTest : InstrumentedTest {
 
     @Test
-    fun shouldSuccessfullyBuildChannels() = CommonTestHelper.runCryptoTest(context()) { _, _ ->
+    fun shouldSuccessfullyBuildMSC3906V1Channels() = CommonTestHelper.runCryptoTest(context()) { _, _ ->
         val cases = listOf(
-            // v1:
+            // MSC3903 v1 + MSC3906 v1:
             "{\"rendezvous\":{\"algorithm\":\"org.matrix.msc3903.rendezvous.v1.curve25519-aes-sha256\"," +
             "\"key\":\"aeSGwYTV1IUhikUyCapzC6p2xG5NpJ4Lwj2UgUMlcTk\",\"transport\":" +
             "{\"type\":\"org.matrix.msc3886.http.v1\",\"uri\":\"https://rendezvous.lab.element.dev/bcab62cd-3e34-48b4-bc39-90895da8f6fe\"}}," +
             "\"intent\":\"login.reciprocate\"}",
-            // v2:
+            // MSC3903 v2 + MSC3906 v1:
             "{\"rendezvous\":{\"algorithm\":\"org.matrix.msc3903.rendezvous.v2.curve25519-aes-sha256\"," +
             "\"key\":\"aeSGwYTV1IUhikUyCapzC6p2xG5NpJ4Lwj2UgUMlcTk\",\"transport\":" +
             "{\"type\":\"org.matrix.msc3886.http.v1\",\"uri\":\"https://rendezvous.lab.element.dev/bcab62cd-3e34-48b4-bc39-90895da8f6fe\"}}," +
-            "\"intent\":\"login.reciprocate\"}",
+            "\"intent\":\"login.reciprocate\"}"
         )
 
         cases.forEach { input ->
-            Rendezvous.buildChannelFromCode(input).channel shouldBeInstanceOf ECDHRendezvousChannel::class
+            val rz = Rendezvous.buildChannelFromCode(input)
+            rz.channel shouldBeInstanceOf ECDHRendezvousChannel::class
+            rz.flow shouldBeEqualTo RendezvousFlow.SETUP_ADDITIONAL_DEVICE_V1
+        }
+    }
+
+    fun shouldSuccessfullyBuildMSC3906V2Channels() = CommonTestHelper.runCryptoTest(context()) { _, _ ->
+        val cases = listOf(
+                // MSC3903 v1:
+                "{\"rendezvous\":{\"algorithm\":\"org.matrix.msc3903.rendezvous.v1.curve25519-aes-sha256\"," +
+                        "\"key\":\"aeSGwYTV1IUhikUyCapzC6p2xG5NpJ4Lwj2UgUMlcTk\",\"transport\":" +
+                        "{\"type\":\"org.matrix.msc3886.http.v1\",\"uri\":\"https://rendezvous.lab.element.dev/bcab62cd-3e34-48b4-bc39-90895da8f6fe\"}}," +
+                        "\"flow\":\"org.matrix.msc3906.setup.additional_device.v2\"," +
+                        "\"intent\":\"login.reciprocate\"}",
+                // MSC3903 v2:
+                "{\"rendezvous\":{\"algorithm\":\"org.matrix.msc3903.rendezvous.v2.curve25519-aes-sha256\"," +
+                        "\"key\":\"aeSGwYTV1IUhikUyCapzC6p2xG5NpJ4Lwj2UgUMlcTk\",\"transport\":" +
+                        "{\"type\":\"org.matrix.msc3886.http.v1\",\"uri\":\"https://rendezvous.lab.element.dev/bcab62cd-3e34-48b4-bc39-90895da8f6fe\"}}," +
+                        "\"flow\":\"org.matrix.msc3906.setup.additional_device.v2\"," +
+                        "\"intent\":\"login.reciprocate\"}"
+        )
+
+        cases.forEach { input ->
+            val rz = Rendezvous.buildChannelFromCode(input)
+            rz.channel shouldBeInstanceOf ECDHRendezvousChannel::class
+            rz.flow shouldBeEqualTo RendezvousFlow.SETUP_ADDITIONAL_DEVICE_V2
         }
     }
 
@@ -56,6 +82,7 @@ class RendezvousTest : InstrumentedTest {
                 "{\"rendezvous\":{\"algorithm\":\"bad algo\"," +
                 "\"key\":\"aeSGwYTV1IUhikUyCapzC6p2xG5NpJ4Lwj2UgUMlcTk\",\"transport\":" +
                 "{\"type\":\"org.matrix.msc3886.http.v1\",\"uri\":\"https://rendezvous.lab.element.dev/bcab62cd-3e34-48b4-bc39-90895da8f6fe\"}}," +
+                "\"flow\":\"org.matrix.msc3906.setup.additional_device.v2\"," +
                 "\"intent\":\"login.reciprocate\"}"
             )
         } shouldThrow RendezvousError::class with {
@@ -70,6 +97,7 @@ class RendezvousTest : InstrumentedTest {
                     "{\"rendezvous\":{\"algorithm\":\"org.matrix.msc3903.rendezvous.v1.curve25519-aes-sha256\"," +
                             "\"key\":\"aeSGwYTV1IUhikUyCapzC6p2xG5NpJ4Lwj2UgUMlcTk\",\"transport\":" +
                             "{\"type\":\"bad transport\",\"uri\":\"https://rendezvous.lab.element.dev/bcab62cd-3e34-48b4-bc39-90895da8f6fe\"}}," +
+                            "\"flow\":\"org.matrix.msc3906.setup.additional_device.v2\"," +
                             "\"intent\":\"login.reciprocate\"}"
             )
         } shouldThrow RendezvousError::class with {
@@ -84,6 +112,7 @@ class RendezvousTest : InstrumentedTest {
                     "{\"rendezvous\":{\"algorithm\":\"org.matrix.msc3903.rendezvous.v1.curve25519-aes-sha256\"," +
                             "\"key\":\"aeSGwYTV1IUhikUyCapzC6p2xG5NpJ4Lwj2UgUMlcTk\",\"transport\":" +
                             "{\"type\":\"org.matrix.msc3886.http.v1\",\"uri\":\"https://rendezvous.lab.element.dev/bcab62cd-3e34-48b4-bc39-90895da8f6fe\"}}," +
+                            "\"flow\":\"org.matrix.msc3906.setup.additional_device.v2\"," +
                             "\"intent\":\"foo\"}"
             )
         } shouldThrow RendezvousError::class with {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/channels/ECDHRendezvousChannel.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/channels/ECDHRendezvousChannel.kt
@@ -40,6 +40,8 @@ import javax.crypto.spec.SecretKeySpec
 /**
  *  Implements X25519 ECDH key agreement and AES-256-GCM encryption channel as per MSC3903:
  *  https://github.com/matrix-org/matrix-spec-proposals/pull/3903
+ *
+ * @alpha This is an experimental API, and is subject to change until MSC3903 is stabilised and accepted.
  */
 class ECDHRendezvousChannel(
         override var transport: RendezvousTransport,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/ECDHRendezvousCode.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/ECDHRendezvousCode.kt
@@ -21,5 +21,6 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class ECDHRendezvousCode(
         val intent: RendezvousIntent,
+        val flow: RendezvousFlow?,
         val rendezvous: ECDHRendezvous
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/FailureReason.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/FailureReason.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Matrix.org Foundation C.I.C.
+ * Copyright 2023 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,23 +19,17 @@ package org.matrix.android.sdk.api.rendezvous.model
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
-/**
- * This is only used for v1 of MSC3906 and will be removed in future. FailureReason is used in v2.
- */
 @JsonClass(generateAdapter = false)
-enum class Outcome(val value: String) {
-    @Json(name = "success")
-    SUCCESS("success"),
-
-    @Json(name = "declined")
-    DECLINED("declined"),
+enum class FailureReason(val value: String) {
+    @Json(name = "cancelled")
+    CANCELLED("cancelled"),
 
     @Json(name = "unsupported")
     UNSUPPORTED("unsupported"),
 
-    @Json(name = "verified")
-    VERIFIED("verified"),
-
     @Json(name = "e2ee_security_error")
-    E2EE_SECURITY_ERROR("e2ee_security_error")
+    E2EE_SECURITY_ERROR("e2ee_security_error"),
+
+    @Json(name = "incompatible_intent")
+    INCOMPATIBLE_INTENT("incompatible_intent")
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/Payload.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/Payload.kt
@@ -23,7 +23,11 @@ import com.squareup.moshi.JsonClass
 internal data class Payload(
         val type: PayloadType,
         val intent: RendezvousIntent? = null,
+        /**
+         * This is only used in v1 of MSC3906 and will be removed in future.
+         */
         val outcome: Outcome? = null,
+        val reason: FailureReason? = null,
         val protocols: List<Protocol>? = null,
         val protocol: Protocol? = null,
         val homeserver: String? = null,
@@ -32,5 +36,5 @@ internal data class Payload(
         @Json(name = "device_key") val deviceKey: String? = null,
         @Json(name = "verifying_device_id") val verifyingDeviceId: String? = null,
         @Json(name = "verifying_device_key") val verifyingDeviceKey: String? = null,
-        @Json(name = "master_key") val masterKey: String? = null
+        @Json(name = "master_key") val masterKey: String? = null,
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/PayloadType.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/PayloadType.kt
@@ -22,7 +22,7 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = false)
 internal enum class PayloadType(val value: String) {
     /**
-     * This is only used in v1 of MSC3906 and will be removed in future
+     * This is only used in v1 of MSC3906 and will be removed in future.
      */
     @Json(name = "m.login.finish")
     FINISH("m.login.finish"),

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/PayloadType.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/PayloadType.kt
@@ -21,12 +21,33 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = false)
 internal enum class PayloadType(val value: String) {
-    @Json(name = "m.login.start")
-    START("m.login.start"),
-
+    /**
+     * This is only used in v1 of MSC3906 and will be removed in future
+     */
     @Json(name = "m.login.finish")
     FINISH("m.login.finish"),
 
     @Json(name = "m.login.progress")
-    PROGRESS("m.login.progress")
+    PROGRESS("m.login.progress"),
+
+    @Json(name = "m.login.protocol")
+    PROTOCOL("m.login.protocol"),
+
+    @Json(name = "m.login.protocols")
+    PROTOCOLS("m.login.protocols"),
+
+    @Json(name = "m.login.approved")
+    APPROVED("m.login.approved"),
+
+    @Json(name = "m.login.success")
+    SUCCESS("m.login.success"),
+
+    @Json(name = "m.login.verified")
+    VERIFIED("m.login.verified"),
+
+    @Json(name = "m.login.failure")
+    FAILURE("m.login.failure"),
+
+    @Json(name = "m.login.declined")
+    DECLINED("m.login.declined"),
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/RendezvousCode.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/RendezvousCode.kt
@@ -21,5 +21,6 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 open class RendezvousCode(
         open val intent: RendezvousIntent,
+        open val flow: String?,
         open val rendezvous: Rendezvous
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/RendezvousFlow.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/RendezvousFlow.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Matrix.org Foundation C.I.C.
+ * Copyright 2023 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,23 +19,12 @@ package org.matrix.android.sdk.api.rendezvous.model
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
-/**
- * This is only used for v1 of MSC3906 and will be removed in future. FailureReason is used in v2.
- */
 @JsonClass(generateAdapter = false)
-enum class Outcome(val value: String) {
-    @Json(name = "success")
-    SUCCESS("success"),
-
-    @Json(name = "declined")
-    DECLINED("declined"),
-
-    @Json(name = "unsupported")
-    UNSUPPORTED("unsupported"),
-
-    @Json(name = "verified")
-    VERIFIED("verified"),
-
-    @Json(name = "e2ee_security_error")
-    E2EE_SECURITY_ERROR("e2ee_security_error")
+enum class RendezvousFlow(val value: String) {
+    /**
+     * v1 is never represented in JSON so we don't annotate it
+     */
+    SETUP_ADDITIONAL_DEVICE_V1("org.matrix.msc3906.v1"),
+    @Json(name = "org.matrix.msc3906.setup.additional_device.v2")
+    SETUP_ADDITIONAL_DEVICE_V2("org.matrix.msc3906.setup.additional_device.v2"),
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/RendezvousFlow.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/model/RendezvousFlow.kt
@@ -21,9 +21,7 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = false)
 enum class RendezvousFlow(val value: String) {
-    /**
-     * v1 is never represented in JSON so we don't annotate it
-     */
+    // v1 is never represented in JSON so we don't annotate it
     SETUP_ADDITIONAL_DEVICE_V1("org.matrix.msc3906.v1"),
     @Json(name = "org.matrix.msc3906.setup.additional_device.v2")
     SETUP_ADDITIONAL_DEVICE_V2("org.matrix.msc3906.setup.additional_device.v2"),

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/transports/SimpleHttpRendezvousTransport.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/rendezvous/transports/SimpleHttpRendezvousTransport.kt
@@ -33,6 +33,8 @@ import java.util.Locale
 
 /**
  * Implementation of the Simple HTTP transport MSC3886: https://github.com/matrix-org/matrix-spec-proposals/pull/3886
+ *
+ * @alpha This is an experimental API, and is subject to change until MSC3886 is stabilised and accepted.
  */
 class SimpleHttpRendezvousTransport(rendezvousUri: String?) : RendezvousTransport {
     companion object {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

This PR adds support for v2 of [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) which is used for Sign in with QR.

Both v1 and v2 are supported so compatibility is maintained.

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Tested against an Element Web which generates a v1 QR
- Tested against an Element Web which generates a v2 QR

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

Signed-off-by: Hugh Nimmo-Smith <hughns@element.io>