### PR TITLE
Show correct details when a poll is ended.

### DIFF
--- a/changelog.d/8471.bugfix
+++ b/changelog.d/8471.bugfix
@@ -1,0 +1,1 @@
+The correct title and options are now displayed When a poll that was edited is ended.

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -286,7 +286,10 @@ class MessageItemFactory @Inject constructor(
         } else {
             null
         }
-        val pollContent = pollStartEvent?.root?.getClearContent()?.toModel<MessagePollContent>()
+
+        val editedContent = pollStartEvent?.annotations?.editSummary?.latestEdit?.getClearContent()?.toModel<MessagePollContent>()?.newContent
+        val latestContent = editedContent ?: pollStartEvent?.root?.getClearContent()
+        val pollContent = latestContent?.toModel<MessagePollContent>()
 
         return if (pollContent == null) {
             val title = stringProvider.getString(R.string.message_reply_to_ended_poll_preview).toEpoxyCharSequence()


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Previously, the "end poll" timeline item always showed the title and options from the start event, regardless of whether any edits had been made.

Now we show the latest edit, if available, falling back to the original otherwise.

## Screenshots / GIFs

[device-2023-05-26-114409.webm](https://github.com/vector-im/element-android/assets/189133/e19376ba-9efd-412a-9fe7-840b3c93f15d)

## Tests

- Create a poll
- Edit the poll
- Vote (optional)
- End the poll
- Look at the created ended poll result event in the timeline

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s): 11

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
