### PR TITLE
Ensure Background sync is not stopped when there is an active call.

### DIFF
--- a/changelog.d/4066.bugfix
+++ b/changelog.d/4066.bugfix
@@ -1,0 +1,1 @@
+Stop incoming call ringing if the call is cancelled or answered on another session.

--- a/vector-app/src/main/java/im/vector/app/VectorApplication.kt
+++ b/vector-app/src/main/java/im/vector/app/VectorApplication.kt
@@ -108,6 +108,7 @@ class VectorApplication :
     @Inject lateinit var buildMeta: BuildMeta
     @Inject lateinit var leakDetector: LeakDetector
     @Inject lateinit var vectorLocale: VectorLocale
+    @Inject lateinit var webRtcCallManager: WebRtcCallManager
 
     // font thread handler
     private var fontThreadHandler: Handler? = null
@@ -167,20 +168,33 @@ class VectorApplication :
         notificationUtils.createNotificationChannels()
 
         ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
+            private var stopBackgroundSync = false
+
             override fun onResume(owner: LifecycleOwner) {
                 Timber.i("App entered foreground")
                 fcmHelper.onEnterForeground(activeSessionHolder)
-                activeSessionHolder.getSafeActiveSessionAsync {
-                    it?.syncService()?.stopAnyBackgroundSync()
+                if (webRtcCallManager.currentCall.get() == null) {
+                    Timber.i("App entered foreground and no active call: stop any background sync")
+                    activeSessionHolder.getSafeActiveSessionAsync {
+                        it?.syncService()?.stopAnyBackgroundSync()
+                    }
+                } else {
+                    Timber.i("App entered foreground: there is an active call, set stopBackgroundSync to true")
+                    stopBackgroundSync = true
                 }
-//                activeSessionHolder.getSafeActiveSession()?.also {
-//                    it.syncService().stopAnyBackgroundSync()
-//                }
             }
 
             override fun onPause(owner: LifecycleOwner) {
                 Timber.i("App entered background")
                 fcmHelper.onEnterBackground(activeSessionHolder)
+
+                if (stopBackgroundSync) {
+                    Timber.i("App entered background: stop any background sync")
+                    activeSessionHolder.getSafeActiveSessionAsync {
+                        it?.syncService()?.stopAnyBackgroundSync()
+                    }
+                    stopBackgroundSync = false
+                }
             }
         })
         ProcessLifecycleOwner.get().lifecycle.addObserver(spaceStateHandler)

--- a/vector-app/src/main/java/im/vector/app/VectorApplication.kt
+++ b/vector-app/src/main/java/im/vector/app/VectorApplication.kt
@@ -189,11 +189,15 @@ class VectorApplication :
                 fcmHelper.onEnterBackground(activeSessionHolder)
 
                 if (stopBackgroundSync) {
-                    Timber.i("App entered background: stop any background sync")
-                    activeSessionHolder.getSafeActiveSessionAsync {
-                        it?.syncService()?.stopAnyBackgroundSync()
+                    if (webRtcCallManager.currentCall.get() == null) {
+                        Timber.i("App entered background: stop any background sync")
+                        activeSessionHolder.getSafeActiveSessionAsync {
+                            it?.syncService()?.stopAnyBackgroundSync()
+                        }
+                        stopBackgroundSync = false
+                    } else {
+                        Timber.i("App entered background: there is an active call do not stop background sync")
                     }
-                    stopBackgroundSync = false
                 }
             }
         })


### PR DESCRIPTION


<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Ensure Background sync is not stopped when there is an active call.
It was happening since the application is foregrounded when VectorCallActivity is displayed.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
Closes #4066 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->


1. Clear task (make sure Element is not running on the background).
2. Turn off/lock the screen.
3. Don't do anything, let the screen wake up by itself from call notification.
4. Don't pick up the call.

Then either the caller cancel the call, or answer the call from another session.

Previously the call was ringing forever. With this change, the device stops ringing, and the background sync is correctly cancelled. The device does not need to sync forever once the call is over.

Also did some smoke test around call, since this code is quite complex and not covered by unit tests.

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
