### PR TITLE
Enable free style cropping for camera and gallery images

### DIFF
--- a/changelog.d/8325.feature
+++ b/changelog.d/8325.feature
@@ -1,0 +1,1 @@
+Enable free style cropping for camera and gallery images

--- a/vector/src/main/java/im/vector/app/features/media/UCropHelper.kt
+++ b/vector/src/main/java/im/vector/app/features/media/UCropHelper.kt
@@ -39,8 +39,7 @@ fun createUCropWithDefaultSettings(
                                         /* tabAspectRatio = */ UCropActivity.SCALE
                                 )
                                 setToolbarTitle(toolbarTitle)
-                                // Disable freestyle crop, usability was not easy
-                                // setFreeStyleCropEnabled(true)
+                                setFreeStyleCropEnabled(true)
                                 // Color used for toolbar icon and text
                                 setToolbarColor(colorProvider.getColorFromAttribute(android.R.attr.colorBackground))
                                 setToolbarWidgetColor(colorProvider.getColorFromAttribute(R.attr.vctr_content_primary))


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other:

## Content

This pull request enables the ability to crop images uploaded from the gallery or taken from within the app without a fixed aspect ratio. This allows users to be specific about the parts of an image they wish to send.

## Motivation and context

A friend told me how she has to use another messaging application to crop images as her screenshot tool has no editing tools and Element doesn't allow her to be specific.

Resolves #2356, which shows popular demand for the feature.

Note that support for free style cropping was previously removed in 3ac2296464f348e98341bdbefe8e285da3597b45.

## Screenshots / GIFs

|Before|After|
|-|-|
|![old](https://user-images.githubusercontent.com/42888162/231284095-1d9e4400-e0e5-48e7-aa4a-bd5537ca280c.gif)|![new](https://user-images.githubusercontent.com/42888162/231283584-707889a6-2365-490b-9cec-00886af2214a.gif)|

## Tests

- In a room, click on the plus icon left to the text input
- Either use the gallery icon and select and image or take a photo
- Click on the editing pen in the top right corner
- The "Crop" tab now allows the dimensions of the rectangle selection to be edited with handles

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 5.0, 12.0

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
