### PR TITLE
Upgrade jitsi to version 8.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,9 +96,9 @@ allprojects {
         }
         // Jitsi repo
         maven {
-            url "https://github.com/vector-im/jitsi_libre_maven/raw/main/android-sdk-6.2.2"
+            url "https://github.com/vector-im/jitsi_libre_maven/raw/main/android-sdk-8.1.1"
             // Note: to test Jitsi release you can use a local file like this:
-            // url "file:///Users/bmarty/workspaces/jitsi_libre_maven/android-sdk-6.2.2"
+            // url "file:///Users/bmarty/workspaces/jitsi_libre_maven/android-sdk-8.1.1"
             content {
                 groups.jitsi.regex.each { includeGroupByRegex it }
                 groups.jitsi.group.each { includeGroup it }

--- a/changelog.d/7619.bugfix
+++ b/changelog.d/7619.bugfix
@@ -1,0 +1,1 @@
+Upgrade Jitsi SDK from 6.2.2 to 8.1.1. This fixes video call on some Android devices.

--- a/dependencies_groups.gradle
+++ b/dependencies_groups.gradle
@@ -203,6 +203,7 @@ ext.groups = [
                         'org.jetbrains.kotlin',
                         'org.jetbrains.kotlinx',
                         'org.jetbrains.trove4j',
+                        'org.jitsi',
                         'org.json',
                         'org.jsoup',
                         'org.junit',

--- a/docs/jitsi.md
+++ b/docs/jitsi.md
@@ -32,7 +32,7 @@ Update the script `./tools/jitsi/build_jisti_libs.sh` with the tag of the projec
 
 Latest tag can be found from this page: https://github.com/jitsi/jitsi-meet-release-notes/blob/master/CHANGELOG-MOBILE-SDKS.md
 
-Currently we are building the version with the tag `android-sdk-3.10.0`.
+Currently we are building the version with the tag `android-sdk-8.1.1`.
 
 #### Run the build script
 
@@ -49,7 +49,7 @@ It will build the Jitsi Meet Android library and put every generated files in th
 - Update the file `./build.gradle` to use the previously created local Maven repository. Currently we have this line:
 
 ```groovy
-url "https://github.com/vector-im/jitsi_libre_maven/raw/master/android-sdk-3.10.0"
+url "https://github.com/vector-im/jitsi_libre_maven/raw/main/android-sdk-8.1.1"
 ```
 
 You can uncomment and update the line starting with `// url "file://...` and comment the line starting with `url`, to test the library using the locally generated Maven repository.
@@ -57,13 +57,13 @@ You can uncomment and update the line starting with `// url "file://...` and com
 - Update the dependency of the Jitsi Meet library in the file `./vector/build.gradle`. Currently we have this line:
 
 ```groovy
-implementation('org.jitsi.react:jitsi-meet-sdk:3.10.0')
+api('org.jitsi.react:jitsi-meet-sdk:8.1.1')
 ```
 
 - Update the dependency of the WebRTC library in the file `./vector/build.gradle`. Currently we have this line:
 
 ```groovy
-implementation('com.facebook.react:react-native-webrtc:1.92.1-jitsi-9093212@aar')
+implementation('com.facebook.react:react-native-webrtc:111.0.0-jitsi-13672566@aar')
 ```
 
 - Perform a gradle sync and build the project
@@ -88,7 +88,7 @@ If all the tests are passed, you can export the generated Jitsi library to our M
 - Update the file `./build.gradle` to use the previously created Maven repository. Currently we have this line:
 
 ```groovy
-url "https://github.com/vector-im/jitsi_libre_maven/raw/master/android-sdk-3.10.0"
+url "https://github.com/vector-im/jitsi_libre_maven/raw/main/android-sdk-8.1.1"
 ```
 
 - Build the project and perform the sanity tests again.

--- a/tools/jitsi/build_jisti_libs.sh
+++ b/tools/jitsi/build_jisti_libs.sh
@@ -26,7 +26,7 @@ export LIBRE_BUILD=true
 cd jitsi-meet
 
 # Get the latest version from the changelog: https://github.com/jitsi/jitsi-meet-release-notes/blob/master/CHANGELOG-MOBILE-SDKS.md
-git checkout android-sdk-6.2.2
+git checkout android-sdk-8.1.1
 
 echo
 echo "##################################################"

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -249,10 +249,9 @@ dependencies {
     // WebRTC
     // org.webrtc:google-webrtc is for development purposes only
     // implementation 'org.webrtc:google-webrtc:1.0.+'
-    implementation('com.facebook.react:react-native-webrtc:1.106.1-jitsi-12039821@aar')
+    implementation('com.facebook.react:react-native-webrtc:111.0.0-jitsi-13672566@aar')
     // Jitsi
-    // Note: version is 6.2.0, but built from the tag `android-sdk-6.2.2`.
-    api('org.jitsi.react:jitsi-meet-sdk:6.2.0') {
+    api('org.jitsi.react:jitsi-meet-sdk:8.1.1') {
         exclude group: 'com.google.firebase'
         exclude group: 'com.google.android.gms'
         exclude group: 'com.android.installreferrer'

--- a/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
@@ -475,8 +475,8 @@ class DefaultNavigator @Inject constructor(
 
     override fun openRoomWidget(context: Context, roomId: String, widget: Widget, options: Map<String, Any>?) {
         if (widget.type is WidgetType.Jitsi) {
-            // Jitsi SDK is now for API 23+
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            // Jitsi SDK is now for API 24+
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
                 MaterialAlertDialogBuilder(context)
                         .setTitle(R.string.dialog_title_error)
                         .setMessage(R.string.error_jitsi_not_supported_on_old_device)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Upgrade Jitsi library to 8.1.1. Note: SDK is now supporting API 24 and more, so the check on API 23 has been updated. See https://github.com/jitsi/jitsi-meet-release-notes/blob/master/CHANGELOG-MOBILE-SDKS.md for mre details.

Should fix #7619

The Jitsi libre SDK has been built and published at https://github.com/vector-im/jitsi_libre_maven/tree/main/android-sdk-8.1.1

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
fixes #7619

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Make audio call
- Make video call
- Join Jitsi meeting

## Tested devices

- [x] Physical (API 10)
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
