### PR TITLE
update to release 0.16.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,9 +24,7 @@ def mavericks = "3.0.1"
 def glide = "4.15.1"
 def bigImageViewer = "1.8.1"
 def jjwt = "0.11.5"
-// Temporary version to unblock #6929. Once 0.16.0 is released we should use it, and revert
-// the whole commit which set version 0.16.0-SNAPSHOT
-def vanniktechEmoji = "0.16.0-SNAPSHOT"
+def vanniktechEmoji = "0.16.0"
 def sentry = "6.16.0"
 // Use 1.6.0 alpha to fix issue with test
 def fragment = "1.6.0-alpha08"

--- a/dependencies_groups.gradle
+++ b/dependencies_groups.gradle
@@ -42,7 +42,6 @@ ext.groups = [
                 regex: [
                 ],
                 group: [
-                        'com.vanniktech',
                 ]
         ],
         mavenCentral: [
@@ -128,7 +127,7 @@ ext.groups = [
                         'com.sun.xml.bind.mvn',
                         'com.sun.xml.fastinfoset',
                         'com.thoughtworks.qdox',
-                        // 'com.vanniktech',
+                        'com.vanniktech',
                         'commons-cli',
                         'commons-codec',
                         'commons-io',


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Update vanniktech emoji to release 0.16.0

## Motivation and context

Build failed

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
