### PR TITLE
Add user completion for matrix ids

### DIFF
--- a/changelog.d/8217.bugfix
+++ b/changelog.d/8217.bugfix
@@ -1,0 +1,1 @@
+Add user completion for matrix ids

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/members/RoomMemberQueryParams.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/members/RoomMemberQueryParams.kt
@@ -30,7 +30,8 @@ data class RoomMemberQueryParams(
         val displayName: QueryStringValue,
         val memberships: List<Membership>,
         val userId: QueryStringValue,
-        val excludeSelf: Boolean
+        val excludeSelf: Boolean,
+        val displayNameOrUserId: QueryStringValue,
 ) {
 
     class Builder {
@@ -39,12 +40,14 @@ data class RoomMemberQueryParams(
         var displayName: QueryStringValue = QueryStringValue.IsNotEmpty
         var memberships: List<Membership> = Membership.all()
         var excludeSelf: Boolean = false
+        var displayNameOrUserId: QueryStringValue = QueryStringValue.IsNotNull
 
         fun build() = RoomMemberQueryParams(
                 displayName = displayName,
                 memberships = memberships,
                 userId = userId,
-                excludeSelf = excludeSelf
+                excludeSelf = excludeSelf,
+                displayNameOrUserId = displayNameOrUserId
         )
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/members/RoomMemberQueryParams.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/members/RoomMemberQueryParams.kt
@@ -40,7 +40,7 @@ data class RoomMemberQueryParams(
         var displayName: QueryStringValue = QueryStringValue.IsNotEmpty
         var memberships: List<Membership> = Membership.all()
         var excludeSelf: Boolean = false
-        var displayNameOrUserId: QueryStringValue = QueryStringValue.IsNotNull
+        var displayNameOrUserId: QueryStringValue = QueryStringValue.NoCondition
 
         fun build() = RoomMemberQueryParams(
                 displayName = displayName,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/DefaultMembershipService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/DefaultMembershipService.kt
@@ -17,14 +17,12 @@
 package org.matrix.android.sdk.internal.session.room.membership
 
 import androidx.lifecycle.LiveData
-import com.otaliastudios.opengl.core.use
 import com.zhuinden.monarchy.Monarchy
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import io.realm.Realm
 import io.realm.RealmQuery
-import org.matrix.android.sdk.api.MatrixConfiguration
 import org.matrix.android.sdk.api.session.crypto.CryptoService
 import org.matrix.android.sdk.api.session.identity.ThreePid
 import org.matrix.android.sdk.api.session.room.members.MembershipService
@@ -58,7 +56,6 @@ internal class DefaultMembershipService @AssistedInject constructor(
         private val cryptoService: CryptoService,
         @UserId
         private val userId: String,
-        private val matrixConfiguration: MatrixConfiguration,
         private val queryStringValueProcessor: QueryStringValueProcessor
 ) : MembershipService {
 
@@ -116,6 +113,11 @@ internal class DefaultMembershipService @AssistedInject constructor(
                     .process(RoomMemberSummaryEntityFields.USER_ID, queryParams.userId)
                     .process(RoomMemberSummaryEntityFields.MEMBERSHIP_STR, queryParams.memberships)
                     .process(RoomMemberSummaryEntityFields.DISPLAY_NAME, queryParams.displayName)
+                    .beginGroup()
+                    .process(RoomMemberSummaryEntityFields.USER_ID, queryParams.displayNameOrUserId)
+                    .or()
+                    .process(RoomMemberSummaryEntityFields.DISPLAY_NAME, queryParams.displayNameOrUserId)
+                    .endGroup()
                     .apply {
                         if (queryParams.excludeSelf) {
                             notEqualTo(RoomMemberSummaryEntityFields.USER_ID, userId)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/DefaultMembershipService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/membership/DefaultMembershipService.kt
@@ -23,6 +23,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import io.realm.Realm
 import io.realm.RealmQuery
+import org.matrix.android.sdk.api.query.QueryStringValue
 import org.matrix.android.sdk.api.session.crypto.CryptoService
 import org.matrix.android.sdk.api.session.identity.ThreePid
 import org.matrix.android.sdk.api.session.room.members.MembershipService
@@ -113,14 +114,16 @@ internal class DefaultMembershipService @AssistedInject constructor(
                     .process(RoomMemberSummaryEntityFields.USER_ID, queryParams.userId)
                     .process(RoomMemberSummaryEntityFields.MEMBERSHIP_STR, queryParams.memberships)
                     .process(RoomMemberSummaryEntityFields.DISPLAY_NAME, queryParams.displayName)
-                    .beginGroup()
-                    .process(RoomMemberSummaryEntityFields.USER_ID, queryParams.displayNameOrUserId)
-                    .or()
-                    .process(RoomMemberSummaryEntityFields.DISPLAY_NAME, queryParams.displayNameOrUserId)
-                    .endGroup()
                     .apply {
                         if (queryParams.excludeSelf) {
                             notEqualTo(RoomMemberSummaryEntityFields.USER_ID, userId)
+                        }
+                        if (queryParams.displayNameOrUserId != QueryStringValue.NoCondition) {
+                            beginGroup()
+                            process(RoomMemberSummaryEntityFields.USER_ID, queryParams.displayNameOrUserId)
+                            or()
+                            process(RoomMemberSummaryEntityFields.DISPLAY_NAME, queryParams.displayNameOrUserId)
+                            endGroup()
                         }
                     }
         }

--- a/vector/src/main/java/im/vector/app/features/autocomplete/member/AutocompleteMemberController.kt
+++ b/vector/src/main/java/im/vector/app/features/autocomplete/member/AutocompleteMemberController.kt
@@ -76,6 +76,7 @@ class AutocompleteMemberController @Inject constructor(private val context: Cont
             roomMember.roomMemberSummary.let { user ->
                 id(user.userId)
                 matrixItem(user.toMatrixItem())
+                subName(user.userId)
                 avatarRenderer(host.avatarRenderer)
                 clickListener { host.listener?.onItemClick(roomMember) }
             }

--- a/vector/src/main/java/im/vector/app/features/autocomplete/member/AutocompleteMemberPresenter.kt
+++ b/vector/src/main/java/im/vector/app/features/autocomplete/member/AutocompleteMemberPresenter.kt
@@ -113,7 +113,7 @@ class AutocompleteMemberPresenter @AssistedInject constructor(
 
     private fun createQueryParams(query: CharSequence?) = roomMemberQueryParams {
         displayNameOrUserId = if (query.isNullOrBlank()) {
-            QueryStringValue.IsNotNull
+            QueryStringValue.NoCondition
         } else {
             QueryStringValue.Contains(query.toString(), QueryStringValue.Case.INSENSITIVE)
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Add user completion for matrix ids

## Motivation and context

#8217 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
