### PR TITLE
Replace matrix ids by displayname in notice event

### DIFF
--- a/changelog.d/8365.misc
+++ b/changelog.d/8365.misc
@@ -1,0 +1,1 @@
+Matrix-Ids are sometimes shown in notice events instead of display names

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -39,7 +39,7 @@
     <string name="notice_avatar_url_changed_by_you">You changed your avatar</string>
     <string name="notice_display_name_set">%1$s set their display name to %2$s</string>
     <string name="notice_display_name_set_by_you">You set your display name to %1$s</string>
-    <string name="notice_display_name_changed_from">%1$s changed their display name from %2$s to %3$s</string>
+    <string name="notice_display_name_changed_from">%2$s changed their display name to %3$s</string>
     <string name="notice_display_name_changed_from_by_you">You changed your display name from %1$s to %2$s</string>
     <string name="notice_display_name_removed">%1$s removed their display name (it was %2$s)</string>
     <string name="notice_display_name_removed_by_you">You removed your display name (it was %1$s)</string>

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
@@ -214,7 +214,7 @@ class MessageActionsViewModel @AssistedInject constructor(
                     EventType.CALL_CANDIDATES,
                     EventType.CALL_HANGUP,
                     EventType.CALL_ANSWER -> {
-                        noticeEventFormatter.format(timelineEvent, room?.roomSummary()?.isDirect.orFalse())
+                        noticeEventFormatter.format(timelineEvent, room?.roomSummary()?.isDirect.orFalse(), session)
                     }
                     in EventType.POLL_START.values -> {
                         (timelineEvent.getVectorLastMessageContent() as? MessagePollContent)?.getBestPollCreationInfo()?.question?.getBestQuestion()

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/NoticeItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/NoticeItemFactory.kt
@@ -24,18 +24,20 @@ import im.vector.app.features.home.room.detail.timeline.item.NoticeItem
 import im.vector.app.features.home.room.detail.timeline.item.NoticeItem_
 import im.vector.lib.core.utils.epoxy.charsequence.EpoxyCharSequence
 import org.matrix.android.sdk.api.extensions.orFalse
+import org.matrix.android.sdk.api.session.Session
 import javax.inject.Inject
 
 class NoticeItemFactory @Inject constructor(
         private val eventFormatter: NoticeEventFormatter,
         private val avatarRenderer: AvatarRenderer,
         private val informationDataFactory: MessageInformationDataFactory,
-        private val avatarSizeProvider: AvatarSizeProvider
+        private val avatarSizeProvider: AvatarSizeProvider,
+        private val session: Session
 ) {
 
     fun create(params: TimelineItemFactoryParams): NoticeItem? {
         val event = params.event
-        val formattedText = eventFormatter.format(event, isDm = params.partialState.roomSummary?.isDirect.orFalse()) ?: return null
+        val formattedText = eventFormatter.format(event, isDm = params.partialState.roomSummary?.isDirect.orFalse(), session) ?: return null
         val informationData = informationDataFactory.create(params)
         val attributes = NoticeItem.Attributes(
                 avatarRenderer = avatarRenderer,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/format/DisplayableEventFormatter.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/format/DisplayableEventFormatter.kt
@@ -32,6 +32,7 @@ import im.vector.app.features.voicebroadcast.model.asVoiceBroadcastEvent
 import me.gujun.android.span.image
 import me.gujun.android.span.span
 import org.commonmark.node.Document
+import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
 import org.matrix.android.sdk.api.session.events.model.toModel
@@ -55,7 +56,7 @@ class DisplayableEventFormatter @Inject constructor(
         private val htmlRenderer: Lazy<EventHtmlRenderer>
 ) {
 
-    fun format(timelineEvent: TimelineEvent, isDm: Boolean, appendAuthor: Boolean): CharSequence {
+    fun format(timelineEvent: TimelineEvent, isDm: Boolean, appendAuthor: Boolean, session: Session): CharSequence {
         if (timelineEvent.root.isRedacted()) {
             return noticeEventFormatter.formatRedactedEvent(timelineEvent.root)
         }
@@ -155,7 +156,7 @@ class DisplayableEventFormatter @Inject constructor(
             }
             else -> {
                 span {
-                    text = noticeEventFormatter.format(timelineEvent, isDm) ?: ""
+                    text = noticeEventFormatter.format(timelineEvent, isDm, session) ?: ""
                     textStyle = "italic"
                 }
             }

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomSummaryItemFactory.kt
@@ -34,6 +34,7 @@ import im.vector.app.features.voicebroadcast.isLive
 import im.vector.app.features.voicebroadcast.model.asVoiceBroadcastEvent
 import im.vector.lib.core.utils.epoxy.charsequence.toEpoxyCharSequence
 import org.matrix.android.sdk.api.extensions.orFalse
+import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.room.members.ChangeMembershipState
 import org.matrix.android.sdk.api.session.room.model.Membership
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
@@ -49,6 +50,7 @@ class RoomSummaryItemFactory @Inject constructor(
         private val avatarRenderer: AvatarRenderer,
         private val errorFormatter: ErrorFormatter,
         private val getLatestPreviewableEventUseCase: GetLatestPreviewableEventUseCase,
+        private val session: Session
 ) {
 
     fun create(
@@ -136,7 +138,7 @@ class RoomSummaryItemFactory @Inject constructor(
         var latestEventTime = ""
         val latestEvent = getLatestPreviewableEventUseCase.execute(roomSummary.roomId)
         if (latestEvent != null) {
-            latestFormattedEvent = displayableEventFormatter.format(latestEvent, roomSummary.isDirect, roomSummary.isDirect.not())
+            latestFormattedEvent = displayableEventFormatter.format(latestEvent, roomSummary.isDirect, roomSummary.isDirect.not(), session)
             latestEventTime = dateFormatter.format(latestEvent.root.originServerTs, DateFormatKind.ROOM_LIST)
         }
 

--- a/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/NotifiableEventResolver.kt
@@ -137,7 +137,7 @@ class NotifiableEventResolver @Inject constructor(
         return if (room == null) {
             Timber.e("## Unable to resolve room for eventId [$event]")
             // Ok room is not known in store, but we can still display something
-            val body = displayableEventFormatter.format(event, isDm = false, appendAuthor = false)
+            val body = displayableEventFormatter.format(event, isDm = false, appendAuthor = false, session)
             val roomName = stringProvider.getString(R.string.notification_unknown_room_name)
             val senderDisplayName = event.senderInfo.disambiguatedDisplayName
 
@@ -161,7 +161,7 @@ class NotifiableEventResolver @Inject constructor(
             // only convert encrypted messages to NotifiableMessageEvents
             when {
                 event.root.supportsNotification() -> {
-                    val body = displayableEventFormatter.format(event, isDm = room.roomSummary()?.isDirect.orFalse(), appendAuthor = false).toString()
+                    val body = displayableEventFormatter.format(event, isDm = room.roomSummary()?.isDirect.orFalse(), appendAuthor = false, session).toString()
                     val roomName = room.roomSummary()?.displayName ?: ""
                     val senderDisplayName = event.senderInfo.disambiguatedDisplayName
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other :

## Content

#8365 

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
