### PR TITLE
bump crypto sdk to 0.3.16

### DIFF
--- a/changelog.d/8679.misc
+++ b/changelog.d/8679.misc
@@ -1,0 +1,1 @@
+Bump crypto sdk bindings to v0.3.16

--- a/matrix-sdk-android/build.gradle
+++ b/matrix-sdk-android/build.gradle
@@ -215,7 +215,7 @@ dependencies {
 
     implementation libs.google.phonenumber
 
-    implementation("org.matrix.rustcomponents:crypto-android:0.3.15")
+    implementation("org.matrix.rustcomponents:crypto-android:0.3.16")
 //    api project(":library:rustCrypto")
 
     testImplementation libs.tests.junit

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/CryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/crypto/CryptoService.kt
@@ -240,7 +240,8 @@ interface CryptoService {
             toDevice: ToDeviceSyncResponse?,
             deviceChanges: DeviceListResponse?,
             keyCounts: DeviceOneTimeKeysCountSyncResponse?,
-            deviceUnusedFallbackKeyTypes: List<String>?)
+            deviceUnusedFallbackKeyTypes: List<String>?,
+            nextBatch: String?)
 
     suspend fun onLiveEvent(roomId: String, event: Event, isInitialSync: Boolean, cryptoStoreAggregator: CryptoStoreAggregator?)
     suspend fun onStateEvent(roomId: String, event: Event, cryptoStoreAggregator: CryptoStoreAggregator?) {}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
@@ -287,7 +287,7 @@ internal class OlmMachine @Inject constructor(
 
             val outAdapter = moshi.adapter(Event::class.java)
 
-            // we don't need to use `roomKeyInfos` as we are for now we are
+            // we don't need to use `roomKeyInfos` as for now we are manually
             // checking the returned to devices to check for room keys.
             // XXX Anyhow there is now proper signaling we should soon stop parsing them manually
             receiveSyncChanges.toDeviceEvents.map {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
@@ -253,6 +253,8 @@ internal class OlmMachine @Inject constructor(
      *
      * @param deviceUnusedFallbackKeyTypes The key algorithms for which the server has an unused fallback key for the device.
      *
+     * @param nextBatch The batch token to pass in the next sync request.
+     *
      * @return The handled events, decrypted if needed (secrets are zeroised).
      */
     @Throws(CryptoStoreException::class)

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/OlmMachine.kt
@@ -19,7 +19,6 @@ package org.matrix.android.sdk.internal.crypto
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.asLiveData
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.runBlocking
@@ -262,6 +261,7 @@ internal class OlmMachine @Inject constructor(
             deviceChanges: DeviceListResponse?,
             keyCounts: DeviceOneTimeKeysCountSyncResponse?,
             deviceUnusedFallbackKeyTypes: List<String>?,
+            nextBatch: String?
     ): ToDeviceSyncResponse {
         val response = withContext(coroutineDispatchers.io) {
             val counts: MutableMap<String, Int> = mutableMapOf()
@@ -281,18 +281,16 @@ internal class OlmMachine @Inject constructor(
             val events = adapter.toJson(toDevice ?: ToDeviceSyncResponse())
 
             // field pass in the list of unused fallback keys here
-            val receiveSyncChanges = inner.receiveSyncChanges(events, devices, counts, deviceUnusedFallbackKeyTypes)
+            val receiveSyncChanges = inner.receiveSyncChanges(events, devices, counts, deviceUnusedFallbackKeyTypes, nextBatch ?: "")
 
-            val outAdapter = moshi.adapter<List<Event>>(
-                    Types.newParameterizedType(
-                            List::class.java,
-                            Event::class.java,
-                            String::class.java,
-                            Integer::class.java,
-                            Any::class.java,
-                    )
-            )
-            outAdapter.fromJson(receiveSyncChanges) ?: emptyList()
+            val outAdapter = moshi.adapter(Event::class.java)
+
+            // we don't need to use `roomKeyInfos` as we are for now we are
+            // checking the returned to devices to check for room keys.
+            // XXX Anyhow there is now proper signaling we should soon stop parsing them manually
+            receiveSyncChanges.toDeviceEvents.map {
+                        outAdapter.fromJson(it) ?: Event()
+            }
         }
 
         // We may get cross signing keys over a to-device event, update our listeners.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/RustCryptoService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/crypto/RustCryptoService.kt
@@ -618,9 +618,10 @@ internal class RustCryptoService @Inject constructor(
             deviceChanges: DeviceListResponse?,
             keyCounts: DeviceOneTimeKeysCountSyncResponse?,
             deviceUnusedFallbackKeyTypes: List<String>?,
+            nextBatch: String?,
     ) {
         // Decrypt and handle our to-device events
-        val toDeviceEvents = this.olmMachine.receiveSyncChanges(toDevice, deviceChanges, keyCounts, deviceUnusedFallbackKeyTypes)
+        val toDeviceEvents = this.olmMachine.receiveSyncChanges(toDevice, deviceChanges, keyCounts, deviceUnusedFallbackKeyTypes, nextBatch)
 
         // Notify the our listeners about room keys so decryption is retried.
         toDeviceEvents.events.orEmpty().forEach { event ->

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/SyncResponseHandler.kt
@@ -184,7 +184,8 @@ internal class SyncResponseHandler @Inject constructor(
                         syncResponse.toDevice,
                         syncResponse.deviceLists,
                         syncResponse.deviceOneTimeKeysCount,
-                        syncResponse.deviceUnusedFallbackKeyTypes
+                        syncResponse.deviceUnusedFallbackKeyTypes,
+                        syncResponse.nextBatch
                 )
             }.also {
                 Timber.v("Finish handling toDevice in $it ms")


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

Update the rust crypto sdk version. There are a couple of source breaking change on the binding side

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
