### PR TITLE
fix rust isCrossSigningVerified

### DIFF
--- a/changelog.d/8352.bugfix
+++ b/changelog.d/8352.bugfix
@@ -1,0 +1,1 @@
+Fix: RustCrossSigning service API confusion (identity trusted vs own device trusted by identity)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/crosssigning/CrossSigningService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/crosssigning/CrossSigningService.kt
@@ -24,7 +24,7 @@ import org.matrix.android.sdk.api.util.Optional
 
 interface CrossSigningService {
     /**
-     * Is our own device signed by our own cross signing identity.
+     * Is our published identity trusted.
      */
     suspend fun isCrossSigningVerified(): Boolean
 

--- a/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/RustCrossSigningService.kt
+++ b/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/RustCrossSigningService.kt
@@ -36,7 +36,7 @@ internal class RustCrossSigningService @Inject constructor(
 ) : CrossSigningService {
 
     /**
-     * Is our own device signed by our own cross signing identity
+     * Is our own identity trusted
      */
     override suspend fun isCrossSigningVerified(): Boolean {
         return when (val identity = olmMachine.getIdentity(olmMachine.userId())) {

--- a/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/RustCrossSigningService.kt
+++ b/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/RustCrossSigningService.kt
@@ -40,7 +40,7 @@ internal class RustCrossSigningService @Inject constructor(
      */
     override suspend fun isCrossSigningVerified(): Boolean {
         return when (val identity = olmMachine.getIdentity(olmMachine.userId())) {
-            is OwnUserIdentity -> identity.trustsOurOwnDevice()
+            is OwnUserIdentity -> identity.verified()
             else               -> false
         }
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Quick fix on RustCrossSigningService. 
`isCrossSigningVerified()` was checking if the current identity trust the user own device instead of just checking if the user identity is trusted

Fixes https://github.com/vector-im/crypto-internal/issues/57