### PR TITLE
Unified Push: Ignore the potential SSL error when the custom gateway is testing

### DIFF
--- a/changelog.d/8683.bugfix
+++ b/changelog.d/8683.bugfix
@@ -1,0 +1,1 @@
+Unified Push: Ignore the potential SSL error when the custom gateway is testing locally


### PR DESCRIPTION
When the Unified Push is enabled, the application checks the potential custom gateway before applying it. If an SSL error happens, the application may ignore this error and keep using this custom gateway. The actual SSL check will be done server side where this gateway is actually used.

Signed-off-by: giomfo gforet@matrix.org
