### PR TITLE
Fix crash no network

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -8,8 +8,7 @@
         </value>
       </option>
       <option name="ALIGN_IN_COLUMNS_CASE_BRANCH" value="true" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+      <option name="LINE_BREAK_AFTER_MULTILINE_WHEN_ENTRY" value="false" />
       <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="true" />
       <option name="CONTINUATION_INDENT_IN_ARGUMENT_LISTS" value="true" />
       <option name="CONTINUATION_INDENT_FOR_EXPRESSION_BODIES" value="true" />

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/RustCryptoService.kt
+++ b/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/RustCryptoService.kt
@@ -196,9 +196,7 @@ internal class RustCryptoService @Inject constructor(
     override suspend fun fetchDevicesList(): List<DeviceInfo> {
         val devicesList: List<DeviceInfo>
         withContext(coroutineDispatchers.io) {
-            devicesList = tryOrNull {
-                getDevicesTask.execute(Unit).devices
-            }.orEmpty()
+            devicesList = getDevicesTask.execute(Unit).devices.orEmpty()
             cryptoStore.saveMyDevicesInfo(devicesList)
         }
         return devicesList
@@ -247,7 +245,7 @@ internal class RustCryptoService @Inject constructor(
         cryptoCoroutineScope.launch(coroutineDispatchers.io) {
             cryptoStore.open()
             // Just update
-            fetchDevicesList()
+            tryOrNull { fetchDevicesList() }
             cryptoStore.tidyUpDataBase()
         }
     }

--- a/vector/src/main/java/im/vector/app/features/home/UnknownDeviceDetectorSharedViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/UnknownDeviceDetectorSharedViewModel.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.launch
 import org.matrix.android.sdk.api.extensions.orFalse
+import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.crypto.model.DeviceInfo
 import org.matrix.android.sdk.api.session.getUserOrDefault
@@ -101,7 +102,7 @@ class UnknownDeviceDetectorSharedViewModel @AssistedInject constructor(
                 session.flow().liveUserCryptoDevices(session.myUserId),
                 session.flow().liveMyDevicesInfo(),
                 session.flow().liveCrossSigningPrivateKeys(),
-                ) { cryptoList, infoList, pInfo ->
+        ) { cryptoList, infoList, pInfo ->
             Timber.v("## Detector trigger ${cryptoList.map { "${it.deviceId} ${it.trustLevel}" }}")
             Timber.v("## Detector trigger canCrossSign ${pInfo.get().selfSigned != null}")
 
@@ -146,13 +147,13 @@ class UnknownDeviceDetectorSharedViewModel @AssistedInject constructor(
                 .sample(5_000)
                 .onEach {
                     // If we have a new crypto device change, we might want to trigger refresh of device info
-                    session.cryptoService().fetchDevicesList()
+                    tryOrNull { session.cryptoService().fetchDevicesList() }
                 }
                 .launchIn(viewModelScope)
 
         // trigger a refresh of lastSeen / last Ip
         viewModelScope.launch {
-            session.cryptoService().fetchDevicesList()
+            tryOrNull { session.cryptoService().fetchDevicesList() }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
@@ -76,6 +76,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.gujun.android.span.span
 import org.matrix.android.sdk.api.extensions.getFingerprintHumanReadable
+import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.raw.RawService
 import org.matrix.android.sdk.api.session.crypto.crosssigning.isVerified
 import org.matrix.android.sdk.api.session.crypto.model.DeviceInfo
@@ -646,9 +647,11 @@ class VectorSettingsSecurityPrivacyFragment :
             }
         }
         // TODO Move to a ViewModel...
-        val devicesList = session.cryptoService().fetchDevicesList()
-        withContext(Dispatchers.Main) {
-            refreshCryptographyPreference(devicesList)
+        val devicesList = tryOrNull { session.cryptoService().fetchDevicesList() }
+        devicesList?.let {
+            withContext(Dispatchers.Main) {
+                refreshCryptographyPreference(it)
+            }
         }
     }
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
@@ -52,6 +52,7 @@ import org.matrix.android.sdk.api.auth.data.LoginFlowTypes
 import org.matrix.android.sdk.api.auth.registration.RegistrationFlowResponse
 import org.matrix.android.sdk.api.auth.registration.nextUncompletedStage
 import org.matrix.android.sdk.api.extensions.orFalse
+import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.crypto.model.CryptoDeviceInfo
@@ -190,7 +191,7 @@ class DevicesViewModel @AssistedInject constructor(
                 .sample(5_000)
                 .onEach {
                     // If we have a new crypto device change, we might want to trigger refresh of device info
-                    session.cryptoService().fetchDevicesList()
+                    tryOrNull { session.cryptoService().fetchDevicesList() }
                 }
                 .launchIn(viewModelScope)
 
@@ -203,7 +204,7 @@ class DevicesViewModel @AssistedInject constructor(
 
         refreshSource.stream().throttleFirst(4_000)
                 .onEach {
-                    session.cryptoService().fetchDevicesList()
+                    tryOrNull { session.cryptoService().fetchDevicesList() }
                     session.cryptoService().downloadKeysIfNeeded(listOf(session.myUserId), true)
                 }
                 .launchIn(viewModelScope)

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/RefreshDevicesOnCryptoDevicesChangeUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/RefreshDevicesOnCryptoDevicesChangeUseCase.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.sample
+import org.matrix.android.sdk.api.extensions.tryOrNull
 import org.matrix.android.sdk.flow.flow
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
@@ -40,7 +41,7 @@ class RefreshDevicesOnCryptoDevicesChangeUseCase @Inject constructor(
                             .sample(samplingPeriodMs)
                             .onEach {
                                 // If we have a new crypto device change, we might want to trigger refresh of device info
-                                session.cryptoService().fetchDevicesList()
+                                tryOrNull { session.cryptoService().fetchDevicesList() }
                             }
                             .collect()
                 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/RefreshDevicesUseCase.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/RefreshDevicesUseCase.kt
@@ -17,6 +17,7 @@
 package im.vector.app.features.settings.devices.v2
 
 import im.vector.app.core.di.ActiveSessionHolder
+import org.matrix.android.sdk.api.extensions.tryOrNull
 import javax.inject.Inject
 
 class RefreshDevicesUseCase @Inject constructor(
@@ -24,7 +25,7 @@ class RefreshDevicesUseCase @Inject constructor(
 ) {
     suspend fun execute() {
         activeSessionHolder.getSafeActiveSession()?.let { session ->
-            session.cryptoService().fetchDevicesList()
+            tryOrNull { session.cryptoService().fetchDevicesList() }
             session.cryptoService().downloadKeysIfNeeded(listOf(session.myUserId), true)
         }
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Probably due to the merge of EAR rework, the app was crashing again when started without network. This PR fixes that.
I added some `tryOrNull` on the usage and let the Rust implementation fail again. It helps not resetting the lists of session in the settings when there is no network.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Fix crash

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Start the app without network.

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
