### PR TITLE
Allow custom push gateway to use non-default port

### DIFF
--- a/changelog.d/8376.bugfix
+++ b/changelog.d/8376.bugfix
@@ -1,0 +1,1 @@
+Allow custom push gateway to use non-default port

--- a/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
+++ b/vector/src/main/java/im/vector/app/core/pushers/UnifiedPushHelper.kt
@@ -104,7 +104,8 @@ class UnifiedPushHelper @Inject constructor(
         // else, unifiedpush, and pushkey is an endpoint
         val gateway = stringProvider.getString(R.string.default_push_gateway_http_url)
         val parsed = URL(endpoint)
-        val custom = "${parsed.protocol}://${parsed.host}/_matrix/push/v1/notify"
+        val port = if (parsed.port != -1) { ":${parsed.port}" } else { "" }
+        val custom = "${parsed.protocol}://${parsed.host}${port}/_matrix/push/v1/notify"
         Timber.i("Testing $custom")
         try {
             val response = matrix.rawService().getUrl(custom, CacheStrategy.NoCache)


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Allow a custom push gateway to use a non-default port

## Motivation and context

When a custom UnifiedPush push gateway is detected, it's gateway URL is constructed from URL components contained within the push key. However, if the gateway URL contains a custom port, this is ignored and the push gateway test fails.

## Screenshots / GIFs

![image](https://user-images.githubusercontent.com/4940864/235118607-23795fc0-f99b-446e-8947-39040386b9d4.png)


## Tests

- Set up a custom push gateway which uses a custom port
- Go to settings > notifications > troubleshoot

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 13

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
