### PR TITLE
Fix issue with timeline message view reuse while rich text editor is enabled

### DIFF
--- a/changelog.d/8688.bugfix
+++ b/changelog.d/8688.bugfix
@@ -1,0 +1,1 @@
+Fix issue with timeline message view reuse while rich text editor is enabled

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/MessageTextItem.kt
@@ -85,8 +85,13 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
         }
         holder.previewUrlView.delegate = previewUrlCallback
         holder.previewUrlView.renderMessageLayout(attributes.informationData.messageLayout)
-
-        val messageView: AppCompatTextView = if (useRichTextEditorStyle) holder.richMessageView else holder.plainMessageView
+        if (useRichTextEditorStyle) {
+            holder.plainMessageView?.isVisible = false
+        } else {
+            holder.richMessageView?.isVisible = false
+        }
+        val messageView: AppCompatTextView = if (useRichTextEditorStyle) holder.requireRichMessageView() else holder.requirePlainMessageView()
+        messageView.isVisible = true
         if (useBigFont) {
             messageView.textSize = 44F
         } else {
@@ -133,11 +138,21 @@ abstract class MessageTextItem : AbsMessageItem<MessageTextItem.Holder>() {
         val previewUrlView by bind<PreviewUrlView>(R.id.messageUrlPreview)
         private val richMessageStub by bind<ViewStub>(R.id.richMessageTextViewStub)
         private val plainMessageStub by bind<ViewStub>(R.id.plainMessageTextViewStub)
-        val richMessageView: AppCompatTextView by lazy {
-            richMessageStub.inflate().findViewById(R.id.messageTextView)
+        var richMessageView: AppCompatTextView? = null
+            private set
+        var plainMessageView: AppCompatTextView? = null
+            private set
+
+        fun requireRichMessageView(): AppCompatTextView {
+            val view = richMessageView ?: richMessageStub.inflate().findViewById(R.id.messageTextView)
+            richMessageView = view
+            return view
         }
-        val plainMessageView: AppCompatTextView by lazy {
-            plainMessageStub.inflate().findViewById(R.id.messageTextView)
+
+        fun requirePlainMessageView(): AppCompatTextView {
+            val view = plainMessageView ?: plainMessageStub.inflate().findViewById(R.id.messageTextView)
+            plainMessageView = view
+            return view
         }
     }
 


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fix issue with timeline message view reuse while Rich Text Editor (RTE) is enabled.

## Motivation and context

- Fixes https://github.com/vector-im/element-android/issues/8684

## Screenshots / GIFs



## Tests

- With RTE on, then with RTE off
  - In a room with some encryption messages
  - Send some messages
  - Scroll up and down the timeline
  - Observe the messages

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
