### PR TITLE
Create Posthog instance only when user consent is given

### DIFF
--- a/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
+++ b/vector/src/main/java/im/vector/app/features/analytics/impl/DefaultVectorAnalytics.kt
@@ -41,19 +41,23 @@ private val IGNORED_OPTIONS: Options? = null
 
 @Singleton
 class DefaultVectorAnalytics @Inject constructor(
-        postHogFactory: PostHogFactory,
+        private val postHogFactory: PostHogFactory,
         private val sentryAnalytics: SentryAnalytics,
-        analyticsConfig: AnalyticsConfig,
+        private val analyticsConfig: AnalyticsConfig,
         private val analyticsStore: AnalyticsStore,
         private val lateInitUserPropertiesFactory: LateInitUserPropertiesFactory,
         @NamedGlobalScope private val globalScope: CoroutineScope
 ) : VectorAnalytics {
 
-    private val posthog: PostHog? = when {
-        analyticsConfig.isEnabled -> postHogFactory.createPosthog()
-        else -> {
-            Timber.tag(analyticsTag.value).w("Analytics is disabled")
-            null
+    private var posthog: PostHog? = null
+
+    private fun createPosthog(): PostHog? {
+        return when {
+            analyticsConfig.isEnabled -> postHogFactory.createPosthog()
+            else -> {
+                Timber.tag(analyticsTag.value).w("Analytics is disabled")
+                null
+            }
         }
     }
 
@@ -150,6 +154,7 @@ class DefaultVectorAnalytics @Inject constructor(
         userConsent?.let { _userConsent ->
             when (_userConsent) {
                 true -> {
+                    posthog = createPosthog()
                     posthog?.optOut(false)
                     identifyPostHog()
                     pendingUserProperties?.let { doUpdateUserProperties(it) }
@@ -159,6 +164,7 @@ class DefaultVectorAnalytics @Inject constructor(
                     // When opting out, ensure that the queue is flushed first, or it will be flushed later (after user has revoked consent)
                     posthog?.flush()
                     posthog?.optOut(true)
+                    posthog = null
                 }
             }
         }

--- a/vector/src/test/java/im/vector/app/features/analytics/impl/DefaultVectorAnalyticsTest.kt
+++ b/vector/src/test/java/im/vector/app/features/analytics/impl/DefaultVectorAnalyticsTest.kt
@@ -80,6 +80,12 @@ class DefaultVectorAnalyticsTest {
 
     @Test
     fun `when revoking consent to analytics then updates posthog opt out to true and closes Sentry`() = runTest {
+        // For opt-out to have effect on Posthog, it has to be used first, so it has to be opt-in first
+        fakeAnalyticsStore.givenUserContent(consent = true)
+        fakePostHog.verifyOptOutStatus(optedOut = false)
+        fakeSentryAnalytics.verifySentryInit()
+
+        // Then test opt-out
         fakeAnalyticsStore.givenUserContent(consent = false)
 
         fakePostHog.verifyOptOutStatus(optedOut = true)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
The app is creating the Posthog instance even if use consent to use analytics is not given. And when Posthog is created it tries to refresh the feature flag by requesting the server. We want to avoid that.

So in this PR: Create Posthog instance only when user consent is given, to avoid pinging Posthog server at application startup when consent is not given.

Note that feature flag will not work, but for now they are not used. All the `?.takeIf { userConsent == true }` could be removed with this change, but let's keep them for safety...

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes  #8020

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->
N/A

## Tests

<!-- Explain how you tested your development -->

- Add a breakpoint to `com.posthog.android.ConnectionFactory:openConnection`
- Disable analytics
- Start the app in debug mode
- See that no connection is created

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
