### PR TITLE
Feature/bma/OIDC session end

### DIFF
--- a/changelog.d/8616.misc
+++ b/changelog.d/8616.misc
@@ -1,0 +1,1 @@
+If an external account manager is configured on the server, use it to delete other sessions and hide the multi session deletion.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/homeserver/HomeServerCapabilities.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/homeserver/HomeServerCapabilities.kt
@@ -85,6 +85,11 @@ data class HomeServerCapabilities(
          * External account management url for use with MSC3824 delegated OIDC, provided in Wellknown.
          */
         val externalAccountManagementUrl: String? = null,
+
+        /**
+         * Authentication issuer for use with MSC3824 delegated OIDC, provided in Wellknown.
+         */
+        val authenticationIssuer: String? = null,
 ) {
 
     enum class RoomCapabilitySupport {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/homeserver/HomeServerCapabilities.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/homeserver/HomeServerCapabilities.kt
@@ -146,6 +146,8 @@ data class HomeServerCapabilities(
         return cap?.preferred ?: cap?.support?.lastOrNull()
     }
 
+    val delegatedOidcAuthEnabled: Boolean = authenticationIssuer != null
+
     companion object {
         const val MAX_UPLOAD_FILE_SIZE_UNKNOWN = -1L
         const val ROOM_CAP_KNOCK = "knock"

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/DefaultAuthenticationService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/DefaultAuthenticationService.kt
@@ -298,7 +298,7 @@ internal class DefaultAuthenticationService @Inject constructor(
         }
 
         // If an m.login.sso flow is present that is flagged as being for MSC3824 OIDC compatibility then we only return that flow
-        val oidcCompatibilityFlow = loginFlowResponse.flows.orEmpty().firstOrNull { it.type == "m.login.sso" && it.delegatedOidcCompatibilty == true }
+        val oidcCompatibilityFlow = loginFlowResponse.flows.orEmpty().firstOrNull { it.type == "m.login.sso" && it.delegatedOidcCompatibility == true }
         val flows = if (oidcCompatibilityFlow != null) listOf(oidcCompatibilityFlow) else loginFlowResponse.flows
 
         val supportsGetLoginTokenFlow = loginFlowResponse.flows.orEmpty().firstOrNull { it.type == "m.login.token" && it.getLoginToken == true } != null

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/data/LoginFlowResponse.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/auth/data/LoginFlowResponse.kt
@@ -51,7 +51,7 @@ internal data class LoginFlow(
          * See [MSC3824](https://github.com/matrix-org/matrix-spec-proposals/pull/3824)
          */
         @Json(name = "org.matrix.msc3824.delegated_oidc_compatibility")
-        val delegatedOidcCompatibilty: Boolean? = null,
+        val delegatedOidcCompatibility: Boolean? = null,
 
         /**
          * Whether a login flow of type m.login.token could accept a token issued using /login/get_token.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/RealmSessionStoreMigration.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/RealmSessionStoreMigration.kt
@@ -69,6 +69,7 @@ import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo049
 import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo050
 import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo051
 import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo052
+import org.matrix.android.sdk.internal.database.migration.MigrateSessionTo053
 import org.matrix.android.sdk.internal.util.Normalizer
 import org.matrix.android.sdk.internal.util.database.MatrixRealmMigration
 import javax.inject.Inject
@@ -77,7 +78,7 @@ internal class RealmSessionStoreMigration @Inject constructor(
         private val normalizer: Normalizer
 ) : MatrixRealmMigration(
         dbName = "Session",
-        schemaVersion = 52L,
+        schemaVersion = 53L,
 ) {
     /**
      * Forces all RealmSessionStoreMigration instances to be equal.
@@ -139,5 +140,6 @@ internal class RealmSessionStoreMigration @Inject constructor(
         if (oldVersion < 50) MigrateSessionTo050(realm).perform()
         if (oldVersion < 51) MigrateSessionTo051(realm).perform()
         if (oldVersion < 52) MigrateSessionTo052(realm).perform()
+        if (oldVersion < 53) MigrateSessionTo053(realm).perform()
     }
 }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/HomeServerCapabilitiesMapper.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/mapper/HomeServerCapabilitiesMapper.kt
@@ -49,6 +49,7 @@ internal object HomeServerCapabilitiesMapper {
                 canRemotelyTogglePushNotificationsOfDevices = entity.canRemotelyTogglePushNotificationsOfDevices,
                 canRedactRelatedEvents = entity.canRedactEventWithRelations,
                 externalAccountManagementUrl = entity.externalAccountManagementUrl,
+                authenticationIssuer = entity.authenticationIssuer,
         )
     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/migration/MigrateSessionTo053.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/migration/MigrateSessionTo053.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.android.sdk.internal.database.migration
+
+import io.realm.DynamicRealm
+import org.matrix.android.sdk.internal.database.model.HomeServerCapabilitiesEntityFields
+import org.matrix.android.sdk.internal.extensions.forceRefreshOfHomeServerCapabilities
+import org.matrix.android.sdk.internal.util.database.RealmMigrator
+
+internal class MigrateSessionTo053(realm: DynamicRealm) : RealmMigrator(realm, 53) {
+    override fun doMigrate(realm: DynamicRealm) {
+        realm.schema.get("HomeServerCapabilitiesEntity")
+                ?.addField(HomeServerCapabilitiesEntityFields.AUTHENTICATION_ISSUER, String::class.java)
+                ?.forceRefreshOfHomeServerCapabilities()
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/HomeServerCapabilitiesEntity.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/database/model/HomeServerCapabilitiesEntity.kt
@@ -36,6 +36,7 @@ internal open class HomeServerCapabilitiesEntity(
         var canRemotelyTogglePushNotificationsOfDevices: Boolean = false,
         var canRedactEventWithRelations: Boolean = false,
         var externalAccountManagementUrl: String? = null,
+        var authenticationIssuer: String? = null,
 ) : RealmObject() {
 
     companion object

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetHomeServerCapabilitiesTask.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/homeserver/GetHomeServerCapabilitiesTask.kt
@@ -165,6 +165,7 @@ internal class DefaultGetHomeServerCapabilitiesTask @Inject constructor(
                     Timber.v("Extracted integration config : $config")
                     realm.insertOrUpdate(config)
                 }
+                homeServerCapabilitiesEntity.authenticationIssuer = getWellknownResult.wellKnown.unstableDelegatedAuthConfig?.issuer
                 homeServerCapabilitiesEntity.externalAccountManagementUrl = getWellknownResult.wellKnown.unstableDelegatedAuthConfig?.accountManagementUrl
             }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewEvents.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewEvents.kt
@@ -50,4 +50,6 @@ sealed class DevicesViewEvents : VectorViewEvents {
     data class ShowManuallyVerify(val cryptoDeviceInfo: CryptoDeviceInfo) : DevicesViewEvents()
 
     object PromptResetSecrets : DevicesViewEvents()
+
+    data class OpenBrowser(val url: String) : DevicesViewEvents()
 }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/DevicesViewModel.kt
@@ -346,6 +346,20 @@ class DevicesViewModel @AssistedInject constructor(
     private fun handleDelete(action: DevicesAction.Delete) {
         val deviceId = action.deviceId
 
+        val accountManagementUrl = session.homeServerCapabilitiesService().getHomeServerCapabilities().externalAccountManagementUrl
+        if (accountManagementUrl != null) {
+            // Open external browser to delete this session
+            _viewEvents.post(
+                    DevicesViewEvents.OpenBrowser(
+                            url = accountManagementUrl.removeSuffix("/") + "?action=session_end&device_id=$deviceId"
+                    )
+            )
+        } else {
+            doDelete(deviceId)
+        }
+    }
+
+    private fun doDelete(deviceId: String) {
         setState {
             copy(
                     request = Loading()

--- a/vector/src/main/java/im/vector/app/features/settings/devices/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/VectorSettingsDevicesFragment.kt
@@ -35,6 +35,7 @@ import im.vector.app.core.extensions.cleanup
 import im.vector.app.core.extensions.configureWith
 import im.vector.app.core.extensions.registerStartForActivityResult
 import im.vector.app.core.platform.VectorBaseFragment
+import im.vector.app.core.utils.openUrlInChromeCustomTab
 import im.vector.app.databinding.DialogBaseEditTextBinding
 import im.vector.app.databinding.FragmentGenericRecyclerBinding
 import im.vector.app.features.auth.ReAuthActivity
@@ -94,6 +95,9 @@ class VectorSettingsDevicesFragment :
                 }
                 is DevicesViewEvents.PromptResetSecrets -> {
                     navigator.open4SSetup(requireActivity(), SetupMode.PASSPHRASE_AND_NEEDED_SECRETS_RESET)
+                }
+                is DevicesViewEvents.OpenBrowser -> {
+                    openUrlInChromeCustomTab(requireContext(), null, it.url)
                 }
             }
         }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewModel.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.uia.DefaultBaseAuth
 import timber.log.Timber
 
@@ -69,16 +70,17 @@ class DevicesViewModel @AssistedInject constructor(
         refreshDeviceList()
         refreshIpAddressVisibility()
         observePreferences()
-        initExternalAccountManagementUrl()
+        initDelegatedOidcAuthEnabled()
     }
 
-    private fun initExternalAccountManagementUrl() {
+    private fun initDelegatedOidcAuthEnabled() {
         setState {
             copy(
-                    externalAccountManagementUrl = activeSessionHolder.getSafeActiveSession()
+                    delegatedOidcAuthEnabled = activeSessionHolder.getSafeActiveSession()
                             ?.homeServerCapabilitiesService()
                             ?.getHomeServerCapabilities()
-                            ?.externalAccountManagementUrl
+                            ?.delegatedOidcAuthEnabled
+                            .orFalse()
             )
         }
     }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewModel.kt
@@ -40,7 +40,7 @@ import timber.log.Timber
 
 class DevicesViewModel @AssistedInject constructor(
         @Assisted initialState: DevicesViewState,
-        activeSessionHolder: ActiveSessionHolder,
+        private val activeSessionHolder: ActiveSessionHolder,
         private val getCurrentSessionCrossSigningInfoUseCase: GetCurrentSessionCrossSigningInfoUseCase,
         private val getDeviceFullInfoListUseCase: GetDeviceFullInfoListUseCase,
         private val refreshDevicesOnCryptoDevicesChangeUseCase: RefreshDevicesOnCryptoDevicesChangeUseCase,
@@ -69,6 +69,18 @@ class DevicesViewModel @AssistedInject constructor(
         refreshDeviceList()
         refreshIpAddressVisibility()
         observePreferences()
+        initExternalAccountManagementUrl()
+    }
+
+    private fun initExternalAccountManagementUrl() {
+        setState {
+            copy(
+                    externalAccountManagementUrl = activeSessionHolder.getSafeActiveSession()
+                            ?.homeServerCapabilitiesService()
+                            ?.getHomeServerCapabilities()
+                            ?.externalAccountManagementUrl
+            )
+        }
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewState.kt
@@ -26,6 +26,7 @@ data class DevicesViewState(
         val devices: Async<DeviceFullInfoList> = Uninitialized,
         val isLoading: Boolean = false,
         val isShowingIpAddress: Boolean = false,
+        val externalAccountManagementUrl: String? = null,
 ) : MavericksState
 
 data class DeviceFullInfoList(

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/DevicesViewState.kt
@@ -26,7 +26,7 @@ data class DevicesViewState(
         val devices: Async<DeviceFullInfoList> = Uninitialized,
         val isLoading: Boolean = false,
         val isShowingIpAddress: Boolean = false,
-        val externalAccountManagementUrl: String? = null,
+        val delegatedOidcAuthEnabled: Boolean = false,
 ) : MavericksState
 
 data class DeviceFullInfoList(

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
@@ -355,8 +355,8 @@ class VectorSettingsDevicesFragment :
             views.deviceListHeaderOtherSessions.isVisible = true
             val colorDestructive = colorProvider.getColorFromAttribute(R.attr.colorError)
             val multiSignoutItem = views.deviceListHeaderOtherSessions.menu.findItem(R.id.otherSessionsHeaderMultiSignout)
-            // Hide multi signout if we have an external account manager
-            multiSignoutItem.isVisible = state.externalAccountManagementUrl == null
+            // Hide multi signout if the homeserver delegates the account management
+            multiSignoutItem.isVisible = state.delegatedOidcAuthEnabled.not()
             val nbDevices = otherDevices.size
             multiSignoutItem.title = stringProvider.getQuantityString(R.plurals.device_manager_other_sessions_multi_signout_all, nbDevices, nbDevices)
             multiSignoutItem.setTextColor(colorDestructive)
@@ -396,8 +396,8 @@ class VectorSettingsDevicesFragment :
         signoutSessionItem.setTextColor(colorDestructive)
         val signoutOtherSessionsItem = views.deviceListHeaderCurrentSession.menu.findItem(R.id.currentSessionHeaderSignoutOtherSessions)
         signoutOtherSessionsItem.setTextColor(colorDestructive)
-        // Hide signout other sessions if we have an external account manager
-        signoutOtherSessionsItem.isVisible = hasOtherDevices && state.externalAccountManagementUrl == null
+        // Hide signout other sessions if the homeserver delegates the account management
+        signoutOtherSessionsItem.isVisible = hasOtherDevices && state.delegatedOidcAuthEnabled.not()
     }
 
     private fun renderCurrentSessionListView(currentDeviceInfo: DeviceFullInfo) {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/VectorSettingsDevicesFragment.kt
@@ -290,8 +290,8 @@ class VectorSettingsDevicesFragment :
             val unverifiedSessionsCount = deviceFullInfoList?.unverifiedSessionsCount ?: 0
 
             renderSecurityRecommendations(inactiveSessionsCount, unverifiedSessionsCount)
-            renderCurrentSessionView(currentDeviceInfo, hasOtherDevices = otherDevices?.isNotEmpty().orFalse())
-            renderOtherSessionsView(otherDevices, state.isShowingIpAddress)
+            renderCurrentSessionView(currentDeviceInfo, hasOtherDevices = otherDevices?.isNotEmpty().orFalse(), state)
+            renderOtherSessionsView(otherDevices, state)
         } else {
             hideSecurityRecommendations()
             hideCurrentSessionView()
@@ -347,13 +347,16 @@ class VectorSettingsDevicesFragment :
         hideInactiveSessionsRecommendation()
     }
 
-    private fun renderOtherSessionsView(otherDevices: List<DeviceFullInfo>?, isShowingIpAddress: Boolean) {
+    private fun renderOtherSessionsView(otherDevices: List<DeviceFullInfo>?, state: DevicesViewState) {
+        val isShowingIpAddress = state.isShowingIpAddress
         if (otherDevices.isNullOrEmpty()) {
             hideOtherSessionsView()
         } else {
             views.deviceListHeaderOtherSessions.isVisible = true
             val colorDestructive = colorProvider.getColorFromAttribute(R.attr.colorError)
             val multiSignoutItem = views.deviceListHeaderOtherSessions.menu.findItem(R.id.otherSessionsHeaderMultiSignout)
+            // Hide multi signout if we have an external account manager
+            multiSignoutItem.isVisible = state.externalAccountManagementUrl == null
             val nbDevices = otherDevices.size
             multiSignoutItem.title = stringProvider.getQuantityString(R.plurals.device_manager_other_sessions_multi_signout_all, nbDevices, nbDevices)
             multiSignoutItem.setTextColor(colorDestructive)
@@ -377,23 +380,24 @@ class VectorSettingsDevicesFragment :
         views.deviceListOtherSessions.isVisible = false
     }
 
-    private fun renderCurrentSessionView(currentDeviceInfo: DeviceFullInfo?, hasOtherDevices: Boolean) {
+    private fun renderCurrentSessionView(currentDeviceInfo: DeviceFullInfo?, hasOtherDevices: Boolean, state: DevicesViewState) {
         currentDeviceInfo?.let {
-            renderCurrentSessionHeaderView(hasOtherDevices)
+            renderCurrentSessionHeaderView(hasOtherDevices, state)
             renderCurrentSessionListView(it)
         } ?: run {
             hideCurrentSessionView()
         }
     }
 
-    private fun renderCurrentSessionHeaderView(hasOtherDevices: Boolean) {
+    private fun renderCurrentSessionHeaderView(hasOtherDevices: Boolean, state: DevicesViewState) {
         views.deviceListHeaderCurrentSession.isVisible = true
         val colorDestructive = colorProvider.getColorFromAttribute(R.attr.colorError)
         val signoutSessionItem = views.deviceListHeaderCurrentSession.menu.findItem(R.id.currentSessionHeaderSignout)
         signoutSessionItem.setTextColor(colorDestructive)
         val signoutOtherSessionsItem = views.deviceListHeaderCurrentSession.menu.findItem(R.id.currentSessionHeaderSignoutOtherSessions)
         signoutOtherSessionsItem.setTextColor(colorDestructive)
-        signoutOtherSessionsItem.isVisible = hasOtherDevices
+        // Hide signout other sessions if we have an external account manager
+        signoutOtherSessionsItem.isVisible = hasOtherDevices && state.externalAccountManagementUrl == null
     }
 
     private fun renderCurrentSessionListView(currentDeviceInfo: DeviceFullInfo) {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsFragment.kt
@@ -308,7 +308,10 @@ class OtherSessionsFragment :
                         )
                 )
                 views.otherSessionsNotFoundTextView.text = getString(R.string.device_manager_other_sessions_no_inactive_sessions_found)
-                updateSecurityLearnMoreButton(R.string.device_manager_learn_more_sessions_inactive_title, R.string.device_manager_learn_more_sessions_inactive)
+                updateSecurityLearnMoreButton(
+                        R.string.device_manager_learn_more_sessions_inactive_title,
+                        R.string.device_manager_learn_more_sessions_inactive
+                )
             }
             DeviceManagerFilterType.ALL_SESSIONS -> { /* NOOP. View is not visible */
             }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsFragment.kt
@@ -103,8 +103,8 @@ class OtherSessionsFragment :
             val nbDevices = viewState.devices()?.size ?: 0
             stringProvider.getQuantityString(R.plurals.device_manager_other_sessions_multi_signout_all, nbDevices, nbDevices)
         }
-        multiSignoutItem.isVisible = if (viewState.externalAccountManagementUrl != null) {
-            // Hide multi signout if we have an external account manager
+        multiSignoutItem.isVisible = if (viewState.delegatedOidcAuthEnabled) {
+            // Hide multi signout if the homeserver delegates the account management
             false
         } else {
             if (viewState.isSelectModeEnabled) {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsFragment.kt
@@ -103,10 +103,15 @@ class OtherSessionsFragment :
             val nbDevices = viewState.devices()?.size ?: 0
             stringProvider.getQuantityString(R.plurals.device_manager_other_sessions_multi_signout_all, nbDevices, nbDevices)
         }
-        multiSignoutItem.isVisible = if (viewState.isSelectModeEnabled) {
-            viewState.devices.invoke()?.any { it.isSelected }.orFalse()
+        multiSignoutItem.isVisible = if (viewState.externalAccountManagementUrl != null) {
+            // Hide multi signout if we have an external account manager
+            false
         } else {
-            viewState.devices.invoke()?.isNotEmpty().orFalse()
+            if (viewState.isSelectModeEnabled) {
+                viewState.devices.invoke()?.any { it.isSelected }.orFalse()
+            } else {
+                viewState.devices.invoke()?.isNotEmpty().orFalse()
+            }
         }
         val showAsActionFlag = if (viewState.isSelectModeEnabled) MenuItem.SHOW_AS_ACTION_IF_ROOM else MenuItem.SHOW_AS_ACTION_NEVER
         multiSignoutItem.setShowAsAction(showAsActionFlag or MenuItem.SHOW_AS_ACTION_WITH_TEXT)

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsViewModel.kt
@@ -36,6 +36,7 @@ import im.vector.app.features.settings.devices.v2.signout.SignoutSessionsReAuthN
 import im.vector.app.features.settings.devices.v2.signout.SignoutSessionsUseCase
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.uia.DefaultBaseAuth
 import timber.log.Timber
 
@@ -65,16 +66,17 @@ class OtherSessionsViewModel @AssistedInject constructor(
         observeDevices(initialState.currentFilter)
         refreshIpAddressVisibility()
         observePreferences()
-        initExternalAccountManagementUrl()
+        initDelegatedOidcAuthEnabled()
     }
 
-    private fun initExternalAccountManagementUrl() {
+    private fun initDelegatedOidcAuthEnabled() {
         setState {
             copy(
-                    externalAccountManagementUrl = activeSessionHolder.getSafeActiveSession()
+                    delegatedOidcAuthEnabled = activeSessionHolder.getSafeActiveSession()
                             ?.homeServerCapabilitiesService()
                             ?.getHomeServerCapabilities()
-                            ?.externalAccountManagementUrl
+                            ?.delegatedOidcAuthEnabled
+                            .orFalse()
             )
         }
     }

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsViewModel.kt
@@ -41,7 +41,7 @@ import timber.log.Timber
 
 class OtherSessionsViewModel @AssistedInject constructor(
         @Assisted private val initialState: OtherSessionsViewState,
-        activeSessionHolder: ActiveSessionHolder,
+        private val activeSessionHolder: ActiveSessionHolder,
         private val getDeviceFullInfoListUseCase: GetDeviceFullInfoListUseCase,
         private val signoutSessionsUseCase: SignoutSessionsUseCase,
         private val pendingAuthHandler: PendingAuthHandler,
@@ -65,6 +65,18 @@ class OtherSessionsViewModel @AssistedInject constructor(
         observeDevices(initialState.currentFilter)
         refreshIpAddressVisibility()
         observePreferences()
+        initExternalAccountManagementUrl()
+    }
+
+    private fun initExternalAccountManagementUrl() {
+        setState {
+            copy(
+                    externalAccountManagementUrl = activeSessionHolder.getSafeActiveSession()
+                            ?.homeServerCapabilitiesService()
+                            ?.getHomeServerCapabilities()
+                            ?.externalAccountManagementUrl
+            )
+        }
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsViewState.kt
@@ -29,7 +29,7 @@ data class OtherSessionsViewState(
         val isSelectModeEnabled: Boolean = false,
         val isLoading: Boolean = false,
         val isShowingIpAddress: Boolean = false,
-        val externalAccountManagementUrl: String? = null,
+        val delegatedOidcAuthEnabled: Boolean = false,
 ) : MavericksState {
 
     constructor(args: OtherSessionsArgs) : this(excludeCurrentDevice = args.excludeCurrentDevice)

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/othersessions/OtherSessionsViewState.kt
@@ -29,6 +29,7 @@ data class OtherSessionsViewState(
         val isSelectModeEnabled: Boolean = false,
         val isLoading: Boolean = false,
         val isShowingIpAddress: Boolean = false,
+        val externalAccountManagementUrl: String? = null,
 ) : MavericksState {
 
     constructor(args: OtherSessionsArgs) : this(excludeCurrentDevice = args.excludeCurrentDevice)

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewFragment.kt
@@ -39,6 +39,7 @@ import im.vector.app.core.platform.VectorMenuProvider
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.DrawableProvider
 import im.vector.app.core.resources.StringProvider
+import im.vector.app.core.utils.openUrlInChromeCustomTab
 import im.vector.app.databinding.FragmentSessionOverviewBinding
 import im.vector.app.features.auth.ReAuthActivity
 import im.vector.app.features.crypto.recover.SetupMode
@@ -135,10 +136,19 @@ class SessionOverviewFragment :
         activity?.let { SignOutUiWorker(it).perform() }
     }
 
-    private fun confirmSignoutOtherSession() {
-        activity?.let {
-            buildConfirmSignoutDialogUseCase.execute(it, this::signoutSession)
-                    .show()
+    private fun confirmSignoutOtherSession() = withState(viewModel) { state ->
+        if (state.externalAccountManagementUrl != null) {
+            // Manage in external account manager
+            openUrlInChromeCustomTab(
+                    requireContext(),
+                    null,
+                    state.externalAccountManagementUrl.removeSuffix("/") + "?action=session_end&device_id=${state.deviceId}"
+            )
+        } else {
+            activity?.let {
+                buildConfirmSignoutDialogUseCase.execute(it, this::signoutSession)
+                        .show()
+            }
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewModel.kt
@@ -75,6 +75,18 @@ class SessionOverviewViewModel @AssistedInject constructor(
         observeNotificationsStatus(initialState.deviceId)
         refreshIpAddressVisibility()
         observePreferences()
+        initExternalAccountManagementUrl()
+    }
+
+    private fun initExternalAccountManagementUrl() {
+        setState {
+            copy(
+                    externalAccountManagementUrl = activeSessionHolder.getSafeActiveSession()
+                            ?.homeServerCapabilitiesService()
+                            ?.getHomeServerCapabilities()
+                            ?.externalAccountManagementUrl
+            )
+        }
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {

--- a/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/devices/v2/overview/SessionOverviewViewState.kt
@@ -29,6 +29,7 @@ data class SessionOverviewViewState(
         val isLoading: Boolean = false,
         val notificationsStatus: NotificationsStatus = NotificationsStatus.NOT_SUPPORTED,
         val isShowingIpAddress: Boolean = false,
+        val externalAccountManagementUrl: String? = null,
 ) : MavericksState {
     constructor(args: SessionOverviewArgs) : this(
             deviceId = args.deviceId


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : #8616 

## Content

<!-- Describe shortly what has been changed -->

If an external account manager is configured on the server, use it to delete other session.

Note that the session Id is provided, but the web page does not use it. This is out of scope of this PR to fix that.

Also in this case, hide the delete all other sessions menu entries.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

Closes #8616

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Tested OK with my account on element.io.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
