### PR TITLE
Respect isShareKeysOnInviteEnabled() flag when creating new outbound megolm sessions

### DIFF
--- a/matrix-sdk-android/src/kotlinCrypto/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
+++ b/matrix-sdk-android/src/kotlinCrypto/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt
@@ -930,7 +930,7 @@ internal class RealmCryptoStore @Inject constructor(
                     val info = realm.createObject(OutboundGroupSessionInfoEntity::class.java).apply {
                         creationTime = clock.epochMillis()
                         // Store the room history visibility on the outbound session creation
-                        shouldShareHistory = entity.shouldShareHistory
+                        shouldShareHistory = isShareKeysOnInviteEnabled() && entity.shouldShareHistory
                         putOutboundGroupSession(outboundGroupSession)
                     }
                     entity.outboundSessionInfo = info


### PR DESCRIPTION
Signed-off-by: Brad Murray <brad@beeper.com>

## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

This code (https://github.com/vector-im/element-android/blob/cf366f7a9c1e83284e91702400fde2371af2b02a/matrix-sdk-android/src/kotlinCrypto/java/org/matrix/android/sdk/internal/crypto/algorithms/megolm/MXMegolmEncryption.kt#L211) was comparing what's currently in the CryptoStore for the room to the current session were using and rotating the session if they disagreed about sharing history. When checking the CryptoStore for the current room state, the feature flag is respected (https://github.com/vector-im/element-android/blob/77a6c67ea6adb8a599f9f521e23c0b374fdca341/matrix-sdk-android/src/kotlinCrypto/java/org/matrix/android/sdk/internal/crypto/store/db/RealmCryptoStore.kt#L760) but when we were creating a new session as a result we aren't checking the state of the flag, meaning we'll create new sessions with shouldShareHistory = true. This will lead to the session still mismatching and continuing to get unecessarily rotated.

## Motivation and context

We shouldn't unecessarily rotate the megolm keys more than necessary when this feature flag is off, which is the default setting.

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
