### PR TITLE
Add RTL support to RemoveJitsiWidgetView

### DIFF
--- a/changelog.d/8210.bugfix
+++ b/changelog.d/8210.bugfix
@@ -1,0 +1,1 @@
+Add RTL support to RemoveJitsiWidgetView

--- a/vector/src/main/java/im/vector/app/features/call/conference/RemoveJitsiWidgetView.kt
+++ b/vector/src/main/java/im/vector/app/features/call/conference/RemoveJitsiWidgetView.kt
@@ -29,6 +29,7 @@ import im.vector.app.R
 import im.vector.app.databinding.ViewRemoveJitsiWidgetBinding
 import im.vector.app.features.home.room.detail.RoomDetailViewState
 import org.matrix.android.sdk.api.session.room.model.Membership
+import kotlin.math.absoluteValue
 
 @SuppressLint("ClickableViewAccessibility") class RemoveJitsiWidgetView @JvmOverloads constructor(
         context: Context,
@@ -55,7 +56,7 @@ import org.matrix.android.sdk.api.session.room.model.Membership
             return@setOnTouchListener when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
                     if (currentState == State.Idle) {
-                        val initialX = views.removeJitsiSlidingContainer.x - event.rawX
+                        val initialX = event.rawX
                         updateState(State.Sliding(initialX, 0f, false))
                     }
                     true
@@ -73,8 +74,9 @@ import org.matrix.android.sdk.api.session.room.model.Membership
                 }
                 MotionEvent.ACTION_MOVE -> {
                     if (currentState is State.Sliding) {
-                        val translationX = (currentState.initialX + event.rawX).coerceAtLeast(0f)
-                        val hasReachedActivationThreshold = translationX >= views.root.width / 4
+                        val deltaX = event.rawX - currentState.initialX
+                        val translationX = if (!isRtl) deltaX.coerceAtLeast(0f) else deltaX.coerceAtMost(0f)
+                        val hasReachedActivationThreshold = translationX.absoluteValue >= views.root.width / 4
                         updateState(State.Sliding(currentState.initialX, translationX, hasReachedActivationThreshold))
                     }
                     true


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content
<!-- Describe shortly what has been changed -->
This PR adds RTL support to ```RemoveJitsiWidgetView``` as the original code did not seem to consider RTL.
In RTL, ```translationX``` can be a negative value in RTL since it slides from right to left.
Therefore I updated ```translationX```calculation logic so that it can accept negative value in RTL.
Additionally, I modified the activation threshold check logic to use the absolute value of ```traslationX``` since it can be negative in RTL.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix #8210 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->
### Before
https://user-images.githubusercontent.com/39683194/224473109-4ec51e27-63d4-49de-aedd-b5134732cc85.mp4

### After
https://user-images.githubusercontent.com/39683194/224473094-b0c84f37-6612-4a94-b87f-d543068f026f.mp4

## Tests

<!-- Explain how you tested your development -->

- Step 1. Set the device environment to the RTL
- Step 2. Launch the element App and enter the room
- Step 3. Start a room call and come back to the room chat
- Step 4. Use a ```removeJitsiWidgetView``` to slide to end a call.

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s): Android 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
