### PR TITLE
Deactivation test broken by latest synapse

### DIFF
--- a/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/account/DeactivateAccountTest.kt
+++ b/matrix-sdk-android/src/androidTest/java/org/matrix/android/sdk/account/DeactivateAccountTest.kt
@@ -64,9 +64,15 @@ class DeactivateAccountTest : InstrumentedTest {
 
         // Test the error
         assertTrue(
+                "Unexpected deactivated error $throwable",
                 throwable is Failure.ServerError &&
-                        throwable.error.code == MatrixError.M_USER_DEACTIVATED &&
-                        throwable.error.message == "This account has been deactivated"
+                        (
+                                (throwable.error.code == MatrixError.M_USER_DEACTIVATED &&
+                                        throwable.error.message == "This account has been deactivated") ||
+                                        // Workaround for a breaking change on synapse to fix CI
+                                        // https://github.com/matrix-org/synapse/issues/15747
+                                        throwable.error.code == MatrixError.M_FORBIDDEN
+                                )
         )
 
         // Try to create an account with the deactivate account user id, it will fail (M_USER_IN_USE)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Deactivation test is broken with latest synapse
https://github.com/matrix-org/synapse/issues/15747

For now update the test to restore CI

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
