### PR TITLE
Fix fallbackKeySharingStrategy

### DIFF
--- a/changelog.d/8541.bugfix
+++ b/changelog.d/8541.bugfix
@@ -1,0 +1,1 @@
+Fix crypto config fallback key sharing strategy

--- a/vector/src/main/java/im/vector/app/core/di/ConfigurationModule.kt
+++ b/vector/src/main/java/im/vector/app/core/di/ConfigurationModule.kt
@@ -77,8 +77,8 @@ object ConfigurationModule {
     fun providesCryptoConfig() = CryptoConfig(
             fallbackKeySharingStrategy = when (Config.KEY_SHARING_STRATEGY) {
                 KeySharingStrategy.WhenSendingEvent -> OutboundSessionKeySharingStrategy.WhenSendingEvent
-                KeySharingStrategy.WhenEnteringRoom -> OutboundSessionKeySharingStrategy.WhenSendingEvent
-                KeySharingStrategy.WhenTyping -> OutboundSessionKeySharingStrategy.WhenSendingEvent
+                KeySharingStrategy.WhenEnteringRoom -> OutboundSessionKeySharingStrategy.WhenEnteringRoom
+                KeySharingStrategy.WhenTyping -> OutboundSessionKeySharingStrategy.WhenTyping
             }
     )
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [X] Bugfix
- [ ] Technical
- [ ] Other :

## Content

This PR fixes the fallback key sharing strategy to return the correct value

## Motivation and context

The fallback key sharing strategy was always set to `OutboundSessionKeySharingStrategy.WhenSendingEvent` regardless of the config setting

## Checklist

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [X] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [X] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
