### PR TITLE
Support for stable MSC3882 get_login_token

### DIFF
--- a/changelog.d/8299.feature
+++ b/changelog.d/8299.feature
@@ -1,0 +1,1 @@
+Updates to protocol used for Sign in with QR code

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/DefaultAuthenticationService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/DefaultAuthenticationService.kt
@@ -301,6 +301,9 @@ internal class DefaultAuthenticationService @Inject constructor(
         val oidcCompatibilityFlow = loginFlowResponse.flows.orEmpty().firstOrNull { it.type == "m.login.sso" && it.delegatedOidcCompatibilty == true }
         val flows = if (oidcCompatibilityFlow != null) listOf(oidcCompatibilityFlow) else loginFlowResponse.flows
 
+        val supportsGetLoginTokenFlow = loginFlowResponse.flows.orEmpty().firstOrNull { it.type == "m.login.token" && it.getLoginToken == true } != null
+
+        @Suppress("DEPRECATION")
         return LoginFlowResult(
                 supportedLoginTypes = flows.orEmpty().mapNotNull { it.type },
                 ssoIdentityProviders = flows.orEmpty().firstOrNull { it.type == LoginFlowTypes.SSO }?.ssoIdentityProvider,
@@ -309,7 +312,7 @@ internal class DefaultAuthenticationService @Inject constructor(
                 isOutdatedHomeserver = !versions.isSupportedBySdk(),
                 hasOidcCompatibilityFlow = oidcCompatibilityFlow != null,
                 isLogoutDevicesSupported = versions.doesServerSupportLogoutDevices(),
-                isLoginWithQrSupported = versions.doesServerSupportQrCodeLogin(),
+                isLoginWithQrSupported = supportsGetLoginTokenFlow || versions.doesServerSupportQrCodeLogin(),
         )
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/data/LoginFlowResponse.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/data/LoginFlowResponse.kt
@@ -51,5 +51,13 @@ internal data class LoginFlow(
          * See [MSC3824](https://github.com/matrix-org/matrix-spec-proposals/pull/3824)
          */
         @Json(name = "org.matrix.msc3824.delegated_oidc_compatibility")
-        val delegatedOidcCompatibilty: Boolean? = null
+        val delegatedOidcCompatibilty: Boolean? = null,
+
+        /**
+         * Whether a login flow of type m.login.token could accept a token issued using MSC3882.
+         *
+         * See [MSC3882](https://github.com/matrix-org/matrix-spec-proposals/pull/3882)
+         */
+        @Json(name = "org.matrix.msc3882.get_login_token")
+        val getLoginToken: Boolean? = null
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/data/LoginFlowResponse.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/data/LoginFlowResponse.kt
@@ -54,10 +54,10 @@ internal data class LoginFlow(
         val delegatedOidcCompatibilty: Boolean? = null,
 
         /**
-         * Whether a login flow of type m.login.token could accept a token issued using MSC3882.
+         * Whether a login flow of type m.login.token could accept a token issued using /login/get_token.
          *
-         * See [MSC3882](https://github.com/matrix-org/matrix-spec-proposals/pull/3882)
+         * See https://spec.matrix.org/v1.7/client-server-api/#post_matrixclientv1loginget_token
          */
-        @Json(name = "org.matrix.msc3882.get_login_token")
+        @Json(name = "get_login_token")
         val getLoginToken: Boolean? = null
 )

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/version/Versions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/version/Versions.kt
@@ -54,7 +54,7 @@ private const val FEATURE_ID_ACCESS_TOKEN = "m.id_access_token"
 private const val FEATURE_SEPARATE_ADD_AND_BIND = "m.separate_add_and_bind"
 private const val FEATURE_THREADS_MSC3440 = "org.matrix.msc3440"
 private const val FEATURE_THREADS_MSC3440_STABLE = "org.matrix.msc3440.stable"
-@Deprecated("The availability of MSC3882 is now exposed as a capability or part of login flow from revision 1 onwards")
+@Deprecated("The availability of stable get_login_token is now exposed as a capability and part of login flow")
 private const val FEATURE_QR_CODE_LOGIN = "org.matrix.msc3882"
 private const val FEATURE_THREADS_MSC3771 = "org.matrix.msc3771"
 private const val FEATURE_THREADS_MSC3773 = "org.matrix.msc3773"
@@ -95,7 +95,7 @@ internal fun Versions.doesServerSupportThreadUnreadNotifications(): Boolean {
     return getMaxVersion() >= HomeServerVersion.v1_4_0 || (msc3771 && msc3773)
 }
 
-@Deprecated("The availability of MSC3882 is now exposed as a capability or part of login flow from revision 1 onwards")
+@Deprecated("The availability of stable get_login_token is now exposed as a capability and part of login flow")
 internal fun Versions.doesServerSupportQrCodeLogin(): Boolean {
     @Suppress("DEPRECATION")
     return unstableFeatures?.get(FEATURE_QR_CODE_LOGIN) ?: false

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/version/Versions.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/version/Versions.kt
@@ -54,6 +54,7 @@ private const val FEATURE_ID_ACCESS_TOKEN = "m.id_access_token"
 private const val FEATURE_SEPARATE_ADD_AND_BIND = "m.separate_add_and_bind"
 private const val FEATURE_THREADS_MSC3440 = "org.matrix.msc3440"
 private const val FEATURE_THREADS_MSC3440_STABLE = "org.matrix.msc3440.stable"
+@Deprecated("The availability of MSC3882 is now exposed as a capability or part of login flow from revision 1 onwards")
 private const val FEATURE_QR_CODE_LOGIN = "org.matrix.msc3882"
 private const val FEATURE_THREADS_MSC3771 = "org.matrix.msc3771"
 private const val FEATURE_THREADS_MSC3773 = "org.matrix.msc3773"
@@ -94,7 +95,9 @@ internal fun Versions.doesServerSupportThreadUnreadNotifications(): Boolean {
     return getMaxVersion() >= HomeServerVersion.v1_4_0 || (msc3771 && msc3773)
 }
 
+@Deprecated("The availability of MSC3882 is now exposed as a capability or part of login flow from revision 1 onwards")
 internal fun Versions.doesServerSupportQrCodeLogin(): Boolean {
+    @Suppress("DEPRECATION")
     return unstableFeatures?.get(FEATURE_QR_CODE_LOGIN) ?: false
 }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetCapabilitiesResult.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetCapabilitiesResult.kt
@@ -74,10 +74,10 @@ internal data class Capabilities(
         val threads: BooleanCapability? = null,
 
         /**
-         * Capability to indicate if the server supports MSC3882 login token issuance for signing in another deivce.
+         * Capability to indicate if the server supports login token issuance for signing in another device.
          * True if the user can use /login/get_token, false otherwise.
          */
-        @Json(name = "org.matrix.msc3882.get_login_token")
+        @Json(name = "m.get_login_token")
         val getLoginToken: BooleanCapability? = null
 )
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetCapabilitiesResult.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetCapabilitiesResult.kt
@@ -71,7 +71,14 @@ internal data class Capabilities(
          * True if the user can use m.thread relation, false otherwise.
          */
         @Json(name = "m.thread")
-        val threads: BooleanCapability? = null
+        val threads: BooleanCapability? = null,
+
+        /**
+         * Capability to indicate if the server supports MSC3882 login token issuance for signing in another deivce.
+         * True if the user can use /login/get_token, false otherwise.
+         */
+        @Json(name = "org.matrix.msc3882.get_login_token")
+        val getLoginToken: BooleanCapability? = null
 )
 
 @JsonClass(generateAdapter = true)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetHomeServerCapabilitiesTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetHomeServerCapabilitiesTask.kt
@@ -175,9 +175,9 @@ internal class DefaultGetHomeServerCapabilitiesTask @Inject constructor(
     }
 
     private fun canLoginWithQrCode(getCapabilitiesResult: GetCapabilitiesResult?, getVersionResult: Versions?): Boolean {
-        // in r0 of MSC3882 an unstable feature was exposed. In r1 it is done via /capabilities and /login
+        // in r0 of MSC3882 an unstable feature was exposed. In stable it is done via /capabilities and /login
 
-        // in r1 of MSC3882 a capability is exposed for the authenticated in user
+        // in stable 1.7 a capability is exposed for the authenticated user
         if (getCapabilitiesResult?.capabilities?.getLoginToken != null) {
             return getCapabilitiesResult.capabilities.getLoginToken.enabled == true
         }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetHomeServerCapabilitiesTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetHomeServerCapabilitiesTask.kt
@@ -135,10 +135,6 @@ internal class DefaultGetHomeServerCapabilitiesTask @Inject constructor(
                 homeServerCapabilitiesEntity.roomVersionsJson = capabilities?.roomVersions?.let {
                     MoshiProvider.providesMoshi().adapter(RoomVersions::class.java).toJson(it)
                 }
-                // in r1 of MSC3882 a capability is exposed for the authenticated in user
-                if (capabilities?.getLoginToken != null) {
-                    homeServerCapabilitiesEntity.canLoginWithQrCode = capabilities.getLoginToken.enabled == true
-                }
             }
 
             if (getMediaConfigResult != null) {
@@ -155,20 +151,10 @@ internal class DefaultGetHomeServerCapabilitiesTask @Inject constructor(
                         getVersionResult.doesServerSupportThreads()
                 homeServerCapabilitiesEntity.canUseThreadReadReceiptsAndNotifications =
                         getVersionResult.doesServerSupportThreadUnreadNotifications()
-                @Suppress("DEPRECATION")
-                homeServerCapabilitiesEntity.canLoginWithQrCode =
-                        getVersionResult.doesServerSupportQrCodeLogin()
                 homeServerCapabilitiesEntity.canRemotelyTogglePushNotificationsOfDevices =
                         getVersionResult.doesServerSupportRemoteToggleOfPushNotifications()
                 homeServerCapabilitiesEntity.canRedactEventWithRelations =
                         getVersionResult.doesServerSupportRedactEventWithRelations()
-
-                // in r0 of MSC3882 an unstable feature was exposed. In r1 it is done via /capabilities and /login
-                // so, only use it if set to true, otherwise we use the default or previous value
-                @Suppress("DEPRECATION")
-                if (getVersionResult.doesServerSupportQrCodeLogin()) {
-                    homeServerCapabilitiesEntity.canLoginWithQrCode = true
-                }
             }
 
             if (getWellknownResult != null && getWellknownResult is WellknownResult.Prompt) {
@@ -181,8 +167,23 @@ internal class DefaultGetHomeServerCapabilitiesTask @Inject constructor(
                 }
                 homeServerCapabilitiesEntity.externalAccountManagementUrl = getWellknownResult.wellKnown.unstableDelegatedAuthConfig?.accountManagementUrl
             }
+
+            homeServerCapabilitiesEntity.canLoginWithQrCode = canLoginWithQrCode(getCapabilitiesResult, getVersionResult)
+
             homeServerCapabilitiesEntity.lastUpdatedTimestamp = Date().time
         }
+    }
+
+    private fun canLoginWithQrCode(getCapabilitiesResult: GetCapabilitiesResult?, getVersionResult: Versions?): Boolean {
+        // in r0 of MSC3882 an unstable feature was exposed. In r1 it is done via /capabilities and /login
+
+        // in r1 of MSC3882 a capability is exposed for the authenticated in user
+        if (getCapabilitiesResult?.capabilities?.getLoginToken != null) {
+            return getCapabilitiesResult.capabilities.getLoginToken.enabled == true
+        }
+
+        @Suppress("DEPRECATION")
+        return getVersionResult?.doesServerSupportQrCodeLogin() == true
     }
 
     companion object {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

This adds support for the stable capability negotiation for the [get login token](https://spec.matrix.org/v1.7/client-server-api/#post_matrixclientv1loginget_token) endpoint used by Sign in with QR.

These PR leaves support for the unstable release 0 in place. It is my intention that the support for the unstable version would be removed in a future release once the stable support has made it into Synapse via https://github.com/matrix-org/synapse/pull/15388.

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): SDK 33

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

Signed-off-by: Hugh Nimmo-Smith <hughns@element.io>