### PR TITLE
Fix emoji verification for RTL languages #8237

### DIFF
--- a/changelog.d/8237.bugfix
+++ b/changelog.d/8237.bugfix
@@ -1,0 +1,1 @@
+Verification emojis are now in a correct order for a right-to-left language

--- a/vector/src/main/res/layout/item_verification_emojis.xml
+++ b/vector/src/main/res/layout/item_verification_emojis.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/layout_vertical_margin"
+    android:layoutDirection="ltr"
     tools:viewBindingIgnore="true">
 
     <include


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

As mentioned in #8237, the emojis are in a wrong order in RTL.

## Screenshots / GIFs

![image](https://github.com/vector-im/element-android/assets/616399/93c01e8e-89dc-41c9-9320-374649fcb7eb)

<img src="https://github.com/vector-im/element-android/assets/616399/089ea17b-96f6-4300-83b0-2da97a1af4ef" width=240> <img src="https://github.com/vector-im/element-android/assets/616399/4e7f6d1c-b379-499f-8478-e67e74e9b3d4" width=480>

## Tests

1. Change phone language to Hebrew or RTL languages
2. Go through the verification using emoji
3. Compare the emojis

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s): Android 5, 11 and 12

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
