### PR TITLE
Fix custom sticker url loading

### DIFF
--- a/changelog.d/8026.bugfix
+++ b/changelog.d/8026.bugfix
@@ -1,0 +1,1 @@
+Maunium sticker picker loads indefinitely on new update

--- a/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/widgets/WidgetFragment.kt
@@ -218,7 +218,7 @@ class WidgetFragment :
 
     override fun invalidate() = withState(viewModel) { state ->
         Timber.v("Invalidate state: $state")
-        when (state.formattedURL) {
+        when (val formattedUrl = state.formattedURL) {
             Uninitialized,
             is Loading -> {
                 setStateError(null)
@@ -227,6 +227,9 @@ class WidgetFragment :
                 views.widgetProgressBar.isVisible = true
             }
             is Success -> {
+                if (views.widgetWebView.url == null) {
+                    loadFormattedUrl(formattedUrl())
+                }
                 setStateError(null)
                 when (state.webviewLoadedUrl) {
                     Uninitialized -> {
@@ -253,7 +256,7 @@ class WidgetFragment :
                 // we need to show Error
                 views.widgetWebView.isInvisible = true
                 views.widgetProgressBar.isVisible = false
-                setStateError(state.formattedURL.error.message)
+                setStateError(formattedUrl.error.message)
             }
         }
     }
@@ -323,8 +326,12 @@ class WidgetFragment :
     }
 
     private fun loadFormattedUrl(event: WidgetViewEvents.OnURLFormatted) {
+        loadFormattedUrl(event.formattedURL)
+    }
+
+    private fun loadFormattedUrl(formattedUrl: String) {
         views.widgetWebView.clearHistory()
-        views.widgetWebView.loadUrl(event.formattedURL)
+        views.widgetWebView.loadUrl(formattedUrl)
     }
 
     private fun setStateError(message: String?) {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

#8026 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
