### PR TITLE
Fix SAS strings import URL

### DIFF
--- a/changelog.d/8623.misc
+++ b/changelog.d/8623.misc
@@ -1,0 +1,1 @@
+Fix import of SAS Emoji string translations.

--- a/tools/import_sas_strings.py
+++ b/tools/import_sas_strings.py
@@ -35,7 +35,7 @@ if args.verbose:
     print("Argument:")
     print(args)
 
-base_url = "https://raw.githubusercontent.com/matrix-org/matrix-doc/master/data-definitions/sas-emoji.json"
+base_url = "https://raw.githubusercontent.com/matrix-org/matrix-spec/main/data-definitions/sas-emoji.json"
 
 print("Downloading " + base_url + "…")
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

See https://github.com/vector-im/element-android/issues/8525

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

N/A

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->


N/A

## Tests

<!-- Explain how you tested your development -->


N/A

## Tested devices


N/A

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)

----

Signed-off-by: Travis Ralston <travis.ralston@matrix.org>
Signed-off-by: Travis Ralston <travis.ralston@element.io>
