### PR TITLE
Allow stateloss on verification dialogfragment

### DIFF
--- a/changelog.d/8439.bugfix
+++ b/changelog.d/8439.bugfix
@@ -1,0 +1,1 @@
+Allow stateloss on verification dialogfragment

--- a/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
+++ b/vector/src/main/java/im/vector/app/features/navigation/DefaultNavigator.kt
@@ -38,6 +38,7 @@ import im.vector.app.config.OnboardingVariant
 import im.vector.app.core.debug.DebugNavigator
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.error.fatalError
+import im.vector.app.core.extensions.commitTransaction
 import im.vector.app.features.VectorFeatures
 import im.vector.app.features.analytics.AnalyticsTracker
 import im.vector.app.features.analytics.extensions.toAnalyticsViewRoom
@@ -256,8 +257,9 @@ class DefaultNavigator @Inject constructor(
                     otherSessionId
             )
             if (context is AppCompatActivity) {
-                SelfVerificationBottomSheet.forTransaction(request.transactionId)
-                        .show(context.supportFragmentManager, "VERIF")
+                context.supportFragmentManager.commitTransaction(allowStateLoss = true) {
+                    add(SelfVerificationBottomSheet.forTransaction(request.transactionId), "VERIF")
+                }
             }
         }
     }
@@ -271,8 +273,9 @@ class DefaultNavigator @Inject constructor(
 //                    .filter { it.deviceId != session.sessionParams.deviceId }
 //                    .map { it.deviceId }
             if (context is AppCompatActivity) {
-                SelfVerificationBottomSheet.verifyOwnUntrustedDevice()
-                        .show(context.supportFragmentManager, "VERIF")
+                context.supportFragmentManager.commitTransaction(allowStateLoss = true) {
+                    add(SelfVerificationBottomSheet.verifyOwnUntrustedDevice(), "VERIF")
+                }
 //                if (otherSessions.isNotEmpty()) {
 //                    val pr = session.cryptoService().verificationService().requestSelfKeyVerification(
 //                            supportedVerificationMethodsProvider.provide())


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

The app crashes sometimes when self verification dialog tries to show.

## Motivation and context

```
Exception java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
  at androidx.fragment.app.FragmentManager.checkStateLoss (FragmentManager.java:1610)
  at androidx.fragment.app.FragmentManager.enqueueAction (FragmentManager.java:1650)
  at androidx.fragment.app.BackStackRecord.commitInternal (BackStackRecord.java:341)
  at androidx.fragment.app.BackStackRecord.commit (BackStackRecord.java:306)
  at androidx.fragment.app.DialogFragment.show (DialogFragment.java:262)
  at im.vector.app.features.navigation.DefaultNavigator.requestSelfSessionVerification (DefaultNavigator.kt:273)
  at im.vector.app.features.home.HomeActivity$onCreate$3.invoke (HomeActivity.kt:275)
  at im.vector.app.features.home.HomeActivity$onCreate$3.invoke (HomeActivity.kt:266)
```

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
