### PR TITLE
Fix multiple read receipts for the same user in timeline #7882

### DIFF
--- a/changelog.d/7882.bugfix
+++ b/changelog.d/7882.bugfix
@@ -1,0 +1,1 @@
+Fix multiple read receipts for the same user in timeline.

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineFragment.kt
@@ -139,7 +139,6 @@ import im.vector.app.features.home.room.detail.composer.MessageComposerViewModel
 import im.vector.app.features.home.room.detail.composer.boolean
 import im.vector.app.features.home.room.detail.composer.voice.VoiceRecorderFragment
 import im.vector.app.features.home.room.detail.error.RoomNotFound
-import im.vector.app.features.home.room.detail.readreceipts.DisplayReadReceiptsBottomSheet
 import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 import im.vector.app.features.home.room.detail.timeline.action.EventSharedAction
 import im.vector.app.features.home.room.detail.timeline.action.MessageActionsBottomSheet
@@ -156,6 +155,7 @@ import im.vector.app.features.home.room.detail.timeline.item.MessageTextItem
 import im.vector.app.features.home.room.detail.timeline.item.MessageVoiceItem
 import im.vector.app.features.home.room.detail.timeline.item.ReadReceiptData
 import im.vector.app.features.home.room.detail.timeline.reactions.ViewReactionsBottomSheet
+import im.vector.app.features.home.room.detail.timeline.readreceipts.DisplayReadReceiptsBottomSheet
 import im.vector.app.features.home.room.detail.timeline.url.PreviewUrlRetriever
 import im.vector.app.features.home.room.detail.upgrade.MigrateRoomBottomSheet
 import im.vector.app.features.home.room.detail.views.RoomDetailLazyLoadedViews

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/readreceipts/DisplayReadReceiptItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/readreceipts/DisplayReadReceiptItem.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.home.room.detail.readreceipts
+package im.vector.app.features.home.room.detail.timeline.readreceipts
 
 import android.widget.ImageView
 import android.widget.TextView

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/readreceipts/DisplayReadReceiptsBottomSheet.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/readreceipts/DisplayReadReceiptsBottomSheet.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.home.room.detail.readreceipts
+package im.vector.app.features.home.room.detail.timeline.readreceipts
 
 import android.os.Bundle
 import android.os.Parcelable

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/readreceipts/DisplayReadReceiptsController.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/readreceipts/DisplayReadReceiptsController.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 New Vector Ltd
+ * Copyright (c) 2023 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package im.vector.app.features.home.room.detail.readreceipts
+package im.vector.app.features.home.room.detail.timeline.readreceipts
 
 import com.airbnb.epoxy.TypedEpoxyController
 import im.vector.app.core.date.DateFormatKind

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/readreceipts/ReadReceiptsCache.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/readreceipts/ReadReceiptsCache.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.home.room.detail.timeline.readreceipts
+
+import im.vector.lib.core.utils.compat.removeIfCompat
+import org.matrix.android.sdk.api.session.room.model.ReadReceipt
+
+class ReadReceiptsCache {
+
+    private val receiptsByEventId = HashMap<String, MutableList<ReadReceipt>>()
+
+    // Key is userId, Value is eventId
+    private val receiptEventIdByUserId = HashMap<String, String>()
+
+    fun receiptsByEvent(): Map<String, List<ReadReceipt>> {
+        return receiptsByEventId
+    }
+
+    fun addReceiptsOnEvent(receipts: List<ReadReceipt>, eventId: String) {
+        val existingReceipts = receiptsByEventId.getOrPut(eventId) { ArrayList() }
+        receipts.forEach { readReceipt ->
+            val receiptUserId = readReceipt.roomMember.userId
+            val receiptEventId = receiptEventIdByUserId[receiptUserId]
+            // If we already have a read receipt for this user, move it so we only
+            // use the most recent. It can happen because of threaded read receipts.
+            if (receiptEventId != null) {
+                receiptsByEventId[receiptEventId]?.removeIfCompat {
+                    it.roomMember.userId == receiptUserId
+                }
+            }
+            receiptEventIdByUserId[receiptUserId] = eventId
+            existingReceipts.add(readReceipt)
+        }
+    }
+
+    fun clear() {
+        receiptsByEventId.clear()
+        receiptEventIdByUserId.clear()
+    }
+}


### PR DESCRIPTION
Fixes #7882 
As we can now have multiple read receipts for the same user because of threads, we need to ensure we only show the most recent in a timeline.
We also need to handle clients not handling threads.
It could be handled in the sdk but it's easier to manage in the presentation layer.