### PR TITLE
Always allow users sign out

### DIFF
--- a/changelog.d/4855.bugfix
+++ b/changelog.d/4855.bugfix
@@ -1,0 +1,1 @@
+Fix: Allow users to sign out even if the sign out request fails.

--- a/library/ui-strings/src/main/res/values/strings.xml
+++ b/library/ui-strings/src/main/res/values/strings.xml
@@ -328,6 +328,9 @@
     <string name="backup">Back up</string>
     <string name="sign_out_bottom_sheet_will_lose_secure_messages">You’ll lose access to your encrypted messages unless you back up your keys before signing out.</string>
 
+    <string name="sign_out_failed_dialog_message">Cannot reach the homeserver. If you sign out anyway, this device will not be erased from your device list, you may want to remove it using another client.</string>
+    <string name="sign_out_anyway">Sign out anyway</string>
+
     <!-- splash screen accessibility -->
     <string name="loading">Loading…</string>
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/signout/SignOutService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/signout/SignOutService.kt
@@ -37,6 +37,7 @@ interface SignOutService {
     /**
      * Sign out, and release the session, clear all the session data, including crypto data.
      * @param signOutFromHomeserver true if the sign out request has to be done
+     * @param ignoreServerRequestError true to ignore server error if any
      */
-    suspend fun signOut(signOutFromHomeserver: Boolean)
+    suspend fun signOut(signOutFromHomeserver: Boolean, ignoreServerRequestError: Boolean = false)
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/signout/DefaultSignOutService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/signout/DefaultSignOutService.kt
@@ -35,7 +35,12 @@ internal class DefaultSignOutService @Inject constructor(
         sessionParamsStore.updateCredentials(credentials)
     }
 
-    override suspend fun signOut(signOutFromHomeserver: Boolean) {
-        return signOutTask.execute(SignOutTask.Params(signOutFromHomeserver))
+    override suspend fun signOut(signOutFromHomeserver: Boolean, ignoreServerRequestError: Boolean) {
+        return signOutTask.execute(
+                SignOutTask.Params(
+                        signOutFromHomeserver = signOutFromHomeserver,
+                        ignoreServerRequestError = ignoreServerRequestError
+                )
+        )
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/signout/SignOutTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/signout/SignOutTask.kt
@@ -30,7 +30,8 @@ import javax.inject.Inject
 
 internal interface SignOutTask : Task<SignOutTask.Params, Unit> {
     data class Params(
-            val signOutFromHomeserver: Boolean
+            val signOutFromHomeserver: Boolean,
+            val ignoreServerRequestError: Boolean,
     )
 }
 
@@ -59,7 +60,9 @@ internal class DefaultSignOutTask @Inject constructor(
                     // Ignore
                     Timber.w("Ignore error due to https://github.com/matrix-org/synapse/issues/5755")
                 } else {
-                    throw throwable
+                    if (!params.ignoreServerRequestError) {
+                        throw throwable
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-android/issues/4855

<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

- Updates the sign out error dialog with a more helpful message for the user, letting them know what happens if they logout without informing the homeserver and giving them the option to sign out anyway.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<img src="https://github.com/vector-im/element-android/assets/6135282/7a0dcd0d-d734-426f-b303-b64479083eee" width=200/>

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Manually tested the alert shows correctly if the server is not reachable
- Manually tested each of the actions on the dialog
- Manually tested the normal sign out flow, when the dialog does not display in the case the request succeeds.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
